### PR TITLE
fix(ca-client): do not emit NativeTypeChanged on first connect

### DIFF
--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -3734,8 +3734,20 @@ async fn run_coordinator(
                             });
                             // epics-base `16877577` parity: surface native
                             // DBR type changes so consumers can react before
-                            // the next event flows.
-                            if native_changed {
+                            // the next event flows. Only a transition from a
+                            // *known* prior native type counts: on the first
+                            // connect `previous_native` is `None` — the type is
+                            // being discovered, not changed, and the `Connected`
+                            // event already carries it. Firing NativeTypeChanged
+                            // here too would make every first connect look like a
+                            // type change and push consumers into a redundant
+                            // metadata refetch (and, if their connect handler is
+                            // not idempotent, a duplicate initial value). The
+                            // `native_changed` flag itself is left as-is — it
+                            // still drives the auto-derived decoder reset in
+                            // `restore_for_channel`; only the consumer-facing
+                            // event is gated on a real prior type.
+                            if native_changed && previous_native.is_some() {
                                 if let Some(cur) = dbr_type {
                                     let _ = ch.conn_tx.send(ConnectionEvent::NativeTypeChanged {
                                         previous: previous_native,

--- a/crates/epics-ca-rs/tests/protocol_tests.rs
+++ b/crates/epics-ca-rs/tests/protocol_tests.rs
@@ -2188,3 +2188,86 @@ async fn server_read_sync_echoes_request_header() {
     assert_eq!(echo.available, 0xDEAD_BEEF, "m_available echoed");
     assert_eq!(echo.postsize, 0, "no payload");
 }
+
+// ---------------------------------------------------------------------------
+// NativeTypeChanged is a *transition* signal, not a *discovery* signal
+// ---------------------------------------------------------------------------
+
+/// On the very first connect a channel has no prior native DBR type, so the
+/// type is being discovered — the `Connected` event already carries it. The
+/// client must NOT also emit `NativeTypeChanged` here: doing so makes every
+/// first connect look like a type change and pushes consumers into a redundant
+/// metadata refetch (and, if their connect handler is not idempotent, a
+/// duplicate initial value). `NativeTypeChanged` is reserved for a genuine
+/// transition from a known prior type (an IOC redefining the record, or a
+/// reconnect to a differently-typed record).
+#[tokio::test]
+async fn first_connect_does_not_emit_native_type_changed() {
+    use std::time::Duration;
+
+    use epics_ca_rs::client::{CaClient, ConnectionEvent};
+
+    let port = {
+        let probe =
+            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
+        let p = probe.local_addr().unwrap().port();
+        drop(probe);
+        p
+    };
+
+    let server = CaServer::builder()
+        .port(port)
+        .pv("NTC:FIRST:PV", EpicsValue::Double(1.0))
+        .build()
+        .await
+        .expect("build CA server");
+    let _server_handle = tokio::spawn(async move { server.run().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Target the in-process server directly (no process-global env mutation),
+    // so this test needs no `#[serial]` and cannot race the env other tests set.
+    let client = CaClient::new().await.expect("client");
+    client.add_address(([127, 0, 0, 1], port).into());
+    let channel = client.create_channel("NTC:FIRST:PV");
+    // Subscribe to the event stream synchronously, before the async connect can
+    // complete: the connect involves a UDP search + TCP handshake (ms), this
+    // subscribe is µs, so `Connected` cannot slip past. The `saw_connected`
+    // assertion below fails loudly if it ever does, so a missed window can never
+    // masquerade as "no NativeTypeChanged".
+    let mut events = channel.connection_events();
+
+    channel
+        .wait_connected(Duration::from_secs(5))
+        .await
+        .expect("channel connects to the in-process server");
+
+    // Drain events up to and just past connect. `Connected` (and
+    // `AccessRightsChanged`) are expected; `NativeTypeChanged` is not. If the
+    // client wrongly emitted it, it lands right after `Connected` in the same
+    // burst, well within this idle window.
+    let mut saw_connected = false;
+    loop {
+        match tokio::time::timeout(Duration::from_millis(300), events.recv()).await {
+            Ok(Ok(ev)) => {
+                if matches!(ev, ConnectionEvent::Connected) {
+                    saw_connected = true;
+                }
+                assert!(
+                    !matches!(ev, ConnectionEvent::NativeTypeChanged { .. }),
+                    "first connect must not emit NativeTypeChanged: the native \
+                     type was discovered, not changed"
+                );
+            }
+            // Lagged or closed: no more meaningful events to inspect.
+            Ok(Err(_)) => break,
+            // Idle window elapsed with no further event — the burst is over.
+            Err(_) => break,
+        }
+    }
+
+    assert!(
+        saw_connected,
+        "expected a Connected event on first connect (else the event window was \
+         missed and the NativeTypeChanged check is meaningless)"
+    );
+}


### PR DESCRIPTION
## Summary

`NativeTypeChanged` is meant to surface a *transition* of a channel's native
DBR type across reconnects (an IOC redefining the record, or a reconnect to a
differently-typed record) so consumers rebuild their decoders / display
metadata. On the very first connect there is no prior type: `previous_native`
is `None`, so `(None, Some) => true` in the `native_changed` match made every
first connect emit `NativeTypeChanged` even though the type was merely
*discovered* — the `Connected` event already carries it.

This gates only the consumer-facing event on `previous_native.is_some()`, so it
fires solely on a genuine transition from a known prior type. The
`native_changed` flag is unchanged: it still drives the auto-derived type/count
reset in `restore_for_channel`.

## Impact

For consumers that refetch CTRL metadata on `NativeTypeChanged` (rsdm's CA
plugin, and PyDM-style layers generally), the old behavior fired a redundant
metadata round-trip on every connection; where the connect handler was not
idempotent it re-emitted the initial value, leaking a duplicate sample to any
value subscriber created between the two posts.

## C parity

Verified against the upstream epics-base commit this behavior is modeled on —
`168775775` ("catools: make camonitor handle type changes"). In
`camonitor.c`'s `connection_handler` the type-change/rebuild branch is guarded
by `ppv->onceConnected`:

```c
if (ppv->onceConnected && ppv->dbfType != ca_field_type(ppv->chid)) {
    /* Data type has changed. Rebuild connection with new type. */
    ca_clear_subscription(ppv->evid);
    ppv->evid = NULL;
}
```

On the first connect `onceConnected == 0`, so the type-change path is never
taken. The Rust guard `previous_native.is_some()` is the exact equivalent of
`onceConnected`; the retained `ch.native_type` across disconnect matches C not
resetting `dbfType` in the `CA_OP_CONN_DOWN` handler. This change *restores*
parity — the pre-fix code diverged by treating first-connect as a type change.

## Test

Adds `first_connect_does_not_emit_native_type_changed`: against an in-process
`CaServer` it asserts the first connect carries `Connected` but no
`NativeTypeChanged`. Fails on the pre-fix code, passes after.
