### PR TITLE
test(pva-rs): re-send v6 beacon each poll to deflake loopback UDP loss

### DIFF
--- a/crates/epics-pva-rs/src/client_native/search_engine.rs
+++ b/crates/epics-pva-rs/src/client_native/search_engine.rs
@@ -4992,7 +4992,6 @@ mod tests {
             .await
             .expect("tx bind");
         let dest = SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0));
-        tx.send_to(&frame, dest).await.expect("send beacon");
 
         // Poll the tracker for up to ~2s — the engine processes the
         // beacon asynchronously. The tracker keys on the resolved
@@ -5005,8 +5004,18 @@ mod tests {
             0,
             0,
         ));
+        // Re-transmit the beacon on every poll iteration instead of once up
+        // front. A single UDP datagram over the v6 loopback is not
+        // guaranteed to arrive: CI runners drop occasional v6 loopback
+        // packets even when bind + multicast-group-join succeed (the sibling
+        // v6_beacon_socket_binds_and_joins_default_group test passes on the
+        // same runner where a one-shot send here timed out). Periodic re-send
+        // mirrors the real PVA beacon cadence and makes the recv-decode-track
+        // chain this test guards deterministic without masking a recv bug —
+        // if the v6 arm were broken, no number of re-sends would be observed.
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
         let found_guid = loop {
+            tx.send_to(&frame, dest).await.expect("send beacon");
             if let Some(g) = engine.beacon_guid_for(resolved_server) {
                 break Some(g);
             }


### PR DESCRIPTION
## What

Deflake `v6_beacon_arriving_at_engine_is_observed_by_tracker`
(`epics-pva-rs`), which was failing on the `main` CI run for
7a384c81 (Rust job).

## Root cause

The test sent a **single** UDP beacon datagram to `[::1]:port` and then
polled `beacon_guid_for` for 2s. A lone datagram over the v6 loopback is
not guaranteed to be delivered — some GitHub Actions runners drop
occasional v6 loopback packets even when bind + multicast-group-join
succeed.

Evidence this is a delivery flake and **not** a broken v6 recv arm: on
the same failing `main` runner the siblings
`v6_beacon_socket_binds_and_joins_default_group` and
`v6_search_advertises_v6_socket_port` both **PASSED**, while this test
timed out at the full 2s deadline. It also passes locally 3/3 (~0.09s).

## Fix

Re-transmit the beacon on **every** poll iteration instead of once up
front. This mirrors the real periodic PVA beacon cadence and makes the
recv-decode-track chain deterministic. It does not mask a recv bug: if
the v6 arm were broken, no number of re-sends would ever be observed.
The happy path is unchanged (first send still arrives immediately
locally).

## Scope

Test-only change in `crates/epics-pva-rs/src/client_native/search_engine.rs`.
Anchor search (`send_to(&frame` + `beacon_guid_for` poll) confirms this
is the sole site of the one-shot-send pattern — no sibling test shares
it.

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7420 passed, 2 skipped, 0 failed
- Target test 3/3 PASS locally
