### PR TITLE
fix(ad): replace sleep-based test sync with param barrier + condition waits

### DIFF
--- a/crates/ad-core-rs/src/plugin/runtime.rs
+++ b/crates/ad-core-rs/src/plugin/runtime.rs
@@ -36,6 +36,20 @@ use super::channel::{
 use super::params::PluginBaseParams;
 use super::wiring::{WiringRegistry, upstream_key};
 
+/// Message sent through the param channel from control plane to data plane.
+///
+/// The channel is FIFO, which is what gives [`PluginParamMsg::Barrier`] its
+/// meaning: when the data thread acknowledges a barrier, every `Change`
+/// enqueued before it has been fully applied (enable flips, wiring rewires,
+/// processor param updates).
+#[derive(Debug)]
+enum PluginParamMsg {
+    /// A param write to apply.
+    Change(usize, i32, ParamChangeValue),
+    /// Sync barrier — acknowledged (best-effort send of `()`) when consumed.
+    Barrier(std::sync::mpsc::SyncSender<()>),
+}
+
 /// Value sent through the param change channel from control plane to data plane.
 #[derive(Debug, Clone)]
 pub enum ParamChangeValue {
@@ -1161,7 +1175,7 @@ pub struct PluginPortDriver {
     base: PortDriverBase,
     ndarray_params: NDArrayDriverParams,
     plugin_params: PluginBaseParams,
-    param_change_tx: tokio::sync::mpsc::UnboundedSender<(usize, i32, ParamChangeValue)>,
+    param_change_tx: tokio::sync::mpsc::UnboundedSender<PluginParamMsg>,
     /// Optional handle to the latest NDArray for array read methods (used by StdArrays).
     array_data: Option<Arc<parking_lot::Mutex<Option<Arc<NDArray>>>>>,
     /// Param index for STD_ARRAY_DATA (triggers I/O Intr on ArrayData waveform).
@@ -1175,7 +1189,7 @@ impl PluginPortDriver {
         queue_size: usize,
         ndarray_port: &str,
         max_addr: usize,
-        param_change_tx: tokio::sync::mpsc::UnboundedSender<(usize, i32, ParamChangeValue)>,
+        param_change_tx: tokio::sync::mpsc::UnboundedSender<PluginParamMsg>,
         processor: &mut P,
         array_data: Option<Arc<parking_lot::Mutex<Option<Arc<NDArray>>>>>,
     ) -> AsynResult<Self> {
@@ -1462,9 +1476,11 @@ impl PortDriver for PluginPortDriver {
         self.base.set_int32_param(reason, addr, value)?;
         self.base.call_param_callbacks(addr)?;
         // B14: reliable send on an unbounded channel — never drop param changes.
-        let _ = self
-            .param_change_tx
-            .send((reason, addr, ParamChangeValue::Int32(value)));
+        let _ = self.param_change_tx.send(PluginParamMsg::Change(
+            reason,
+            addr,
+            ParamChangeValue::Int32(value),
+        ));
         Ok(())
     }
 
@@ -1473,9 +1489,11 @@ impl PortDriver for PluginPortDriver {
         let addr = user.addr;
         self.base.set_float64_param(reason, addr, value)?;
         self.base.call_param_callbacks(addr)?;
-        let _ = self
-            .param_change_tx
-            .send((reason, addr, ParamChangeValue::Float64(value)));
+        let _ = self.param_change_tx.send(PluginParamMsg::Change(
+            reason,
+            addr,
+            ParamChangeValue::Float64(value),
+        ));
         Ok(())
     }
 
@@ -1485,9 +1503,11 @@ impl PortDriver for PluginPortDriver {
         let s = String::from_utf8_lossy(data).into_owned();
         self.base.set_string_param(reason, addr, s.clone())?;
         self.base.call_param_callbacks(addr)?;
-        let _ = self
-            .param_change_tx
-            .send((reason, addr, ParamChangeValue::Octet(s)));
+        let _ = self.param_change_tx.send(PluginParamMsg::Change(
+            reason,
+            addr,
+            ParamChangeValue::Octet(s),
+        ));
         Ok(data.len())
     }
 
@@ -1549,6 +1569,7 @@ pub struct PluginRuntimeHandle {
     array_sender: NDArraySender,
     array_output: Arc<parking_lot::Mutex<NDArrayOutput>>,
     port_name: String,
+    param_tx: tokio::sync::mpsc::UnboundedSender<PluginParamMsg>,
     pub ndarray_params: NDArrayDriverParams,
     pub plugin_params: PluginBaseParams,
 }
@@ -1564,6 +1585,27 @@ impl PluginRuntimeHandle {
 
     pub fn array_output(&self) -> &Arc<parking_lot::Mutex<NDArrayOutput>> {
         &self.array_output
+    }
+
+    /// Block until the plugin's data thread has applied every control-plane
+    /// param change submitted before this call.
+    ///
+    /// `write_*_blocking` on the port handle returns once the port actor has
+    /// recorded the write and queued it for the data plane; the data thread
+    /// applies it (the EnableCallbacks flip, NDArrayPort/NDArrayAddr rewiring,
+    /// processor param updates) asynchronously. This is the fence between the
+    /// two planes: it enqueues a barrier behind every already-queued change
+    /// and waits for the data thread to consume it — the param channel is
+    /// FIFO, so consumption of the barrier implies every earlier change is
+    /// fully applied.
+    ///
+    /// Returns `false` if the data thread has exited or `timeout` elapsed.
+    pub fn wait_params_applied(&self, timeout: std::time::Duration) -> bool {
+        let (ack_tx, ack_rx) = std::sync::mpsc::sync_channel(1);
+        if self.param_tx.send(PluginParamMsg::Barrier(ack_tx)).is_err() {
+            return false;
+        }
+        ack_rx.recv_timeout(timeout).is_ok()
     }
 
     pub fn port_name(&self) -> &str {
@@ -1612,8 +1654,8 @@ pub fn create_plugin_runtime_multi_addr<P: NDPluginProcess>(
     // B14: unbounded so control-plane param changes (e.g. autosave restoring
     // hundreds of PVs at IOC init) are never silently dropped before the
     // data plane sees them.
-    let (param_tx, param_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(usize, i32, ParamChangeValue)>();
+    let (param_tx, param_rx) = tokio::sync::mpsc::unbounded_channel::<PluginParamMsg>();
+    let handle_param_tx = param_tx.clone();
 
     // Capture plugin type and array data handle before mutable borrow
     let plugin_type_name = processor.plugin_type().to_string();
@@ -1726,6 +1768,7 @@ pub fn create_plugin_runtime_multi_addr<P: NDPluginProcess>(
         array_sender,
         array_output: array_output_for_handle,
         port_name: port_name.to_string(),
+        param_tx: handle_param_tx,
         ndarray_params,
         plugin_params,
     };
@@ -1780,7 +1823,7 @@ async fn clamp_writeback(port: &PortHandle, reason: usize, value: i32) {
 fn plugin_data_loop<P: NDPluginProcess>(
     shared: Arc<parking_lot::Mutex<SharedProcessorInner<P>>>,
     mut array_rx: NDArrayReceiver,
-    mut param_rx: tokio::sync::mpsc::UnboundedReceiver<(usize, i32, ParamChangeValue)>,
+    mut param_rx: tokio::sync::mpsc::UnboundedReceiver<PluginParamMsg>,
     plugin_params: PluginBaseParams,
     array_counter_reason: usize,
     enabled: Arc<AtomicBool>,
@@ -1887,7 +1930,13 @@ fn plugin_data_loop<P: NDPluginProcess>(
                 }
                 param = param_rx.recv() => {
                     match param {
-                        Some((reason, addr, value)) => {
+                        // Barrier: every Change enqueued before it has been
+                        // applied by the arms below (FIFO channel). Ack and
+                        // move on; a gone waiter is not an error.
+                        Some(PluginParamMsg::Barrier(ack)) => {
+                            let _ = ack.try_send(());
+                        }
+                        Some(PluginParamMsg::Change(reason, addr, value)) => {
                             if reason == enable_callbacks_reason {
                                 let on = value.as_i32() != 0;
                                 enabled.store(on, Ordering::Release);
@@ -2150,8 +2199,8 @@ pub fn create_plugin_runtime_with_output<P: NDPluginProcess>(
     // B14: unbounded so control-plane param changes (e.g. autosave restoring
     // hundreds of PVs at IOC init) are never silently dropped before the
     // data plane sees them.
-    let (param_tx, param_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(usize, i32, ParamChangeValue)>();
+    let (param_tx, param_rx) = tokio::sync::mpsc::unbounded_channel::<PluginParamMsg>();
+    let handle_param_tx = param_tx.clone();
 
     let plugin_type_name = processor.plugin_type().to_string();
     let compression_aware = processor.compression_aware();
@@ -2252,6 +2301,7 @@ pub fn create_plugin_runtime_with_output<P: NDPluginProcess>(
         array_sender,
         array_output: array_output_for_handle,
         port_name: port_name.to_string(),
+        param_tx: handle_param_tx,
         ndarray_params,
         plugin_params,
     };
@@ -2302,14 +2352,40 @@ mod tests {
         Arc::new(WiringRegistry::new())
     }
 
-    /// Enable callbacks on a plugin handle (plugins default to disabled).
+    /// Fence: wait until the data thread has applied every param change
+    /// submitted so far. `write_*_blocking` only guarantees the change is
+    /// queued for the data plane; asserting on data-plane behaviour without
+    /// this fence is a race.
+    fn params_applied(handle: &PluginRuntimeHandle) {
+        assert!(
+            handle.wait_params_applied(std::time::Duration::from_secs(10)),
+            "data thread did not apply queued param changes"
+        );
+    }
+
+    /// Poll `cond` until it holds; panic after 10 s. Waits on the observable
+    /// state itself instead of sleeping a guessed duration, so a loaded
+    /// machine cannot flake the test.
+    fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !cond() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {what}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+    }
+
+    /// Enable callbacks on a plugin handle (plugins default to disabled) and
+    /// fence until the data thread has actually flipped the enable flag.
     fn enable_callbacks(handle: &PluginRuntimeHandle) {
         handle
             .port_runtime()
             .port_handle()
             .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        params_applied(handle);
     }
 
     /// Send an array via the sender from a sync test context.
@@ -2373,10 +2449,12 @@ mod tests {
         send_array(handle.array_sender(), make_test_array(1));
         send_array(handle.array_sender(), make_test_array(2));
 
-        // Give processing thread time
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        // No crash, no output needed
+        // ArrayCounter advances once per processed frame — both consumed.
+        let port = handle.port_runtime().port_handle().clone();
+        let counter = handle.ndarray_params.array_counter;
+        wait_until("sink to process both arrays", || {
+            port.read_int32_blocking(counter, 0).is_ok_and(|v| v == 2)
+        });
         assert_eq!(handle.port_name(), "SINK1");
     }
 
@@ -2516,7 +2594,7 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.blocking_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        params_applied(&handle);
 
         send_array(handle.array_sender(), make_test_array(1));
         let received = downstream_rx.blocking_recv().unwrap();
@@ -2528,7 +2606,7 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.blocking_callbacks, 0, 0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        params_applied(&handle);
 
         // Send in non-blocking mode — goes through channel to data thread
         send_array(handle.array_sender(), make_test_array(2));
@@ -2559,7 +2637,7 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        params_applied(&handle);
 
         // Send array — should be silently dropped by sender (callbacks disabled)
         send_array(handle.array_sender(), make_test_array(99));
@@ -2648,7 +2726,7 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        params_applied(&handle);
 
         // Still works after param update
         send_array(handle.array_sender(), make_test_array(2));
@@ -2764,7 +2842,7 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.sort_mode, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        params_applied(&handle);
 
         // B2: in-order arrays (1,2,3) must be emitted IMMEDIATELY via the
         // fast path — they are NOT delayed by the sort buffer.
@@ -2792,8 +2870,8 @@ mod tests {
         // unblocks it.
         send_array(handle.array_sender(), make_test_array(5));
         send_array(handle.array_sender(), make_test_array(4));
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        // 4 emitted immediately (in order), then 5 released by contiguity.
+        // 4 emitted immediately (in order), then 5 released by contiguity;
+        // blocking_recv below is the wait.
         assert_eq!(downstream_rx.blocking_recv().unwrap().unique_id, 4);
         assert_eq!(downstream_rx.blocking_recv().unwrap().unique_id, 5);
     }
@@ -2825,12 +2903,20 @@ mod tests {
             .port_handle()
             .write_float64_blocking(handle.plugin_params.max_byte_rate, 0, 8.0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        params_applied(&handle);
 
         for id in 1..=5 {
             send_array(handle.array_sender(), make_test_array(id));
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // ArrayCounter counts every processed frame (throttle drops happen on
+        // the output side, after counting), and its flush follows the array
+        // publish — so counter == 5 means everything that will ever reach the
+        // downstream queue is already there.
+        let port = handle.port_runtime().port_handle().clone();
+        let counter = handle.ndarray_params.array_counter;
+        wait_until("all 5 frames to be processed", || {
+            port.read_int32_blocking(counter, 0).is_ok_and(|v| v == 5)
+        });
 
         // Drain whatever made it through — strictly fewer than 5.
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -2922,11 +3008,10 @@ mod tests {
             .port_handle()
             .write_float64_blocking(handle.plugin_params.min_callback_time, 0, 10.0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        params_applied(&handle);
 
         send_array(handle.array_sender(), make_test_array(1));
         send_array(handle.array_sender(), make_test_array(2));
-        std::thread::sleep(std::time::Duration::from_millis(50));
 
         assert_eq!(downstream_rx.blocking_recv().unwrap().unique_id, 1);
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -2974,10 +3059,15 @@ mod tests {
         // Disable downstream array callbacks.
         port.write_int32_blocking(handle.ndarray_params.array_callbacks, 0, 0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        params_applied(&handle);
 
         send_array(handle.array_sender(), make_test_array(1));
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Processing fence: the counter flush follows any downstream publish,
+        // so once it reads 1, a delivery that was going to happen already has.
+        wait_until("frame 1 to be processed", || {
+            port.read_int32_blocking(handle.ndarray_params.array_counter, 0)
+                .is_ok_and(|v| v == 1)
+        });
 
         // No downstream delivery.
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -3002,9 +3092,8 @@ mod tests {
         // Re-enable: the next array IS delivered downstream.
         port.write_int32_blocking(handle.ndarray_params.array_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        params_applied(&handle);
         send_array(handle.array_sender(), make_test_array(2));
-        std::thread::sleep(std::time::Duration::from_millis(50));
         assert_eq!(downstream_rx.blocking_recv().unwrap().unique_id, 2);
     }
 
@@ -3052,12 +3141,14 @@ mod tests {
             enable_callbacks(&handle);
             let port = handle.port_runtime().port_handle().clone();
             send_array(handle.array_sender(), make_test_array(1));
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            assert_eq!(
-                port.read_int32_blocking(handle.ndarray_params.compressed_size, 0)
-                    .unwrap(),
-                4,
-                "uncompressed output must publish CompressedSize == raw byte count"
+            // The read errors with ParamUndefined until the first flush — treat
+            // that as "not yet".
+            wait_until(
+                "uncompressed output to publish CompressedSize == raw byte count",
+                || {
+                    port.read_int32_blocking(handle.ndarray_params.compressed_size, 0)
+                        .is_ok_and(|v| v == 4)
+                },
             );
         }
 
@@ -3079,12 +3170,12 @@ mod tests {
             enable_callbacks(&handle);
             let port = handle.port_runtime().port_handle().clone();
             send_array(handle.array_sender(), make_test_array(1));
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            assert_eq!(
-                port.read_int32_blocking(handle.ndarray_params.compressed_size, 0)
-                    .unwrap(),
-                7,
-                "compressed output must publish CompressedSize == codec.compressed_size"
+            wait_until(
+                "compressed output to publish CompressedSize == codec.compressed_size",
+                || {
+                    port.read_int32_blocking(handle.ndarray_params.compressed_size, 0)
+                        .is_ok_and(|v| v == 7)
+                },
             );
         }
     }
@@ -3117,11 +3208,10 @@ mod tests {
             .port_handle()
             .write_float64_blocking(handle.plugin_params.min_callback_time, 0, 10.0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        params_applied(&handle);
 
         send_array(handle.array_sender(), make_test_array(1));
         send_array(handle.array_sender(), make_test_array(2));
-        std::thread::sleep(std::time::Duration::from_millis(50));
 
         // Array 1 was processed and emitted; array 2 was throttled out.
         assert_eq!(downstream_rx.blocking_recv().unwrap().unique_id, 1);
@@ -3135,7 +3225,9 @@ mod tests {
             .port_handle()
             .write_float64_blocking(handle.plugin_params.min_callback_time, 0, 0.0)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // No fence needed: the MinCallbackTime reset and the ProcessPlugin
+        // trigger below travel the same FIFO param channel, so the reset is
+        // applied before the trigger by construction.
         handle
             .port_runtime()
             .port_handle()

--- a/crates/ad-plugins-rs/src/codec.rs
+++ b/crates/ad-plugins-rs/src/codec.rs
@@ -1470,7 +1470,11 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        // Fence: the write only queues the enable for the data thread.
+        assert!(
+            handle.wait_params_applied(std::time::Duration::from_secs(10)),
+            "data thread did not apply EnableCallbacks"
+        );
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/crates/ad-plugins-rs/src/stats.rs
+++ b/crates/ad-plugins-rs/src/stats.rs
@@ -2042,13 +2042,17 @@ mod tests {
         let (handle, stats, _params, _jh) =
             create_stats_runtime("STATS_RT", pool, 10, "", wiring, &ts_registry);
 
-        // Plugins default to disabled — enable for test
+        // Plugins default to disabled — enable for test, and fence until the
+        // data thread has applied the flip (the write only queues it).
         handle
             .port_runtime()
             .port_handle()
             .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert!(
+            handle.wait_params_applied(std::time::Duration::from_secs(10)),
+            "data thread did not apply EnableCallbacks"
+        );
 
         let mut arr = NDArray::new(
             vec![NDDimension::new(4), NDDimension::new(4)],
@@ -2065,7 +2069,17 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(handle.array_sender().publish(Arc::new(arr)));
-        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Wait on the observable itself — the stats land when the data thread
+        // processes the array; a fixed sleep is a race on a loaded machine.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while stats.lock().num_elements != 16 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for stats to be computed"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
 
         let result = stats.lock().clone();
         assert_eq!(result.min, 1.0);

--- a/crates/ad-plugins-rs/src/std_arrays.rs
+++ b/crates/ad-plugins-rs/src/std_arrays.rs
@@ -89,6 +89,26 @@ mod tests {
         Arc::new(arr)
     }
 
+    /// Fence: `write_*_blocking` only queues param changes for the data
+    /// thread; the barrier ack proves they have been applied.
+    fn params_applied(handle: &PluginRuntimeHandle) {
+        assert!(
+            handle.wait_params_applied(std::time::Duration::from_secs(10)),
+            "data thread did not apply queued param changes"
+        );
+    }
+
+    fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !cond() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for {what}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+    }
+
     #[test]
     fn test_processor_stores_and_passes_through() {
         let mut proc = StdArraysProcessor::new();
@@ -114,18 +134,16 @@ mod tests {
             .port_handle()
             .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 1)
             .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        params_applied(&handle);
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
         rt.block_on(handle.array_sender().publish(make_array(42)));
-        std::thread::sleep(std::time::Duration::from_millis(100));
-
-        let latest = data.lock().clone();
-        assert!(latest.is_some());
-        assert_eq!(latest.unwrap().unique_id, 42);
+        wait_until("StdArrays to store the published array", || {
+            data.lock().as_ref().is_some_and(|a| a.unique_id == 42)
+        });
     }
 
     #[test]
@@ -180,7 +198,6 @@ mod tests {
         // must still update with NDArrayCallbacks=0. This guards against the
         // STD_ARRAY_DATA interrupt being gated by the downstream-delivery flag.
         use asyn_rs::param::ParamValue;
-        use std::time::Duration;
 
         let pool = Arc::new(NDArrayPool::new(1_000_000));
         let wiring = Arc::new(WiringRegistry::new());
@@ -193,7 +210,7 @@ mod tests {
         // waveform output must still fire.
         port.write_int32_blocking(handle.ndarray_params.array_callbacks, 0, 0)
             .unwrap();
-        std::thread::sleep(Duration::from_millis(20));
+        params_applied(&handle);
 
         let mut rx = port.interrupts().subscribe_async();
 
@@ -202,7 +219,12 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(handle.array_sender().publish(make_array(7)));
-        std::thread::sleep(Duration::from_millis(100));
+        // ArrayCounter==1 ⟹ the frame was processed and its param batch
+        // (including the waveform interrupts) flushed.
+        wait_until("StdArrays to process the frame", || {
+            port.read_int32_blocking(handle.ndarray_params.array_counter, 0)
+                .is_ok_and(|v| v == 1)
+        });
 
         // make_array(7) is a 4-element UInt8 array → the STD_ARRAY_DATA
         // interrupt carries it as an Int8Array; the dimensions interrupt carries
@@ -232,7 +254,6 @@ mod tests {
         // MaxByteRate throttle drops the waveform output, so a throttled frame
         // leaves ArrayCounter unchanged (ImageJ etc. see no new data) while
         // DroppedArrays advances.
-        use std::time::Duration;
 
         let pool = Arc::new(NDArrayPool::new(1_000_000));
         let wiring = Arc::new(WiringRegistry::new());
@@ -245,7 +266,7 @@ mod tests {
         // (sent before a meaningful refill) is throttled.
         port.write_float64_blocking(handle.plugin_params.max_byte_rate, 0, 4.0)
             .unwrap();
-        std::thread::sleep(Duration::from_millis(20));
+        params_applied(&handle);
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -253,13 +274,21 @@ mod tests {
             .unwrap();
 
         rt.block_on(handle.array_sender().publish(make_array(1)));
-        std::thread::sleep(Duration::from_millis(40));
+        wait_until("first frame to be served and counted", || {
+            port.read_int32_blocking(handle.ndarray_params.array_counter, 0)
+                .is_ok_and(|v| v == 1)
+        });
         let counter_after_first = port
             .read_int32_blocking(handle.ndarray_params.array_counter, 0)
             .unwrap();
 
         rt.block_on(handle.array_sender().publish(make_array(2)));
-        std::thread::sleep(Duration::from_millis(40));
+        // The throttled frame leaves ArrayCounter unchanged, so wait on the
+        // observable it DOES advance: DroppedArrays.
+        wait_until("throttled frame to advance DroppedArrays", || {
+            port.read_int32_blocking(handle.plugin_params.dropped_output_arrays, 0)
+                .is_ok_and(|v| v == 1)
+        });
         let counter_after_second = port
             .read_int32_blocking(handle.ndarray_params.array_counter, 0)
             .unwrap();

--- a/crates/ad-plugins-rs/tests/integration.rs
+++ b/crates/ad-plugins-rs/tests/integration.rs
@@ -7,10 +7,31 @@ use ad_core_rs::attributes::{NDAttrSource, NDAttrValue, NDAttribute};
 use ad_core_rs::driver::ad_driver::ADDriverBase;
 use ad_core_rs::ndarray::{NDArray, NDDataBuffer, NDDataType, NDDimension};
 use ad_core_rs::ndarray_pool::NDArrayPool;
-use ad_core_rs::plugin::runtime::NDPluginProcess;
+use ad_core_rs::plugin::runtime::{NDPluginProcess, PluginRuntimeHandle};
 use ad_core_rs::plugin::wiring::WiringRegistry;
 use ad_plugins_rs::stats::create_stats_runtime;
 use ad_plugins_rs::std_arrays::create_std_arrays_runtime;
+
+/// Fence: `write_*_blocking`/`submit_blocking` only queue param changes for
+/// the plugin's data thread; the barrier ack proves they have been applied
+/// (enable flips, ROI sizes, NDArrayPort rewires).
+fn params_applied(handle: &PluginRuntimeHandle) {
+    assert!(
+        handle.wait_params_applied(std::time::Duration::from_secs(10)),
+        "data thread did not apply queued param changes"
+    );
+}
+
+fn wait_until(what: &str, mut cond: impl FnMut() -> bool) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !cond() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for {what}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+}
 
 #[test]
 fn test_driver_to_stats_pipeline() {
@@ -26,7 +47,7 @@ fn test_driver_to_stats_pipeline() {
         .port_handle()
         .write_int32_blocking(stats_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&stats_handle);
 
     let mut driver = ADDriverBase::new("SIM1", 64, 64, 10_000_000).unwrap();
     driver.connect_downstream(stats_handle.array_sender().clone());
@@ -52,7 +73,9 @@ fn test_driver_to_stats_pipeline() {
         .unwrap();
     rt.block_on(driver.array_output.publish(to_publish));
 
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    wait_until("stats to process the frame", || {
+        stats_data.lock().num_elements == 64 * 64
+    });
 
     let result = stats_data.lock().clone();
     assert_eq!(result.num_elements, 64 * 64);
@@ -72,7 +95,7 @@ fn test_driver_to_std_arrays_pipeline() {
         .port_handle()
         .write_int32_blocking(image_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&image_handle);
 
     let mut driver = ADDriverBase::new("SIM1", 32, 32, 10_000_000).unwrap();
     driver.connect_downstream(image_handle.array_sender().clone());
@@ -93,7 +116,12 @@ fn test_driver_to_std_arrays_pipeline() {
         .unwrap();
     rt.block_on(driver.array_output.publish(to_publish));
 
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    wait_until("StdArrays to store the published array", || {
+        image_data
+            .lock()
+            .as_ref()
+            .is_some_and(|a| a.unique_id == id)
+    });
 
     let latest = image_data.lock().clone().unwrap();
     assert_eq!(latest.unique_id, id);
@@ -181,18 +209,15 @@ fn test_rewire_ndarray_port_at_runtime() {
         .port_handle()
         .write_int32_blocking(handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&handle);
 
     // Send array from SIM1
     let mut arr = NDArray::new(vec![NDDimension::new(4)], NDDataType::UInt8);
     arr.unique_id = 100;
     rt.block_on(sim_publisher.publish(Arc::new(arr)));
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    assert_eq!(
-        *last_id.lock(),
-        100,
-        "STATS1 should receive array from SIM1"
-    );
+    wait_until("STATS1 to receive array from SIM1", || {
+        *last_id.lock() == 100
+    });
 
     // Now rewire STATS1 from SIM1 → ROI1 via OctetWrite
     handle
@@ -205,13 +230,14 @@ fn test_rewire_ndarray_port_at_runtime() {
             AsynUser::new(handle.plugin_params.nd_array_port),
         )
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    params_applied(&handle);
 
-    // Send array from SIM1 — should NOT reach STATS1 anymore
+    // Send array from SIM1 — should NOT reach STATS1 anymore. The rewire is
+    // already applied (barrier above), so SIM1's output no longer carries
+    // STATS1's sender and delivery is impossible — no wait needed.
     let mut arr2 = NDArray::new(vec![NDDimension::new(4)], NDDataType::UInt8);
     arr2.unique_id = 200;
     rt.block_on(sim_publisher.publish(Arc::new(arr2)));
-    std::thread::sleep(std::time::Duration::from_millis(50));
     assert_eq!(
         *last_id.lock(),
         100,
@@ -222,12 +248,9 @@ fn test_rewire_ndarray_port_at_runtime() {
     let mut arr3 = NDArray::new(vec![NDDimension::new(4)], NDDataType::UInt8);
     arr3.unique_id = 300;
     rt.block_on(roi_publisher.publish(Arc::new(arr3)));
-    std::thread::sleep(std::time::Duration::from_millis(50));
-    assert_eq!(
-        *last_id.lock(),
-        300,
-        "STATS1 should receive from ROI1 after rewire"
-    );
+    wait_until("STATS1 to receive from ROI1 after rewire", || {
+        *last_id.lock() == 300
+    });
 }
 
 #[test]
@@ -288,7 +311,7 @@ fn test_rewire_through_real_roi_plugin() {
         .port_handle()
         .write_int32_blocking(roi_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&roi_handle);
 
     // Create STATS1 (tracking processor) initially wired to SIM1
     struct TrackingProcessor {
@@ -326,7 +349,7 @@ fn test_rewire_through_real_roi_plugin() {
         .port_handle()
         .write_int32_blocking(stats_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&stats_handle);
 
     // Send array from SIM1 → both ROI1 and STATS1 receive directly
     let mut arr = NDArray::new(
@@ -335,8 +358,9 @@ fn test_rewire_through_real_roi_plugin() {
     );
     arr.unique_id = 100;
     rt.block_on(sim_publisher.publish(Arc::new(arr)));
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    assert_eq!(*last_id.lock(), 100, "STATS1 gets array from SIM1");
+    wait_until("STATS1 to get the array from SIM1", || {
+        *last_id.lock() == 100
+    });
 
     // Rewire STATS1 from SIM1 → ROI1
     stats_handle
@@ -349,7 +373,7 @@ fn test_rewire_through_real_roi_plugin() {
             AsynUser::new(stats_handle.plugin_params.nd_array_port),
         )
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    params_applied(&stats_handle);
 
     // Send another array from SIM1
     // ROI1 gets it from SIM1, processes it, publishes to its output
@@ -360,13 +384,9 @@ fn test_rewire_through_real_roi_plugin() {
     );
     arr2.unique_id = 200;
     rt.block_on(sim_publisher.publish(Arc::new(arr2)));
-    std::thread::sleep(std::time::Duration::from_millis(200));
-
-    let received_id = *last_id.lock();
-    assert!(
-        received_id != 100,
-        "STATS1 should receive new array through ROI1, got {received_id}"
-    );
+    wait_until("STATS1 to receive the new array through ROI1", || {
+        *last_id.lock() != 100
+    });
 }
 
 #[test]
@@ -401,7 +421,7 @@ fn test_roi_param_change_enables_output() {
         .port_handle()
         .write_int32_blocking(roi_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&roi_handle);
 
     // Tracking processor downstream of ROI1
     struct TrackingProcessor {
@@ -436,7 +456,7 @@ fn test_roi_param_change_enables_output() {
         .port_handle()
         .write_int32_blocking(stats_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&stats_handle);
 
     // Send array — ROI1 has default size=0. Matching C++ NDPluginROI
     // (size = MAX(size, 1)), an enabled ROI dim with size 0 clamps to a
@@ -447,12 +467,10 @@ fn test_roi_param_change_enables_output() {
     );
     arr.unique_id = 100;
     rt.block_on(sim_publisher.publish(Arc::new(arr)));
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    assert_eq!(
-        *last_id.lock(),
-        100,
-        "ROI size=0 clamps to a 1-pixel ROI (C++ MAX(size,1)) and still emits"
-    );
+    // ROI size=0 clamps to a 1-pixel ROI (C++ MAX(size,1)) and still emits.
+    wait_until("STATS1 to receive the 1-pixel ROI output", || {
+        *last_id.lock() == 100
+    });
 
     // Now set ROI size via param write (like PINI or user).
     let roi_ph = roi_handle.port_runtime().port_handle();
@@ -462,7 +480,7 @@ fn test_roi_param_change_enables_output() {
     roi_ph
         .write_int32_blocking(roi_params.dims[1].size, 0, 8)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    params_applied(&roi_handle);
 
     // Send another array — now ROI1 has size=8x8, should produce output
     let mut arr2 = NDArray::new(
@@ -471,12 +489,9 @@ fn test_roi_param_change_enables_output() {
     );
     arr2.unique_id = 200;
     rt.block_on(sim_publisher.publish(Arc::new(arr2)));
-    std::thread::sleep(std::time::Duration::from_millis(200));
-    assert_eq!(
-        *last_id.lock(),
-        200,
-        "STATS1 should receive after ROI size set to 8x8"
-    );
+    wait_until("STATS1 to receive after ROI size set to 8x8", || {
+        *last_id.lock() == 200
+    });
 }
 
 // --- Phase 5: New integration tests ---
@@ -715,7 +730,7 @@ fn test_process_and_publish_writes_array_size_params() {
     let ph = image_handle.port_runtime().port_handle();
     ph.write_int32_blocking(image_handle.plugin_params.enable_callbacks, 0, 1)
         .unwrap();
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    params_applied(&image_handle);
 
     // Connect and send a 64x48 array
     let mut driver =
@@ -734,7 +749,12 @@ fn test_process_and_publish_writes_array_size_params() {
         .unwrap();
     rt.block_on(driver.array_output.publish(to_publish));
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    // The frame's params (sizes, counter, unique id) flush as one batch, so
+    // ArrayCounter==1 implies every param below is already readable.
+    wait_until("StdArrays to process the frame", || {
+        ph.read_int32_blocking(image_handle.ndarray_params.array_counter, 0)
+            .is_ok_and(|v| v == 1)
+    });
 
     // Verify the StdArrays data was stored
     let latest = image_data.lock().clone();


### PR DESCRIPTION
## Problem

Plugin tests synchronized control-plane param writes and data-plane processing with fixed `thread::sleep` calls. Under CI load these flake — `test_rewire_ndarray_port_at_runtime` and `test_driver_to_stats_pipeline` failed on a loaded runner (main CI run on bbaf4f9a).

## Structural fix

The control→data param channel now carries `PluginParamMsg` (`Change` | `Barrier`). The data thread acks a `Barrier` only after applying every previously queued `Change` — the channel is FIFO and `io_write_*` enqueues before the port actor replies, so a returned blocking write implies its change is already ahead of the barrier. Exposed as `PluginRuntimeHandle::wait_params_applied(timeout)`.

## Test conversions (51 of 54 sleep sites)

- **param writes** (enable flips, ROI sizes, NDArrayPort rewires): sleep → `wait_params_applied` fence
- **post-publish waits**: sleep → poll an observable the frame flushes (`array_counter`, `dropped_output_arrays`, processor data handles, tracking `last_id`) with a 10 s deadline
- **negative rewire assert**: no wait at all — the barrier proves the rewire happened-before the publish, so delivery to the rewired-away plugin is impossible

Files: `ad-core-rs/src/plugin/runtime.rs` (mechanism + 20 sites), `ad-plugins-rs/tests/integration.rs` (21), `std_arrays.rs` (7), `stats.rs` (2), `codec.rs` (1).

Kept as-is (genuinely time-based, not sync-by-sleep): sort-deadline aging (30 ms), SlowProcessor queue-pressure test (200 ms), `ad_driver.rs` framerate pacing (production logic).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7424 passed, 2 skipped (pre-existing `#[ignore]` network tests)
- `cargo nextest run -p ad-plugins-rs --features ioc` — 467/467
- converted tests (incl. both originally-flaked) stress-looped 30× — 30/30