### PR TITLE
build(ad-plugins-rs): bump rust-hdf5 0.2.28 -> 0.3.0, enable parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,13 +3184,14 @@ dependencies = [
 
 [[package]]
 name = "rust-hdf5"
-version = "0.2.28"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fdee252e1681973e737d12c31f4edcaf30c4a9a1e3a7af4d12cbfdc60ff43d"
+checksum = "16b605c13c5e85d8c6e4a7bba78ef4862a96dcad0d6f39acbffe4d426c7caf06"
 dependencies = [
  "bzip2",
  "flate2",
  "lz4_flex",
+ "rayon",
  "rust-zstd",
  "snap",
 ]

--- a/crates/ad-plugins-rs/Cargo.toml
+++ b/crates/ad-plugins-rs/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 netcdf3 = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif", "tiff"] }
 rayon = { version = "1", optional = true }
-rust-hdf5 = { version = "0.2.28", features = ["threadsafe", "all_filters"] }
+rust-hdf5 = { version = "0.3.0", features = ["threadsafe", "all_filters", "parallel"] }
 epics-pva-rs = { workspace = true, optional = true }
 epics-bridge-rs = { workspace = true, features = ["qsrv"], optional = true }
 


### PR DESCRIPTION
## Summary
- Bump `rust-hdf5` `0.2.28` -> `0.3.0` in `ad-plugins-rs`.
- Enable the `parallel` feature (`rayon` + `deflate`) for faster compression/IO. Pure-Rust rayon parallelism, no MPI.
- Feature set otherwise unchanged (`threadsafe`, `all_filters` retained). 0.3.0 exposes the same features as 0.2.28.

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7421 passed, 2 skipped
- `cargo test --doc -p ad-plugins-rs` — no doctests