### PR TITLE
build(ad-plugins-rs): bump rust-hdf5 0.2.23 -> 0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "rust-hdf5"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba28d5939df0fec07054175c1c0d0a9c4040e088f4bf88fa4657cf4b14d4bb13"
+checksum = "29fdee252e1681973e737d12c31f4edcaf30c4a9a1e3a7af4d12cbfdc60ff43d"
 dependencies = [
  "bzip2",
  "flate2",

--- a/crates/ad-plugins-rs/Cargo.toml
+++ b/crates/ad-plugins-rs/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 netcdf3 = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif", "tiff"] }
 rayon = { version = "1", optional = true }
-rust-hdf5 = { version = "0.2.23", features = ["threadsafe", "all_filters"] }
+rust-hdf5 = { version = "0.2.28", features = ["threadsafe", "all_filters"] }
 epics-pva-rs = { workspace = true, optional = true }
 epics-bridge-rs = { workspace = true, features = ["qsrv"], optional = true }
 

--- a/crates/ad-plugins-rs/src/file_hdf5.rs
+++ b/crates/ad-plugins-rs/src/file_hdf5.rs
@@ -4813,10 +4813,30 @@ mod tests {
         writer.write_file(&arr).unwrap();
         writer.close_file().unwrap();
 
-        let file_size = std::fs::metadata(&path).unwrap().len();
+        // Assert compression by COMPARING against an uncompressed baseline of
+        // the same frame, not against a fixed byte threshold. Since rust-hdf5
+        // 0.2.25 the NeXus group string attributes (NX_class, …) are stored as
+        // variable-length UTF-8 in the global heap, so the file's constant
+        // metadata overhead now dwarfs this 8 KiB frame — an absolute
+        // "< 8192" check no longer reflects whether the data chunk was
+        // compressed (h5dump confirms the chunk itself is ~412 B, ~20:1).
+        // Writing the identical array uncompressed cancels that shared
+        // overhead, isolating the deflate saving on the data chunk.
+        let raw_path = temp_path("hdf5_deflate_raw");
+        {
+            let mut raw_writer = Hdf5Writer::new();
+            raw_writer.set_compression_type(COMPRESS_NONE);
+            raw_writer
+                .open_file(&raw_path, NDFileMode::Single, &arr)
+                .unwrap();
+            raw_writer.write_file(&arr).unwrap();
+            raw_writer.close_file().unwrap();
+        }
+        let compressed_size = std::fs::metadata(&path).unwrap().len();
+        let raw_size = std::fs::metadata(&raw_path).unwrap().len();
         assert!(
-            file_size < 8192,
-            "compressed file should be smaller than raw data"
+            compressed_size + 4096 < raw_size,
+            "deflate must shrink the data chunk: compressed={compressed_size} raw={raw_size}"
         );
 
         let h5file = H5File::open(&path).unwrap();


### PR DESCRIPTION
## What

Bump `rust-hdf5` `0.2.23` → `0.2.28` (`ad-plugins-rs` is the only crate
that depends on it; features unchanged: `["threadsafe", "all_filters"]`).

## Test adaptation

`test_deflate_compressed_write` asserted total `file_size < 8192` as a
proxy for "deflate applied". Since rust-hdf5 **0.2.25** the NeXus group
string attributes (`NX_class`, …) are written as variable-length UTF-8
backed by global-heap collections, so the file's constant metadata
overhead now dwarfs the small compressed frame — an absolute `< 8192`
check no longer reflects whether the **data chunk** was compressed.

`h5dump` confirms compression still works under 0.2.28: `DATASET "data"`
uses `DEFLATE` level 6 with a stored chunk SIZE of ~412 B (~20:1). The
file merely grew because of the shared vlen-attribute metadata.

Fix: compare the deflate file against an **uncompressed baseline** of the
same frame (`COMPRESS_NONE`) so the shared metadata cancels, isolating
the deflate saving on the data chunk (`compressed + 4096 < raw`).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7420 passed, 2 skipped, 0 failed
- `cargo nextest run -p ad-plugins-rs` — 459 passed
