### PR TITLE
fix(db-loader): give device-support init the link text of record-owned INP/OUT

### DIFF
--- a/crates/epics-base-rs/src/server/db_loader/mod.rs
+++ b/crates/epics-base-rs/src/server/db_loader/mod.rs
@@ -1086,6 +1086,15 @@ pub fn resolve_linr_breaktable_names(
     }
 }
 
+/// The link fields whose value must reach [`RecordCommon`] — and therefore
+/// device-support init via `DeviceSupportContext` — for every record type,
+/// even one that stores the field itself.
+///
+/// [`RecordCommon`]: crate::server::record::RecordCommon
+fn is_common_link_field(upper_name: &str) -> bool {
+    matches!(upper_name, "INP" | "OUT")
+}
+
 pub fn apply_fields(
     record: &mut Box<dyn Record>,
     fields: &[(String, String)],
@@ -1125,6 +1134,29 @@ pub fn apply_fields(
                 })?
             };
             record.put_field(&upper_name, value)?;
+            // A record type may declare INP/OUT in its own `field_list`,
+            // mirroring its C `.dbd` (`scalerRecord`, `motorRecord`,
+            // `acalcout`, …). The value is then stored by the record — but in
+            // C the link is *also* what device support reads at init:
+            // `devXxx.c::init_record` dereferences `prec->out` / `prec->inp`
+            // directly (e.g. `devScalerAsyn.c::scaler_init_record` parses OUT
+            // to pick its board), and a record owning the field changes
+            // nothing about that. Routing the value to the record ALONE left
+            // `RecordCommon.inp`/`.out` — the single source of truth
+            // `DeviceSupportContext` is built from — empty, so a dynamic
+            // device-support factory saw `ctx.out == ""` and could not
+            // disambiguate. Mirror link fields into the common fields as well
+            // so the link text reaches device-support init for every record
+            // type. This is text only: `RecordInstance::put_common_field`
+            // arms the framework's own link dispatch (`parsed_inp` /
+            // `parsed_out`) only for a record that does NOT declare the field,
+            // so a record driving its own link is not driven twice.
+            if is_common_link_field(&upper_name) {
+                common_fields.push((
+                    upper_name.clone(),
+                    EpicsValue::String(value_str.clone().into()),
+                ));
+            }
         } else {
             // Store as common field for RecordInstance to handle
             common_fields.push((upper_name, EpicsValue::String(value_str.clone().into())));

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -1240,6 +1240,25 @@ impl RecordInstance {
     }
 
     /// Set a common field value. Returns what scan index changes are needed.
+    /// `true` when the record type declares `name` in its own `field_list`,
+    /// i.e. the record stores the field itself and owns whatever behaviour
+    /// hangs off it.
+    ///
+    /// This separates the two meanings a link field carries. `common.inp` /
+    /// `common.out` is the link *text* — always the value the `.db` file
+    /// wrote, for every record type, because C device support reads
+    /// `prec->inp` / `prec->out` at `init_record` no matter which layer owns
+    /// the field ([`crate::server::db_loader::apply_fields`] keeps it
+    /// populated). `parsed_inp` / `parsed_out` is the *framework's* dispatch
+    /// of that link, and is armed only for a record type that does NOT
+    /// declare the field: a record that declares it drives the link itself
+    /// (`multi_output_links` for `acalcout`/`scalcout`, device support for
+    /// `motorRecord`/`scalerRecord`, or its own `process`). Arming the
+    /// framework path for those too would write the link twice per cycle.
+    fn record_declares_field(&self, name: &str) -> bool {
+        self.record.field_list().iter().any(|f| f.name == name)
+    }
+
     pub fn put_common_field(
         &mut self,
         name: &str,
@@ -1386,7 +1405,9 @@ impl RecordInstance {
             "INP" => {
                 if let EpicsValue::String(s) = value {
                     self.common.inp = s.as_str_lossy().into_owned();
-                    self.parsed_inp = parse_link_v2(&self.common.inp);
+                    if !self.record_declares_field("INP") {
+                        self.parsed_inp = parse_link_v2(&self.common.inp);
+                    }
                 }
             }
             "OUT" => {
@@ -1414,7 +1435,9 @@ impl RecordInstance {
                     // downgrades the modifier-less `ProcessPassive`
                     // default that `parse_link_v2` would otherwise
                     // apply.
-                    self.parsed_out = parse_output_link_v2(&self.common.out);
+                    if !self.record_declares_field("OUT") {
+                        self.parsed_out = parse_output_link_v2(&self.common.out);
+                    }
                     // C `longoutRecord.c::special` (PR #6c573b4 part 2)
                     // and similar OOCH-style hooks need `after=true`
                     // to fire after the link has actually moved. The

--- a/crates/epics-base-rs/tests/db_loader_link_context.rs
+++ b/crates/epics-base-rs/tests/db_loader_link_context.rs
@@ -1,0 +1,189 @@
+//! A record type that declares `INP`/`OUT` in its own `field_list` — mirroring
+//! its C `.dbd`, as `scalerRecord`, `motorRecord` and `acalcout` do — must still
+//! hand the link text to device-support init.
+//!
+//! C parity: device support dereferences the link itself at init, regardless of
+//! which layer "owns" the field. `devScalerAsyn.c::scaler_init_record` reads
+//! `prec->out` to pick the board a `scalerRecord` instance talks to; the record
+//! owning `OUT` in its dbd changes nothing about that. The Rust loader used to
+//! route a record-declared field to `Record::put_field` *only*, leaving
+//! `RecordCommon.out` — the single source of truth `DeviceSupportContext` is
+//! built from — empty. A dynamic factory therefore saw `ctx.out == ""` and could
+//! not disambiguate two boards by their OUT link.
+//!
+//! The two halves of the invariant are pinned separately below, because they are
+//! deliberately distinct: `common.out` is the link *text* (always populated),
+//! while `parsed_out` is the *framework's* dispatch of that link (armed only for
+//! a record type that does not declare the field, so a record driving its own
+//! link is not driven twice per cycle).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::error::CaResult;
+use epics_base_rs::server::device_support::DeviceSupport;
+use epics_base_rs::server::ioc_app::DeviceSupportContext;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::record::{FieldDesc, ParsedLink, Record};
+use epics_base_rs::types::{DbFieldType, EpicsValue};
+
+/// Stand-in for a C-faithful custom record type: it declares `OUT` in its own
+/// field list, exactly as `scalerRecord.dbd` does.
+#[derive(Default)]
+struct OwnsOutRecord {
+    val: i32,
+    out: String,
+}
+
+static OWNS_OUT_FIELDS: &[FieldDesc] = &[
+    FieldDesc {
+        name: "VAL",
+        dbf_type: DbFieldType::Long,
+        read_only: false,
+    },
+    FieldDesc {
+        name: "OUT",
+        dbf_type: DbFieldType::String,
+        read_only: false,
+    },
+];
+
+impl Record for OwnsOutRecord {
+    fn record_type(&self) -> &'static str {
+        "ownsOut"
+    }
+
+    fn field_list(&self) -> &'static [FieldDesc] {
+        OWNS_OUT_FIELDS
+    }
+
+    fn get_field(&self, name: &str) -> Option<EpicsValue> {
+        match name {
+            "VAL" => Some(EpicsValue::Long(self.val)),
+            "OUT" => Some(EpicsValue::String(self.out.clone().into())),
+            _ => None,
+        }
+    }
+
+    fn put_field(&mut self, name: &str, value: EpicsValue) -> CaResult<()> {
+        match (name, value) {
+            ("VAL", EpicsValue::Long(v)) => self.val = v,
+            ("OUT", EpicsValue::String(s)) => self.out = s.as_str_lossy().into_owned(),
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+struct NoopDevice;
+
+impl DeviceSupport for NoopDevice {
+    fn write(&mut self, _record: &mut dyn Record) -> CaResult<()> {
+        Ok(())
+    }
+
+    fn dtyp(&self) -> &str {
+        "ownsOutDev"
+    }
+}
+
+const OUT_LINK: &str = "#C0 S0 @scaler1";
+
+/// The db file's `OUT` value must reach the dynamic device-support factory.
+/// Before the fix `ctx.out` was `""` and a factory keying on the link (C
+/// `scaler_init_record`) could not tell two boards apart.
+#[tokio::test]
+async fn record_owned_out_link_reaches_device_support_context() {
+    let seen: Arc<Mutex<Vec<(String, String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&seen);
+
+    let db = format!(
+        r#"
+record(ownsOut, "SCALER:1") {{
+    field(DTYP, "ownsOutDev")
+    field(OUT, "{OUT_LINK}")
+}}
+"#
+    );
+
+    let (database, _) = IocBuilder::new()
+        .register_record_type("ownsOut", || Box::new(OwnsOutRecord::default()))
+        .register_dynamic_device_support(move |ctx: &DeviceSupportContext| {
+            captured.lock().unwrap().push((
+                ctx.dtyp.to_string(),
+                ctx.inp.to_string(),
+                ctx.out.to_string(),
+            ));
+            Some(Box::new(NoopDevice) as Box<dyn DeviceSupport>)
+        })
+        .db_string(&db, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    let contexts = std::mem::take(&mut *seen.lock().unwrap());
+    assert_eq!(contexts.len(), 1, "dynamic factory should run once");
+    let (dtyp, inp, out) = &contexts[0];
+    assert_eq!(dtyp, "ownsOutDev");
+    assert_eq!(inp, "", "record declares no INP");
+    assert_eq!(
+        out, OUT_LINK,
+        "record-owned OUT must reach DeviceSupportContext.out"
+    );
+
+    // The record still stores the field itself — the mirror into the common
+    // fields adds a reader, it does not move ownership.
+    let instance = database
+        .get_record("SCALER:1")
+        .await
+        .expect("record loaded");
+    let instance = instance.read().await;
+    assert_eq!(
+        instance.record.get_field("OUT"),
+        Some(EpicsValue::String(OUT_LINK.into()))
+    );
+    assert_eq!(instance.common.out, OUT_LINK);
+}
+
+/// The other half of the invariant: mirroring the link *text* must not arm the
+/// framework's generic single-OUT dispatch for a record that owns its OUT. If
+/// `parsed_out` were populated here, a record driving its own link (`acalcout`
+/// and `scalcout` via `multi_output_links`, `motorRecord`/`scalerRecord` via
+/// device support) would write that link twice per process cycle.
+#[tokio::test]
+async fn record_owned_out_link_does_not_arm_framework_dispatch() {
+    let db = r#"
+record(ownsOut, "SCALER:2") {
+    field(DTYP, "ownsOutDev")
+    field(OUT, "TARGET:PV PP")
+}
+"#;
+
+    let (database, _) = IocBuilder::new()
+        .register_record_type("ownsOut", || Box::new(OwnsOutRecord::default()))
+        .register_dynamic_device_support(|_ctx: &DeviceSupportContext| {
+            Some(Box::new(NoopDevice) as Box<dyn DeviceSupport>)
+        })
+        .db_string(db, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    let instance = database
+        .get_record("SCALER:2")
+        .await
+        .expect("record loaded");
+    let instance = instance.read().await;
+
+    // Link text: populated, so device support sees it.
+    assert_eq!(instance.common.out, "TARGET:PV PP");
+    // Framework dispatch: unarmed, because the record type owns the field.
+    assert!(
+        matches!(instance.parsed_out, ParsedLink::None),
+        "framework OUT dispatch must stay unarmed for a record that owns OUT, \
+         got {:?}",
+        instance.parsed_out
+    );
+}


### PR DESCRIPTION
## Defect

`DeviceSupportContext.inp` / `.out` are always empty for a record type that declares its own `INP`/`OUT` `FieldDesc`.

When a custom record type mirrors its C `.dbd` by declaring `OUT` in its own `field_list` (as `scalerRecord` does), `db_loader::apply_fields` routes the parsed `OUT` value into the record's own `put_field` and never populates `RecordCommon.out`. `register_dynamic_device_support` factories are handed `ctx.out == ""` and cannot disambiguate multiple boards by their OUT link — which is exactly what C's `devScalerAsyn.c::scaler_init_record` does to pick the board a `scalerRecord` instance talks to.

**C semantics (parity reference):** device support dereferences `prec->out` / `prec->inp` directly at `init_record`. The record type owning the field in its dbd changes nothing about that — in C there is only one storage location, and both the record and its device support read it.

## Root cause

The loader made link-field storage **exclusive**: `apply_fields` sends a field either to `Record::put_field` (if the record type declares it) or to the common fields (if it does not) — never both. So a link value could reach the record *or* the framework, but not both.

This is a defect *family*, not one site. Five in-repo record types declare `INP`/`OUT` in their own `field_list` (`scaler-rs`, `motor-rs`, `std-rs` throttle + epid, base's `acalcout`), and all of them load with an empty `common.inp`/`.out`. Record types had already been working around the same cause by *deliberately omitting* fields from their dbd surface just to reach the common path:

- `swait.rs:178` — *"OUT and OUTN are intentionally absent: both route to RecordInstance::common.out via put_common_field so that parsed_out is populated for output dispatch."*
- `int64in.rs:10` / `int64out.rs:11` — alarm limits *"intentionally absent from the field list so they route to RecordInstance::common"*.

Those comments are the cause stated out loud: a record type had to choose between owning a field and having its value reach the framework.

## Fix approach

The common link fields were carrying **two meanings at once**. Separate them, so each has one meaning that holds on every path:

- **`common.inp` / `common.out` = the link TEXT.** Always the value the `.db` file wrote, for every record type. `apply_fields` now mirrors a record-owned `INP`/`OUT` into the common fields in addition to the record's own storage, so the text always reaches device-support init.
- **`parsed_inp` / `parsed_out` = the FRAMEWORK's dispatch of that link.** Armed only when the record type does *not* declare the field. A record that declares it drives the link itself (`multi_output_links` for `acalcout`/`scalcout`, device support for `motorRecord`/`scalerRecord`, or its own `process`), so the framework must not drive it a second time.

The ownership test (`RecordInstance::record_declares_field`) is **derived from `field_list()`**, not a hard-coded list of record types — a new C-faithful record type gets the correct behaviour by construction. Both load paths (`dbLoadRecords` and `IocBuilder`) funnel through `apply_fields` + `put_common_field`, so the fix lands once for both rather than being patched per call site.

## Semantic change + caller audit

The behaviour change is confined to record types that **declare `INP`/`OUT` in their own `field_list`** — for every other record type the routing is byte-identical (the field was already going to the common path, and `parsed_*` is still armed there).

For the affected types, `common.inp`/`.out` goes from `""` to the db's link text. `parsed_inp`/`parsed_out` stay `None` for them, exactly as before, so **no output/input dispatch changes** — this is what prevents a double write.

Anchor: `rg -n 'name: "(INP|OUT)"'` over the workspace. Every hit classified:

| Record type | Field | Own dispatch | Effect of this change |
|---|---|---|---|
| `scaler-rs` `scalerRecord` | `OUT` | device support (asyn) | **Fixed** — `ctx.out` now carries the link; `parsed_out` still unarmed |
| `motor-rs` `motorRecord` | `OUT` | device support (asyn) | `ctx.out` now populated; dispatches by DTYP, so no behaviour change |
| `epics-base-rs` `acalcout` | `OUT` | `multi_output_links` | Text populated only; `parsed_out` stays unarmed → **no double write** |
| `std-rs` `throttle` | `OUT` | own `process` | Text populated only; dispatch unchanged |
| `std-rs` `epid` | `INP` | own `process` | Text populated only; `parsed_inp` stays unarmed |

`special()` hooks on the affected types were checked: `scaler` (`CNT`, …) and `throttle` (`DLY`, …) do not match `INP`/`OUT`; `motor`, `epid` and `acalcout` implement no `special`. So routing the mirrored value through `put_common_field` fires no record-specific hook.

**Downstream audit — `/home/stevek/work/epics-rs-iocs`** (driver/IOC workspace on crates.io 0.22.1, read-only): `rg -n 'name: "(INP|OUT)"'` → **no hits** (no downstream record type declares its own link fields), and `rg -n 'ctx\.(out|inp)'` → **no hits** (no downstream dynamic factory reads the context directly). Downstream is a pure consumer here: it gains the fix (the scaler port can disambiguate boards by OUT) and loses nothing.

## Regression test

`crates/epics-base-rs/tests/db_loader_link_context.rs` — a custom record type declaring `OUT` in its own `field_list` plus a dynamic device-support factory:

- `record_owned_out_link_reaches_device_support_context` — asserts `ctx.out` carries the db file's value. **Fails on unfixed main** with `left: ""`, `right: "#C0 S0 @scaler1"`.
- `record_owned_out_link_does_not_arm_framework_dispatch` — asserts the link text is populated *and* `parsed_out` stays `ParsedLink::None`, pinning the half of the invariant that prevents a record from writing its own link twice per cycle. Also fails on unfixed main (empty `common.out`).

Both pass after the fix.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7423 passed, 0 failed, 2 skipped
- `cargo test --doc -p epics-base-rs` — ok