### PR TITLE
fix(ca): UDP recv errors must not kill server/repeater loops; CI: never cancel main runs

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -23,10 +23,15 @@ on:
     branches: [ "main" ]
   workflow_dispatch: {}
 
-# A new push to the same ref cancels the in-flight matrix.
+# A new push to the same PR branch cancels the in-flight matrix. On main,
+# never cancel: a `gh run rerun --failed` of an OLDER main run re-enters
+# this group and would cancel the in-progress run for the newer commit
+# (observed 2026-07-12: rerunning the run for a merge commit cancelled the
+# release-commit run that followed it). Main runs are rare enough that
+# letting them coexist costs less than losing head-of-main coverage.
 concurrency:
   group: cross-platform-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/crates/ad-core-rs/src/ioc/plugin_manager.rs
+++ b/crates/ad-core-rs/src/ioc/plugin_manager.rs
@@ -57,26 +57,46 @@ impl PluginManager {
 
     /// Register a plugin. The port is registered in the global asyn port registry
     /// so the universal asyn device support factory can find it.
-    pub fn add_plugin(&self, _dtyp: &str, handle: &PluginRuntimeHandle) {
+    ///
+    /// Errors on a duplicate port name (the registry refuses overwrites,
+    /// matching C `asynManager::registerPort`); nothing is stored in that
+    /// case, so the rejected plugin's runtime shuts down when `handle`'s
+    /// last clone drops.
+    pub fn add_plugin(
+        &self,
+        _dtyp: &str,
+        handle: &PluginRuntimeHandle,
+    ) -> asyn_rs::error::AsynResult<()> {
         let port_handle = handle.port_runtime().port_handle().clone();
         let port_name = port_handle.port_name().to_string();
+
+        // Claim the port name first: a duplicate must not leave a wiring
+        // output or a parked handle behind for a plugin that was refused.
+        asyn_rs::asyn_record::register_port(&port_name, port_handle, self.trace.clone())?;
 
         // Register this plugin's output in the wiring registry
         self.wiring
             .register_output(&port_name, handle.array_output().clone());
 
         self.plugin_handles.lock().push(handle.clone());
-        asyn_rs::asyn_record::register_port(&port_name, port_handle, self.trace.clone());
+        Ok(())
     }
 
     /// Register a raw port (not a plugin runtime) for auxiliary ports like TimeSeries.
     ///
     /// The `PortRuntimeHandle` is stored to keep the actor thread alive.
-    pub fn add_port(&self, _dtyp: &str, runtime: asyn_rs::runtime::port::PortRuntimeHandle) {
+    /// Errors on a duplicate port name; the rejected runtime is not stored,
+    /// so it shuts down when the caller drops it.
+    pub fn add_port(
+        &self,
+        _dtyp: &str,
+        runtime: asyn_rs::runtime::port::PortRuntimeHandle,
+    ) -> asyn_rs::error::AsynResult<()> {
         let port_handle = runtime.port_handle().clone();
         let port_name = port_handle.port_name().to_string();
+        asyn_rs::asyn_record::register_port(&port_name, port_handle, self.trace.clone())?;
         self.port_runtimes.lock().push(runtime);
-        asyn_rs::asyn_record::register_port(&port_name, port_handle, self.trace.clone());
+        Ok(())
     }
 
     /// Print a report of registered plugins.

--- a/crates/ad-plugins-rs/src/ioc.rs
+++ b/crates/ad-plugins-rs/src/ioc.rs
@@ -46,7 +46,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     &ndarray_port,
                     m.wiring().clone(),
                 );
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDStdArraysConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                     eprintln!("NDStdArraysConfigure: wiring failed: {e}");
                 }
@@ -78,7 +81,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     &tsr,
                 );
 
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDStatsConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                     eprintln!("NDStatsConfigure: wiring failed: {e}");
                 }
@@ -108,7 +114,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     &ndarray_port,
                     m.wiring().clone(),
                 );
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDROIConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                     eprintln!("NDROIConfigure: wiring failed: {e}");
                 }
@@ -309,7 +318,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     }
                 }
 
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDGatherConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 println!("NDGatherConfigure: port={port_name}");
                 Ok(CommandOutcome::Continue)
             },
@@ -391,7 +403,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     m.wiring().clone(),
                     max_addr,
                 );
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDAttrPlotConfig: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &in_port) {
                     eprintln!("NDAttrPlotConfig: wiring failed: {e}");
                 }
@@ -510,7 +525,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     &tsr,
                     max_attributes,
                 );
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDAttrConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                     eprintln!("NDAttrConfigure: wiring failed: {e}");
                 }
@@ -543,7 +561,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     32,
                     &tsr,
                 );
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDROIStatConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                     eprintln!("NDROIStatConfigure: wiring failed: {e}");
                 }
@@ -634,7 +655,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                             // address is reserved at addr == maxSignals).
                             max_signals + 1,
                         );
-                        m.add_plugin(&dtyp, &handle);
+                        if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                            eprintln!("NDTimeSeriesConfigure: {e}");
+                            return Ok(CommandOutcome::Continue);
+                        }
                         if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port)
                         {
                             eprintln!("NDTimeSeriesConfigure: wiring failed: {e}");
@@ -657,7 +681,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                         2048,
                         ts_rx,
                     );
-                m.add_port(&dtyp, ts_runtime);
+                if let Err(e) = m.add_port(&dtyp, ts_runtime) {
+                    eprintln!("NDTimeSeriesConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 println!("NDTimeSeriesConfigure: port={port_name} (upstream={ndarray_port})");
 
                 Ok(CommandOutcome::Continue)
@@ -731,7 +758,10 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
                     &ndarray_port,
                     m.wiring().clone(),
                 );
-                m.add_plugin(&dtyp, &handle);
+                if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                    eprintln!("NDPvaConfigure: {e}");
+                    return Ok(CommandOutcome::Continue);
+                }
                 if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                     eprintln!("NDPvaConfigure: wiring failed: {e}");
                 }
@@ -834,7 +864,10 @@ where
                 pool,
                 m.wiring().clone(),
             );
-            m.add_plugin(&dtyp, &handle);
+            if let Err(e) = m.add_plugin(&dtyp, &handle) {
+                eprintln!("{cmd_name}: {e}");
+                return Ok(CommandOutcome::Continue);
+            }
             if let Err(e) = m.wiring().rewire(handle.array_sender(), "", &ndarray_port) {
                 eprintln!("{cmd_name}: wiring failed: {e}");
             }

--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -3940,7 +3940,8 @@ mod tests {
             "ts_factory",
             handle,
             Arc::new(crate::trace::TraceManager::new()),
-        );
+        )
+        .unwrap();
 
         let ctx = DeviceSupportContext {
             dtyp: "asynInt32TimeSeries",
@@ -6716,7 +6717,8 @@ mod tests {
             "binwrite_wb",
             handle,
             Arc::new(crate::trace::TraceManager::new()),
-        );
+        )
+        .unwrap();
 
         let ctx = DeviceSupportContext {
             dtyp: "asynOctetWriteBinary",
@@ -6752,7 +6754,8 @@ mod tests {
             "binwrite_text",
             handle,
             Arc::new(crate::trace::TraceManager::new()),
-        );
+        )
+        .unwrap();
 
         let ctx = DeviceSupportContext {
             dtyp: "asynOctetWrite",
@@ -7046,7 +7049,8 @@ mod tests {
             "cmdresp_factory",
             handle,
             Arc::new(crate::trace::TraceManager::new()),
-        );
+        )
+        .unwrap();
 
         // The DRVINFO tail "*IDN?\r\n" is the literal command — the "\r\n" is two
         // escape sequences (four chars) in the link, decoded to 0x0D 0x0A.
@@ -7102,7 +7106,8 @@ mod tests {
             "cmdresp_nul",
             handle,
             Arc::new(crate::trace::TraceManager::new()),
-        );
+        )
+        .unwrap();
 
         // "AB\000CD": dbTranslateEscape yields A B 0x00 C D; C strlen stops at the
         // NUL, so only "AB" reaches the wire.
@@ -7140,7 +7145,8 @@ mod tests {
             "cmdresp_lnul",
             handle,
             Arc::new(crate::trace::TraceManager::new()),
-        );
+        )
+        .unwrap();
 
         // Raw DRVINFO "\000CD" is non-empty (C strlen != 0 -> no reject); it
         // escapes to [0x00,'C','D'] and truncates at the leading NUL -> empty

--- a/crates/asyn-rs/src/asyn_record/mod.rs
+++ b/crates/asyn-rs/src/asyn_record/mod.rs
@@ -3201,7 +3201,7 @@ mod tests {
         let handle = PortHandle::new(tx, "test_asyn_rec".into(), interrupts);
         let trace = Arc::new(TraceManager::new());
 
-        register_port("test_asyn_rec", handle, trace);
+        register_port("test_asyn_rec", handle, trace).unwrap();
 
         let entry = registry::get_port("test_asyn_rec");
         assert!(entry.is_some());
@@ -3246,7 +3246,7 @@ mod tests {
         let mut handle = PortHandle::new(tx, port_name.into(), interrupts);
         handle.set_capabilities(true, 4);
         let trace = Arc::new(TraceManager::new());
-        register_port(port_name, handle, trace.clone());
+        register_port(port_name, handle, trace.clone()).unwrap();
 
         let mut rec = AsynRecord::default();
         rec.port = port_name.to_string();
@@ -3312,7 +3312,7 @@ mod tests {
             Some(port_name),
             TraceInfoMask::SOURCE | TraceInfoMask::THREAD,
         );
-        register_port(port_name, handle, trace);
+        register_port(port_name, handle, trace).unwrap();
 
         let mut rec = AsynRecord::default();
         rec.port = port_name.to_string();
@@ -3366,7 +3366,7 @@ mod tests {
         // it); without it the record's subscription is a no-op.
         trace.set_exception_sink(Arc::new(ExceptionManager::new()));
         trace.set_trace_info_mask(Some(port_name), TraceInfoMask::TIME);
-        register_port(port_name, handle, trace.clone());
+        register_port(port_name, handle, trace.clone()).unwrap();
 
         let mut rec = AsynRecord::default();
         rec.port = port_name.to_string();
@@ -3447,7 +3447,7 @@ mod tests {
         );
         std::thread::spawn(move || actor.run());
         let handle = PortHandle::new(tx, port_name.into(), interrupts);
-        register_port(port_name, handle, Arc::new(TraceManager::new()));
+        register_port(port_name, handle, Arc::new(TraceManager::new())).unwrap();
 
         // ASCII read: AINP gets the (lossy) text; BINP must stay untouched.
         let mut ascii = AsynRecord::default();
@@ -3545,7 +3545,7 @@ mod tests {
         );
         std::thread::spawn(move || actor.run());
         let handle = PortHandle::new(tx, port_name.into(), interrupts);
-        register_port(port_name, handle, Arc::new(TraceManager::new()));
+        register_port(port_name, handle, Arc::new(TraceManager::new())).unwrap();
 
         // ASCII read failure: NORD/EOMR cleared to 0, AINP/TINP cleared to "",
         // and BINP (not the IFMT-selected field) left as it was — matching C,
@@ -3684,7 +3684,7 @@ mod tests {
         );
         std::thread::spawn(move || actor.run());
         let handle = PortHandle::new(tx, port_name.into(), interrupts);
-        register_port(port_name, handle, Arc::new(TraceManager::new()));
+        register_port(port_name, handle, Arc::new(TraceManager::new())).unwrap();
 
         let mk = |iface: i32, tmod: TransferMode| {
             let mut rec = AsynRecord::default();
@@ -3792,7 +3792,7 @@ mod tests {
         );
         std::thread::spawn(move || actor.run());
         let handle = PortHandle::new(tx, port_name.into(), interrupts);
-        register_port(port_name, handle, Arc::new(TraceManager::new()));
+        register_port(port_name, handle, Arc::new(TraceManager::new())).unwrap();
 
         let mut rec = AsynRecord::default();
         rec.port = port_name.to_string();
@@ -4248,7 +4248,7 @@ mod tests {
         trace.set_exception_sink(Arc::new(ExceptionManager::new()));
         // Known baseline mask, then register the port for the record to find.
         trace.set_trace_mask(Some(port_name), TraceMask::empty());
-        super::registry::register_port(port_name, handle, trace.clone());
+        super::registry::register_port(port_name, handle, trace.clone()).unwrap();
 
         // Build the record, hand it the database handle, and connect it —
         // connecting registers the trace exception callback with the same
@@ -4361,7 +4361,7 @@ mod tests {
         // `monitorStatus`): TMSK = ERROR, all IO bits clear.
         trace.set_trace_mask(Some(port_name), TraceMask::ERROR);
         trace.set_trace_io_mask(Some(port_name), TraceIoMask::empty());
-        super::registry::register_port(port_name, handle, trace.clone());
+        super::registry::register_port(port_name, handle, trace.clone()).unwrap();
 
         let db = PvDatabase::new();
         let rec_name = "TRACE_POSTIFNEW_REC";

--- a/crates/asyn-rs/src/asyn_record/registry.rs
+++ b/crates/asyn-rs/src/asyn_record/registry.rs
@@ -4,8 +4,10 @@
 //! a global static fallback for backward compatibility.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::error::{AsynError, AsynResult};
 use crate::port_handle::PortHandle;
 use crate::trace::TraceManager;
 
@@ -37,9 +39,27 @@ impl PortRegistry {
         }
     }
 
-    pub fn register(&self, name: &str, handle: PortHandle, trace: Arc<TraceManager>) {
+    /// Publish a port. Errors with [`AsynError::PortAlreadyRegistered`]
+    /// if `name` is already present — C parity: `asynManager::registerPort`
+    /// refuses a duplicate name ("port %s already registered") instead of
+    /// replacing the entry. A silent overwrite would orphan the prior
+    /// handle: its runtime keeps running while the name resolves to the
+    /// new port, silently shadowing legitimate I/O. To replace a port,
+    /// [`Self::remove`] it first.
+    pub fn register(
+        &self,
+        name: &str,
+        handle: PortHandle,
+        trace: Arc<TraceManager>,
+    ) -> AsynResult<()> {
         let mut reg = self.inner.lock().unwrap();
-        reg.insert(name.to_string(), PortEntry { handle, trace });
+        match reg.entry(name.to_string()) {
+            Entry::Occupied(_) => Err(AsynError::PortAlreadyRegistered(name.to_string())),
+            Entry::Vacant(slot) => {
+                slot.insert(PortEntry { handle, trace });
+                Ok(())
+            }
+        }
     }
 
     pub fn get(&self, name: &str) -> Option<PortEntry> {
@@ -77,8 +97,11 @@ fn global_registry() -> &'static PortRegistry {
 
 /// Register a port via the global registry.
 /// Prefer using a shared `PortRegistry` instance for better test isolation.
-pub fn register_port(name: &str, handle: PortHandle, trace: Arc<TraceManager>) {
-    global_registry().register(name, handle, trace);
+///
+/// Errors with [`AsynError::PortAlreadyRegistered`] on a duplicate name —
+/// see [`PortRegistry::register`].
+pub fn register_port(name: &str, handle: PortHandle, trace: Arc<TraceManager>) -> AsynResult<()> {
+    global_registry().register(name, handle, trace)
 }
 
 /// Look up a port via the global registry.
@@ -116,3 +139,60 @@ pub fn register_asyn_record_type() {
 }
 
 // ===== Transfer Mode =====
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interrupt::InterruptManager;
+
+    fn dummy_handle(name: &str) -> PortHandle {
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        PortHandle::new(tx, name.to_string(), Arc::new(InterruptManager::new(4)))
+    }
+
+    /// C parity: `asynManager::registerPort` refuses a duplicate name
+    /// instead of replacing the entry — a silent overwrite would orphan
+    /// the prior handle.
+    #[test]
+    fn register_rejects_duplicate_name() {
+        let reg = PortRegistry::new();
+        reg.register(
+            "regdup",
+            dummy_handle("regdup"),
+            Arc::new(TraceManager::new()),
+        )
+        .unwrap();
+        match reg.register(
+            "regdup",
+            dummy_handle("regdup"),
+            Arc::new(TraceManager::new()),
+        ) {
+            Err(AsynError::PortAlreadyRegistered(name)) => assert_eq!(name, "regdup"),
+            other => panic!("expected PortAlreadyRegistered, got {other:?}"),
+        }
+        // The original entry survives the rejected attempt.
+        assert!(reg.get("regdup").is_some());
+    }
+
+    /// Boundary: `remove()` frees the name for re-registration.
+    #[test]
+    fn removed_name_can_be_reregistered() {
+        let reg = PortRegistry::new();
+        reg.register(
+            "regrecycle",
+            dummy_handle("regrecycle"),
+            Arc::new(TraceManager::new()),
+        )
+        .unwrap();
+        reg.remove("regrecycle");
+        assert!(
+            reg.register(
+                "regrecycle",
+                dummy_handle("regrecycle"),
+                Arc::new(TraceManager::new())
+            )
+            .is_ok(),
+            "re-register after remove must succeed"
+        );
+    }
+}

--- a/crates/asyn-rs/src/iocsh.rs
+++ b/crates/asyn-rs/src/iocsh.rs
@@ -704,7 +704,15 @@ pub fn drv_asyn_ip_port_configure_command(trace: Arc<TraceManager>) -> CommandDe
                 };
 
             let (handle, _jh) = create_port_runtime(driver, RuntimeConfig::default());
-            crate::asyn_record::register_port(&port, handle.port_handle().clone(), trace.clone());
+            if let Err(e) = crate::asyn_record::register_port(
+                &port,
+                handle.port_handle().clone(),
+                trace.clone(),
+            ) {
+                ctx.println(&format!("drvAsynIPPortConfigure: {e}"));
+                handle.shutdown();
+                return Ok(CommandOutcome::Continue);
+            }
             keep_port_runtime(handle);
             ctx.println(&format!(
                 "drvAsynIPPortConfigure: octet port '{port}' -> {host}"
@@ -780,7 +788,15 @@ pub fn drv_asyn_serial_port_configure_command(trace: Arc<TraceManager>) -> Comma
                 };
 
             let (handle, _jh) = create_port_runtime(driver, RuntimeConfig::default());
-            crate::asyn_record::register_port(&port, handle.port_handle().clone(), trace.clone());
+            if let Err(e) = crate::asyn_record::register_port(
+                &port,
+                handle.port_handle().clone(),
+                trace.clone(),
+            ) {
+                ctx.println(&format!("drvAsynSerialPortConfigure: {e}"));
+                handle.shutdown();
+                return Ok(CommandOutcome::Continue);
+            }
             keep_port_runtime(handle);
             ctx.println(&format!(
                 "drvAsynSerialPortConfigure: octet port '{port}' -> {tty}"
@@ -850,7 +866,15 @@ pub fn drv_asyn_prologix_port_configure_command(trace: Arc<TraceManager>) -> Com
             };
 
             let (handle, _jh) = create_port_runtime(driver, RuntimeConfig::default());
-            crate::asyn_record::register_port(&port, handle.port_handle().clone(), trace.clone());
+            if let Err(e) = crate::asyn_record::register_port(
+                &port,
+                handle.port_handle().clone(),
+                trace.clone(),
+            ) {
+                ctx.println(&format!("prologixGPIBConfigure: {e}"));
+                handle.shutdown();
+                return Ok(CommandOutcome::Continue);
+            }
             keep_port_runtime(handle);
             ctx.println(&format!(
                 "prologixGPIBConfigure: GPIB port '{port}' -> {host}"

--- a/crates/asyn-rs/src/manager.rs
+++ b/crates/asyn-rs/src/manager.rs
@@ -53,12 +53,16 @@ impl PortManager {
     /// and client access.
     ///
     /// **Errors with `PortAlreadyRegistered`** if a port with the same name
-    /// is already in the registry. Mirrors asyn upstream issue #34
-    /// (`asynPortDriver` segfault on duplicate port name): a silent
-    /// overwrite would orphan the prior `PortRuntimeHandle` (its runtime
-    /// thread would keep running on a now-unreachable handle, leaking
-    /// resources and silently shadowing legitimate I/O). To replace a
-    /// port, call [`Self::unregister_port`] first.
+    /// already exists anywhere in the process — this manager's map or the
+    /// process port registry (ports created by the `drvAsyn*PortConfigure`
+    /// iocsh commands, plugin ports, hand-registered ports). C parity:
+    /// `asynManager::registerPort` refuses duplicate names. Mirrors asyn
+    /// upstream issue #34 (`asynPortDriver` segfault on duplicate port
+    /// name): a silent overwrite would orphan the prior
+    /// `PortRuntimeHandle` (its runtime thread would keep running on a
+    /// now-unreachable handle, leaking resources and silently shadowing
+    /// legitimate I/O). To replace a port, call
+    /// [`Self::unregister_port`] first.
     pub fn register_port<D: PortDriver>(&self, driver: D) -> AsynResult<PortRuntimeHandle> {
         self.register_port_with_config(driver, RuntimeConfig::default())
     }
@@ -72,42 +76,47 @@ impl PortManager {
         config: RuntimeConfig,
     ) -> AsynResult<PortRuntimeHandle> {
         let name = driver.base().port_name.clone();
-        // Pre-flight under both locks: refuse before we spawn the
-        // runtime thread, so a rejected duplicate doesn't burn a
-        // thread + create a half-initialized PortRuntimeHandle.
+        // Pre-flight: refuse before we spawn the runtime thread, so a
+        // rejected duplicate doesn't burn a thread + create a
+        // half-initialized PortRuntimeHandle. The manager map catches a
+        // stale manager-owned entry whose registry entry was withdrawn
+        // externally; the registry check catches ports published by any
+        // other creator (drvAsyn*PortConfigure, plugins, hand-registered).
         {
             let ph = self.port_handles.lock();
             if ph.contains_key(&name) {
                 return Err(AsynError::PortAlreadyRegistered(name));
             }
         }
+        if crate::asyn_record::get_port(&name).is_some() {
+            return Err(AsynError::PortAlreadyRegistered(name));
+        }
         driver.base_mut().exception_sink = Some(self.exceptions.clone());
         driver.base_mut().trace = Some(self.trace.clone());
 
         let (handle, _jh) = create_port_runtime(driver, config);
 
-        // Re-check under the write lock to close the TOCTOU window
-        // between the pre-flight read and the actual insert. If a
-        // concurrent caller raced us in, drop the runtime we just
-        // built and report the duplicate.
+        // The process-registry insert is the atomic claim on the name —
+        // it is the single place every consumer resolves a name through
+        // (asyn iocsh commands, asynRecord device support, the asyn
+        // device-support adapter), and it refuses duplicates. Losing the
+        // claim means a concurrent registrant won between the pre-flight
+        // and here: drop the runtime we just built and report the
+        // duplicate.
+        if let Err(e) = crate::asyn_record::register_port(
+            &name,
+            handle.port_handle().clone(),
+            self.trace.clone(),
+        ) {
+            handle.shutdown();
+            return Err(e);
+        }
         let mut ph = self.port_handles.lock();
         let mut rh = self.runtime_handles.lock();
-        if ph.contains_key(&name) {
-            drop(rh);
-            drop(ph);
-            handle.shutdown();
-            return Err(AsynError::PortAlreadyRegistered(name));
-        }
         ph.insert(name.clone(), handle.port_handle().clone());
         rh.insert(name.clone(), handle.clone());
         drop(rh);
         drop(ph);
-
-        // Publish into the process port registry, the single place every
-        // consumer resolves a name through: the asyn iocsh commands, asynRecord
-        // device support, and the asyn device-support adapter. A port that only
-        // this manager knows about would be invisible to all three.
-        crate::asyn_record::register_port(&name, handle.port_handle().clone(), self.trace.clone());
 
         Ok(handle)
     }
@@ -346,6 +355,39 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_against_process_registry_rejected() {
+        // A name already published to the process port registry (e.g. by a
+        // drvAsyn*PortConfigure command or a hand-registered driver port)
+        // must block manager registration too — the registry is the
+        // process-wide authority on port names, matching C
+        // asynManager::registerPort.
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        let ext = crate::port_handle::PortHandle::new(
+            tx,
+            "extowned".to_string(),
+            Arc::new(crate::interrupt::InterruptManager::new(4)),
+        );
+        crate::asyn_record::register_port(
+            "extowned",
+            ext,
+            Arc::new(crate::trace::TraceManager::new()),
+        )
+        .unwrap();
+
+        let mgr = PortManager::new();
+        match mgr.register_port(DummyDriver::new("extowned")) {
+            Err(crate::error::AsynError::PortAlreadyRegistered(name)) => {
+                assert_eq!(name, "extowned")
+            }
+            Err(other) => panic!("expected PortAlreadyRegistered, got {other:?}"),
+            Ok(_) => panic!("registration over a process-registry name must fail"),
+        }
+        // The externally published entry survives the rejected attempt.
+        assert!(crate::asyn_record::get_port("extowned").is_some());
+        crate::asyn_record::unregister_port("extowned");
+    }
+
+    #[test]
     fn duplicate_after_unregister_succeeds() {
         // Replace-via-unregister must work cleanly.
         let mgr = PortManager::new();
@@ -382,7 +424,10 @@ mod tests {
     #[test]
     fn set_input_eos_via_actor_reaches_driver_base() {
         let mgr = PortManager::new();
-        let mut drv = DummyDriver::new("eos_port");
+        // "mgr_eos_port", not "eos_port": the iocsh EOS-command test
+        // registers "eos_port" in the same process-global registry, and
+        // duplicate names now error (C registerPort parity).
+        let mut drv = DummyDriver::new("mgr_eos_port");
         drv.base.create_param("VAL", ParamType::Int32).unwrap();
         let handle = mgr.register_port(drv).unwrap();
 

--- a/crates/asyn-rs/src/transport/in_process.rs
+++ b/crates/asyn-rs/src/transport/in_process.rs
@@ -162,8 +162,12 @@ mod tests {
     }
 
     impl TestPort {
-        fn new() -> Self {
-            let mut base = PortDriverBase::new("ipc_test", 1, PortFlags::default());
+        // Per-test unique port names: registration goes through the
+        // process-global registry, which now errors on duplicates
+        // (C registerPort parity), so tests sharing one name would
+        // collide when run in a single process (`cargo test`).
+        fn new(name: &str) -> Self {
+            let mut base = PortDriverBase::new(name, 1, PortFlags::default());
             base.create_param("VAL", ParamType::Int32).unwrap();
             base.create_param("F64", ParamType::Float64).unwrap();
             base.create_param("MSG", ParamType::Octet).unwrap();
@@ -180,9 +184,9 @@ mod tests {
         }
     }
 
-    fn make_client() -> (PortManager, InProcessClient) {
+    fn make_client(name: &str) -> (PortManager, InProcessClient) {
         let mgr = PortManager::new();
-        let rt_handle = mgr.register_port(TestPort::new()).unwrap();
+        let rt_handle = mgr.register_port(TestPort::new(name)).unwrap();
         let client = InProcessClient::new(rt_handle.port_handle().clone());
         (mgr, client)
     }
@@ -204,7 +208,7 @@ mod tests {
 
     #[tokio::test]
     async fn int32_write_read_cycle() {
-        let (_mgr, client) = make_client();
+        let (_mgr, client) = make_client("ipc_int32");
 
         // Write
         let req = make_request(PortCommand::Int32Write { value: 42 }, 0);
@@ -222,7 +226,7 @@ mod tests {
 
     #[tokio::test]
     async fn float64_write_read_cycle() {
-        let (_mgr, client) = make_client();
+        let (_mgr, client) = make_client("ipc_f64");
 
         let req = make_request(PortCommand::Float64Write { value: 3.14 }, 1);
         let reply = client.request(req).await.unwrap();
@@ -243,7 +247,7 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let (_mgr, client) = rt.block_on(async { make_client() });
+        let (_mgr, client) = rt.block_on(async { make_client("ipc_blocking") });
 
         let req = make_request(PortCommand::Int32Write { value: 99 }, 0);
         let reply = client.request_blocking(req).unwrap();
@@ -264,13 +268,13 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        let (_mgr, client) = rt.block_on(async { make_client() });
+        let (_mgr, client) = rt.block_on(async { make_client("ipc_conn") });
         assert_eq!(client.connection_state(), ConnectionState::Connected);
     }
 
     #[tokio::test]
     async fn event_subscription() {
-        let (_mgr, client) = make_client();
+        let (_mgr, client) = make_client("ipc_event");
 
         let mut rx = client.subscribe(EventFilter::default()).await.unwrap();
 
@@ -290,7 +294,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(event.port_name, "ipc_test");
+        assert_eq!(event.port_name, "ipc_event");
         match event.payload {
             EventPayload::ValueChanged {
                 reason,
@@ -307,7 +311,7 @@ mod tests {
 
     #[tokio::test]
     async fn event_subscription_filtered() {
-        let (_mgr, client) = make_client();
+        let (_mgr, client) = make_client("ipc_event_filt");
 
         let mut rx = client
             .subscribe(EventFilter {

--- a/crates/asyn-rs/tests/port_driver_tests.rs
+++ b/crates/asyn-rs/tests/port_driver_tests.rs
@@ -254,23 +254,39 @@ impl PortDriver for ErrorDriver {
 // Helpers
 // ============================================================
 
+/// Per-call unique port name. Registration goes through the
+/// process-global registry, which errors on duplicates (C registerPort
+/// parity) — tests sharing one fixed name would collide when several
+/// run in the same process (`cargo test` thread mode).
+fn unique_name(prefix: &str) -> String {
+    static PORT_SEQ: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let n = PORT_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!("{prefix}_{n}")
+}
+
 fn setup_scope() -> (PortManager, asyn_rs::port_handle::PortHandle) {
     let mgr = PortManager::new();
-    let rt = mgr.register_port(TestScopeDriver::new("SCOPE")).unwrap();
+    let rt = mgr
+        .register_port(TestScopeDriver::new(&unique_name("SCOPE")))
+        .unwrap();
     let handle = rt.port_handle().clone();
     (mgr, handle)
 }
 
 fn setup_echo() -> (PortManager, asyn_rs::port_handle::PortHandle) {
     let mgr = PortManager::new();
-    let rt = mgr.register_port(EchoDriver::new("ECHO")).unwrap();
+    let rt = mgr
+        .register_port(EchoDriver::new(&unique_name("ECHO")))
+        .unwrap();
     let handle = rt.port_handle().clone();
     (mgr, handle)
 }
 
 fn setup_error() -> (PortManager, asyn_rs::port_handle::PortHandle) {
     let mgr = PortManager::new();
-    let rt = mgr.register_port(ErrorDriver::new("ERRTEST")).unwrap();
+    let rt = mgr
+        .register_port(ErrorDriver::new(&unique_name("ERRTEST")))
+        .unwrap();
     let handle = rt.port_handle().clone();
     (mgr, handle)
 }

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -1239,7 +1239,6 @@ impl RecordInstance {
         }
     }
 
-    /// Set a common field value. Returns what scan index changes are needed.
     /// `true` when the record type declares `name` in its own `field_list`,
     /// i.e. the record stores the field itself and owns whatever behaviour
     /// hangs off it.
@@ -1259,6 +1258,7 @@ impl RecordInstance {
         self.record.field_list().iter().any(|f| f.name == name)
     }
 
+    /// Set a common field value. Returns what scan index changes are needed.
     pub fn put_common_field(
         &mut self,
         name: &str,

--- a/crates/epics-ca-rs/src/repeater.rs
+++ b/crates/epics-ca-rs/src/repeater.rs
@@ -149,8 +149,27 @@ pub async fn run_repeater_with_debug(debug: u8) -> io::Result<()> {
     let mut prev_drops: u32 = 0;
 
     loop {
+        // C `repeater.cpp:589-605`: a recv error never exits the repeater —
+        // `ECONNREFUSED` (Linux ICMP bug) and `ECONNRESET` (Windows KB263823)
+        // are silently skipped, anything else is logged, and the loop always
+        // continues. A repeater client that vanished between our fan-out send
+        // and this recv otherwise killed the whole repeater.
         let (len, src, drops) =
-            epics_base_rs::net::recv_from_with_drop_count_socket(&socket, &mut buf).await?;
+            match epics_base_rs::net::recv_from_with_drop_count_socket(&socket, &mut buf).await {
+                Ok(v) => v,
+                Err(e) => {
+                    if !matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset
+                    ) {
+                        tracing::warn!(
+                            target: "epics_ca_rs::repeater",
+                            "CA Repeater: unexpected UDP recv err: {e}"
+                        );
+                    }
+                    continue;
+                }
+            };
         if drops != 0 && drops != prev_drops {
             tracing::debug!(
                 target: "epics_ca_rs::repeater",

--- a/crates/epics-ca-rs/src/server/udp.rs
+++ b/crates/epics-ca-rs/src/server/udp.rs
@@ -292,7 +292,25 @@ async fn recv_loop(
     let mut peek_buf = vec![0u8; 64 * 1024];
 
     loop {
-        let (len, src, drops) = recv_from_with_drop_count_socket(&socket, &mut buf).await?;
+        // C `cast_server.c:171-179`: a UDP recv error never exits the cast
+        // server thread — it logs and sleeps 1 s, then keeps receiving. On
+        // Windows, `WSAECONNRESET` (os error 10054) surfaces here whenever an
+        // earlier send from this socket drew an ICMP port-unreachable
+        // (KB263823); on Linux a connected-socket ICMP shows as
+        // `ECONNREFUSED`. Propagating the error instead killed the SEARCH
+        // responder for the rest of the server's life.
+        let (len, src, drops) = match recv_from_with_drop_count_socket(&socket, &mut buf).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    target: "epics_ca_rs::server::udp",
+                    %bind_ip,
+                    "CAS: UDP recv error: {e}"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                continue;
+            }
+        };
         if drops != 0 && drops != prev_drops {
             tracing::debug!(
                 target: "epics_ca_rs::server::udp",

--- a/crates/epics-ca-rs/tests/protocol_tests.rs
+++ b/crates/epics-ca-rs/tests/protocol_tests.rs
@@ -1903,49 +1903,92 @@ async fn mr_r7_rejected_queued_datagram_does_not_reparse_stale_buffer() {
     // so when the server peeks via `try_recv_from` it finds the
     // queued short junk datagram while the prior SEARCH is still in
     // `current_buf`.
-    const N: u32 = 300;
-    let first_cid = 0xC000_0000u32;
-    for i in 0..N {
-        peer.send_to(&search_datagram(first_cid + i), server_addr)
-            .await
-            .expect("send SEARCH");
-        // 8-byte datagram: below the 16-byte CA header size.
-        peer.send_to(&[0u8; 8], server_addr)
-            .await
-            .expect("send short junk datagram");
-    }
-
-    // Collect every reply datagram for up to ~1.5s, walking each
-    // 16-byte header and counting SEARCH replies per echoed cid.
+    //
+    // UDP makes no delivery promise under this burst: 600 datagrams
+    // can overflow the server socket's kernel recv queue
+    // (net.core.rmem_default ≈ 212 KB < 600 × skb truesize) and the
+    // kernel legitimately drops the excess — that is loss, not the
+    // re-parse defect this test pins. Real CA clients retry SEARCH
+    // (`searchTimer`), so unanswered slots are retried with FRESH cids
+    // each round: a kernel-dropped request cannot fail the test, while
+    // any single cid answered twice (the actual R7 regression) still
+    // can, because no cid is ever sent twice.
+    const N: usize = 300;
+    let mut answered = [false; N];
+    let mut cid_to_slot: Map<u32, usize> = Map::new();
+    // Per-cid reply count, across every cid ever sent (dup check).
     let mut counts: Map<u32, u32> = Map::new();
+    let mut next_cid = 0xC000_0000u32;
     let mut rbuf = [0u8; 64 * 1024];
-    let deadline = std::time::Instant::now() + Duration::from_millis(1500);
-    while std::time::Instant::now() < deadline {
-        match tokio::time::timeout(Duration::from_millis(200), peer.recv_from(&mut rbuf)).await {
-            Ok(Ok((got, _from))) => {
-                let mut off = 0;
-                while off + CaHeader::SIZE <= got {
-                    let Ok(h) = CaHeader::from_bytes(&rbuf[off..off + CaHeader::SIZE]) else {
-                        break;
-                    };
-                    if h.cmmd == CA_PROTO_SEARCH {
-                        *counts.entry(h.available).or_insert(0) += 1;
-                    }
-                    off += CaHeader::SIZE + ((h.postsize as usize + 7) & !7);
-                }
+
+    'rounds: for _round in 0..5 {
+        for (slot, done) in answered.iter().enumerate() {
+            if *done {
+                continue;
             }
-            Ok(Err(e)) => panic!("peer recv error: {e}"),
-            Err(_) => {
-                if counts.len() as u32 >= N {
-                    break;
+            let cid = next_cid;
+            next_cid += 1;
+            cid_to_slot.insert(cid, slot);
+            peer.send_to(&search_datagram(cid), server_addr)
+                .await
+                .expect("send SEARCH");
+            // 8-byte datagram: below the 16-byte CA header size.
+            peer.send_to(&[0u8; 8], server_addr)
+                .await
+                .expect("send short junk datagram");
+        }
+
+        // Collect this round's replies for up to ~1.5s, walking each
+        // 16-byte header and counting SEARCH replies per echoed cid.
+        let deadline = std::time::Instant::now() + Duration::from_millis(1500);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_millis(200), peer.recv_from(&mut rbuf)).await
+            {
+                Ok(Ok((got, _from))) => {
+                    let mut off = 0;
+                    while off + CaHeader::SIZE <= got {
+                        let Ok(h) = CaHeader::from_bytes(&rbuf[off..off + CaHeader::SIZE]) else {
+                            break;
+                        };
+                        if h.cmmd == CA_PROTO_SEARCH {
+                            *counts.entry(h.available).or_insert(0) += 1;
+                            if let Some(&slot) = cid_to_slot.get(&h.available) {
+                                answered[slot] = true;
+                            }
+                        }
+                        off += CaHeader::SIZE + ((h.postsize as usize + 7) & !7);
+                    }
+                }
+                // C client parity (`udpiiu.cpp:420-426`): UDP recv errors
+                // `ECONNRESET` (Windows KB263823 — an earlier send drew an
+                // ICMP port-unreachable) and `ECONNREFUSED` (Linux
+                // equivalent) are ignored and receiving continues; libca
+                // never fails on them.
+                Ok(Err(e))
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionRefused
+                    ) =>
+                {
+                    continue;
+                }
+                Ok(Err(e)) => panic!("peer recv error: {e}"),
+                Err(_) => {
+                    if answered.iter().all(|&a| a) {
+                        break;
+                    }
                 }
             }
         }
+        if answered.iter().all(|&a| a) {
+            break 'rounds;
+        }
     }
 
-    // Every valid SEARCH cid must be answered exactly once. A cid
-    // answered twice means the server re-parsed a stale `current_buf`
-    // after draining a rejected short datagram.
+    // No cid may be answered more than once. A cid answered twice means
+    // the server re-parsed a stale `current_buf` after draining a
+    // rejected short datagram — every cid is sent exactly once, so
+    // retries cannot produce a legitimate duplicate.
     let duplicated: Vec<(u32, u32)> = counts
         .iter()
         .filter(|&(_, &c)| c > 1)
@@ -1958,12 +2001,15 @@ async fn mr_r7_rejected_queued_datagram_does_not_reparse_stale_buffer() {
         duplicated.len(),
         duplicated,
     );
+    // Every slot must be answered within the retry budget. Persistent
+    // non-answers (with retries absorbing kernel drops) mean the
+    // responder died or stopped serving — e.g. the pre-fix cast server
+    // exiting its recv loop on a transient UDP recv error.
+    let unanswered = answered.iter().filter(|&&a| !a).count();
     assert_eq!(
-        counts.len() as u32,
-        N,
-        "every valid SEARCH cid must be answered exactly once \
-         (got {} distinct cids, expected {N})",
-        counts.len(),
+        unanswered, 0,
+        "{unanswered} of {N} SEARCH slots never answered across 5 send \
+         rounds — responder lost or stopped serving"
     );
 }
 

--- a/crates/modbus-rs/src/ioc.rs
+++ b/crates/modbus-rs/src/ioc.rs
@@ -1660,7 +1660,10 @@ impl CommandHandler for ModbusConfigHandler {
 
         let (runtime, _jh) = create_port_runtime(driver, RuntimeConfig::default());
         let port_handle = runtime.port_handle().clone();
-        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone());
+        // On a duplicate port name the runtime handle drops here, shutting
+        // the just-spawned actor down.
+        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
+            .map_err(|e| e.to_string())?;
         keep_runtime(runtime);
 
         println!("drvModbusAsynConfigure: port='{port_name}' octet='{octet_port}' link={link:?}");

--- a/crates/mqtt-rs/src/ioc.rs
+++ b/crates/mqtt-rs/src/ioc.rs
@@ -161,7 +161,10 @@ impl CommandHandler for MqttConfigHandler {
         let (runtime_handle, _actor_jh) = create_port_runtime(driver, RuntimeConfig::default());
         let port_handle = runtime_handle.port_handle().clone();
 
-        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone());
+        // On a duplicate port name the runtime handle drops here, shutting
+        // the just-spawned actor down.
+        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
+            .map_err(|e| e.to_string())?;
 
         // Keep the runtime handle alive — dropping it shuts down the actor
         keep_runtime(runtime_handle);

--- a/examples/mini-beamline/src/bin/mini_ioc.rs
+++ b/examples/mini-beamline/src/bin/mini_ioc.rs
@@ -199,7 +199,8 @@ async fn main() -> CaResult<()> {
                     let rt = point_detector::create_point_detector(port, *mode)
                         .map_err(|e| format!("failed to create PointDetector {port}: {e}"))?;
                     let port_handle = rt.port_handle().clone();
-                    asyn_rs::asyn_record::register_port(port, port_handle, h.trace.clone());
+                    asyn_rs::asyn_record::register_port(port, port_handle, h.trace.clone())
+                        .map_err(|e| e.to_string())?;
                     h.pd_runtimes.lock().unwrap().insert(port.to_string(), rt);
                     println!("  PointDetector '{port}' created");
                 }
@@ -235,7 +236,8 @@ async fn main() -> CaResult<()> {
                 )
                 .map_err(|e| format!("failed to create MovingDot: {e}"))?;
                 let dot_handle = dot_rt.port_handle().clone();
-                asyn_rs::asyn_record::register_port("DOT", dot_handle, h.trace.clone());
+                asyn_rs::asyn_record::register_port("DOT", dot_handle, h.trace.clone())
+                    .map_err(|e| e.to_string())?;
 
                 // Connect MovingDot as the data source for the plugin chain
                 // (NDStdArraysConfigure etc. will call connect_downstream on this)

--- a/examples/scope-ioc/src/bin/scope_ioc.rs
+++ b/examples/scope-ioc/src/bin/scope_ioc.rs
@@ -61,7 +61,8 @@ impl CommandHandler for ConfigHandler {
 
         // Register port in global registry so universal asyn device support can find it
         let port_handle = runtime_handle.port_handle().clone();
-        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone());
+        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
+            .map_err(|e| e.to_string())?;
 
         // Start background simulation task using the PortHandle API
         let sim_notify = notify.clone();

--- a/examples/sim-detector/src/ioc_support.rs
+++ b/examples/sim-detector/src/ioc_support.rs
@@ -46,7 +46,8 @@ pub fn register(ioc: &mut ad_plugins_rs::ioc::AdIoc) {
 
                 let port_handle = runtime.port_handle().clone();
 
-                asyn_rs::asyn_record::register_port(&port_name, port_handle, trace.clone());
+                asyn_rs::asyn_record::register_port(&port_name, port_handle, trace.clone())
+                    .map_err(|e| e.to_string())?;
 
                 mgr.set_driver(Arc::new(GenericDriverContext::new(
                     runtime.pool().clone(),

--- a/examples/xrt-beamline/src/bin/xrt_ioc.rs
+++ b/examples/xrt-beamline/src/bin/xrt_ioc.rs
@@ -152,7 +152,8 @@ async fn main() -> CaResult<()> {
                         .map_err(|e| format!("failed to create XRT detector: {e}"))?;
 
                 let xrt_handle = xrt_rt.port_handle().clone();
-                asyn_rs::asyn_record::register_port("XRT", xrt_handle, h.trace.clone());
+                asyn_rs::asyn_record::register_port("XRT", xrt_handle, h.trace.clone())
+                    .map_err(|e| e.to_string())?;
 
                 mgr_c.set_driver(Arc::new(ad_core_rs::ioc::GenericDriverContext::new(
                     xrt_rt.pool().clone(),


### PR DESCRIPTION
Two findings, one commit each (both were listed UNFIXED in the v0.23.0 release report).

## 1. windows-arm64 `epics-ca-rs` 10054 flake — root causes fixed (44b0f109)

`mr_r7_rejected_queued_datagram_does_not_reparse_stale_buffer` flaked with two distinct signatures, one per platform:

**Windows death mode (production defect).** The cast server (`server/udp.rs`) and the repeater (`repeater.rs`) propagated UDP recv errors with `?`, exiting the loop. On Windows, `WSAECONNRESET` (os error 10054, KB263823) is queued onto a UDP socket whenever an earlier send drew an ICMP port-unreachable — so one transient error killed the SEARCH responder for the rest of the server's life (the observed `0 distinct cids` try, and peer-side 10054 when subsequent sends hit the dead port). C never dies here:

- `cast_server.c:171-179` — log + sleep 1 s + continue (now mirrored in `server/udp.rs`)
- `repeater.cpp:589-605` — skip `ECONNREFUSED`/`ECONNRESET` silently, log anything else, always continue (now mirrored in `repeater.rs`)

Family audit: the client search loop and all three PVA UDP loops already continue on error (`udpiiu.cpp:420-426` parity); `repeater.rs`'s bounded confirm-wait correctly treats an error as not-confirmed (`repeater.cpp:180-189`); `async_udp_v4.rs` primitives are one-shot recvs where propagation is the correct layering.

**Linux loss mode (test-structure defect).** The 600-datagram burst can overflow the server socket's kernel recv queue (`net.core.rmem_default` < 600 × skb truesize) and the kernel legitimately drops requests — reproduced on unmodified main at **4/20 local runs** (278–282 of 300 cids, zero duplicates). The test assumed lossless UDP. Real CA clients retry SEARCH, so the test now retries unanswered slots with **fresh cids** (≤5 rounds): kernel drops cannot fail it, while a duplicated reply for any single cid — the R7 re-parse regression it pins — still can, since no cid is ever sent twice. The peer also ignores `ECONNRESET`/`ECONNREFUSED` on recv, as libca does.

## 2. CI: rerun of an old main run cancelled the head run (cc9a63c5)

`gh run rerun --failed` on an older main run re-enters the `cross-platform-refs/heads/main` concurrency group and, with `cancel-in-progress: true`, cancels the in-progress run for the newer commit (observed twice on 2026-07-12). Now `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` — PR branches keep supersede-cancel, main runs coexist.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run -p epics-ca-rs` — 447/447; `--workspace` — 7424 passed, 2 skipped (pre-existing `#[ignore]`)
- previously flaky test: baseline 4/20 failed → **30/30 multi-core, 15/15 single-CPU (`taskset -c 0`)** after the fix

---

## Added: two minor findings from the PR #12 / #15 reviews (one commit each)

## 3. `put_common_field` doc line was heading `record_declares_field` (cbda8464)

The one-line summary of `put_common_field` was left atop the later-inserted `record_declares_field` helper in `record_instance.rs`, leaving `put_common_field` undocumented and the helper with a wrong first doc line. Doc-only move.

## 4. asyn port registry silently overwrote duplicate names (85ab826f)

C parity: `asynManager::registerPort` errors on a duplicate port name; `PortRegistry::register` silently replaced the entry, orphaning the prior handle, and `PortManager` checked duplicates only against its own map — a name published by any other creator (`drvAsyn*PortConfigure`, plugin ports, hand-registered ports) was silently shadowed.

Structural fix: `PortRegistry::register` is now insert-if-absent returning `PortAlreadyRegistered`, making the registry the single owner of the name-uniqueness invariant. The registry insert is `PortManager`'s atomic claim (a lost race tears the just-built runtime down). All 20 registration sites audited and updated: iocsh/NDPlugin configure commands print + continue (a failed configure does not abort iocsh, as in C); mqtt/modbus/example handlers propagate; `PluginManager::add_plugin`/`add_port` became fallible and store nothing for a refused plugin. New boundary tests: registry duplicate rejection, remove-then-reregister, and manager-vs-process-registry duplicate. Tests sharing fixed port names got unique names (same-name tests in one process now collide by design; verified green under both nextest and plain `cargo test`).

### Verification (added commits)

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7427 passed, 2 skipped
- single-process runs (`cargo test`): asyn-rs 691+20+1, std-rs epid_tests 59, ad-core-rs 233, ad-plugins-rs 448, mqtt-rs 106, epics-modbus-rs 76 — all pass
