### PR TITLE
fix(asyn): dropping a PortRuntimeHandle must not kill a reachable port

### DIFF
--- a/crates/asyn-rs/src/iocsh.rs
+++ b/crates/asyn-rs/src/iocsh.rs
@@ -601,21 +601,6 @@ pub fn build_asyn_commands(mgr: Arc<PortManager>) -> Vec<CommandDef> {
     out
 }
 
-/// Keeps the [`PortRuntimeHandle`]s created by the port-configure iocsh
-/// commands (`drvAsynIPPortConfigure`, `drvAsynSerialPortConfigure`)
-/// alive for the process lifetime. Dropping a handle shuts the port's
-/// actor thread down, so a startup-script-created port must be parked
-/// somewhere with a 'static lifetime.
-static PORT_RUNTIMES: OnceLock<Mutex<Vec<PortRuntimeHandle>>> = OnceLock::new();
-
-fn keep_port_runtime(handle: PortRuntimeHandle) {
-    PORT_RUNTIMES
-        .get_or_init(|| Mutex::new(Vec::new()))
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .push(handle);
-}
-
 /// Build the `drvAsynIPPortConfigure` iocsh command.
 ///
 /// C parity: `drvAsynIPPort.c::drvAsynIPPortConfigure(portName,
@@ -705,7 +690,9 @@ pub fn drv_asyn_ip_port_configure_command(trace: Arc<TraceManager>) -> CommandDe
 
             let (handle, _jh) = create_port_runtime(driver, RuntimeConfig::default());
             crate::asyn_record::register_port(&port, handle.port_handle().clone(), trace.clone());
-            keep_port_runtime(handle);
+            // The registry above holds a live `PortHandle` for this port, which is
+            // what keeps its actor alive; the `PortRuntimeHandle` may drop here.
+            drop(handle);
             ctx.println(&format!(
                 "drvAsynIPPortConfigure: octet port '{port}' -> {host}"
             ));
@@ -781,7 +768,9 @@ pub fn drv_asyn_serial_port_configure_command(trace: Arc<TraceManager>) -> Comma
 
             let (handle, _jh) = create_port_runtime(driver, RuntimeConfig::default());
             crate::asyn_record::register_port(&port, handle.port_handle().clone(), trace.clone());
-            keep_port_runtime(handle);
+            // The registry above holds a live `PortHandle` for this port, which is
+            // what keeps its actor alive; the `PortRuntimeHandle` may drop here.
+            drop(handle);
             ctx.println(&format!(
                 "drvAsynSerialPortConfigure: octet port '{port}' -> {tty}"
             ));
@@ -851,7 +840,9 @@ pub fn drv_asyn_prologix_port_configure_command(trace: Arc<TraceManager>) -> Com
 
             let (handle, _jh) = create_port_runtime(driver, RuntimeConfig::default());
             crate::asyn_record::register_port(&port, handle.port_handle().clone(), trace.clone());
-            keep_port_runtime(handle);
+            // The registry above holds a live `PortHandle` for this port, which is
+            // what keeps its actor alive; the `PortRuntimeHandle` may drop here.
+            drop(handle);
             ctx.println(&format!(
                 "prologixGPIBConfigure: GPIB port '{port}' -> {host}"
             ));

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -139,28 +139,56 @@ impl PortActor {
     /// Run the actor loop with a dedicated shutdown channel.
     /// Calls `shutdown()` on the driver before returning.
     ///
-    /// Returns when either:
-    /// - The main request channel is closed (all senders dropped)
-    /// - The shutdown channel is closed (shutdown signaled)
+    /// A port stops for exactly two reasons, and dropping a
+    /// [`PortRuntimeHandle`](crate::runtime::port::PortRuntimeHandle) is
+    /// neither of them:
+    ///
+    /// - **Someone asked it to.** An explicit shutdown *sends* `()` on the
+    ///   shutdown channel (`PortRuntimeHandle::shutdown`). It outranks every
+    ///   outstanding handle: the port stops even while other `PortHandle`s
+    ///   could still reach it.
+    /// - **Nobody can reach it any more.** The request channel closed, i.e.
+    ///   the last `PortHandle` was dropped. No request can ever arrive again,
+    ///   so stopping is unobservable.
+    ///
+    /// The shutdown channel *closing* (every `PortRuntimeHandle` dropped) is
+    /// deliberately NOT a stop condition. It used to be — closing was the only
+    /// shutdown signal — which conflated "the creator dropped its handle" with
+    /// "shut this port down" and killed ports that the registry still held a
+    /// live `PortHandle` for.
     pub fn run_with_shutdown(mut self, mut shutdown_rx: mpsc::Receiver<()>) {
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();
         rt.block_on(async {
+            // Once every PortRuntimeHandle is gone no explicit shutdown can
+            // ever arrive, so the (now permanently ready) shutdown branch is
+            // disabled rather than spun on.
+            let mut can_be_shut_down = true;
             loop {
                 // Drain all pending messages into the heap
                 self.drain_channel();
 
                 if self.heap.is_empty() {
-                    // Wait for either a message or shutdown
+                    // Wait for a request, or for an explicit shutdown
                     tokio::select! {
                         msg = self.rx.recv() => {
                             match msg {
                                 Some(m) => self.enqueue_message(m),
+                                // Unreachable: the last PortHandle is gone.
                                 None => break,
                             }
                         }
-                        _ = shutdown_rx.recv() => break,
+                        signal = shutdown_rx.recv(), if can_be_shut_down => {
+                            match signal {
+                                // Explicit shutdown.
+                                Some(()) => break,
+                                // Every PortRuntimeHandle was dropped. Not a
+                                // shutdown — keep serving whoever still holds
+                                // a PortHandle.
+                                None => can_be_shut_down = false,
+                            }
+                        }
                     }
                     // Drain any more that arrived
                     self.drain_channel();

--- a/crates/asyn-rs/src/runtime/port.rs
+++ b/crates/asyn-rs/src/runtime/port.rs
@@ -14,12 +14,24 @@ use super::config::RuntimeConfig;
 use super::event::RuntimeEvent;
 
 /// Handle to a running PortRuntime. Provides shutdown and event subscription.
+///
+/// **Dropping this handle does not stop the port.** A port stops only when it
+/// is explicitly shut down ([`Self::shutdown`], [`Self::shutdown_and_wait`]) or
+/// when nothing can reach it any more — that is, when its last [`PortHandle`]
+/// is dropped. So publishing a port's `PortHandle` (to the
+/// [`crate::asyn_record`] registry, a [`crate::manager::PortManager`], a
+/// driver) is by itself enough to keep the port alive for as long as that
+/// publication lives; no caller has to park the runtime handle in a static to
+/// stop the actor thread from dying underneath it.
 #[derive(Clone)]
 pub struct PortRuntimeHandle {
     port_handle: PortHandle,
     client: InProcessClient,
     event_tx: broadcast::Sender<RuntimeEvent>,
-    /// Dropping this sender closes the shutdown channel, signaling the actor to exit.
+    /// Carries an explicit shutdown *request* to the actor. The actor stops on
+    /// a `()` **sent** here — never on this channel closing, which merely means
+    /// the last `PortRuntimeHandle` went away (see
+    /// `PortActor::run_with_shutdown`).
     shutdown_tx: Arc<std::sync::Mutex<Option<mpsc::Sender<()>>>>,
     /// Receives a single () when the actor thread exits. Used by shutdown_and_wait().
     completion_rx: Arc<std::sync::Mutex<Option<std::sync::mpsc::Receiver<()>>>>,
@@ -44,15 +56,24 @@ impl PortRuntimeHandle {
 
     /// Signal the runtime to shut down (non-blocking).
     ///
-    /// Closes the shutdown channel, causing the actor thread to exit after
-    /// completing any in-progress request. Does not wait for the thread to stop.
+    /// Sends an explicit shutdown request; the actor thread exits after
+    /// completing any in-progress request. Does not wait for the thread to
+    /// stop. This outranks reachability: the port stops even while other
+    /// `PortHandle`s (a registry entry, a device-support binding) could still
+    /// submit to it, and those submissions then fail — which is the point of
+    /// asking for a shutdown.
+    ///
+    /// Repeated calls are harmless: the request is already queued (or the actor
+    /// has already gone), and both are a no-op.
     pub fn shutdown(&self) {
         // Poison-tolerant: shutdown must stay infallible even if a thread
         // panicked while holding the lock.
-        self.shutdown_tx
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .take();
+        let guard = self.shutdown_tx.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(tx) = guard.as_ref() {
+            // Capacity-1 channel: `Full` means a shutdown is already queued,
+            // `Closed` means the actor has already stopped. Neither is an error.
+            let _ = tx.try_send(());
+        }
     }
 
     /// Signal shutdown and wait for the actor thread to exit.

--- a/crates/asyn-rs/tests/port_runtime_lifetime.rs
+++ b/crates/asyn-rs/tests/port_runtime_lifetime.rs
@@ -1,0 +1,143 @@
+//! A registered port must not die because whoever created it dropped its
+//! [`PortRuntimeHandle`].
+//!
+//! `create_port_runtime` hands back a `PortRuntimeHandle`. An iocsh port-create
+//! command — in this crate or in any downstream IOC crate — publishes the
+//! port's `PortHandle` to the registry and then returns, dropping its
+//! `PortRuntimeHandle` at the end of the closure. That drop used to close the
+//! actor's shutdown channel, killing the port: every later request through the
+//! registry failed with "actor channel closed for port …".
+//!
+//! Staying alive must be a property of the port being *reachable*, not of
+//! someone remembering to park the runtime handle in a static.
+
+use std::time::Duration;
+
+use asyn_rs::asyn_record::{get_port, register_port};
+use asyn_rs::param::ParamType;
+use asyn_rs::port::{PortDriver, PortDriverBase, PortFlags};
+use asyn_rs::port_handle::PortHandle;
+use asyn_rs::runtime::config::RuntimeConfig;
+use asyn_rs::runtime::port::create_port_runtime;
+use asyn_rs::trace::TraceManager;
+use std::sync::Arc;
+
+/// Blocking I/O below must fail, never hang, if this regresses.
+const WATCHDOG: Duration = Duration::from_secs(10);
+
+/// Run `f` on a scratch thread, failing (never hanging) if it does not finish
+/// within [`WATCHDOG`]. A panic inside `f` is re-raised as a panic here, so a
+/// regression is reported as the assertion that actually failed rather than as
+/// a timeout.
+fn with_watchdog<T: Send + 'static>(what: &str, f: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name(format!("watchdog-{what}"))
+        .spawn(move || {
+            let _ = tx.send(std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)));
+        })
+        .expect("spawn");
+    match rx.recv_timeout(WATCHDOG) {
+        Ok(Ok(value)) => value,
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(_) => panic!("{what} hung (no result within {WATCHDOG:?})"),
+    }
+}
+
+struct TestPort {
+    base: PortDriverBase,
+}
+
+impl TestPort {
+    fn new(name: &str) -> Self {
+        let mut base = PortDriverBase::new(name, 1, PortFlags::default());
+        base.create_param("VAL", ParamType::Int32).unwrap();
+        Self { base }
+    }
+}
+
+impl PortDriver for TestPort {
+    fn base(&self) -> &PortDriverBase {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut PortDriverBase {
+        &mut self.base
+    }
+}
+
+/// Exactly what an out-of-tree `drvAsynXxxPortConfigure` does: create the port,
+/// publish it, return. The `PortRuntimeHandle` dies with the closure.
+fn configure_port_like_iocsh(name: &str) {
+    let (runtime, _join) = create_port_runtime(TestPort::new(name), RuntimeConfig::default());
+    register_port(
+        name,
+        runtime.port_handle().clone(),
+        Arc::new(TraceManager::new()),
+    );
+    // `runtime` (and the actor thread's JoinHandle) drop here — the only thing
+    // still reaching this port is the registry's PortHandle.
+}
+
+/// The defect. On unfixed main every request after the closure returns fails
+/// with `actor channel closed for port drop_survivor`.
+#[test]
+fn registered_port_survives_drop_of_its_runtime_handle() {
+    configure_port_like_iocsh("drop_survivor");
+
+    let entry = get_port("drop_survivor").expect("port registered");
+    let port: PortHandle = entry.handle.clone();
+
+    with_watchdog("registered-port-io", move || {
+        port.write_int32_blocking(0, 0, 42)
+            .expect("write must succeed: the registry still reaches this port");
+        assert_eq!(
+            port.read_int32_blocking(0, 0)
+                .expect("read must succeed: the registry still reaches this port"),
+            42
+        );
+    });
+}
+
+/// Explicit shutdown is still explicit: it stops the actor even while other
+/// `PortHandle`s (here, the registry's) can still reach the port. Dropping a
+/// runtime handle must not be a shutdown, but calling `shutdown_and_wait` must.
+#[test]
+fn explicit_shutdown_still_stops_a_registered_port() {
+    let (runtime, _join) = create_port_runtime(
+        TestPort::new("explicit_shutdown_reg"),
+        RuntimeConfig::default(),
+    );
+    register_port(
+        "explicit_shutdown_reg",
+        runtime.port_handle().clone(),
+        Arc::new(TraceManager::new()),
+    );
+    let registry_handle: PortHandle = get_port("explicit_shutdown_reg").unwrap().handle.clone();
+
+    // Alive before.
+    registry_handle.write_int32_blocking(0, 0, 1).unwrap();
+
+    with_watchdog("explicit-shutdown", move || runtime.shutdown_and_wait());
+
+    // Dead after — an explicit shutdown outranks any outstanding handle.
+    with_watchdog("post-shutdown-io", move || {
+        assert!(
+            registry_handle.write_int32_blocking(0, 0, 2).is_err(),
+            "an explicitly shut-down port must refuse further requests"
+        );
+    });
+}
+
+/// A port nobody can reach any more must still stop its actor thread — the
+/// fix must not leak a thread per created-and-forgotten port.
+#[test]
+fn unreachable_port_stops_its_actor_thread() {
+    let (runtime, join) =
+        create_port_runtime(TestPort::new("unreachable"), RuntimeConfig::default());
+    // No registry entry, no surviving PortHandle clone.
+    drop(runtime);
+    with_watchdog("unreachable-join", move || {
+        join.join()
+            .expect("actor thread must exit once nothing can reach the port");
+    });
+}


### PR DESCRIPTION
## The defect

`create_port_runtime` returns a `PortRuntimeHandle`. Its **drop** shut the port down, because the shutdown signal was the shutdown channel *closing* — so "the last runtime handle went out of scope" and "shut this port down" were literally the same event.

A port-create iocsh command publishes the port's `PortHandle` to the registry and returns. The `PortRuntimeHandle` drops at the end of the closure, and the port dies under the registry's feet. Every later request:

```
Status { status: Error, message: "actor channel closed for port drop_survivor" }
```

asyn-rs's own `drvAsynIPPortConfigure` / `drvAsynSerialPortConfigure` / `prologixGPIBConfigure` escaped this only because they parked the handle in a process-lifetime static (`keep_port_runtime`). So the API handed every out-of-tree port creator a live grenade whose pin was "remember to call `keep_port_runtime`". Confirmed at six downstream sites (syringepump-ioc, love-ioc, delaygen-ioc); in-tree, `ad-core`'s `plugin_manager` (`port_runtimes: Mutex<Vec<PortRuntimeHandle>>`) and `ad-plugins`' `time_series` each re-invent the same "store it so the actor stays alive" convention.

## The fix — remove the dual meaning, don't document it

An explicit shutdown now **sends** `()` on the shutdown channel. The channel *closing* is no longer a stop condition. A port stops for exactly two reasons, and dropping a `PortRuntimeHandle` is neither:

- **Someone asked it to** (`shutdown` / `shutdown_and_wait`). This outranks reachability: the port stops even while other `PortHandle`s could still submit to it — which is the point of asking.
- **Nothing can reach it any more** — its last `PortHandle` dropped, so the request channel closed. No request can ever arrive again, so stopping is unobservable.

Publishing a port's `PortHandle` — to the `asyn_record` registry, a `PortManager`, a driver — is now *by itself* sufficient to keep the port alive for as long as that publication lives. That is what every caller already believed, and it is now true by construction: a port that is still reachable cannot be dead. `keep_port_runtime` and its `PORT_RUNTIMES` static are deleted; the convention they encoded is now the ownership model's job.

This is the "handle is not droppable in a way that kills a registered port" shape rather than "registration takes ownership of the runtime handle". It is strictly stronger: it protects *every* reachable port, not only ports that happen to go through one registry, so the six downstream sites and the two in-tree keep-it-alive conventions are all covered by the same rule, and a downstream crate that never registers anything but keeps a `PortHandle` is covered too. It is also fully additive — no in-tree caller changes signature.

## API / semantic change (please review)

**`PortRuntimeHandle::drop` is no longer a shutdown.**

- Code that relied on `drop(handle)` to stop a port **still works whenever that handle owned the only `PortHandle`** — the port becomes unreachable and stops anyway. The pre-existing `port_runtime_shutdown` unit test (which asserts exactly this, by dropping the handle and joining the actor thread) passes unchanged, now for the right reason.
- Code that dropped a runtime handle to stop a port that *other* handles could still reach must now call `shutdown()` explicitly. Nothing in-tree did this.

The `unreachable_port_stops_its_actor_thread` regression test pins the no-thread-leak half: a created-and-forgotten port still exits its actor thread.

## Regression tests

`crates/asyn-rs/tests/port_runtime_lifetime.rs`, each with a 10s watchdog so a regression fails rather than hanging CI.

**On unfixed main (56a6dbf):**

```
running 3 tests
test unreachable_port_stops_its_actor_thread ... ok
test registered_port_survives_drop_of_its_runtime_handle ... FAILED
test explicit_shutdown_still_stops_a_registered_port ... ok

---- registered_port_survives_drop_of_its_runtime_handle ----
thread 'watchdog-registered-port-io' panicked at tests/port_runtime_lifetime.rs:81:14:
write must succeed: the registry still reaches this port:
Status { status: Error, message: "actor channel closed for port drop_survivor" }

test result: FAILED. 2 passed; 1 failed
```

The other two pass on main by construction and are there to pin the halves the fix must NOT break (explicit shutdown still stops a port that the registry can still reach; an unreachable port still stops its thread). **With the fix: 3 passed.**

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7427 passed, 2 skipped
- `cargo test --doc --workspace` — pass

Note on flakes: the workspace contains load-sensitive network/timing tests (`epics-pva-rs::stability`, `epics-ca-rs::protocol_tests`, `epics-bridge-rs::ca_gateway`, `regression-ioc::families c_periodic_scan_runs`) that flake under scheduling pressure. This is **pre-existing and unrelated**: pristine main run with `-j 32` fails 3 runs out of 4 across five different such tests, and three of the four I saw flake on this branch live in crates (`epics-ca-rs`, `epics-bridge-rs`) that do not link `asyn-rs` at all. Reported here, not addressed.
