### PR TITLE
fix(qsrv): make AccessControl async so ACF cannot answer from the wrong ASG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ name = "epics-bridge-rs"
 version = "0.23.0"
 dependencies = [
  "arc-swap",
+ "async-trait",
  "bytes",
  "chrono",
  "clap",

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -89,6 +89,7 @@ dual-gateway-bin = [
 
 [dependencies]
 epics-base-rs = { workspace = true }
+async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 # Refcounted byte buffer for the raw-frame fan-out path (F-G12).
 bytes = "1"

--- a/crates/epics-bridge-rs/src/lib.rs
+++ b/crates/epics-bridge-rs/src/lib.rs
@@ -82,6 +82,11 @@ pub mod pvalink;
 #[cfg(feature = "pva-gateway")]
 pub mod pva_gateway;
 
+// `AccessControl` is an `#[async_trait]` trait: re-exported so an out-of-tree
+// impl can annotate itself (`#[epics_bridge_rs::async_trait]`) without taking
+// its own `async-trait` dependency and risking a version mismatch.
+pub use async_trait::async_trait;
+
 // Convenience re-exports for the QSRV bridge (default feature).
 // External users can write `epics_bridge_rs::BridgeProvider` directly.
 #[cfg(feature = "qsrv")]

--- a/crates/epics-bridge-rs/src/qsrv/channel.rs
+++ b/crates/epics-bridge-rs/src/qsrv/channel.rs
@@ -632,7 +632,7 @@ impl BridgeChannel {
         // the matched rule's TRAPWRITE flag (`WriteGrant`). The grant is
         // the single source of "is this a trapped write" — the PUT below
         // routes through it and never re-derives the trap flag.
-        let grant = self.access.write_grant(&self.pv_name);
+        let grant = self.access.write_grant(&self.pv_name).await;
         if !grant.allowed {
             return Err(BridgeError::PutRejected(format!(
                 "write denied for {} (user='{}' host='{}')",
@@ -809,7 +809,7 @@ impl Channel for BridgeChannel {
     }
 
     async fn get(&self, request: &PvStructure) -> BridgeResult<PvStructure> {
-        if !self.access.can_read(&self.pv_name) {
+        if !self.access.can_read(&self.pv_name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for {} (user='{}' host='{}')",
                 self.pv_name, self.access.user, self.access.host
@@ -889,7 +889,7 @@ impl BridgeChannel {
         // Check read permission up front so a denied client cannot
         // even obtain a monitor handle. start() also re-checks (defense
         // in depth: handles created via with_access elsewhere).
-        if !self.access.can_read(&self.pv_name) {
+        if !self.access.can_read(&self.pv_name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor create denied for {} (user='{}' host='{}')",
                 self.pv_name, self.access.user, self.access.host

--- a/crates/epics-bridge-rs/src/qsrv/group.rs
+++ b/crates/epics-bridge-rs/src/qsrv/group.rs
@@ -793,7 +793,7 @@ impl GroupChannel {
     /// the group default. Used by `Channel::get` when the operation
     /// pvRequest carries `record._options.atomic`.
     pub(crate) async fn read_group_atomic(&self, atomic: bool) -> BridgeResult<PvStructure> {
-        if !self.access.can_read(&self.def.name) {
+        if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for group {} (user='{}' host='{}')",
                 self.def.name, self.access.user, self.access.host
@@ -912,7 +912,7 @@ impl GroupChannel {
     /// Same access enforcement as [`read_group`].
     #[allow(dead_code)]
     async fn read_partial(&self, field_names: &[String]) -> BridgeResult<PvStructure> {
-        if !self.access.can_read(&self.def.name) {
+        if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for group {} (user='{}' host='{}')",
                 self.def.name, self.access.user, self.access.host
@@ -1366,7 +1366,7 @@ impl GroupChannel {
         opts: super::channel::PutOptions,
         atomic_override: Option<bool>,
     ) -> BridgeResult<()> {
-        if !self.access.can_write(&self.def.name) {
+        if !self.access.can_write(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "write denied for group {} (user='{}' host='{}')",
                 self.def.name, self.access.user, self.access.host
@@ -1524,7 +1524,7 @@ impl GroupChannel {
                 // SecurityClient list as well.
                 continue;
             }
-            let grant = self.access.write_grant(&m.channel);
+            let grant = self.access.write_grant(&m.channel).await;
             if !grant.allowed {
                 return Err(BridgeError::PutRejected(format!(
                     "group {} PUT: member '{}' field '{}' write denied for \
@@ -1768,7 +1768,7 @@ impl super::provider::Channel for GroupChannel {
     }
 
     async fn get(&self, request: &PvStructure) -> BridgeResult<PvStructure> {
-        if !self.access.can_read(&self.def.name) {
+        if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for group {} (user='{}' host='{}')",
                 self.def.name, self.access.user, self.access.host
@@ -1882,7 +1882,7 @@ impl super::provider::Channel for GroupChannel {
     async fn create_monitor(&self) -> BridgeResult<AnyMonitor> {
         // Read enforcement: deny monitor creation when the client lacks
         // read access. start() also re-checks defensively.
-        if !self.access.can_read(&self.def.name) {
+        if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor create denied for group {} (user='{}' host='{}')",
                 self.def.name, self.access.user, self.access.host
@@ -2336,7 +2336,7 @@ impl super::provider::PvaMonitor for GroupMonitor {
 
         // Read enforcement: refuse to spin up upstream subscriptions
         // for a client that lacks read permission on this group.
-        if !self.access.can_read(&self.def.name) {
+        if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor read denied for group {} (user='{}' host='{}')",
                 self.def.name, self.access.user, self.access.host
@@ -4743,8 +4743,9 @@ mod tests {
 
         // Deny writes to member b's backing channel only.
         struct DenyChannel(&'static str);
+        #[async_trait::async_trait]
         impl AccessControl for DenyChannel {
-            fn can_write(&self, channel: &str, _user: &str, _host: &str) -> bool {
+            async fn can_write(&self, channel: &str, _user: &str, _host: &str) -> bool {
                 channel != self.0
             }
         }
@@ -4825,8 +4826,9 @@ mod tests {
 
         // Deny writes to the proc member's backing channel only.
         struct DenyChannel(&'static str);
+        #[async_trait::async_trait]
         impl AccessControl for DenyChannel {
-            fn can_write(&self, channel: &str, _user: &str, _host: &str) -> bool {
+            async fn can_write(&self, channel: &str, _user: &str, _host: &str) -> bool {
                 channel != self.0
             }
         }

--- a/crates/epics-bridge-rs/src/qsrv/monitor.rs
+++ b/crates/epics-bridge-rs/src/qsrv/monitor.rs
@@ -179,7 +179,7 @@ impl PvaMonitor for BridgeMonitor {
 
         // Read enforcement: a client without read permission must not be
         // allowed to subscribe to monitor events either.
-        if !self.access.can_read(&self.record_name) {
+        if !self.access.can_read(&self.record_name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor read denied for {} (user='{}' host='{}')",
                 self.record_name, self.access.user, self.access.host

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -77,14 +77,24 @@ pub struct WriteGrant {
 ///
 /// Corresponds to C++ QSRV's per-channel ASCLIENT checks.
 /// Default implementation allows all access.
+///
+/// The methods are **async** because an ACF answer depends on the record's
+/// `ASG`/`ASL` fields, which live behind the database's async locks
+/// ([`AcfAccessControl`]). A sync trait here would force each impl to invent a
+/// blocking bridge to reach that state, and a blocking bridge is only sound on
+/// some runtime flavors — which made the access decision a function of how the
+/// server's runtime happened to be built. Every caller of these methods is
+/// already an `async fn`, so awaiting the answer costs nothing and removes the
+/// bridge (and the wrong-answer fallback it needed) entirely.
+#[async_trait::async_trait]
 pub trait AccessControl: Send + Sync {
     /// Check if the client can read this channel.
-    fn can_read(&self, _channel: &str, _user: &str, _host: &str) -> bool {
+    async fn can_read(&self, _channel: &str, _user: &str, _host: &str) -> bool {
         true
     }
 
     /// Check if the client can write to this channel.
-    fn can_write(&self, _channel: &str, _user: &str, _host: &str) -> bool {
+    async fn can_write(&self, _channel: &str, _user: &str, _host: &str) -> bool {
         true
     }
 
@@ -94,13 +104,13 @@ pub trait AccessControl: Send + Sync {
     /// impls that do not need method/authority/roles need not override.
     /// `AcfAccessControl` overrides to pass the full credential set to
     /// `check_access_method`.
-    fn can_read_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
-        self.can_read(channel, &creds.user, &creds.host)
+    async fn can_read_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
+        self.can_read(channel, &creds.user, &creds.host).await
     }
 
     /// Method/authority/roles-aware write check.
-    fn can_write_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
-        self.can_write(channel, &creds.user, &creds.host)
+    async fn can_write_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
+        self.can_write(channel, &creds.user, &creds.host).await
     }
 
     /// Authorize a write and surface the matched ACF/ASG rule's
@@ -113,9 +123,9 @@ pub trait AccessControl: Send + Sync {
     /// mask, matching C `asComputePvt` leaving `trapMask = 0`.
     /// [`AcfAccessControl`] overrides this to read the granting rule's
     /// trap flag via `check_access_method_trap`.
-    fn write_grant(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
+    async fn write_grant(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
         WriteGrant {
-            allowed: self.can_write_creds(channel, creds),
+            allowed: self.can_write_creds(channel, creds).await,
             rule_was_trap: false,
         }
     }
@@ -156,31 +166,23 @@ impl AcfAccessControl {
     /// `dbChannelFldDes(ch)->as_level` as the ASL. Our Rust model stores a
     /// per-record `common.asl` (same approach as
     /// `epics-ca-rs/src/server/tcp.rs:459`).
-    fn resolve_asg_and_asl_blocking(&self, channel: &str) -> (String, u8) {
+    /// The `DEFAULT` ASG is the fallback for a channel that genuinely has no
+    /// record-level ASG — a simple PV, or a name the database does not know. It
+    /// must never stand in for an ASG the code failed to look up: doing so
+    /// evaluates the wrong access group, which for a record in a read-only
+    /// group means granting a write the ACF denies.
+    async fn resolve_asg_and_asl(&self, channel: &str) -> (String, u8) {
         let (record_name, _field) = epics_base_rs::server::database::parse_pv_name(channel);
-        let db = self.db.clone();
-        let name = record_name.to_string();
-        let lookup = async move {
-            if let Some(rec) = db.get_record(&name).await {
-                let inst = rec.read().await;
-                let asg = if inst.common.asg.is_empty() {
-                    "DEFAULT".to_string()
-                } else {
-                    inst.common.asg.clone()
-                };
-                return (asg, inst.common.asl);
-            }
-            ("DEFAULT".to_string(), 0u8)
-        };
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => match handle.runtime_flavor() {
-                tokio::runtime::RuntimeFlavor::MultiThread => {
-                    tokio::task::block_in_place(|| handle.block_on(lookup))
-                }
-                _ => ("DEFAULT".to_string(), 0u8),
-            },
-            Err(_) => ("DEFAULT".to_string(), 0u8),
+        if let Some(rec) = self.db.get_record(record_name).await {
+            let inst = rec.read().await;
+            let asg = if inst.common.asg.is_empty() {
+                "DEFAULT".to_string()
+            } else {
+                inst.common.asg.clone()
+            };
+            return (asg, inst.common.asl);
         }
+        ("DEFAULT".to_string(), 0u8)
     }
 
     /// Build pvxs-style credential strings from `ClientCreds`.
@@ -210,9 +212,9 @@ impl AcfAccessControl {
     /// strings, then calls `check_access_method` for each. Access is the
     /// maximum level across all credentials — mirrors `SecurityClient::canWrite`
     /// `any_of` semantics (`pvxs/ioc/securityclient.cpp:42-45`).
-    fn level_for_creds(&self, channel: &str, creds: &ClientCreds) -> AccessLevelLite {
+    async fn level_for_creds(&self, channel: &str, creds: &ClientCreds) -> AccessLevelLite {
         use epics_base_rs::server::access_security::AccessLevel;
-        let (asg, asl) = self.resolve_asg_and_asl_blocking(channel);
+        let (asg, asl) = self.resolve_asg_and_asl(channel).await;
         let cred_strings = Self::credential_strings(creds);
         // a QSRV access context built through the legacy
         // no-method constructors (`AccessContext::anonymous`,
@@ -271,9 +273,9 @@ impl AcfAccessControl {
     /// rule that set the granted access (`asLibRoutines.c:1041-1048`).
     /// A denied write carries `rule_was_trap = false` (`asComputePvt`
     /// leaves `trapMask = 0` on a `NoAccess` outcome).
-    fn grant_for_creds(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
+    async fn grant_for_creds(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
         use epics_base_rs::server::access_security::AccessLevel;
-        let (asg, asl) = self.resolve_asg_and_asl_blocking(channel);
+        let (asg, asl) = self.resolve_asg_and_asl(channel).await;
         let cred_strings = Self::credential_strings(creds);
         // Same empty-method → "anonymous" normalization as
         // `level_for_creds` (see that method for the rationale).
@@ -312,8 +314,9 @@ enum AccessLevelLite {
     ReadWrite,
 }
 
+#[async_trait::async_trait]
 impl AccessControl for AcfAccessControl {
-    fn can_read(&self, channel: &str, user: &str, host: &str) -> bool {
+    async fn can_read(&self, channel: &str, user: &str, host: &str) -> bool {
         self.can_read_creds(
             channel,
             &ClientCreds {
@@ -322,9 +325,10 @@ impl AccessControl for AcfAccessControl {
                 ..Default::default()
             },
         )
+        .await
     }
 
-    fn can_write(&self, channel: &str, user: &str, host: &str) -> bool {
+    async fn can_write(&self, channel: &str, user: &str, host: &str) -> bool {
         self.can_write_creds(
             channel,
             &ClientCreds {
@@ -333,21 +337,22 @@ impl AccessControl for AcfAccessControl {
                 ..Default::default()
             },
         )
+        .await
     }
 
-    fn can_read_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
-        self.level_for_creds(channel, creds) != AccessLevelLite::None
+    async fn can_read_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
+        self.level_for_creds(channel, creds).await != AccessLevelLite::None
     }
 
-    fn can_write_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
+    async fn can_write_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
         // Route through `grant_for_creds` (the trap-carrying path) so the
         // allow/deny decision and the trap flag come from one rule
         // evaluation — `write_grant` cannot disagree with `can_write_creds`.
-        self.grant_for_creds(channel, creds).allowed
+        self.grant_for_creds(channel, creds).await.allowed
     }
 
-    fn write_grant(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
-        self.grant_for_creds(channel, creds)
+    async fn write_grant(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
+        self.grant_for_creds(channel, creds).await
     }
 }
 
@@ -415,13 +420,16 @@ impl AccessContext {
         Self::anonymous(Arc::new(AllowAllAccess))
     }
 
-    pub fn can_read(&self, channel: &str) -> bool {
-        self.access.can_read_creds(channel, &self.to_client_creds())
+    pub async fn can_read(&self, channel: &str) -> bool {
+        self.access
+            .can_read_creds(channel, &self.to_client_creds())
+            .await
     }
 
-    pub fn can_write(&self, channel: &str) -> bool {
+    pub async fn can_write(&self, channel: &str) -> bool {
         self.access
             .can_write_creds(channel, &self.to_client_creds())
+            .await
     }
 
     /// Authorize a write to `channel` and surface the matched rule's
@@ -429,8 +437,10 @@ impl AccessContext {
     /// this once and uses the result both to gate the write and to gate
     /// `asTrapWrite` put-logging — the grant is the single source of the
     /// trap decision.
-    pub fn write_grant(&self, channel: &str) -> WriteGrant {
-        self.access.write_grant(channel, &self.to_client_creds())
+    pub async fn write_grant(&self, channel: &str) -> WriteGrant {
+        self.access
+            .write_grant(channel, &self.to_client_creds())
+            .await
     }
 
     fn to_client_creds(&self) -> ClientCreds {
@@ -694,24 +704,34 @@ struct LiveAccessProxy {
     cell: Arc<parking_lot::RwLock<Arc<dyn AccessControl>>>,
 }
 
+impl LiveAccessProxy {
+    /// Snapshot the live policy and release the lock *before* awaiting it: the
+    /// checks below are async now, and the sync `parking_lot` guard must not be
+    /// held across an await point.
+    fn policy(&self) -> Arc<dyn AccessControl> {
+        self.cell.read().clone()
+    }
+}
+
+#[async_trait::async_trait]
 impl AccessControl for LiveAccessProxy {
-    fn can_read(&self, channel: &str, user: &str, host: &str) -> bool {
-        self.cell.read().can_read(channel, user, host)
+    async fn can_read(&self, channel: &str, user: &str, host: &str) -> bool {
+        self.policy().can_read(channel, user, host).await
     }
-    fn can_write(&self, channel: &str, user: &str, host: &str) -> bool {
-        self.cell.read().can_write(channel, user, host)
+    async fn can_write(&self, channel: &str, user: &str, host: &str) -> bool {
+        self.policy().can_write(channel, user, host).await
     }
-    fn can_read_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
-        self.cell.read().can_read_creds(channel, creds)
+    async fn can_read_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
+        self.policy().can_read_creds(channel, creds).await
     }
-    fn can_write_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
-        self.cell.read().can_write_creds(channel, creds)
+    async fn can_write_creds(&self, channel: &str, creds: &ClientCreds) -> bool {
+        self.policy().can_write_creds(channel, creds).await
     }
-    fn write_grant(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
+    async fn write_grant(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
         // Forward to the live inner policy so a swapped-in
         // `AcfAccessControl`'s trap flag is observed; the default impl
         // would drop it to `rule_was_trap = false`.
-        self.cell.read().write_grant(channel, creds)
+        self.policy().write_grant(channel, creds).await
     }
 }
 
@@ -845,13 +865,15 @@ impl BridgeProvider {
     }
 
     /// Check if a client can write to a channel.
-    pub fn can_write(&self, channel: &str, user: &str, host: &str) -> bool {
-        self.access_cell.read().can_write(channel, user, host)
+    pub async fn can_write(&self, channel: &str, user: &str, host: &str) -> bool {
+        let policy = self.access_cell.read().clone();
+        policy.can_write(channel, user, host).await
     }
 
     /// Check if a client can read from a channel.
-    pub fn can_read(&self, channel: &str, user: &str, host: &str) -> bool {
-        self.access_cell.read().can_read(channel, user, host)
+    pub async fn can_read(&self, channel: &str, user: &str, host: &str) -> bool {
+        let policy = self.access_cell.read().clone();
+        policy.can_read(channel, user, host).await
     }
 
     /// Load group PV definitions from a JSON config string. Takes
@@ -1192,7 +1214,7 @@ impl BridgeProvider {
         user: &str,
         host: &str,
     ) -> BridgeResult<()> {
-        if !self.can_write(group, user, host) {
+        if !self.can_write(group, user, host).await {
             return Err(crate::error::BridgeError::PutRejected(format!(
                 "write denied for group {group} (user='{user}' host='{host}')"
             )));
@@ -1700,19 +1722,21 @@ mod tests {
 
     /// Access control that denies all writes, allows all reads.
     struct ReadOnly;
+    #[async_trait::async_trait]
     impl AccessControl for ReadOnly {
-        fn can_write(&self, _: &str, _: &str, _: &str) -> bool {
+        async fn can_write(&self, _: &str, _: &str, _: &str) -> bool {
             false
         }
     }
 
     /// Access control that denies a specific channel name.
     struct DenySpecific(String);
+    #[async_trait::async_trait]
     impl AccessControl for DenySpecific {
-        fn can_read(&self, channel: &str, _: &str, _: &str) -> bool {
+        async fn can_read(&self, channel: &str, _: &str, _: &str) -> bool {
             channel != self.0
         }
-        fn can_write(&self, channel: &str, _: &str, _: &str) -> bool {
+        async fn can_write(&self, channel: &str, _: &str, _: &str) -> bool {
             channel != self.0
         }
     }
@@ -1750,11 +1774,11 @@ ASG(SECURE) {
 
         let acl = AcfAccessControl::new(db.clone(), cfg);
         // Anyone can read.
-        assert!(acl.can_read("AI:SEC", "guest", "anywhere"));
-        assert!(acl.can_read("AI:SEC", "admin", "anywhere"));
+        assert!(acl.can_read("AI:SEC", "guest", "anywhere").await);
+        assert!(acl.can_read("AI:SEC", "admin", "anywhere").await);
         // Only admin can write.
-        assert!(acl.can_write("AI:SEC", "admin", "anywhere"));
-        assert!(!acl.can_write("AI:SEC", "guest", "anywhere"));
+        assert!(acl.can_write("AI:SEC", "admin", "anywhere").await);
+        assert!(!acl.can_write("AI:SEC", "guest", "anywhere").await);
     }
 
     /// Regression: AcfAccessControl must honor method, authority,
@@ -1834,13 +1858,13 @@ ASG(ROLE_GATED) {
         // ── Axis 4: field ASL ────────────────────────────────────────────
         // ASL=0 record: RULE(0, WRITE) applies.
         assert!(
-            acl.can_write("AI:ASL0", "alice", "h"),
+            acl.can_write("AI:ASL0", "alice", "h").await,
             "ASL=0: alice should be allowed to write"
         );
         // ASL=1 record: RULE(0, WRITE) is skipped (epics-base asLibRoutines.c:1006:
         // `if(pasgclient->level > pasgrule->level) goto next_rule`).
         assert!(
-            !acl.can_write("AI:ASL1", "alice", "h"),
+            !acl.can_write("AI:ASL1", "alice", "h").await,
             "ASL=1: RULE(0,WRITE) must be skipped → write denied"
         );
 
@@ -1855,7 +1879,7 @@ ASG(ROLE_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            acl.can_write_creds("AI:METH", &x509_creds),
+            acl.can_write_creds("AI:METH", &x509_creds).await,
             "x509 client must match METHOD(\"x509\") rule"
         );
         let ca_creds = ClientCreds {
@@ -1866,7 +1890,7 @@ ASG(ROLE_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            !acl.can_write_creds("AI:METH", &ca_creds),
+            !acl.can_write_creds("AI:METH", &ca_creds).await,
             "ca client must NOT match METHOD(\"x509\")-only rule"
         );
 
@@ -1879,7 +1903,7 @@ ASG(ROLE_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            acl.can_write_creds("AI:AUTH", &trusted_creds),
+            acl.can_write_creds("AI:AUTH", &trusted_creds).await,
             "correct authority must match AUTHORITY(\"Trusted Root\")"
         );
         let other_ca_creds = ClientCreds {
@@ -1890,7 +1914,7 @@ ASG(ROLE_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            !acl.can_write_creds("AI:AUTH", &other_ca_creds),
+            !acl.can_write_creds("AI:AUTH", &other_ca_creds).await,
             "wrong authority must NOT match"
         );
 
@@ -1905,7 +1929,7 @@ ASG(ROLE_GATED) {
             roles: vec!["ops".to_string()],
         };
         assert!(
-            acl.can_write_creds("AI:ROLE", &ops_creds),
+            acl.can_write_creds("AI:ROLE", &ops_creds).await,
             "client with role 'ops' must match UAG entry 'role/ops'"
         );
         let no_role_creds = ClientCreds {
@@ -1916,54 +1940,54 @@ ASG(ROLE_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            !acl.can_write_creds("AI:ROLE", &no_role_creds),
+            !acl.can_write_creds("AI:ROLE", &no_role_creds).await,
             "client without 'ops' role must NOT write to ROLE_GATED"
         );
     }
 
-    #[test]
-    fn access_context_allow_all() {
+    #[tokio::test]
+    async fn access_context_allow_all() {
         let ctx = AccessContext::allow_all();
-        assert!(ctx.can_read("ANY"));
-        assert!(ctx.can_write("ANY"));
+        assert!(ctx.can_read("ANY").await);
+        assert!(ctx.can_write("ANY").await);
     }
 
-    #[test]
-    fn access_context_read_only() {
+    #[tokio::test]
+    async fn access_context_read_only() {
         let ctx = AccessContext::anonymous(Arc::new(ReadOnly));
-        assert!(ctx.can_read("X"));
-        assert!(!ctx.can_write("X"));
+        assert!(ctx.can_read("X").await);
+        assert!(!ctx.can_write("X").await);
     }
 
-    #[test]
-    fn access_context_with_identity() {
+    #[tokio::test]
+    async fn access_context_with_identity() {
         let ctx =
             AccessContext::with_identity(Arc::new(AllowAllAccess), "alice".into(), "host1".into());
         assert_eq!(ctx.user, "alice");
         assert_eq!(ctx.host, "host1");
     }
 
-    #[test]
-    fn access_context_deny_specific() {
+    #[tokio::test]
+    async fn access_context_deny_specific() {
         let ctx = AccessContext::anonymous(Arc::new(DenySpecific("SECRET".to_string())));
-        assert!(ctx.can_read("PUBLIC"));
-        assert!(!ctx.can_read("SECRET"));
-        assert!(ctx.can_write("PUBLIC"));
-        assert!(!ctx.can_write("SECRET"));
+        assert!(ctx.can_read("PUBLIC").await);
+        assert!(!ctx.can_read("SECRET").await);
+        assert!(ctx.can_write("PUBLIC").await);
+        assert!(!ctx.can_write("SECRET").await);
     }
 
-    #[test]
-    fn provider_set_access_control() {
+    #[tokio::test]
+    async fn provider_set_access_control() {
         let db = Arc::new(PvDatabase::new());
         let provider = BridgeProvider::new(db);
         // Default policy
-        assert!(provider.can_read("X", "u", "h"));
-        assert!(provider.can_write("X", "u", "h"));
+        assert!(provider.can_read("X", "u", "h").await);
+        assert!(provider.can_write("X", "u", "h").await);
 
         // Swap to read-only
         provider.set_access_control(Arc::new(ReadOnly));
-        assert!(provider.can_read("X", "u", "h"));
-        assert!(!provider.can_write("X", "u", "h"));
+        assert!(provider.can_read("X", "u", "h").await);
+        assert!(!provider.can_write("X", "u", "h").await);
     }
 
     #[tokio::test]
@@ -2040,8 +2064,9 @@ ASG(ROLE_GATED) {
     /// Read-deny access control: blocks all reads, allows all writes.
     /// Used to verify monitor enforcement (which is read).
     struct WriteOnly;
+    #[async_trait::async_trait]
     impl AccessControl for WriteOnly {
-        fn can_read(&self, _: &str, _: &str, _: &str) -> bool {
+        async fn can_read(&self, _: &str, _: &str, _: &str) -> bool {
             false
         }
     }
@@ -2080,8 +2105,8 @@ ASG(ROLE_GATED) {
     /// on its very next can_read / can_write call, without channel
     /// recreation. The earlier `Arc<dyn AccessControl>` direct-clone
     /// pattern pinned each channel to the policy at creation time.
-    #[test]
-    fn live_access_proxy_observes_policy_swap() {
+    #[tokio::test]
+    async fn live_access_proxy_observes_policy_swap() {
         let db = Arc::new(PvDatabase::new());
         let provider = BridgeProvider::new(db);
 
@@ -2089,26 +2114,26 @@ ASG(ROLE_GATED) {
         // AllowAllAccess.
         let ctx =
             AccessContext::with_identity(provider.live_access(), "alice".into(), "host1".into());
-        assert!(ctx.can_read("ANY"));
-        assert!(ctx.can_write("ANY"));
+        assert!(ctx.can_read("ANY").await);
+        assert!(ctx.can_write("ANY").await);
 
         // Swap to a deny-specific policy AFTER the context was created.
         provider.set_access_control(Arc::new(DenySpecific("SECRET".into())));
-        assert!(ctx.can_read("ALLOWED"));
-        assert!(!ctx.can_read("SECRET"), "swap must be observed live");
-        assert!(!ctx.can_write("SECRET"));
+        assert!(ctx.can_read("ALLOWED").await);
+        assert!(!ctx.can_read("SECRET").await, "swap must be observed live");
+        assert!(!ctx.can_write("SECRET").await);
 
         // Swap to read-only — same context, fresh decision.
         provider.set_access_control(Arc::new(ReadOnly));
-        assert!(ctx.can_read("X"));
+        assert!(ctx.can_read("X").await);
         assert!(
-            !ctx.can_write("X"),
+            !ctx.can_write("X").await,
             "policy swap must take effect immediately"
         );
 
         // Swap back to allow-all — proxy still tracks.
         provider.set_access_control(Arc::new(AllowAllAccess));
-        assert!(ctx.can_write("X"));
+        assert!(ctx.can_write("X").await);
     }
 
     #[tokio::test]
@@ -2173,7 +2198,7 @@ ASG(ANON_GATED) {
         // Legacy 3-arg path (create_channel / create_channel_for
         // funnel through these). Empty method on the branch.
         assert!(
-            acl.can_read("AI:ANON", "alice", "h"),
+            acl.can_read("AI:ANON", "alice", "h").await,
             "legacy can_read must match METHOD(\"anonymous\") rule"
         );
 
@@ -2186,7 +2211,7 @@ ASG(ANON_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            acl.can_read_creds("AI:ANON", &id_creds),
+            acl.can_read_creds("AI:ANON", &id_creds).await,
             "empty-method ClientCreds must match METHOD(\"anonymous\") rule"
         );
 
@@ -2201,7 +2226,7 @@ ASG(ANON_GATED) {
             roles: Vec::new(),
         };
         assert!(
-            !acl.can_read_creds("AI:ANON", &ca_creds),
+            !acl.can_read_creds("AI:ANON", &ca_creds).await,
             "an explicit 'ca' method must NOT match a METHOD(\"anonymous\")-only rule"
         );
     }

--- a/crates/epics-bridge-rs/tests/acf_access_control_contexts.rs
+++ b/crates/epics-bridge-rs/tests/acf_access_control_contexts.rs
@@ -1,0 +1,89 @@
+//! `AcfAccessControl` must enforce the record's ASG in every caller context.
+//!
+//! The ACF answer depends on the record's `ASG` field, which lives behind the
+//! database's async locks. Reaching it from a *sync* access check needs a
+//! blocking bridge, and that bridge only works on a multi-threaded runtime —
+//! so on a current-thread runtime the old code quietly fell back to
+//! `("DEFAULT", 0)`, i.e. it evaluated the wrong access group and answered the
+//! wrong access question. Not a panic, not an error: a silently wrong
+//! access-security decision, which for a write check means granting a write the
+//! ACF denies.
+//!
+//! Access control must not be a function of which runtime flavor the server
+//! happens to be built with.
+
+use std::sync::Arc;
+
+use epics_base_rs::server::access_security::parse_acf;
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::records::ai::AiRecord;
+use epics_base_rs::types::EpicsValue;
+use epics_bridge_rs::qsrv::{AccessContext, AcfAccessControl, ClientCreds};
+
+/// `DEFAULT` grants write to anyone; `RESTRICTED` grants read only. A record in
+/// `RESTRICTED` must therefore be read-only for our test client — and the only
+/// way to know it is in `RESTRICTED` is to read its `ASG` field from the
+/// database.
+const ACF: &str = r#"
+ASG(DEFAULT) {
+    RULE(1, WRITE)
+}
+ASG(RESTRICTED) {
+    RULE(1, READ)
+}
+"#;
+
+async fn restricted_context() -> (AccessContext, &'static str) {
+    let db = Arc::new(PvDatabase::new());
+    db.add_record("SECURE:ai", Box::new(AiRecord::new(1.0)))
+        .await
+        .unwrap();
+    db.put_pv("SECURE:ai.ASG", EpicsValue::String("RESTRICTED".into()))
+        .await
+        .unwrap();
+
+    let acf = AcfAccessControl::new(db, parse_acf(ACF).unwrap());
+    let ctx = AccessContext::with_creds(
+        Arc::new(acf),
+        ClientCreds {
+            user: "operator".into(),
+            host: "workstation".into(),
+            method: "ca".into(),
+            authority: String::new(),
+            roles: Vec::new(),
+        },
+    );
+    (ctx, "SECURE:ai")
+}
+
+/// A multi-threaded runtime — the one context the blocking bridge supported.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn restricted_asg_denies_write_on_multi_thread_runtime() {
+    let (ctx, pv) = restricted_context().await;
+    assert!(ctx.can_read(pv).await, "RESTRICTED grants READ");
+    assert!(
+        !ctx.can_write(pv).await,
+        "RESTRICTED grants no WRITE — the record's ASG must decide, not DEFAULT"
+    );
+    assert!(!ctx.write_grant(pv).await.allowed);
+}
+
+/// The same check on a current-thread runtime must produce the same answer.
+///
+/// On unfixed main it does not: the blocking ASG lookup is skipped and the
+/// record is evaluated against `DEFAULT`, which grants WRITE. The write check
+/// returns `true` for a record the ACF puts in a read-only group.
+#[tokio::test(flavor = "current_thread")]
+async fn restricted_asg_denies_write_on_current_thread_runtime() {
+    let (ctx, pv) = restricted_context().await;
+    assert!(ctx.can_read(pv).await, "RESTRICTED grants READ");
+    assert!(
+        !ctx.can_write(pv).await,
+        "RESTRICTED grants no WRITE — a current-thread runtime must not silently \
+         fall back to the DEFAULT ASG and grant the write"
+    );
+    assert!(
+        !ctx.write_grant(pv).await.allowed,
+        "a denied write must stay denied on a current-thread runtime"
+    );
+}

--- a/crates/epics-bridge-rs/tests/testqgroup.rs
+++ b/crates/epics-bridge-rs/tests/testqgroup.rs
@@ -747,8 +747,9 @@ async fn group_put_member_acf_denial_rejects_entire_put() {
     /// Deny writes to a specific record (matching by full PV name as
     /// stored on the GroupMember.channel — `record.FIELD`).
     struct DenySpecific(String);
+    #[async_trait::async_trait]
     impl AccessControl for DenySpecific {
-        fn can_write(&self, channel: &str, _: &str, _: &str) -> bool {
+        async fn can_write(&self, channel: &str, _: &str, _: &str) -> bool {
             channel != self.0
         }
     }
@@ -1534,8 +1535,9 @@ async fn trapped_group_put_emits_per_member_astrapwrite() {
 
     /// Grant every write with the `TRAPWRITE` flag set.
     struct TrapAll;
+    #[async_trait::async_trait]
     impl AccessControl for TrapAll {
-        fn write_grant(&self, _channel: &str, _creds: &ClientCreds) -> WriteGrant {
+        async fn write_grant(&self, _channel: &str, _creds: &ClientCreds) -> WriteGrant {
             WriteGrant {
                 allowed: true,
                 rule_was_trap: true,

--- a/crates/epics-bridge-rs/tests/testqsingle.rs
+++ b/crates/epics-bridge-rs/tests/testqsingle.rs
@@ -1006,8 +1006,9 @@ struct CapturedTrap {
 struct TrapStub {
     rule_was_trap: bool,
 }
+#[async_trait::async_trait]
 impl AccessControl for TrapStub {
-    fn write_grant(&self, _channel: &str, _creds: &ClientCreds) -> WriteGrant {
+    async fn write_grant(&self, _channel: &str, _creds: &ClientCreds) -> WriteGrant {
         WriteGrant {
             allowed: true,
             rule_was_trap: self.rule_was_trap,
@@ -1145,8 +1146,9 @@ async fn non_trap_single_put_emits_nothing() {
 #[tokio::test]
 async fn denied_single_put_emits_nothing() {
     struct DenyAll;
+    #[async_trait::async_trait]
     impl AccessControl for DenyAll {
-        fn can_write(&self, _: &str, _: &str, _: &str) -> bool {
+        async fn can_write(&self, _: &str, _: &str, _: &str) -> bool {
             false
         }
     }


### PR DESCRIPTION
`AcfAccessControl::resolve_asg_and_asl_blocking` (`crates/epics-bridge-rs/src/qsrv/provider.rs:159-184`) needed the record's `ASG`/`ASL` fields to answer an access question, and those live behind the database's async locks. Because `AccessControl` was a **sync** trait, it reached them through a blocking bridge — and a blocking bridge is only sound on a multi-threaded runtime:

```rust
match tokio::runtime::Handle::try_current() {
    Ok(handle) => match handle.runtime_flavor() {
        RuntimeFlavor::MultiThread => block_in_place(|| handle.block_on(lookup)),
        _ => ("DEFAULT".to_string(), 0u8),   // <-- current-thread runtime
    },
    Err(_) => ("DEFAULT".to_string(), 0u8),  // <-- no runtime
}
```

On any other flavor the ASG lookup was **skipped** and the channel was evaluated against the `DEFAULT` access group.

`DEFAULT` is the correct fallback for a channel that genuinely *has* no record-level ASG (a simple PV, an unknown name). It is not a safe stand-in for an ASG the code failed to look up. For a record the ACF places in a read-only group, falling back to a `DEFAULT` that grants `WRITE` **grants a write the ACF denies**. This is worse than the panic in #18's family: no panic, no error, no log — a silently wrong access-security decision, in the component whose entire job is that decision.

Both `level_for_creds` (:213) and `grant_for_creds` (:274) — read gating, write gating, and the `TRAPWRITE` put-log flag — depend on this lookup.

## Fix — remove the sync boundary, don't patch the fallback

The tempting patch is to fail closed on the unsupported flavors. That keeps a security answer dependent on how the runtime was built, and keeps the fallback branch that can be reached again by the next caller.

The sync boundary was **gratuitous**: every caller of these methods is already an `async fn` (`qsrv/channel.rs` get/put, `qsrv/group.rs` get/put/monitor, `qsrv/monitor.rs` start). So the trait becomes async and the blocking bridge is deleted, not fixed:

* `AccessControl` is `#[async_trait]`; `can_read`, `can_write`, `can_read_creds`, `can_write_creds`, `write_grant` are `async fn`.
* `AcfAccessControl::resolve_asg_and_asl` is a plain `async fn` — it always reads the real ASG/ASL, on every runtime flavor, because there is no longer any context in which it *can't*.
* The `("DEFAULT", 0)` fallback now exists only where it is correct: a channel with no record-level ASG.
* `LiveAccessProxy` snapshots the policy `Arc` and releases its `parking_lot` guard before awaiting, so no sync lock is held across an await point.

With no blocking bridge there is no flavor dependence, and with no flavor dependence there is nothing to fall back *from*.

## API change (stated explicitly)

* **Breaking for out-of-tree impls:** `AccessControl` is now an `#[async_trait]` trait. An impl gains `#[epics_bridge_rs::async_trait]` and `async fn`; `async_trait` is re-exported from the crate root so no new dependency is needed downstream.
* **Breaking for out-of-tree callers:** `AccessContext::{can_read, can_write, write_grant}` and `BridgeProvider::{can_read, can_write}` are `async fn` and must be `.await`ed. All are called from `async fn` context already.
* New dependency: `async-trait` on `epics-bridge-rs` (already used by `epics-ca-rs`). The trait is `dyn`-erased (`Arc<dyn AccessControl>`), so native AFIT is not usable here.

## Regression test — verified to fail on unfixed main

`crates/epics-bridge-rs/tests/acf_access_control_contexts.rs`: an ACF where `DEFAULT` grants `WRITE` and `RESTRICTED` grants `READ` only, and a record whose `ASG` field is `RESTRICTED`. The same write check is run on a multi-thread and on a current-thread runtime; both must deny.

On unfixed main (`56a6dbf8`), with the checks in their pre-fix sync form:

```
running 2 tests
test restricted_asg_denies_write_on_current_thread_runtime ... FAILED
test restricted_asg_denies_write_on_multi_thread_runtime ... ok

---- restricted_asg_denies_write_on_current_thread_runtime stdout ----
thread 'restricted_asg_denies_write_on_current_thread_runtime' panicked at
crates/epics-bridge-rs/tests/acf_access_control_contexts.rs:80:5:
RESTRICTED grants no WRITE — a current-thread runtime must not silently fall back
to the DEFAULT ASG and grant the write

test result: FAILED. 1 passed; 1 failed
```

i.e. on main `ctx.can_write("SECURE:ai")` returns **`true`** for a record the ACF makes read-only. With the fix: `2 passed; 0 failed`, both flavors denying.

## Gates

* `cargo fmt --all` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo nextest run --workspace` — 7426 passed, 2 skipped
* `cargo test --doc --workspace` — clean

## Relation to #18 / #21

Third site from #18's UNFIXED list, same root cause (a sync bridge over async state that only works on one runtime flavor), different failure mode: #18 and #21 panic, this one answers wrongly. The remaining site — the `LinkSet` sync trait shared by `pvalink` and `calink` — is a separate PR.