### PR TITLE
fix(base): pick the blocking mechanism by runtime flavor in get_pv_blocking

### DIFF
--- a/crates/epics-base-rs/src/runtime/task.rs
+++ b/crates/epics-base-rs/src/runtime/task.rs
@@ -1,9 +1,84 @@
 use std::future::Future;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
 use std::time::Duration;
+use tokio::runtime::RuntimeFlavor;
 use tokio::task::JoinHandle;
 
 pub use tokio::runtime::Handle as RuntimeHandle;
 pub use tokio::time::interval;
+
+/// A synchronous caller asked to block on an async operation from a thread
+/// where blocking cannot be made sound: a **current-thread** tokio runtime.
+///
+/// Parking that thread stops every task on that runtime, including whichever
+/// one holds the state the awaited future is waiting for — so the block would
+/// never be woken. No blocking mechanism can fix this; the caller has to `await`
+/// the async operation instead of blocking on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NotBlockable;
+
+impl std::fmt::Display for NotBlockable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("cannot block a current-thread runtime")
+    }
+}
+
+impl std::error::Error for NotBlockable {}
+
+/// Drive `fut` to completion on this thread, parking between polls.
+///
+/// The future must only await runtime-agnostic primitives (`tokio::sync`
+/// locks/channels/notifies): nothing here drives a reactor or a timer wheel, so
+/// whoever wakes us must be running on some other thread.
+fn park_on<F: Future>(fut: F) -> F::Output {
+    struct ThreadWaker(std::thread::Thread);
+    impl Wake for ThreadWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.unpark();
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.unpark();
+        }
+    }
+
+    let mut fut = std::pin::pin!(fut);
+    let waker = Waker::from(Arc::new(ThreadWaker(std::thread::current())));
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        if let Poll::Ready(value) = fut.as_mut().poll(&mut cx) {
+            return value;
+        }
+        std::thread::park();
+    }
+}
+
+/// Block the calling thread on `fut`, picking the mechanism that is sound for
+/// the thread we are actually on.
+///
+/// This is the single owner of "sync call over async state" in this crate; the
+/// three caller contexts are not interchangeable and picking one mechanism for
+/// all of them is what makes such bridges panic:
+///
+/// - **No runtime entered** (a plain `std::thread`, an iocsh thread) — park the
+///   thread. Nothing else runs here, so there is nothing to starve; the tasks
+///   that will wake us live on some other runtime's threads.
+/// - **Multi-thread runtime worker** — [`tokio::task::block_in_place`], which
+///   hands this worker's remaining tasks to a sibling before it is parked.
+/// - **Current-thread runtime** — [`Err(NotBlockable)`](NotBlockable). Parking
+///   the only thread of that runtime halts every task on it, including the one
+///   that would wake us. This is unsound for *any* blocking mechanism, so it is
+///   reported to the caller instead of being panicked on (today) or deadlocked
+///   on (the worse alternative).
+pub fn block_on_sync<F: Future>(fut: F) -> Result<F::Output, NotBlockable> {
+    match RuntimeHandle::try_current() {
+        Ok(handle) => match handle.runtime_flavor() {
+            RuntimeFlavor::CurrentThread => Err(NotBlockable),
+            _ => Ok(tokio::task::block_in_place(|| handle.block_on(fut))),
+        },
+        Err(_) => Ok(park_on(fut)),
+    }
+}
 
 pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
 where

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -37,23 +37,24 @@ fn coerce_write_value(
 }
 
 impl PvDatabase {
-    /// Get a PV value synchronously from a blocking thread.
+    /// Get a PV value synchronously, from a thread that cannot `await`.
     ///
-    /// Uses `block_in_place` + `Handle::block_on` to bridge the async
-    /// `get_pv` call. Safe to call from std::threads spawned within
-    /// a tokio runtime context.
+    /// Works from a plain thread with no runtime entered (an iocsh thread, a
+    /// driver's own thread) and from a multi-threaded runtime worker; see
+    /// [`crate::runtime::task::block_on_sync`] for which mechanism is used
+    /// where.
+    ///
+    /// Returns an error on a **current-thread** runtime, where blocking cannot
+    /// be made sound: parking that runtime's only thread halts the task holding
+    /// the database lock this call awaits. Such callers must `await`
+    /// [`Self::get_pv`] instead.
     pub fn get_pv_blocking(&self, name: &str) -> CaResult<EpicsValue> {
-        let db = self.clone();
-        let name = name.to_string();
-        if crate::runtime::task::RuntimeHandle::try_current().is_ok() {
-            crate::__tokio::task::block_in_place(|| {
-                crate::runtime::task::RuntimeHandle::current().block_on(db.get_pv(&name))
-            })
-        } else {
+        crate::runtime::task::block_on_sync(self.get_pv(name)).unwrap_or_else(|_| {
             Err(CaError::InvalidValue(
-                "no runtime for get_pv_blocking".into(),
+                "get_pv_blocking cannot block a current-thread runtime; await get_pv() instead"
+                    .into(),
             ))
-        }
+        })
     }
 
     /// Get the current value of a PV or record field.

--- a/crates/epics-base-rs/tests/get_pv_blocking_contexts.rs
+++ b/crates/epics-base-rs/tests/get_pv_blocking_contexts.rs
@@ -1,0 +1,117 @@
+//! `PvDatabase::get_pv_blocking` across caller contexts.
+//!
+//! It is a sync bridge over the async `get_pv`, and whether blocking is sound
+//! depends entirely on which thread the caller is on:
+//!
+//! - **No tokio runtime** (a plain `std::thread`) — sound. `get_pv` awaits only
+//!   `tokio::sync` primitives; whoever holds them is a task on some *other*
+//!   runtime's threads and keeps running while we park. This is the one context
+//!   the name "blocking" is actually for, and it is the one the old code
+//!   *rejected* outright ("no runtime for get_pv_blocking").
+//! - **Multi-threaded runtime** — sound via `block_in_place`, which hands this
+//!   worker's other tasks to a sibling before we park it.
+//! - **Current-thread runtime** — NOT soundly blockable. Parking the thread
+//!   halts every task on that runtime, including whichever one holds the
+//!   database lock we are about to await. The old code called `block_in_place`,
+//!   which panics there.
+
+use std::time::Duration;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::types::EpicsValue;
+
+const WATCHDOG: Duration = Duration::from_secs(10);
+
+/// Never let a regression hang CI: run on a scratch thread with a deadline and
+/// re-raise a panic as a panic.
+fn with_watchdog<T: Send + 'static>(what: &str, f: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name(format!("watchdog-{what}"))
+        .spawn(move || {
+            let _ = tx.send(std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)));
+        })
+        .expect("spawn");
+    match rx.recv_timeout(WATCHDOG) {
+        Ok(Ok(value)) => value,
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(_) => panic!("{what} hung (no result within {WATCHDOG:?})"),
+    }
+}
+
+async fn db_with_pv() -> PvDatabase {
+    let db = PvDatabase::new();
+    db.add_pv("BLOCKING:PV", EpicsValue::Long(7)).await.unwrap();
+    db
+}
+
+/// The context the API exists for: a plain thread with no runtime entered.
+///
+/// On unfixed main this returns
+/// `Err(InvalidValue("no runtime for get_pv_blocking"))` — the predicate is
+/// inverted, refusing the one caller it can safely serve.
+#[test]
+fn get_pv_blocking_from_a_plain_thread_succeeds() {
+    let db = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(db_with_pv());
+
+    with_watchdog("plain-thread", move || {
+        // No runtime is entered on this thread.
+        assert!(tokio::runtime::Handle::try_current().is_err());
+        let value = db
+            .get_pv_blocking("BLOCKING:PV")
+            .expect("a plain thread is exactly the context this API is for");
+        assert_eq!(value, EpicsValue::Long(7));
+    });
+}
+
+/// A multi-threaded worker stays supported: `block_in_place` yields this worker
+/// before parking it, so the tasks that hold the database locks keep running.
+#[test]
+fn get_pv_blocking_from_multi_thread_runtime_succeeds() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let db = rt.block_on(db_with_pv());
+
+    rt.block_on(async move {
+        let value = tokio::task::spawn_blocking(move || db.get_pv_blocking("BLOCKING:PV"))
+            .await
+            .unwrap()
+            .expect("multi-thread runtime must keep working");
+        assert_eq!(value, EpicsValue::Long(7));
+    });
+}
+
+/// A current-thread runtime cannot be blocked soundly: parking its only thread
+/// stops every task on it, including whichever holds the lock we would await.
+/// This must be an ERROR naming the async alternative — not a panic (today), and
+/// not a silent deadlock.
+///
+/// On unfixed main this panics:
+/// `can call blocking only when running on the multi-threaded runtime`.
+#[test]
+fn get_pv_blocking_from_current_thread_runtime_errors() {
+    with_watchdog("current-thread", || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let db = db_with_pv().await;
+            let err = db
+                .get_pv_blocking("BLOCKING:PV")
+                .expect_err("a current-thread runtime cannot be blocked soundly");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("get_pv"),
+                "the error must name the async alternative, got: {msg}"
+            );
+        });
+    });
+}


### PR DESCRIPTION
`PvDatabase::get_pv_blocking` (`crates/epics-base-rs/src/server/database/field_io.rs:45`) decided whether it could block by asking *"is a tokio runtime entered on this thread?"*. That is the wrong question — the mechanism that is sound depends on the runtime **flavor**, not on its presence — and the old code got both answers backwards:

```rust
if RuntimeHandle::try_current().is_ok() {
    block_in_place(|| RuntimeHandle::current().block_on(db.get_pv(&name)))
} else {
    Err(CaError::InvalidValue("no runtime for get_pv_blocking".into()))
}
```

* **No runtime entered** — a plain `std::thread`: an iocsh thread (`ioc_app.rs:671` deliberately runs the startup script on one), a driver's own thread. This is the context a `_blocking` API exists for, and it is sound: `get_pv` awaits only `tokio::sync` primitives, whose wakers are driven by tasks on *other* runtimes' threads, so parking this thread starves nothing. The old code **refused** it outright.
* **Current-thread runtime** — the one context that cannot be blocked by any mechanism: parking that runtime's only thread halts every task on it, including whichever one holds the database lock the call is about to await, so the wake can never arrive. The old code called `block_in_place`, which **panics** there. This is not exotic — `#[epics::test]` builds a current-thread runtime (`epics-macros-rs/src/lib.rs:170`), as does every per-driver port runtime (`asyn-rs/src/port_actor.rs:146`).
* **Multi-thread worker** — soundly blockable via `block_in_place`, which hands this worker's other tasks to a sibling before parking it. The only case the old code got right.

## Fix — structural, not a corrected predicate

The defect is that the flavor decision was made ad-hoc at the call site. It now has a single owner, `epics_base_rs::runtime::task::block_on_sync`, which maps each caller context to the mechanism that is sound for it and is the crate's one bridge from sync callers to async state:

| caller context | mechanism |
| --- | --- |
| no runtime entered | park the thread (`std::thread::park` + a `Wake` that unparks) |
| multi-thread worker | `tokio::task::block_in_place` |
| current-thread runtime | `Err(NotBlockable)` |

`get_pv_blocking` becomes a thin caller of it and now works from a plain thread (its intended context), keeps working from a multi-thread worker, and on a current-thread runtime returns an error naming the async alternative instead of panicking. Turning the panic into a *silent hang* would be worse than the bug, which is why the unsound context is reported rather than blocked on.

## Semantic / API change (stated explicitly)

* **New public item:** `epics_base_rs::runtime::task::block_on_sync` and the `NotBlockable` marker error it returns. Additive.
* **Behavior change, both directions:** `get_pv_blocking` from a no-runtime thread previously returned `Err("no runtime for get_pv_blocking")` and now **succeeds**; from a current-thread runtime it previously **panicked** and now returns `Err(InvalidValue("get_pv_blocking cannot block a current-thread runtime; await get_pv() instead"))`. Nothing in the workspace calls `get_pv_blocking` (`rg get_pv_blocking` finds only the definition), so no in-tree caller changes; out-of-tree callers that were structured to work *around* the old inverted predicate (entering a multi-thread runtime just to be allowed to call it) keep working unchanged.
* A current-thread caller cannot be served by any blocking mechanism, so there is no fix that makes this case succeed. It must `await get_pv()`. That is why it is an error and not a cleverer block.

## Regression test — verified to fail on unfixed main

`crates/epics-base-rs/tests/get_pv_blocking_contexts.rs`, one case per caller context, each on a watchdog thread so a regression fails within 10s rather than hanging CI.

On unfixed main (`56a6dbf8`), 2 of the 3 fail — the two contexts the predicate got backwards:

```
running 3 tests
test get_pv_blocking_from_current_thread_runtime_errors ... FAILED
test get_pv_blocking_from_multi_thread_runtime_succeeds ... ok
test get_pv_blocking_from_a_plain_thread_succeeds ... FAILED

---- get_pv_blocking_from_current_thread_runtime_errors stdout ----
thread 'watchdog-current-thread' panicked at crates/epics-base-rs/src/server/database/field_io.rs:49:13:
can call blocking only when running on the multi-threaded runtime

---- get_pv_blocking_from_a_plain_thread_succeeds stdout ----
thread 'watchdog-plain-thread' panicked at crates/epics-base-rs/tests/get_pv_blocking_contexts.rs:66:14:
a plain thread is exactly the context this API is for: InvalidValue("no runtime for get_pv_blocking")

test result: FAILED. 1 passed; 2 failed
```

With the fix: `3 passed; 0 failed`.

## Gates

* `cargo fmt --all` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo nextest run --workspace` — 7427 passed, 2 skipped
* `cargo test --doc --workspace` — clean

## Relation to #18

Same root cause family as #18 (`PortHandle::submit_blocking`): a sync-over-async bridge that assumed one runtime flavor. This site was listed as UNFIXED there. The park-executor mechanism is spelled out independently in each crate because `epics-base-rs` does not depend on `asyn-rs`; if both PRs land, `asyn-rs`'s copy can be replaced by this one (`asyn-rs` → `epics-base-rs` is an allowed dependency direction). Two further sites from that UNFIXED list — the `AccessControl` and `LinkSet` sync trait bridges — are separate PRs.