### PR TITLE
fix(ad-plugins): expose the asyn iocsh command set to AdIoc st.cmd

### DIFF
--- a/crates/ad-plugins-rs/src/ioc.rs
+++ b/crates/ad-plugins-rs/src/ioc.rs
@@ -14,6 +14,7 @@ use ad_core_rs::ioc::{
 };
 use ad_core_rs::plugin::runtime::{create_plugin_runtime, create_plugin_runtime_multi_addr};
 use ad_core_rs::plugin::wiring::WiringRegistry;
+use asyn_rs::manager::PortManager;
 use asyn_rs::trace::TraceManager;
 use epics_base_rs::error::CaResult;
 use epics_base_rs::server::autosave::AutosaveStartupConfig;
@@ -876,6 +877,7 @@ where
 pub struct AdIoc {
     app: Option<IocApplication>,
     mgr: Arc<PluginManager>,
+    ports: Arc<PortManager>,
     trace: Arc<TraceManager>,
     /// Resources kept alive for the IOC's lifetime (e.g. driver runtimes).
     _resources: Vec<Box<dyn std::any::Any + Send>>,
@@ -886,10 +888,15 @@ impl AdIoc {
     pub fn new() -> Self {
         let trace = Arc::new(TraceManager::new());
         let mgr = PluginManager::new(trace.clone());
+        // The asyn iocsh commands resolve ports and mutate trace state through
+        // this manager, so it shares the IOC's `TraceManager` — a manager with
+        // a `TraceManager` of its own would make `asynSetTrace*` mutate state
+        // that no driver or plugin ever reads.
+        let ports = Arc::new(PortManager::with_trace_manager(trace.clone()));
 
         asyn_rs::asyn_record::register_asyn_record_type();
 
-        let app = IocApplication::new().port(
+        let mut app = IocApplication::new().port(
             std::env::var("EPICS_CA_SERVER_PORT")
                 .ok()
                 .and_then(|s| s.parse().ok())
@@ -914,9 +921,29 @@ impl AdIoc {
             concat!(env!("CARGO_MANIFEST_DIR"), "/../autosave"),
         );
 
+        // Everything the IOC always needs is wired here, once. The protocol
+        // runner is the only thing `run` and `run_with_pva` disagree about;
+        // configuring the application separately per runner is how a command
+        // set ends up present on one path and missing from the other.
+        app = register_all_plugins(app, &mgr);
+        app = register_noop_commands(app);
+        app = app.autosave_startup(Arc::new(Mutex::new(AutosaveStartupConfig::new())));
+
+        // Universal asyn device support — handles all standard asyn DTYPs
+        // (asynInt32, asynFloat64, asynOctet, array types) via @asyn() links.
+        app = asyn_rs::adapter::register_asyn_device_support(app);
+
+        // The asyn iocsh command set: port creation (`drvAsynIPPortConfigure`
+        // and friends), `asynOctetSetInputEos` / `asynOctetSetOutputEos`,
+        // `asynSetOption`, `asynReport` and the trace mutators — on the startup
+        // shell as well as the interactive one. A socket detector's st.cmd
+        // creates its port and sets the EOS before `iocInit`.
+        app = asyn_rs::iocsh::register_asyn_commands(app, ports.clone());
+
         Self {
             app: Some(app),
             mgr,
+            ports,
             trace,
             _resources: Vec::new(),
         }
@@ -927,9 +954,31 @@ impl AdIoc {
         &self.mgr
     }
 
+    /// Access the shared [`PortManager`] — the manager the asyn iocsh commands
+    /// resolve against.
+    ///
+    /// A detector crate registers its driver port here (or through the
+    /// `drvAsyn*PortConfigure` iocsh commands, which publish to the same
+    /// registry) so that `asynReport`, `asynSetOption` and the EOS commands can
+    /// act on it from st.cmd.
+    pub fn ports(&self) -> &Arc<PortManager> {
+        &self.ports
+    }
+
     /// Access the shared `TraceManager`.
     pub fn trace(&self) -> &Arc<TraceManager> {
         &self.trace
+    }
+
+    /// The configured [`IocApplication`] this IOC will run.
+    ///
+    /// `AdIoc` wires the application at construction, so
+    /// [`IocApplication::startup_commands`] here is exactly the surface the
+    /// startup script will be executed against.
+    pub fn app(&self) -> &IocApplication {
+        self.app
+            .as_ref()
+            .expect("AdIoc application is taken only by run()")
     }
 
     /// Register a record type (equivalent to C EPICS dbd record type registration).
@@ -1009,35 +1058,7 @@ impl AdIoc {
 
     /// Run the IOC with a given startup script path.
     pub async fn run(self, script: &str) -> CaResult<()> {
-        let mut app = self.app.unwrap();
-
-        // Register all standard plugin configure commands
-        app = register_all_plugins(app, &self.mgr);
-        app = register_noop_commands(app);
-
-        // Enable autosave startup commands (C-compatible iocsh commands)
-        let autosave_config = Arc::new(Mutex::new(AutosaveStartupConfig::new()));
-        app = app.autosave_startup(autosave_config);
-
-        // Universal asyn device support — handles all standard asyn DTYPs
-        // (asynInt32, asynFloat64, asynOctet, array types) via @asyn() links.
-        app = asyn_rs::adapter::register_asyn_device_support(app);
-
-        // asynReport shell command
-        let mgr_r = self.mgr.clone();
-        app = app.register_shell_command(CommandDef::new(
-            "asynReport",
-            vec![ArgDesc {
-                name: "level",
-                arg_type: ArgType::Int,
-                optional: true,
-            }],
-            "asynReport [level] - Report registered ports and plugins",
-            move |_args: &[ArgValue], _ctx: &CommandContext| {
-                mgr_r.report();
-                Ok(CommandOutcome::Continue)
-            },
-        ));
+        let app = self.app.unwrap();
 
         app.startup_script(script)
             // CA links resolve with zero further setup: the `ca` link set
@@ -1056,29 +1077,7 @@ impl AdIoc {
     /// registered during st.cmd are wired into the PVA server automatically.
     #[cfg(feature = "pva")]
     pub async fn run_with_pva(self, script: &str) -> CaResult<()> {
-        let mut app = self.app.unwrap();
-
-        app = register_all_plugins(app, &self.mgr);
-        app = register_noop_commands(app);
-
-        let autosave_config = Arc::new(Mutex::new(AutosaveStartupConfig::new()));
-        app = app.autosave_startup(autosave_config);
-        app = asyn_rs::adapter::register_asyn_device_support(app);
-
-        let mgr_r = self.mgr.clone();
-        app = app.register_shell_command(CommandDef::new(
-            "asynReport",
-            vec![ArgDesc {
-                name: "level",
-                arg_type: ArgType::Int,
-                optional: true,
-            }],
-            "asynReport [level] - Report registered ports and plugins",
-            move |_args: &[ArgValue], _ctx: &CommandContext| {
-                mgr_r.report();
-                Ok(CommandOutcome::Continue)
-            },
-        ));
+        let app = self.app.unwrap();
 
         app.startup_script(script)
             // External links resolve with zero further setup: both link

--- a/crates/ad-plugins-rs/tests/ioc_asyn_commands.rs
+++ b/crates/ad-plugins-rs/tests/ioc_asyn_commands.rs
@@ -1,0 +1,105 @@
+//! An `AdIoc` startup script must be able to create an asyn port and configure
+//! it — the sequence every socket detector (Pilatus, marCCD, mar345 camserver)
+//! opens its st.cmd with.
+#![cfg(feature = "ioc")]
+
+use std::sync::Arc;
+
+use ad_plugins_rs::ioc::AdIoc;
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+/// Build a shell carrying exactly the commands `AdIoc` puts on its startup
+/// shell, which is the surface `st.cmd` is executed against.
+fn shell_with_ad_ioc_startup_commands(ioc: &AdIoc) -> IocShell {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let db = Arc::new(PvDatabase::new());
+    let handle = rt.handle().clone();
+    // The shell's command handlers block on this runtime; it must outlive them.
+    std::mem::forget(rt);
+
+    let shell = IocShell::new(db, handle);
+    for def in ioc.app().startup_commands() {
+        shell.register(def.clone());
+    }
+    shell
+}
+
+/// The asyn iocsh command set has to be on the *startup* shell, not just the
+/// interactive one: `IocApplication` runs `st.cmd` against `startup_commands`
+/// alone, so a command registered only as a shell command is an unknown command
+/// in st.cmd — fatal, before `iocInit`.
+///
+/// Unfixed, `AdIoc` registered none of these (it built its `IocApplication`
+/// internally and never called `asyn_rs::iocsh::register_asyn_commands`), so
+/// every line below died with "unknown command".
+#[test]
+fn ad_ioc_startup_shell_carries_the_asyn_command_set() {
+    let ioc = AdIoc::new();
+    let names: Vec<&str> = ioc
+        .app()
+        .startup_commands()
+        .iter()
+        .map(|def| def.name.as_str())
+        .collect();
+
+    for required in [
+        "drvAsynIPPortConfigure",
+        "drvAsynSerialPortConfigure",
+        "asynOctetSetInputEos",
+        "asynOctetSetOutputEos",
+        "asynSetOption",
+        "asynReport",
+        "asynSetTraceMask",
+    ] {
+        assert!(
+            names.contains(&required),
+            "st.cmd cannot call {required} — AdIoc's startup shell exposes {names:?}"
+        );
+    }
+}
+
+/// End to end: run the detector-style st.cmd prologue against the shell AdIoc
+/// actually builds. Creating the port and then configuring it must both work,
+/// and the port must be resolvable through the IOC's `PortManager` afterwards.
+///
+/// That last assertion is the one that catches the registry split: the
+/// `drvAsyn*PortConfigure` commands publish the port they create into the
+/// process port registry, while `asynSetOption` / the EOS commands resolve
+/// through `PortManager`. With those two disjoint, every command here still
+/// *executes* — they report "port not found" and continue — so a smoke test
+/// that only checked for non-fatal execution would pass against a port nothing
+/// could configure.
+#[test]
+fn ad_ioc_st_cmd_can_create_a_port_and_configure_it() {
+    let ioc = AdIoc::new();
+    let shell = shell_with_ad_ioc_startup_commands(&ioc);
+
+    // noAutoConnect=1: the port is created but never dials, so no detector has
+    // to be listening on the far end.
+    let prologue = [
+        r#"drvAsynIPPortConfigure("SMOKE_DET", "127.0.0.1:65432", 0, 1, 0)"#,
+        r#"asynOctetSetInputEos("SMOKE_DET", 0, "\n")"#,
+        r#"asynOctetSetOutputEos("SMOKE_DET", 0, "\r\n")"#,
+        r#"asynSetTraceMask("SMOKE_DET", 0, 1)"#,
+        "asynReport(1)",
+    ];
+    for line in prologue {
+        shell
+            .execute_line(line)
+            .unwrap_or_else(|e| panic!("st.cmd line `{line}` failed: {e}"));
+    }
+
+    assert!(
+        ioc.ports().find_port_handle("SMOKE_DET").is_ok(),
+        "the port drvAsynIPPortConfigure created is invisible to the IOC's \
+         PortManager, so asynSetOption and the EOS commands cannot act on it"
+    );
+    assert!(
+        ioc.ports()
+            .list_port_names()
+            .iter()
+            .any(|name| name == "SMOKE_DET"),
+        "asynReport with no port argument must list a port created from st.cmd"
+    );
+}

--- a/crates/asyn-rs/src/asyn_record/mod.rs
+++ b/crates/asyn-rs/src/asyn_record/mod.rs
@@ -1,7 +1,7 @@
 pub mod registry;
 pub use registry::{
-    PortEntry, PortRegistry, asyn_record_factory, get_port, register_asyn_record_type,
-    register_port,
+    PortEntry, PortRegistry, asyn_record_factory, get_port, port_names, register_asyn_record_type,
+    register_port, unregister_port,
 };
 
 use std::collections::HashMap;

--- a/crates/asyn-rs/src/asyn_record/registry.rs
+++ b/crates/asyn-rs/src/asyn_record/registry.rs
@@ -46,6 +46,25 @@ impl PortRegistry {
         let reg = self.inner.lock().ok()?;
         reg.get(name).cloned()
     }
+
+    /// Names of every published port, in arbitrary order.
+    ///
+    /// C parity: `asynManager::report` with no port argument walks the
+    /// global port list. Since every port creator publishes here, this is
+    /// that list.
+    pub fn names(&self) -> Vec<String> {
+        match self.inner.lock() {
+            Ok(reg) => reg.keys().cloned().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// Withdraw a port. A name that was never published is a no-op.
+    pub fn remove(&self, name: &str) {
+        if let Ok(mut reg) = self.inner.lock() {
+            reg.remove(name);
+        }
+    }
 }
 
 // ===== Global fallback (backward compatibility) =====
@@ -65,6 +84,21 @@ pub fn register_port(name: &str, handle: PortHandle, trace: Arc<TraceManager>) {
 /// Look up a port via the global registry.
 pub fn get_port(name: &str) -> Option<PortEntry> {
     global_registry().get(name)
+}
+
+/// Names of every port published to the global registry.
+///
+/// This is the process-wide port list: driver ports, ports created by the
+/// `drvAsyn*PortConfigure` iocsh commands, areaDetector plugin ports, and
+/// every port registered through a [`crate::manager::PortManager`]. It is
+/// what `asynReport` with no port argument enumerates.
+pub fn port_names() -> Vec<String> {
+    global_registry().names()
+}
+
+/// Withdraw a port from the global registry.
+pub fn unregister_port(name: &str) {
+    global_registry().remove(name);
 }
 
 /// Return the asyn record type factory for injection into IocBuilder.

--- a/crates/asyn-rs/src/iocsh.rs
+++ b/crates/asyn-rs/src/iocsh.rs
@@ -33,19 +33,24 @@ use crate::trace::{TraceFile, TraceInfoMask, TraceIoMask, TraceManager, TraceMas
 /// command closure so the trace mutators reach the same
 /// [`crate::trace::TraceManager`] the drivers were registered with.
 ///
-/// C parity: the six `asynShellCommands.c` commands (`asynReport /
-/// asynSetOption / asynSetTraceMask / asynSetTraceIOMask /
-/// asynSetTraceInfoMask / asynSetTraceFile`) plus the port-creation
-/// command `drvAsynIPPort.c::drvAsynIPPortConfigure`, registered as a
-/// startup command so it runs before `iocInit`.
+/// C parity: the `asynShellCommands.c` set (`asynReport / asynSetOption /
+/// asynOctetSetInputEos / asynOctetSetOutputEos / asynSetTraceMask /
+/// asynSetTraceIOMask / asynSetTraceInfoMask / asynSetTraceFile`) plus the
+/// port-creation commands (`drvAsynIPPortConfigure`,
+/// `drvAsynSerialPortConfigure`, `drvAsynPrologixPortConfigure`).
+///
+/// Every one of them is registered on **both** shells: the startup shell that
+/// executes `st.cmd` before `iocInit`, and the interactive shell that follows
+/// it. In C these are plain iocsh commands, so a startup script may create a
+/// port and set its EOS before `iocInit` — the usual sequence for a socket
+/// detector. Registering the set as interactive-only would make every one of
+/// them an unknown command in `st.cmd`, which aborts the script.
 pub fn register_asyn_commands(mut app: IocApplication, mgr: Arc<PortManager>) -> IocApplication {
-    let trace = mgr.trace_manager().clone();
     for def in build_asyn_commands(mgr) {
+        app = app.register_startup_command(def.clone());
         app = app.register_shell_command(def);
     }
-    app = app.register_startup_command(drv_asyn_ip_port_configure_command(trace.clone()));
-    app = app.register_startup_command(drv_asyn_serial_port_configure_command(trace.clone()));
-    app.register_startup_command(drv_asyn_prologix_port_configure_command(trace))
+    app
 }
 
 fn arg_int(args: &[ArgValue], i: usize) -> Option<i64> {
@@ -211,25 +216,27 @@ pub fn register_asyn_commands_on_shell(
     shell: &epics_base_rs::server::iocsh::IocShell,
     mgr: Arc<PortManager>,
 ) {
-    let trace = mgr.trace_manager().clone();
     for def in build_asyn_commands(mgr) {
         shell.register(def);
     }
-    shell.register(drv_asyn_ip_port_configure_command(trace.clone()));
-    shell.register(drv_asyn_serial_port_configure_command(trace.clone()));
-    shell.register(drv_asyn_prologix_port_configure_command(trace));
 }
 
-/// Build the asyn iocsh `CommandDef`s without binding them to a specific
-/// carrier: `asynReport`, `asynSetOption`, `asynOctetSetInputEos`,
-/// `asynOctetSetOutputEos`, and the trace mutators (`asynSetTraceMask`,
-/// `asynSetTraceIOMask`, `asynSetTraceInfoMask`). Both
+/// Build the complete asyn iocsh `CommandDef` set without binding it to a
+/// specific carrier: `asynReport`, `asynSetOption`, `asynOctetSetInputEos`,
+/// `asynOctetSetOutputEos`, the trace mutators (`asynSetTraceMask`,
+/// `asynSetTraceIOMask`, `asynSetTraceInfoMask`, `asynSetTraceFile`) and the
+/// port-creation commands (`drvAsynIPPortConfigure`,
+/// `drvAsynSerialPortConfigure`, `drvAsynPrologixPortConfigure`).
+///
 /// [`register_asyn_commands`] (IocApplication path) and
-/// [`register_asyn_commands_on_shell`] (direct IocShell path) delegate
-/// here so the C-parity command set stays in lock step across both entry
-/// points.
+/// [`register_asyn_commands_on_shell`] (direct IocShell path) both delegate
+/// here, so every carrier gets the same set and the C-parity surface cannot
+/// drift between them. Keeping the port-creation commands in this one list is
+/// what stops a shell from being able to *create* a port it cannot then
+/// configure.
 pub fn build_asyn_commands(mgr: Arc<PortManager>) -> Vec<CommandDef> {
     let mut out = Vec::new();
+    let trace = mgr.trace_manager().clone();
 
     // asynReport ----------------------------------------------------------
     {
@@ -584,6 +591,13 @@ pub fn build_asyn_commands(mgr: Arc<PortManager>) -> Vec<CommandDef> {
         ));
     }
 
+    // Port-creation commands ----------------------------------------------
+    // Part of the same set: a shell that can create a port must be able to
+    // configure it in the next line of the same script.
+    out.push(drv_asyn_ip_port_configure_command(trace.clone()));
+    out.push(drv_asyn_serial_port_configure_command(trace.clone()));
+    out.push(drv_asyn_prologix_port_configure_command(trace));
+
     out
 }
 
@@ -917,9 +931,10 @@ mod tests {
         // succeeds) — we count one CommandDef per C-side function.
         assert_eq!(
             cmds.len(),
-            8,
+            11,
             "asyn iocsh command set: asynReport, asynSetOption, \
-             asynOctetSet{{Input,Output}}Eos, and the four trace mutators"
+             asynOctetSet{{Input,Output}}Eos, the four trace mutators, and the \
+             three drvAsyn*PortConfigure port-creation commands"
         );
         assert!(set_trace_mask.args.len() == 3);
 
@@ -935,7 +950,10 @@ mod tests {
     }
 
     /// `build_asyn_commands` exposes the C `asynShellCommands.c` functions
-    /// asyn-rs ports — guards against silent additions / removals.
+    /// asyn-rs ports, plus the `drvAsyn*PortConfigure` port-creation commands —
+    /// guards against silent additions / removals. The port-creation commands
+    /// belong to the same set: a shell that can create a port must be able to
+    /// configure it, so they cannot drift onto a different carrier.
     #[test]
     fn iocsh_registers_c_parity_commands() {
         let mgr = Arc::new(PortManager::new());
@@ -950,6 +968,9 @@ mod tests {
             "asynSetTraceIOMask",
             "asynSetTraceInfoMask",
             "asynSetTraceFile",
+            "drvAsynIPPortConfigure",
+            "drvAsynSerialPortConfigure",
+            "prologixGPIBConfigure",
         ] {
             assert!(
                 names.contains(&expected),

--- a/crates/asyn-rs/src/manager.rs
+++ b/crates/asyn-rs/src/manager.rs
@@ -22,8 +22,18 @@ pub struct PortManager {
 
 impl PortManager {
     pub fn new() -> Self {
+        Self::with_trace_manager(Arc::new(TraceManager::new()))
+    }
+
+    /// Build a manager that shares an existing [`TraceManager`].
+    ///
+    /// The `asynSetTrace*` iocsh commands mutate the trace manager reached
+    /// through [`Self::trace_manager`]. An IOC whose ports and drivers were
+    /// registered against a trace manager it built itself (e.g. `AdIoc`) must
+    /// hand that same instance here, or those commands would mutate a trace
+    /// manager nothing reads and silently do nothing.
+    pub fn with_trace_manager(trace: Arc<TraceManager>) -> Self {
         let exceptions = Arc::new(ExceptionManager::new());
-        let trace = Arc::new(TraceManager::new());
         // Wire the exception sink so `setTrace*` setters announce
         // `asynExceptionTrace*` to subscribers, matching C
         // asynManager.c:2790/2832/2874/2923/2956.
@@ -89,19 +99,33 @@ impl PortManager {
             return Err(AsynError::PortAlreadyRegistered(name));
         }
         ph.insert(name.clone(), handle.port_handle().clone());
-        rh.insert(name, handle.clone());
+        rh.insert(name.clone(), handle.clone());
         drop(rh);
         drop(ph);
+
+        // Publish into the process port registry, the single place every
+        // consumer resolves a name through: the asyn iocsh commands, asynRecord
+        // device support, and the asyn device-support adapter. A port that only
+        // this manager knows about would be invisible to all three.
+        crate::asyn_record::register_port(&name, handle.port_handle().clone(), self.trace.clone());
 
         Ok(handle)
     }
 
     /// Find a port handle by name.
+    ///
+    /// Ports this manager registered itself resolve from its own map; any other
+    /// name falls through to the process port registry, which is where the
+    /// `drvAsyn*PortConfigure` iocsh commands, areaDetector plugins and
+    /// hand-registered driver ports publish. Without that fall-through the asyn
+    /// iocsh commands could not act on a port created from st.cmd — they would
+    /// report "port not found" for a port the IOC had just built.
     pub fn find_port_handle(&self, name: &str) -> AsynResult<PortHandle> {
-        self.port_handles
-            .lock()
-            .get(name)
-            .cloned()
+        if let Some(handle) = self.port_handles.lock().get(name).cloned() {
+            return Ok(handle);
+        }
+        crate::asyn_record::get_port(name)
+            .map(|entry| entry.handle)
             .ok_or_else(|| AsynError::PortNotFound(name.to_string()))
     }
 
@@ -147,10 +171,15 @@ impl PortManager {
     pub fn unregister_port(&self, name: &str) {
         let mut ph = self.port_handles.lock();
         let mut rh = self.runtime_handles.lock();
-        ph.remove(name);
+        let was_ours = ph.remove(name).is_some();
         let runtime = rh.remove(name);
         drop(rh);
         drop(ph);
+        // A port this manager published must not outlive it in the registry,
+        // or the name would keep resolving to a handle whose runtime is gone.
+        if was_ours {
+            crate::asyn_record::unregister_port(name);
+        }
         if let Some(runtime_handle) = runtime {
             runtime_handle.shutdown();
         }
@@ -166,15 +195,23 @@ impl PortManager {
         &self.trace
     }
 
-    /// Names of every currently-registered port, in arbitrary order.
+    /// Names of every port this IOC can act on, in sorted order.
     ///
     /// C parity: `asynManager::report` walks the global port list to
     /// emit one entry per port — iocsh `asynReport` exposes the same
     /// view (no port argument = all ports). Used by
     /// [`crate::iocsh::register_asyn_commands`] for the no-port-arg
     /// case; also useful for diagnostic tooling.
+    ///
+    /// This is the union of the ports this manager registered and the ports
+    /// published to the process registry (`drvAsyn*PortConfigure`, plugin and
+    /// driver ports), so `asynReport` sees the whole IOC rather than only the
+    /// ports that happened to be created through this manager.
     pub fn list_port_names(&self) -> Vec<String> {
-        self.port_handles.lock().keys().cloned().collect()
+        let mut names: std::collections::BTreeSet<String> =
+            self.port_handles.lock().keys().cloned().collect();
+        names.extend(crate::asyn_record::port_names());
+        names.into_iter().collect()
     }
 }
 

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -481,6 +481,19 @@ impl IocApplication {
         self
     }
 
+    /// The commands the startup script (`st.cmd`) may call, in registration
+    /// order.
+    ///
+    /// This is the surface a startup script is executed against — a command
+    /// missing here is a fatal unknown command in `st.cmd`, before `iocInit`.
+    /// Exposed so a pre-configured IOC (e.g. `AdIoc`) can be checked against
+    /// the script it promises to run without booting a server. `CommandDef` is
+    /// `Clone`, so a caller may also install these on an [`iocsh::IocShell`] of
+    /// its own to exercise a script.
+    pub fn startup_commands(&self) -> &[CommandDef] {
+        &self.startup_commands
+    }
+
     /// Register a callback to run after iocInit completes.
     ///
     /// Use this to start pollers and other periodic tasks that should


### PR DESCRIPTION
## Defect

An `AdIoc` st.cmd cannot create an asyn port or configure one. `AdIoc` builds its `IocApplication` internally and never calls `asyn_rs::iocsh::register_asyn_commands`, and it exposes only `mgr() -> PluginManager`, so an IOC crate has no way to wire them itself:

```
drvAsynIPPortConfigure("CAM", "192.168.0.1:41234")   # unknown command -> st.cmd aborts
asynOctetSetInputEos("CAM", 0, "\n")                 # unknown command
```

Both are fatal, before `iocInit()`. This is the prologue every real AD socket detector needs (Pilatus / marCCD / mar345 camserver).

## Root cause

Wiring `AdIoc` to `register_asyn_commands` is necessary but **not sufficient** — two framework defects sit underneath, and the fix is only real if both close.

**1. The asyn command set never reached st.cmd, for anyone.** `register_asyn_commands` registered `asynReport` / `asynSetOption` / `asynOctetSetInput|OutputEos` / the trace mutators via `register_shell_command`. But `IocApplication::run` executes the startup script against `startup_commands` **only** (`ioc_app.rs:645-650`) — shell commands belong to the post-`iocInit` REPL. So the whole set was unreachable from st.cmd even in bare-asyn IOCs; only the three `drvAsyn*PortConfigure` commands were registered as startup commands. In C these are all plain iocsh commands, callable from a startup script.

**2. The port name → handle mapping had two disjoint owners.** The `drvAsyn*PortConfigure` commands publish the port they create into the `asyn_record` process registry (where asynRecord device support and the AD plugin ports also live), while `asynSetOption`, the EOS commands and `asynReport` all resolve through `PortManager::find_port_handle`. A port created from st.cmd was therefore **invisible to the very commands meant to configure it**.

Defect 2 is the nasty one: the lookup failure is *printed and non-fatal* (`CommandOutcome::Continue`), so the IOC boots happily with a port whose EOS was never applied. A smoke test that only asserted "the st.cmd line executes non-fatally" would pass against a completely broken IOC. Demonstrated by reverting only the registry unification:

```
asynOctetSetInputEos: port not found: SMOKE_DET
asynOctetSetOutputEos: port not found: SMOKE_DET
```

## Fix approach

**One command set.** `build_asyn_commands` now returns the complete C surface — the `asynShellCommands.c` set *plus* the port-creation commands, which were the only ones reaching st.cmd. `register_asyn_commands` installs every command on **both** shells (startup and interactive), and `register_asyn_commands_on_shell` installs the same list. A shell that can create a port can now configure it; the two halves cannot drift onto different carriers.

**One port registry.** *Invariant: every port creator publishes into the process port registry, and every consumer resolves through it.* `PortManager::register_port` now publishes there, `find_port_handle` and `list_port_names` resolve through it, and `unregister_port` withdraws. Ports created by `drvAsyn*PortConfigure`, by a plugin, or programmatically are now all visible to every asyn iocsh command and to device support. This restores C's single-registry model (`pasynManager` has one global port list).

**AdIoc.** Owns an `Arc<PortManager>` built with the IOC's *own* `TraceManager` — a manager with a `TraceManager` of its own would make `asynSetTrace*` mutate state no driver or plugin ever reads — registers the asyn command set, and exposes `ports()` for driver wiring. Its application is now configured **once at construction** rather than separately inside `run()` and `run_with_pva()`; that duplicated setup block is exactly how a command set ends up present on one path and missing from the other. The bespoke shell-only `asynReport` is dropped in favour of asyn's, which now reports every port in the IOC, plugin ports included.

## API change

**Additive only — no existing signature changed.** New: `AdIoc::ports()`, `AdIoc::app()`, `IocApplication::startup_commands()`, `PortManager::with_trace_manager()`, `asyn_record::{port_names, unregister_port}`. All four example IOCs (sim-detector, ophyd-test-ioc, mini-beamline, xrt-beamline) build untouched.

Behaviour changes worth calling out:
- `build_asyn_commands` returns 11 commands, not 8 (the three port-creation commands joined the set). The C-parity guard test was updated to cover all 11.
- The asyn command set is now also registered on the startup shell. A downstream IOC that shadowed `drvAsynSerialPortConfigure` with its own startup command still wins — later registration overwrites.
- `asynReport` in an AD IOC now lists every port rather than only the plugin count.

## Regression test

`crates/ad-plugins-rs/tests/ioc_asyn_commands.rs` runs the detector st.cmd prologue against the shell **AdIoc actually builds** (via `app().startup_commands()`, so there is no parallel path that could drift), then asserts the created port is resolvable through the IOC's `PortManager`.

Each layer verified load-bearing by reverting it alone:

| reverted | result |
|---|---|
| AdIoc's `register_asyn_commands` call | `st.cmd cannot call drvAsynIPPortConfigure — AdIoc's startup shell exposes ["NDStdArraysConfigure", …]` |
| the registry unification only | lines execute, but `the port drvAsynIPPortConfigure created is invisible to the IOC's PortManager` |
| nothing (fixed) | PASS |

That second row is why the test asserts port *resolution* and not just command lookup.

## Downstream evidence

Found porting areaDetector drivers in the `epics-rs-iocs` workspace against **published crates.io 0.22.1**. Both framework gaps had already forced hand-rolled workarounds into every serial-port IOC there (`delaygen-ioc`, `love-ioc`): a `build_asyn_commands`-as-startup-commands loop to work around #1, and a `drvAsynSerialPortConfigure` shadow that dual-registers the port into `PortManager` *and* `asyn_record` to work around #2. Both workarounds become unnecessary with this change.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy -p ad-plugins-rs --features ioc`, `-p asyn-rs --features epics` — clean
- `cargo clippy -p sim-detector -p ophyd-test-ioc -p mini-beamline -p xrt-beamline --features ioc` — clean (source compatibility)
- `cargo nextest run --workspace` — 7421 passed, 2 skipped
- `cargo nextest run -p ad-plugins-rs --features ioc` — 466 passed
- `cargo nextest run -p asyn-rs --features epics` — 709 passed
- `cargo nextest run -p ad-core-rs --features ioc` — 280 passed
- `cargo test --doc -p epics-base-rs -p asyn-rs` — ok