### PR TITLE
fix(db-loader): make dbLoadRecords DTYP= a plain macro, not a force-override

### DIFF
--- a/crates/epics-base-rs/src/server/db_loader/include.rs
+++ b/crates/epics-base-rs/src/server/db_loader/include.rs
@@ -379,17 +379,6 @@ pub(crate) fn resolve_include_path(
     })
 }
 
-/// Override DTYP fields on records that already have a DTYP field.
-pub fn override_dtyp(records: &mut [DbRecordDef], dtyp: &str) {
-    for rec in records.iter_mut() {
-        for (name, value) in rec.fields.iter_mut() {
-            if name == "DTYP" {
-                *value = dtyp.to_string();
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod macro_defns_tests {
     use super::*;

--- a/crates/epics-base-rs/src/server/db_loader/mod.rs
+++ b/crates/epics-base-rs/src/server/db_loader/mod.rs
@@ -9,9 +9,7 @@ mod include;
 mod substitution;
 #[cfg(test)]
 pub(crate) use include::parse_include_directive;
-pub use include::{
-    DbLoadConfig, expand_includes, override_dtyp, parse_db_file, parse_db_file_with_breaktables,
-};
+pub use include::{DbLoadConfig, expand_includes, parse_db_file, parse_db_file_with_breaktables};
 pub use substitution::{TemplateLoad, load_substitution_file, parse_substitutions};
 
 /// Factory function that creates a record instance.
@@ -1989,38 +1987,55 @@ record(ai, "T") { field(LINR, "typeJdegC") }
         assert!(result.contains(r#"record(ai, "VIA_PATH")"#));
     }
 
+    /// A `DTYP=` macro is pure text substitution, exactly like every other
+    /// macro: it reaches a record only where the `.db` wrote
+    /// `field(DTYP,"$(DTYP)")`. It must NOT rewrite a record that spells its
+    /// DTYP literally.
+    ///
+    /// This replaces `test_dtyp_override_existing_only`, which pinned the
+    /// opposite (force-override) behaviour. C `dbLoadRecords` runs its macros
+    /// through macLib during lexing (`dbLexRoutines.c`); there is no DTYP
+    /// special case, and a force-override corrupts any multi-record file whose
+    /// helper records carry a literal DTYP — e.g. the vendored
+    /// `scaler-rs/db/scaler.db`, where two `bo` helpers are
+    /// `field(DTYP,"Soft Channel")` and only the `scaler` record references
+    /// `$(DTYP)`.
     #[test]
-    fn test_dtyp_override_existing_only() {
-        let mut records = vec![
-            DbRecordDef {
-                record_type: "ai".to_string(),
-                name: "REC_WITH_DTYP".to_string(),
-                fields: vec![
-                    ("DTYP".to_string(), "oldDtyp".to_string()),
-                    ("VAL".to_string(), "0".to_string()),
-                ],
-                aliases: Vec::new(),
-                info_tags: Vec::new(),
-            },
-            DbRecordDef {
-                record_type: "ao".to_string(),
-                name: "REC_WITHOUT_DTYP".to_string(),
-                fields: vec![("VAL".to_string(), "1".to_string())],
-                aliases: Vec::new(),
-                info_tags: Vec::new(),
-            },
-        ];
+    fn dtyp_macro_substitutes_references_and_leaves_literals_alone() {
+        let input = r#"
+record(bo, "$(P)_calcEnable") {
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "ENABLE")
+}
+record(scaler, "$(P)") {
+    field(DTYP, "$(DTYP)")
+    field(FREQ, "10000000")
+}
+record(ao, "$(P)_noDtyp") {
+    field(VAL, "1")
+}
+"#;
+        let mut macros = HashMap::new();
+        macros.insert("P".to_string(), "SCALER1".to_string());
+        macros.insert("DTYP".to_string(), "Scaler-rs".to_string());
 
-        override_dtyp(&mut records, "newDtyp");
+        let records = parse_db(input, &macros).unwrap();
+        assert_eq!(records.len(), 3);
 
-        // Record with DTYP: value replaced
-        assert_eq!(
-            records[0].fields[0],
-            ("DTYP".to_string(), "newDtyp".to_string())
-        );
-        // Record without DTYP: unchanged (no DTYP added)
-        assert_eq!(records[1].fields.len(), 1);
-        assert!(!records[1].fields.iter().any(|(n, _)| n == "DTYP"));
+        let dtyp_of = |rec: &DbRecordDef| -> Option<String> {
+            rec.fields
+                .iter()
+                .find(|(n, _)| n == "DTYP")
+                .map(|(_, v)| v.clone())
+        };
+
+        // Literal DTYP: untouched by the macro. Force-override used to corrupt
+        // this into "Scaler-rs", breaking the soft helper records.
+        assert_eq!(dtyp_of(&records[0]).as_deref(), Some("Soft Channel"));
+        // $(DTYP) reference: substituted.
+        assert_eq!(dtyp_of(&records[1]).as_deref(), Some("Scaler-rs"));
+        // No DTYP field: none added.
+        assert_eq!(dtyp_of(&records[2]), None);
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -1002,14 +1002,14 @@ fn cmd_db_load_records() -> CommandDef {
                     p.to_path_buf()
                 }
             };
-            let (mut defs, breaktables) =
+            // C `dbLoadRecords` macros are pure text substitution (dbLexRoutines.c
+            // → macLib): a `DTYP=` macro reaches a record only where the file wrote
+            // `field(DTYP,"$(DTYP)")`. It does NOT rewrite a record that spells its
+            // DTYP literally. `parse_db_file_with_breaktables` already performs that
+            // substitution, so there is nothing further to do for DTYP here.
+            let (defs, breaktables) =
                 db_loader::parse_db_file_with_breaktables(&file_path, &macros, &config)
                     .map_err(|e| format!("parse error: {e}"))?;
-
-            // DTYP override: if macros contain DTYP, override existing DTYP fields
-            if let Some(dtyp) = macros.get("DTYP") {
-                db_loader::override_dtyp(&mut defs, dtyp);
-            }
 
             // Merge any `breaktable(...)` definitions into the database's shared
             // breakpoint-table registry (C `bptList`) and snapshot it for the
@@ -1737,6 +1737,70 @@ mod tests {
         let args = parse_args(&tokens, &cmd.args).unwrap();
         let result = cmd.handler.call(&args, &ctx);
         assert!(result.is_err());
+    }
+
+    /// End-to-end through the real `dbLoadRecords` command: a `DTYP=` macro is
+    /// pure text substitution (C `dbLexRoutines.c` runs macros through macLib
+    /// during lexing), so it reaches only the record that wrote
+    /// `field(DTYP,"$(DTYP)")` and must leave a literal DTYP alone.
+    ///
+    /// The db below is the shape of the vendored `scaler-rs/db/scaler.db`: two
+    /// `bo` helper records with a literal `Soft Channel` DTYP plus the counting
+    /// record referencing `$(DTYP)` (an `ai` here, since the built-in loader has no
+    /// `scaler` type). The old force-override rewrote all three,
+    /// leaving the soft helpers bound to a hardware DTYP.
+    #[test]
+    fn db_load_records_dtyp_macro_leaves_literal_dtyp_alone() {
+        use std::io::Write;
+
+        let (db, ctx) = make_ctx();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("scaler_shaped.db");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(
+            f,
+            r#"
+record(bo, "$(P)_calcEnable") {{
+    field(DTYP, "Soft Channel")
+    field(ZNAM, "ENABLE")
+}}
+record(ai, "$(P)") {{
+    field(DTYP, "$(DTYP)")
+}}
+record(bo, "$(P)_calc_ctrl") {{
+    field(DTYP, "Soft Channel")
+    field(ONAM, "Cts/sec")
+}}
+"#
+        )
+        .unwrap();
+        drop(f);
+
+        let mut registry = CommandRegistry::new();
+        register_builtins(&mut registry);
+        let cmd = registry.get("dbLoadRecords").unwrap();
+        let tokens = vec![
+            path.to_str().unwrap().to_string(),
+            "P=SCALER1,DTYP=Scaler-rs".to_string(),
+        ];
+        let args = parse_args(&tokens, &cmd.args).unwrap();
+        cmd.handler.call(&args, &ctx).unwrap();
+
+        let dtyp_of = |name: &str| -> String {
+            ctx.block_on(async {
+                let rec = db.get_record(name).await.expect("record loaded");
+                let inst = rec.read().await;
+                inst.common.dtyp.clone()
+            })
+        };
+
+        // Literal DTYP on the soft helpers: untouched. Force-override used to
+        // corrupt both into "Scaler-rs".
+        assert_eq!(dtyp_of("SCALER1_calcEnable"), "Soft Channel");
+        assert_eq!(dtyp_of("SCALER1_calc_ctrl"), "Soft Channel");
+        // The `$(DTYP)` reference: substituted.
+        assert_eq!(dtyp_of("SCALER1"), "Scaler-rs");
     }
 
     #[test]


### PR DESCRIPTION
## Defect

`dbLoadRecords`' `DTYP=` macro force-overwrites the `DTYP` field of **every** record in the loaded file that has one, instead of substituting only where the file wrote `field(DTYP,"$(DTYP)")`.

## Root cause

In C, `dbLoadRecords` macros are **pure text substitution** — `dbLexRoutines.c` runs them through macLib during lexing, and there is no DTYP special case. A `DTYP=` macro therefore reaches a record only where the `.db` author asked for it with `$(DTYP)`.

The Rust port added `override_dtyp()`, called from the `dbLoadRecords` command, which rewrites every existing `DTYP` field in the file. That gives the DTYP macro a **second, non-uniform meaning that no other macro has** (substitute *and* force-override), and it corrupts any multi-record db whose helper records spell their DTYP literally.

### Why it exists

Traced through history: `override_dtyp` is present in the initial squashed import (`4b16c8b1`) and was only moved by `530b1c23` ("Split db_loader into parser + include modules"). There is **no design rationale in the history**, and — see the audit below — nothing in the repo or downstream depends on it. It appears to be an early convenience that predates `$(DTYP)`-style templates.

### What it corrupts, in this repo

`crates/scaler-rs/db/scaler.db` (and `scaler16.db`, `scaler32.db`, `scaler16m.db` — all vendored verbatim from synApps) has exactly the vulnerable shape:

```
grecord(bo,"$(P)$(S)_calcEnable") {
    field(DTYP,"Soft Channel")     # literal — must not be touched
}
grecord(bo,"$(P)$(S)_calc_ctrl") {
    field(DTYP,"Soft Channel")     # literal — must not be touched
}
grecord(scaler,"$(P)$(S)") {
    field(DTYP,"$(DTYP)")          # reference — must be substituted
}
```

Loading it with `DTYP=Scaler-rs` (the documented way to bind the driver) silently rebound **both soft helper records** to the hardware DTYP.

These db files are already C-correct — they were **victims** of the override, not dependents on it — so **no in-repo db file needed changing**.

## Fix approach

`override_dtyp` is **deleted**, not gated. The uniform rule (macros are text substitution, full stop) is what makes the whole family impossible; a gate or a special case would leave the second meaning in place for the next caller to trip on. `parse_db_file_with_breaktables` already performs the substitution, so the `dbLoadRecords` path needs nothing beyond dropping the call.

## Semantic change — full audit

This changes documented behaviour, so every possible dependent was enumerated.

**Anchor:** `rg -n 'override_dtyp'`, `rg -n 'dbLoadRecords.*DTYP'`, `rg -n 'field\(DTYP'`, `rg -n '\$\(DTYP\)'`

**This repo:**

| Site | Classification |
|---|---|
| `iocsh/commands.rs` `dbLoadRecords` | The only caller — **removed** |
| `db_loader/mod.rs` re-export | Public API — **removed** (see breaking change) |
| `test_dtyp_override_existing_only` | Pinned the defect — **replaced** |
| `.db`/`.template` loaded with a `DTYP=` macro | **None exist** (no st.cmd/iocsh scripts in-repo; the only `DTYP=` strings are log messages and two README snippets) |
| `scaler-rs/db/{scaler,scaler16,scaler32,scaler16m}.db` | Use `$(DTYP)` references + literal `Soft Channel` helpers — **fixed by this change**, no edit needed |
| All other db/templates (e.g. `examples/xrt-beamline`) | Literal DTYPs, loaded **without** a DTYP macro → override never fired → **unaffected** |

**Downstream `/home/stevek/work/epics-rs-iocs`** (driver/IOC workspace on crates.io 0.22.1, audited read-only, not modified):

- `rg 'dbLoadRecords.*DTYP'` → **no call passes a `DTYP=` macro** (only comments/log strings mention DTYP).
- `rg '\$\(DTYP\)'` over `*.db`/`*.template`/`*.substitutions` → **no hits**.
- `rg 'override_dtyp'` → **no hits** (nobody calls the removed public function).
- Its motor templates (`mcb4b.template`, `ang1.template`, `pie816.template`, …) carry literal DTYPs and are loaded **without** a DTYP macro, so the override never fired for them.

**Conclusion: no in-repo or downstream caller depends on the force-override.** Downstream is a pure beneficiary — the bundled `scaler.db` can now be loaded with `DTYP=` without corrupting its soft helper records.

⚠️ **BREAKING CHANGE:** `db_loader::override_dtyp` is removed from the public API. No known consumer calls it.

## Regression tests

1. **`db_load_records_dtyp_macro_leaves_literal_dtyp_alone`** (`iocsh/commands.rs`) — drives the **real `dbLoadRecords` command** over a scaler.db-shaped file (two literal `Soft Channel` helpers + one `$(DTYP)` record) with `P=SCALER1,DTYP=Scaler-rs`, and asserts the literals survive while the reference substitutes.

   **Fails on unfixed main:** `left: "Scaler-rs"`, `right: "Soft Channel"` — the exact corruption.

2. **`dtyp_macro_substitutes_references_and_leaves_literals_alone`** (`db_loader/mod.rs`) — replaces `test_dtyp_override_existing_only`, which pinned the force-override. Documents the C rule at the parser level.

Note: test 2 alone would **not** have been a valid regression test — it passes even with `override_dtyp` restored, because the override was applied in the `dbLoadRecords` command rather than in the parser. Test 1 is the one that actually pins the defect; this was verified by temporarily re-introducing the override and re-running both.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- `cargo nextest run --workspace` — 7422 passed, 0 failed, 2 skipped
- `cargo test --doc --workspace` — ok