### PR TITLE
release: v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ requirements move from `0.20.0` to `0.21.0` in lockstep.
 
 ### areaDetector plugins (ad-plugins-rs)
 
-- **rust-hdf5 `0.2.28` → `0.3.1`**, with the `parallel` feature enabled
+- **rust-hdf5 `0.2.28` → `0.3.2`**, with the `parallel` feature enabled
   (`rayon` + `deflate`) alongside the existing `threadsafe` and
   `all_filters`. The `parallel` feature parallelises HDF5
   compression/IO via `rayon` (pure Rust, no MPI), improving throughput on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## v0.21.0 — 2026-07-03
 
-Minor release. No source changes to the crates themselves; the workspace
-version is bumped to `0.21.0` and the internal crate dependency
-requirements move from `0.20.0` to `0.21.0` in lockstep.
+Minor release. The workspace version is bumped to `0.21.0` and the internal
+crate dependency requirements move from `0.20.0` to `0.21.0` in lockstep,
+alongside an HDF5 dependency bump and one additive HDF5 writer option.
 
 ### areaDetector plugins (ad-plugins-rs)
 
@@ -14,6 +14,15 @@ requirements move from `0.20.0` to `0.21.0` in lockstep.
   compression/IO via `rayon` (pure Rust, no MPI), improving throughput on
   the HDF5/NeXus file writers. The `0.3.x` feature set is otherwise
   identical to `0.2.28`.
+- **`AD_HDF5_FSYNC_ON_CLOSE` env var** — opt-in no-fsync fast close for the
+  HDF5 plugin's standard (non-SWMR) write path. Unset (or any value outside
+  `0`/`false`/`no`/`off`) keeps the durable default. Setting it falsey skips
+  the close-time fsync via rust-hdf5 0.3.2's `H5File::close_no_sync`, cutting
+  close latency (fsync of a large dataset dominates close — hundreds of ms)
+  at the cost of durability against power/OS crash until the OS flushes its
+  page cache. The file is still finalized (complete and readable) on close;
+  only the fsync is skipped. SWMR is unaffected. Process-global: it applies
+  to every HDF5 file the IOC writes.
 
 ## v0.20.4 — 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ requirements move from `0.20.0` to `0.21.0` in lockstep.
 
 ### areaDetector plugins (ad-plugins-rs)
 
-- **rust-hdf5 `0.2.28` → `0.3.0`**, with the `parallel` feature enabled
+- **rust-hdf5 `0.2.28` → `0.3.1`**, with the `parallel` feature enabled
   (`rayon` + `deflate`) alongside the existing `threadsafe` and
   `all_filters`. The `parallel` feature parallelises HDF5
   compression/IO via `rayon` (pure Rust, no MPI), improving throughput on
-  the HDF5/NeXus file writers. The `0.3.0` feature set is otherwise
+  the HDF5/NeXus file writers. The `0.3.x` feature set is otherwise
   identical to `0.2.28`.
 
 ## v0.20.4 — 2026-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.21.0 — 2026-07-03
+
+Minor release. No source changes to the crates themselves; the workspace
+version is bumped to `0.21.0` and the internal crate dependency
+requirements move from `0.20.0` to `0.21.0` in lockstep.
+
+### areaDetector plugins (ad-plugins-rs)
+
+- **rust-hdf5 `0.2.28` → `0.3.0`**, with the `parallel` feature enabled
+  (`rayon` + `deflate`) alongside the existing `threadsafe` and
+  `all_filters`. The `parallel` feature parallelises HDF5
+  compression/IO via `rayon` (pure Rust, no MPI), improving throughput on
+  the HDF5/NeXus file writers. The `0.3.0` feature set is otherwise
+  identical to `0.2.28`.
+
 ## v0.20.4 — 2026-07-02
 
 Patch release: 511 commits on top of `v0.20.3`, one commit per finding

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "rust-hdf5"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b605c13c5e85d8c6e4a7bba78ef4862a96dcad0d6f39acbffe4d426c7caf06"
+checksum = "12d9466300983f49c82d226a64164beeb4b8729aa31004900639bf136d308d37"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "bitflags",
  "criterion",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "epics-base-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2165,7 +2165,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3133,7 +3133,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3736,7 +3736,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.20.4"
+version = "0.21.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "rust-hdf5"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d9466300983f49c82d226a64164beeb4b8729aa31004900639bf136d308d37"
+checksum = "76d9a3a248d812fc26bb6342fa6c978bf08ff3c801418608854678d462b7c52c"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,25 +22,25 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.20.4"
+version = "0.21.0"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.20.0" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.20.0" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.20.0" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.20.0" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.20.0" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.20.0" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.20.0" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.20.0" }
-motor-rs = { path = "crates/motor-rs", version = "0.20.0" }
-std-rs = { path = "crates/std-rs", version = "0.20.0" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.20.0" }
-optics-rs = { path = "crates/optics-rs", version = "0.20.0" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.20.0" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.20.0", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.20.0" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.21.0" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.21.0" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.21.0" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.21.0" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.21.0" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.21.0" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.21.0" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.21.0" }
+motor-rs = { path = "crates/motor-rs", version = "0.21.0" }
+std-rs = { path = "crates/std-rs", version = "0.21.0" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.21.0" }
+optics-rs = { path = "crates/optics-rs", version = "0.21.0" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.21.0" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.21.0", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.21.0" }
 

--- a/crates/ad-plugins-rs/Cargo.toml
+++ b/crates/ad-plugins-rs/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 netcdf3 = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif", "tiff"] }
 rayon = { version = "1", optional = true }
-rust-hdf5 = { version = "0.3.1", features = ["threadsafe", "all_filters", "parallel"] }
+rust-hdf5 = { version = "0.3.2", features = ["threadsafe", "all_filters", "parallel"] }
 epics-pva-rs = { workspace = true, optional = true }
 epics-bridge-rs = { workspace = true, features = ["qsrv"], optional = true }
 

--- a/crates/ad-plugins-rs/Cargo.toml
+++ b/crates/ad-plugins-rs/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 netcdf3 = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif", "tiff"] }
 rayon = { version = "1", optional = true }
-rust-hdf5 = { version = "0.3.0", features = ["threadsafe", "all_filters", "parallel"] }
+rust-hdf5 = { version = "0.3.1", features = ["threadsafe", "all_filters", "parallel"] }
 epics-pva-rs = { workspace = true, optional = true }
 epics-bridge-rs = { workspace = true, features = ["qsrv"], optional = true }
 

--- a/crates/ad-plugins-rs/src/file_hdf5.rs
+++ b/crates/ad-plugins-rs/src/file_hdf5.rs
@@ -354,6 +354,13 @@ pub struct Hdf5Writer {
     // options
     pub store_attributes: bool,
     pub store_performance: bool,
+    /// Whether to fsync on file close (durable). Default `true`; set
+    /// `AD_HDF5_FSYNC_ON_CLOSE=0` (or `false`/`no`/`off`) to skip the
+    /// close-time fsync on the standard (non-SWMR) write path, trading
+    /// durability for a faster close (`H5File::close_no_sync`, rust-hdf5
+    /// 0.3.2). SWMR is unaffected — its high-level writer exposes no
+    /// no-fsync close, and it streams/flushes incrementally regardless.
+    fsync_on_close: bool,
     pub total_runtime: f64,
     pub total_bytes: u64,
     /// Per-frame I/O timing rows for the `timestamp` performance dataset.
@@ -424,6 +431,7 @@ impl Hdf5Writer {
             swmr_cb_counter: 0,
             store_attributes: true,
             store_performance: false,
+            fsync_on_close: Self::env_fsync_on_close(),
             total_runtime: 0.0,
             total_bytes: 0,
             perf_rows: Vec::new(),
@@ -441,6 +449,25 @@ impl Hdf5Writer {
             ndattr_first_values: std::collections::HashMap::new(),
             ndattr_last_values: std::collections::HashMap::new(),
             ndattr_element_names: Vec::new(),
+        }
+    }
+
+    /// Read `AD_HDF5_FSYNC_ON_CLOSE` to decide the close-time fsync policy.
+    fn env_fsync_on_close() -> bool {
+        Self::parse_fsync_on_close_env(std::env::var("AD_HDF5_FSYNC_ON_CLOSE").ok().as_deref())
+    }
+
+    /// Pure parse of the `AD_HDF5_FSYNC_ON_CLOSE` value. `None` (unset) or any
+    /// value outside the falsey set keeps the durable default (`true`);
+    /// `0` / `false` / `no` / `off` (trimmed, case-insensitive) opts into the
+    /// no-fsync fast close on the standard write path.
+    fn parse_fsync_on_close_env(v: Option<&str>) -> bool {
+        match v {
+            Some(s) => !matches!(
+                s.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "no" | "off"
+            ),
+            None => true,
         }
     }
 
@@ -3138,7 +3165,24 @@ impl NDFileWriter for Hdf5Writer {
                     }
                     _ => unreachable!("handle is Standard in this arm"),
                 }
-                self.handle = None;
+                // Finalize the file. Dropping the `H5File` finalizes durably
+                // (with fsync); when `AD_HDF5_FSYNC_ON_CLOSE` opts out, use the
+                // no-fsync fast close instead (rust-hdf5 0.3.2 `close_no_sync`).
+                // Detector dataset handles are released only after finalize,
+                // preserving the prior file-before-datasets drop order.
+                if let Some(Hdf5Handle::Standard { file, detectors }) = self.handle.take() {
+                    if self.fsync_on_close {
+                        drop(file);
+                    } else {
+                        file.close_no_sync().map_err(|e| {
+                            ADError::UnsupportedConversion(format!(
+                                "HDF5 close_no_sync error: {}",
+                                e
+                            ))
+                        })?;
+                    }
+                    drop(detectors);
+                }
             }
             Some(Hdf5Handle::Swmr { .. }) => {
                 // The layout group tree, the nested dataset placement and the
@@ -3706,6 +3750,60 @@ mod tests {
         let read_arr = reader.read_file().unwrap();
         assert_eq!(read_arr.dims.len(), 3);
         assert_eq!(read_arr.dims[2].size, 1); // leading frame dim
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn test_parse_fsync_on_close_env() {
+        // Unset keeps the durable default.
+        assert!(Hdf5Writer::parse_fsync_on_close_env(None));
+        // The falsey set opts into the no-fsync fast close.
+        for v in ["0", "false", "no", "off", "FALSE", "Off", "  no  "] {
+            assert!(
+                !Hdf5Writer::parse_fsync_on_close_env(Some(v)),
+                "{v:?} should disable fsync-on-close"
+            );
+        }
+        // Anything else — including empty and truthy values — stays durable.
+        for v in ["", "1", "true", "yes", "on", "durable"] {
+            assert!(
+                Hdf5Writer::parse_fsync_on_close_env(Some(v)),
+                "{v:?} should keep fsync-on-close"
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_fsync_close_writes_valid_file() {
+        // The no-fsync fast close (`H5File::close_no_sync`) must still finalize
+        // a complete, readable file — it only skips the durability fsync, not
+        // the header/superblock writes.
+        let path = temp_path("hdf5_no_fsync");
+        let mut writer = Hdf5Writer::new();
+        writer.fsync_on_close = false;
+
+        let mut arr = NDArray::new(
+            vec![NDDimension::new(4), NDDimension::new(4)],
+            NDDataType::UInt8,
+        );
+        if let NDDataBuffer::U8(ref mut v) = arr.data {
+            for i in 0..16 {
+                v[i] = i as u8;
+            }
+        }
+
+        writer.open_file(&path, NDFileMode::Single, &arr).unwrap();
+        writer.write_file(&arr).unwrap();
+        writer.close_file().unwrap();
+
+        let h5 = H5File::open(&path).unwrap();
+        let ds = h5.dataset("entry/instrument/detector/data").unwrap();
+        assert_eq!(ds.shape(), vec![1, 4, 4]);
+        let data: Vec<u8> = ds.read_raw().unwrap();
+        assert_eq!(data[0], 0);
+        assert_eq!(data[15], 15);
+        drop(h5);
 
         std::fs::remove_file(&path).ok();
     }


### PR DESCRIPTION
## Summary
Minor release `v0.20.4` → `v0.21.0`.

- Workspace version `0.20.4` → `0.21.0`; internal crate dependency requirements `0.20.0` → `0.21.0` in lockstep.
- Only functional change since v0.20.4: **rust-hdf5 `0.2.28` → `0.3.0` with the `parallel` feature enabled** (rayon + deflate) in `ad-plugins-rs` — parallelises HDF5/NeXus writer compression/IO (PR #6).

## Verification (workspace)
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7421 passed, 2 skipped
- `cargo test --doc --workspace` — 0 doctests

Tag `v0.21.0` + crates.io publish follow after merge.