### PR TITLE
fix(links): make LinkSet and ExternalPvResolver async, deleting the block_on bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
 name = "epics-base-rs"
 version = "0.23.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "chrono",
  "clap",

--- a/crates/epics-base-rs/Cargo.toml
+++ b/crates/epics-base-rs/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
 bytes = "1"

--- a/crates/epics-base-rs/src/lib.rs
+++ b/crates/epics-base-rs/src/lib.rs
@@ -37,6 +37,10 @@
 /// being ported.
 pub const EPICS_BASE_VERSION: &str = "7.0.10.1-DEV";
 
+/// `LinkSet` is an `#[async_trait]` trait: re-exported so an out-of-tree lset
+/// can annotate its impl without taking its own `async-trait` dependency.
+pub use async_trait::async_trait;
+
 pub mod calc;
 pub mod error;
 pub mod net;

--- a/crates/epics-base-rs/src/server/database/link_set.rs
+++ b/crates/epics-base-rs/src/server/database/link_set.rs
@@ -12,20 +12,23 @@
 //! Record-link reads dispatch through the matching lset before
 //! falling back to the legacy `ExternalPvResolver` closure.
 //!
-//! The trait is **synchronous** — record processing is fundamentally
-//! sync at the lset boundary in C EPICS, and most lset
-//! implementations (pvalink, calink) maintain a cached snapshot
-//! that satisfies sync reads without blocking. Implementations that
-//! need to do async I/O can keep a `tokio::runtime::Handle` and
-//! `block_on` internally.
+//! The trait is **async**. An lset's state is async state: pvalink and
+//! calink both open links, and cache them, on a tokio runtime. A sync
+//! trait forced them to reach that state through `block_in_place` +
+//! `Handle::block_on`, which panics on a current-thread runtime —
+//! including the one `#[epics::test]` builds and the one every asyn port
+//! actor runs. Since every caller of these methods is already an
+//! `async fn` (the database's link paths), awaiting the answer costs
+//! nothing and removes the bridge.
 //!
 //! # Adding a new lset
 //!
 //! ```ignore
 //! struct MyLset { /* ... */ }
+//! #[epics_base_rs::async_trait]
 //! impl LinkSet for MyLset {
-//!     fn is_connected(&self, name: &str) -> bool { /* ... */ }
-//!     fn get_value(&self, name: &str) -> Option<EpicsValue> { /* ... */ }
+//!     async fn is_connected(&self, name: &str) -> bool { /* ... */ }
+//!     async fn get_value(&self, name: &str) -> Option<EpicsValue> { /* ... */ }
 //!     /* etc. */
 //! }
 //! db.register_link_set("pva", Arc::new(MyLset { ... })).await;
@@ -184,16 +187,17 @@ impl RemoteAlarm {
 /// mutability for any cached state. None / false is the
 /// "unavailable" sentinel — the database falls back to a generic
 /// LINK/INVALID alarm when an lset returns None.
+#[async_trait::async_trait]
 pub trait LinkSet: Send + Sync {
     /// True iff a fresh value is available for `name` without
     /// blocking. Used by the record processing loop to decide
     /// whether to mark the record's STAT as LINK_ALARM.
-    fn is_connected(&self, name: &str) -> bool;
+    async fn is_connected(&self, name: &str) -> bool;
 
     /// Read the current value of `name`. Returns None when the
     /// upstream isn't yet connected or the lset has no cache for
     /// this name.
-    fn get_value(&self, name: &str) -> Option<EpicsValue>;
+    async fn get_value(&self, name: &str) -> Option<EpicsValue>;
 
     /// Write `value` to `name` with the delivery semantics named by
     /// `op` ([`LinkPutOp::Plain`] for a fire-and-forget put,
@@ -201,7 +205,7 @@ pub trait LinkSet: Send + Sync {
     /// blocking-put chain). Returns Err with a human-readable reason
     /// on failure (denied, type-mismatch, no-such-pv, etc.). Default
     /// impl rejects all writes — read-only lsets keep the default.
-    fn put_value(&self, name: &str, value: EpicsValue, op: LinkPutOp) -> Result<(), String> {
+    async fn put_value(&self, name: &str, value: EpicsValue, op: LinkPutOp) -> Result<(), String> {
         let _ = (name, value, op);
         Err("link set is read-only".into())
     }
@@ -226,7 +230,7 @@ pub trait LinkSet: Send + Sync {
     /// forwards nothing through this hook — a DB FLNK target is processed
     /// directly by the database's `scanOnce` path (the DB lset's
     /// `scanForward`), not through an external link set.
-    fn scan_forward(&self, name: &str) -> Result<(), String> {
+    async fn scan_forward(&self, name: &str) -> Result<(), String> {
         let _ = name;
         Ok(())
     }
@@ -245,11 +249,11 @@ pub trait LinkSet: Send + Sync {
     /// Mirrors the role of pvxs's shared `pvaLinkChannel::put()` being
     /// driven from record processing rather than left to manual calls
     /// (`pvxs/ioc/pvalink_lset.cpp:647`, `pvalink_channel.cpp:220-263`).
-    fn flush_puts(&self) {}
+    async fn flush_puts(&self) {}
 
     /// Most recent alarm message string from the upstream PV, when
     /// available. None means no alarm or no cache.
-    fn alarm_message(&self, _name: &str) -> Option<String> {
+    async fn alarm_message(&self, _name: &str) -> Option<String> {
         None
     }
 
@@ -266,7 +270,7 @@ pub trait LinkSet: Send + Sync {
     /// gated and the record processing loop propagates it verbatim
     /// as a maximize-severity contribution. Mirrors pvxs
     /// `pvalink_lset.cpp` `pvaGetAlarm` feeding `recGblSetSevr`.
-    fn alarm_severity(&self, _name: &str) -> Option<i32> {
+    async fn alarm_severity(&self, _name: &str) -> Option<i32> {
         None
     }
 
@@ -282,7 +286,7 @@ pub trait LinkSet: Send + Sync {
     /// behaviour for every non-`MSS` modifier and for lsets that leave
     /// this default. Mirrors pvxs `pvalink_lset.cpp` `pvaGetAlarm`
     /// surfacing the remote `alarm.status` to `recGblSetSevrMsg`.
-    fn alarm_status(&self, _name: &str) -> Option<i32> {
+    async fn alarm_status(&self, _name: &str) -> Option<i32> {
         None
     }
 
@@ -305,7 +309,7 @@ pub trait LinkSet: Send + Sync {
     /// `None` means the lset cannot report a snapshot: no cache, the
     /// link is not connected (pvxs `CHECK_VALID` — `pvalink_lset.cpp:545`),
     /// or the link set does not track remote alarms. Default: none.
-    fn remote_alarm(&self, _name: &str) -> Option<RemoteAlarm> {
+    async fn remote_alarm(&self, _name: &str) -> Option<RemoteAlarm> {
         None
     }
 
@@ -314,7 +318,7 @@ pub trait LinkSet: Send + Sync {
     /// `timeStamp.userTag` widened to the 64-bit `epicsUTag` tag without
     /// sign extension, or `0` when the source carries none (CA links, or
     /// a PVA source whose timeStamp omits the field).
-    fn time_stamp(&self, _name: &str) -> Option<(i64, i32, u64)> {
+    async fn time_stamp(&self, _name: &str) -> Option<(i64, i32, u64)> {
         None
     }
 
@@ -335,7 +339,7 @@ pub trait LinkSet: Send + Sync {
     /// piece of metadata — the record then keeps its local default,
     /// matching the C getters that leave the caller's buffer
     /// untouched on a missing sub-field. Default impl: no metadata.
-    fn link_metadata(&self, _name: &str) -> Option<LinkMetadata> {
+    async fn link_metadata(&self, _name: &str) -> Option<LinkMetadata> {
         None
     }
 
@@ -343,7 +347,7 @@ pub trait LinkSet: Send + Sync {
     /// actively tracking). Used by `dbpvxr` to dump per-record
     /// link state without forcing the caller to know the full
     /// name list up-front.
-    fn link_names(&self) -> Vec<String> {
+    async fn link_names(&self) -> Vec<String> {
         Vec::new()
     }
 }
@@ -398,24 +402,25 @@ mod tests {
     use super::*;
 
     struct StubLset;
+    #[async_trait::async_trait]
     impl LinkSet for StubLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             Some(EpicsValue::Long(42))
         }
     }
 
-    #[test]
-    fn register_and_lookup() {
+    #[tokio::test]
+    async fn register_and_lookup() {
         let mut reg = LinkSetRegistry::new();
         assert!(reg.is_empty());
         reg.register("pva", Arc::new(StubLset));
         assert_eq!(reg.len(), 1);
         let lset = reg.get("pva").expect("registered");
-        assert!(lset.is_connected("anything"));
-        assert_eq!(lset.get_value("anything"), Some(EpicsValue::Long(42)));
+        assert!(lset.is_connected("anything").await);
+        assert_eq!(lset.get_value("anything").await, Some(EpicsValue::Long(42)));
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/database/links.rs
+++ b/crates/epics-base-rs/src/server/database/links.rs
@@ -453,6 +453,22 @@ impl PvDatabase {
     /// adopts the `userTag` into `common.utag`. The `userTag` is the
     /// remote `timeStamp.userTag` widened without sign extension, or `0`
     /// when the source carries none.
+    /// Every registered lset, as a snapshot.
+    ///
+    /// The bare-name link paths try each lset in turn, and every lset call is
+    /// now an await. Snapshotting the registry (rather than iterating it under
+    /// its read guard) keeps the registry lock off the await path, so an lset
+    /// that registers or unregisters another while resolving cannot deadlock
+    /// against the caller.
+    async fn registered_link_sets(&self) -> Vec<crate::server::database::DynLinkSet> {
+        let registry = self.inner.link_sets.read().await;
+        registry
+            .schemes()
+            .iter()
+            .filter_map(|s| registry.get(s))
+            .collect()
+    }
+
     pub(crate) async fn external_link_time(&self, name: &str) -> Option<(i64, i32, u64)> {
         let (scheme, body) = if let Some(rest) = name.strip_prefix("pva://") {
             ("pva", rest)
@@ -460,18 +476,15 @@ impl PvDatabase {
             ("ca", rest)
         } else {
             // Bare name — try every registered lset.
-            let registry = self.inner.link_sets.read().await;
-            for s in registry.schemes() {
-                if let Some(lset) = registry.get(&s) {
-                    if let Some(ts) = lset.time_stamp(name) {
-                        return Some(ts);
-                    }
+            for lset in self.registered_link_sets().await {
+                if let Some(ts) = lset.time_stamp(name).await {
+                    return Some(ts);
                 }
             }
             return None;
         };
         let lset = self.inner.link_sets.read().await.get(scheme)?;
-        lset.time_stamp(body)
+        lset.time_stamp(body).await
     }
 
     /// Build a [`LinkAlarm`] from the registered lset's alarm
@@ -490,35 +503,34 @@ impl PvDatabase {
         } else {
             // Bare name — try every registered lset until one reports
             // a severity (mirrors `resolve_external_pv`'s bare path).
-            let registry = self.inner.link_sets.read().await;
-            for s in registry.schemes() {
-                if let Some(lset) = registry.get(&s) {
-                    if let Some(sev) = lset.alarm_severity(name) {
-                        return Some(LinkAlarm {
-                            // prefer the remote STAT for MSS;
-                            // fall back to LINK_ALARM when the lset has none.
-                            stat: lset
-                                .alarm_status(name)
-                                .map(|s| s as u16)
-                                .unwrap_or(crate::server::recgbl::alarm_status::LINK_ALARM),
-                            sevr: crate::server::record::AlarmSeverity::from_u16(sev as u16),
-                            amsg: lset.alarm_message(name).unwrap_or_default(),
-                        });
-                    }
+            for lset in self.registered_link_sets().await {
+                if let Some(sev) = lset.alarm_severity(name).await {
+                    return Some(LinkAlarm {
+                        // prefer the remote STAT for MSS;
+                        // fall back to LINK_ALARM when the lset has none.
+                        stat: lset
+                            .alarm_status(name)
+                            .await
+                            .map(|s| s as u16)
+                            .unwrap_or(crate::server::recgbl::alarm_status::LINK_ALARM),
+                        sevr: crate::server::record::AlarmSeverity::from_u16(sev as u16),
+                        amsg: lset.alarm_message(name).await.unwrap_or_default(),
+                    });
                 }
             }
             return None;
         };
         let lset = self.inner.link_sets.read().await.get(scheme)?;
-        let sev = lset.alarm_severity(body)?;
+        let sev = lset.alarm_severity(body).await?;
         Some(LinkAlarm {
             // remote STAT for MSS, else LINK_ALARM.
             stat: lset
                 .alarm_status(body)
+                .await
                 .map(|s| s as u16)
                 .unwrap_or(crate::server::recgbl::alarm_status::LINK_ALARM),
             sevr: crate::server::record::AlarmSeverity::from_u16(sev as u16),
-            amsg: lset.alarm_message(body).unwrap_or_default(),
+            amsg: lset.alarm_message(body).await.unwrap_or_default(),
         })
     }
 
@@ -548,18 +560,15 @@ impl PvDatabase {
         } else if let Some(rest) = name.strip_prefix("ca://") {
             ("ca", rest)
         } else {
-            let registry = self.inner.link_sets.read().await;
-            for s in registry.schemes() {
-                if let Some(lset) = registry.get(&s) {
-                    if let Some(snap) = lset.remote_alarm(name) {
-                        return Some(snap);
-                    }
+            for lset in self.registered_link_sets().await {
+                if let Some(snap) = lset.remote_alarm(name).await {
+                    return Some(snap);
                 }
             }
             return None;
         };
         let lset = self.inner.link_sets.read().await.get(scheme)?;
-        lset.remote_alarm(body)
+        lset.remote_alarm(body).await
     }
 
     /// Remote display / control / valueAlarm metadata for an external
@@ -587,18 +596,15 @@ impl PvDatabase {
         } else if let Some(rest) = name.strip_prefix("ca://") {
             ("ca", rest)
         } else {
-            let registry = self.inner.link_sets.read().await;
-            for s in registry.schemes() {
-                if let Some(lset) = registry.get(&s) {
-                    if let Some(meta) = lset.link_metadata(name) {
-                        return Some(meta);
-                    }
+            for lset in self.registered_link_sets().await {
+                if let Some(meta) = lset.link_metadata(name).await {
+                    return Some(meta);
                 }
             }
             return None;
         };
         let lset = self.inner.link_sets.read().await.get(scheme)?;
-        lset.link_metadata(body)
+        lset.link_metadata(body).await
     }
 
     /// C `dbGetLink` PP rule: if a DB input link is `ProcessPassive`
@@ -879,27 +885,24 @@ impl PvDatabase {
             // Bare name — try every registered lset in turn, first
             // accepting write wins (mirrors `resolve_external_pv`'s
             // bare-name path).
-            let registry = self.inner.link_sets.read().await;
-            let schemes = registry.schemes();
-            if schemes.is_empty() {
+            let lsets = self.registered_link_sets().await;
+            if lsets.is_empty() {
                 return Err(format!("no link set registered for external link '{name}'"));
             }
             let mut last_err = String::new();
-            for s in schemes {
-                if let Some(lset) = registry.get(&s) {
-                    match lset.put_value(name, value.clone(), op) {
-                        Ok(()) => {
-                            // Production drain of any retry-queued OUT
-                            // writes on this lset now that a write has
-                            // reached it (the channel may have just
-                            // reconnected). pvxs replays the queued
-                            // put from record processing, not test code
-                            // (`pvalink_channel.cpp:220-263`).
-                            lset.flush_puts();
-                            return Ok(());
-                        }
-                        Err(e) => last_err = e,
+            for lset in lsets {
+                match lset.put_value(name, value.clone(), op).await {
+                    Ok(()) => {
+                        // Production drain of any retry-queued OUT
+                        // writes on this lset now that a write has
+                        // reached it (the channel may have just
+                        // reconnected). pvxs replays the queued
+                        // put from record processing, not test code
+                        // (`pvalink_channel.cpp:220-263`).
+                        lset.flush_puts().await;
+                        return Ok(());
                     }
+                    Err(e) => last_err = e,
                 }
             }
             return Err(last_err);
@@ -911,9 +914,9 @@ impl PvDatabase {
             .await
             .get(scheme)
             .ok_or_else(|| format!("no '{scheme}' link set registered for '{name}'"))?;
-        let result = lset.put_value(body, value, op);
+        let result = lset.put_value(body, value, op).await;
         if result.is_ok() {
-            lset.flush_puts();
+            lset.flush_puts().await;
         }
         result
     }
@@ -938,18 +941,15 @@ impl PvDatabase {
             // Bare name — try every registered lset in turn, first
             // accepting the forward wins (mirrors `write_external_pv`'s
             // bare-name path so FWD and OUT route a bare target alike).
-            let registry = self.inner.link_sets.read().await;
-            let schemes = registry.schemes();
-            if schemes.is_empty() {
+            let lsets = self.registered_link_sets().await;
+            if lsets.is_empty() {
                 return Err(format!("no link set registered for forward link '{name}'"));
             }
             let mut last_err = String::new();
-            for s in schemes {
-                if let Some(lset) = registry.get(&s) {
-                    match lset.scan_forward(name) {
-                        Ok(()) => return Ok(()),
-                        Err(e) => last_err = e,
-                    }
+            for lset in lsets {
+                match lset.scan_forward(name).await {
+                    Ok(()) => return Ok(()),
+                    Err(e) => last_err = e,
                 }
             }
             return Err(last_err);
@@ -961,7 +961,7 @@ impl PvDatabase {
             .await
             .get(scheme)
             .ok_or_else(|| format!("no '{scheme}' link set registered for '{name}'"))?;
-        lset.scan_forward(body)
+        lset.scan_forward(body).await
     }
 
     /// Map a record's put-completion wait-set to the external-link put
@@ -2004,14 +2004,20 @@ mod nonlocal_db_link_write_tests {
     struct RecordingLset {
         puts: Arc<Mutex<Vec<(String, EpicsValue)>>>,
     }
+    #[async_trait::async_trait]
     impl LinkSet for RecordingLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             None
         }
-        fn put_value(&self, name: &str, value: EpicsValue, _op: LinkPutOp) -> Result<(), String> {
+        async fn put_value(
+            &self,
+            name: &str,
+            value: EpicsValue,
+            _op: LinkPutOp,
+        ) -> Result<(), String> {
             self.puts.lock().unwrap().push((name.to_string(), value));
             Ok(())
         }
@@ -2123,14 +2129,15 @@ mod nonlocal_db_link_write_tests {
         forwards: Arc<Mutex<Vec<String>>>,
         connected: bool,
     }
+    #[async_trait::async_trait]
     impl LinkSet for ForwardingLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             self.connected
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             None
         }
-        fn scan_forward(&self, name: &str) -> Result<(), String> {
+        async fn scan_forward(&self, name: &str) -> Result<(), String> {
             self.forwards.lock().unwrap().push(name.to_string());
             if self.connected {
                 Ok(())
@@ -2369,11 +2376,14 @@ mod nonlocal_db_link_read_tests {
         let db = PvDatabase::new();
         // Stand-in for the calink/pvalink lset: resolve OTHER:PV remotely.
         db.set_external_resolver(Arc::new(|name: &str| {
-            if name == "OTHER:PV" {
-                Some(EpicsValue::Double(42.0))
-            } else {
-                None
-            }
+            let hit = name == "OTHER:PV";
+            Box::pin(async move {
+                if hit {
+                    Some(EpicsValue::Double(42.0))
+                } else {
+                    None
+                }
+            })
         }))
         .await;
 
@@ -2401,11 +2411,14 @@ mod nonlocal_db_link_read_tests {
     async fn nonlocal_db_link_value_and_alarm_via_external() {
         let db = PvDatabase::new();
         db.set_external_resolver(Arc::new(|name: &str| {
-            if name == "OTHER:PV" {
-                Some(EpicsValue::Double(5.0))
-            } else {
-                None
-            }
+            let hit = name == "OTHER:PV";
+            Box::pin(async move {
+                if hit {
+                    Some(EpicsValue::Double(5.0))
+                } else {
+                    None
+                }
+            })
         }))
         .await;
 
@@ -2433,8 +2446,10 @@ mod nonlocal_db_link_read_tests {
         db.add_pv("SRC", EpicsValue::Double(7.0)).await.unwrap();
         // A resolver returning a DIFFERENT value proves the local read
         // wins and the external path is not taken for a local target.
-        db.set_external_resolver(Arc::new(|_name: &str| Some(EpicsValue::Double(-1.0))))
-            .await;
+        db.set_external_resolver(Arc::new(|_name: &str| {
+            Box::pin(async { Some(EpicsValue::Double(-1.0)) })
+        }))
+        .await;
 
         let link = parse_link_v2("SRC");
         let mut visited = HashSet::new();

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 pub mod db_access;
 mod field_io;
 pub mod filters;
@@ -66,7 +68,19 @@ pub enum PvEntry {
 
 /// Callback for resolving external PV names (CA/PVA links).
 /// Returns the current value of the external PV, or None if unavailable.
-pub type ExternalPvResolver = Arc<dyn Fn(&str) -> Option<EpicsValue> + Send + Sync>;
+///
+/// **Async**, for the same reason [`LinkSet`] is: an external link's value
+/// lives on a tokio runtime, and a sync closure could only reach it through a
+/// blocking bridge that panics on a current-thread runtime. The one caller
+/// ([`PvDatabase::resolve_external_pv`]) is already async.
+pub type ExternalPvResolver = Arc<
+    dyn for<'a> Fn(
+            &'a str,
+        )
+            -> std::pin::Pin<Box<dyn Future<Output = Option<EpicsValue>> + Send + 'a>>
+        + Send
+        + Sync,
+>;
 
 /// Async hook invoked by [`PvDatabase::has_name`] when a name is not yet
 /// in the database. Used by the CA gateway and similar proxy components
@@ -698,10 +712,12 @@ impl PvDatabase {
         }
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let connected = targets
-                .iter()
-                .filter(|(lset, name)| lset.is_connected(name))
-                .count();
+            let mut connected = 0usize;
+            for (lset, name) in &targets {
+                if lset.is_connected(name).await {
+                    connected += 1;
+                }
+            }
             if connected == total {
                 return (connected, total);
             }
@@ -742,7 +758,7 @@ impl PvDatabase {
             return Vec::new();
         };
         let mut targets: Vec<(link_set::DynLinkSet, String)> = Vec::new();
-        for n in ca_lset.link_names() {
+        for n in ca_lset.link_names().await {
             if self.has_name_no_resolve(&n).await {
                 targets.push((ca_lset.clone(), n));
             }
@@ -758,12 +774,13 @@ impl PvDatabase {
     /// without, instead of leaving the operator to run `dbcar`.
     /// `pva://` links are not in this set — they never block iocInit.
     pub async fn unconnected_external_links(&self) -> Vec<String> {
-        self.external_link_targets()
-            .await
-            .into_iter()
-            .filter(|(lset, name)| !lset.is_connected(name))
-            .map(|(_, name)| name)
-            .collect()
+        let mut names = Vec::new();
+        for (lset, name) in self.external_link_targets().await {
+            if !lset.is_connected(&name).await {
+                names.push(name);
+            }
+        }
+        names
     }
 
     /// Enumerate every link-shaped field on `record_name`. Returns
@@ -846,25 +863,35 @@ impl PvDatabase {
             // first one with a value for `name` wins. Schemes are
             // single-digit so this is cheap.
             let registry = self.inner.link_sets.read().await;
-            for s in registry.schemes() {
-                if let Some(lset) = registry.get(&s) {
-                    if let Some(v) = lset.get_value(name) {
-                        return Some(v);
-                    }
+            let lsets: Vec<_> = registry
+                .schemes()
+                .iter()
+                .filter_map(|s| registry.get(s))
+                .collect();
+            drop(registry);
+            for lset in lsets {
+                if let Some(v) = lset.get_value(name).await {
+                    return Some(v);
                 }
             }
-            drop(registry);
             // Fall through to legacy resolver.
-            let resolver = self.inner.external_resolver.read().await;
-            return resolver.as_ref().and_then(|r| r(name));
+            let resolver = self.inner.external_resolver.read().await.clone();
+            return match resolver {
+                Some(r) => r(name).await,
+                None => None,
+            };
         };
-        if let Some(lset) = self.inner.link_sets.read().await.get(scheme) {
-            if let Some(v) = lset.get_value(body) {
+        let lset = self.inner.link_sets.read().await.get(scheme);
+        if let Some(lset) = lset {
+            if let Some(v) = lset.get_value(body).await {
                 return Some(v);
             }
         }
-        let resolver = self.inner.external_resolver.read().await;
-        resolver.as_ref().and_then(|r| r(name))
+        let resolver = self.inner.external_resolver.read().await.clone();
+        match resolver {
+            Some(r) => r(name).await,
+            None => None,
+        }
     }
 
     /// Add a simple PV with an initial value.
@@ -1551,14 +1578,15 @@ mod tests {
         connect_at: tokio::time::Instant,
     }
 
+    #[async_trait::async_trait]
     impl link_set::LinkSet for DelayedConnectLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             tokio::time::Instant::now() >= self.connect_at
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             None
         }
-        fn link_names(&self) -> Vec<String> {
+        async fn link_names(&self) -> Vec<String> {
             self.names.clone()
         }
     }

--- a/crates/epics-base-rs/tests/database_tests.rs
+++ b/crates/epics-base-rs/tests/database_tests.rs
@@ -350,17 +350,18 @@ async fn test_pva_link_propagates_alarm_severity_into_link_alarm() {
 
     /// Stub lset: serves a value and a fixed (already gated) severity.
     struct AlarmingLset;
+    #[epics_base_rs::async_trait]
     impl LinkSet for AlarmingLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             Some(EpicsValue::Double(12.0))
         }
-        fn alarm_severity(&self, _: &str) -> Option<i32> {
+        async fn alarm_severity(&self, _: &str) -> Option<i32> {
             Some(2) // MAJOR — as if the link's MS mode let it through
         }
-        fn alarm_message(&self, _: &str) -> Option<String> {
+        async fn alarm_message(&self, _: &str) -> Option<String> {
             Some("remote major".into())
         }
     }
@@ -412,11 +413,12 @@ async fn test_pva_link_no_alarm_when_lset_reports_none() {
     use epics_base_rs::server::record::AlarmSeverity;
 
     struct QuietLset;
+    #[epics_base_rs::async_trait]
     impl LinkSet for QuietLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             Some(EpicsValue::Double(5.0))
         }
         // alarm_severity defaults to None.
@@ -468,14 +470,15 @@ struct CapturingLset {
         >,
     >,
 }
+#[epics_base_rs::async_trait]
 impl epics_base_rs::server::database::LinkSet for CapturingLset {
-    fn is_connected(&self, _: &str) -> bool {
+    async fn is_connected(&self, _: &str) -> bool {
         true
     }
-    fn get_value(&self, _: &str) -> Option<EpicsValue> {
+    async fn get_value(&self, _: &str) -> Option<EpicsValue> {
         None
     }
-    fn put_value(
+    async fn put_value(
         &self,
         name: &str,
         value: EpicsValue,
@@ -1937,11 +1940,12 @@ async fn test_sim_mode_output() {
 async fn test_sim_mode_input_nonlocal_db_siol() {
     use epics_base_rs::server::database::LinkSet;
     struct ValueCaLset(f64);
+    #[epics_base_rs::async_trait]
     impl LinkSet for ValueCaLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, name: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, name: &str) -> Option<EpicsValue> {
             // The bare non-local SIOL record name reaches the CA lset
             // via the read-locality fallback `resolve_external_pv`.
             (name == "REMOTE:SIM").then_some(EpicsValue::Double(self.0))
@@ -5462,14 +5466,15 @@ async fn test_tsel_ca_time_link_copies_source_time() {
         secs: i64,
         nsec: i32,
     }
+    #[epics_base_rs::async_trait]
     impl LinkSet for TimeCaLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             Some(EpicsValue::Double(1.0))
         }
-        fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
+        async fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
             // Only the source record name (with `.TIME` stripped) should
             // reach the lset, mirroring C `TSEL_modified` truncating the
             // pvname at `.TIME`.
@@ -5527,14 +5532,15 @@ async fn test_tsel_nonlocal_db_time_link_copies_remote_time() {
         secs: i64,
         nsec: i32,
     }
+    #[epics_base_rs::async_trait]
     impl LinkSet for TimeCaLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             Some(EpicsValue::Double(1.0))
         }
-        fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
+        async fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
             // The bare Db record name (`.TIME` already split into the link
             // field by the parser) reaches the CA lset via the non-local
             // fallback `external_link_time("ca://TSE_SRC")`.
@@ -6568,14 +6574,15 @@ async fn test_lnk_calc_nonlocal_input_resolves_externally() {
         secs: i64,
         nsec: i32,
     }
+    #[epics_base_rs::async_trait]
     impl LinkSet for CalcCaLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, name: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, name: &str) -> Option<EpicsValue> {
             (name == "REMOTE:A").then_some(EpicsValue::Double(10.0))
         }
-        fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
+        async fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
             (name == "REMOTE:A").then_some((self.secs, self.nsec, 0))
         }
     }
@@ -7208,19 +7215,20 @@ async fn br_fr3_ca_link_applies_maximize_switch_at_processing() {
         sevr: i32,
         stat: i32,
     }
+    #[epics_base_rs::async_trait]
     impl LinkSet for RawCaLset {
-        fn is_connected(&self, _: &str) -> bool {
+        async fn is_connected(&self, _: &str) -> bool {
             true
         }
-        fn get_value(&self, _: &str) -> Option<EpicsValue> {
+        async fn get_value(&self, _: &str) -> Option<EpicsValue> {
             Some(EpicsValue::Double(7.0))
         }
-        fn alarm_severity(&self, _: &str) -> Option<i32> {
+        async fn alarm_severity(&self, _: &str) -> Option<i32> {
             // Mirror the real CA resolver: only a non-zero severity is a
             // contribution worth returning.
             if self.sevr > 0 { Some(self.sevr) } else { None }
         }
-        fn alarm_status(&self, _: &str) -> Option<i32> {
+        async fn alarm_status(&self, _: &str) -> Option<i32> {
             Some(self.stat)
         }
     }

--- a/crates/epics-bridge-rs/src/pvalink/integration.rs
+++ b/crates/epics-bridge-rs/src/pvalink/integration.rs
@@ -28,34 +28,6 @@ use super::config::{LinkDirection, PvaLinkConfig};
 use super::link::{PvaLink, PvaLinkError, PvaLinkResult, ScanEvent, ScanOverrun};
 use super::registry::PvaLinkRegistry;
 
-/// Wrap `tokio::task::block_in_place(f)` with a runtime-flavour check.
-/// Tokio's block_in_place panics under the current_thread runtime; on
-/// that flavour we run `f` directly (the caller's outer block_on then
-/// has nothing to fall back to and may itself fail, but we surface
-/// that as a regular error rather than a panic). Used by every
-/// pvalink LinkSet/Resolver entry point — they're invoked from inside
-/// `PvDatabase::resolve_external_pv`'s async context.
-fn block_in_place_or_warn<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    use tokio::runtime::{Handle, RuntimeFlavor};
-    if let Ok(handle) = Handle::try_current() {
-        match handle.runtime_flavor() {
-            RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
-            // CurrentThread (or any other future flavour) can't park
-            // a worker, so we just call directly. Inside the closure
-            // the caller will likely call Handle::block_on which
-            // panics on current_thread; catch_unwind would mask real
-            // bugs, so we let it propagate. Production IOC binaries
-            // use the multi-threaded runtime.
-            _ => f(),
-        }
-    } else {
-        f()
-    }
-}
-
 /// Resolver wrapping a [`PvaLinkRegistry`] and a tokio runtime handle.
 /// Cheap to clone — both fields are `Arc`-backed.
 #[derive(Clone)]
@@ -761,84 +733,81 @@ impl PvaLinkResolver {
     }
 
     /// Build the [`ExternalPvResolver`] closure that the database
-    /// expects. The closure is sync; it uses
-    /// `Handle::block_on(future)` for the rare uncached path.
-    /// Pre-warm INP links via [`Self::open`] to keep the steady-state
-    /// path lock-free. The returned closure has a sync fast path
-    /// (cache hit on a pre-warmed monitor) and only falls through
-    /// to `block_on` on the first call for a given PV.
+    /// expects. Pre-warm INP links via [`Self::open`] to keep the
+    /// steady-state path lock-free: the closure has a cache-hit fast path
+    /// (a pre-warmed monitor, no I/O) and only opens the link on the first
+    /// call for a given PV.
     pub fn build_resolver(self) -> ExternalPvResolver {
         let resolver = self;
-        Arc::new(move |name: &str| -> Option<EpicsValue> {
-            if !resolver.is_enabled() {
-                return None;
-            }
-            // Strip optional pva:// prefix — the resolver receives the
-            // bare PV name in some link forms but the prefixed form in
-            // others. `ca://` is handled by libca, not pvalink — reject.
-            let full = match name.strip_prefix("pva://") {
-                Some(stripped) => stripped,
-                None => {
-                    if name.starts_with("ca://") {
-                        return None;
-                    }
-                    name
+        Arc::new(move |name: &str| {
+            let resolver = resolver.clone();
+            let name = name.to_string();
+            Box::pin(async move {
+                let name = name.as_str();
+                if !resolver.is_enabled() {
+                    return None;
                 }
-            };
-            // strip query string; lazily register per-link
-            // options; get per-link config before the fast path so the
-            // field selector is available for `try_read_cached_with_field`.
-            let bare = link_pv_name(full);
-            if full != bare {
-                lazy_register_inp_opts(&resolver.link_options, full);
-            }
-            // cfg carries the per-link field (among other opts).
-            let cfg = resolver.inp_cfg_for(full);
+                // Strip optional pva:// prefix — the resolver receives the
+                // bare PV name in some link forms but the prefixed form in
+                // others. `ca://` is handled by libca, not pvalink — reject.
+                let full = match name.strip_prefix("pva://") {
+                    Some(stripped) => stripped,
+                    None => {
+                        if name.starts_with("ca://") {
+                            return None;
+                        }
+                        name
+                    }
+                };
+                // strip query string; lazily register per-link
+                // options; get per-link config before the fast path so the
+                // field selector is available for `try_read_cached_with_field`.
+                let bare = link_pv_name(full);
+                if full != bare {
+                    lazy_register_inp_opts(&resolver.link_options, full);
+                }
+                // cfg carries the per-link field (among other opts).
+                let cfg = resolver.inp_cfg_for(full);
 
-            // Fast path: a previously-opened link with a cached
-            // monitor value. No `block_on`, no async runtime touch.
-            // `try_get_inp` resolves THIS caller's monitor variant
-            // (`pipeline` / `Q`), so a `Q=1` record reads from its own
-            // monitor, not a `Q=64` sibling sharing the PV name.
-            // `try_read_cached_with_field`
-            // then applies the per-link field selector.
-            if let Some(link) = resolver
-                .registry
-                .try_get_inp(bare, cfg.pipeline, cfg.queue_size)
-                && let Some(value) = link.try_read_cached_with_field(&cfg.field)
-            {
-                resolver
-                    .reads
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                return pvfield_to_epics_value(&value);
-            }
+                // Fast path: a previously-opened link with a cached
+                // monitor value. No `block_on`, no async runtime touch.
+                // `try_get_inp` resolves THIS caller's monitor variant
+                // (`pipeline` / `Q`), so a `Q=1` record reads from its own
+                // monitor, not a `Q=64` sibling sharing the PV name.
+                // `try_read_cached_with_field`
+                // then applies the per-link field selector.
+                if let Some(link) =
+                    resolver
+                        .registry
+                        .try_get_inp(bare, cfg.pipeline, cfg.queue_size)
+                    && let Some(value) = link.try_read_cached_with_field(&cfg.field)
+                {
+                    resolver
+                        .reads
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    return pvfield_to_epics_value(&value);
+                }
 
-            // Slow path: link not yet open or first-event not arrived.
-            // Open the link (idempotent) then issue an async read.
-            // B4: use `inp_cfg_for` so a link registered via
-            // `open_link` keeps its options (`sevr`, `Q`, `pipeline`,
-            // `monorder`); `default_inp_cfg` would discard them.
-            // The Lset external resolver is invoked from inside an
-            // async context (PvDatabase::resolve_external_pv runs on a
-            // tokio worker). Bare Handle::block_on panics under those
-            // conditions. block_in_place yields the worker thread for
-            // the duration of the inner block_on so the runtime stays
-            // healthy. Requires the multi-threaded runtime, which is
-            // the only flavour our IOC binaries use.
-            let field = cfg.field.clone();
-            let (link, value) = block_in_place_or_warn(|| {
-                resolver.handle.block_on(async {
+                // Slow path: link not yet open or first-event not arrived.
+                // Open the link (idempotent) then read it.
+                // B4: use `inp_cfg_for` so a link registered via
+                // `open_link` keeps its options (`sevr`, `Q`, `pipeline`,
+                // `monorder`); `default_inp_cfg` would discard them.
+                let field = cfg.field.clone();
+                let (link, value) = async {
                     let link = resolver.registry.get_or_open(cfg).await.ok()?;
                     // use per-link field selector.
                     let value = link.read_with_field(&field).await.ok()?;
                     Some((link, value))
-                })
-            })?;
-            let _ = link;
-            resolver
-                .reads
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            pvfield_to_epics_value(&value)
+                }
+                .await?;
+                let _ = link;
+                resolver
+                    .reads
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                pvfield_to_epics_value(&value)
+            })
+                as std::pin::Pin<Box<dyn std::future::Future<Output = Option<EpicsValue>> + Send>>
         })
     }
 }
@@ -1142,13 +1111,11 @@ async fn scan_once(
     drop(atomic_epoch);
 }
 
+#[epics_base_rs::async_trait]
 impl LinkSet for PvaLinkResolver {
-    fn is_connected(&self, name: &str) -> bool {
-        // Sync-only check: trait can't await. If the link hasn't
-        // been pre-opened we report "not connected" — the resolver
-        // hot path or `pvxr` will open it lazily; any caller that
-        // wants a fresh open should call `Self::open(name).await`
-        // first.
+    async fn is_connected(&self, name: &str) -> bool {
+        // A link that has not been opened reports "not connected"; the
+        // resolver hot path or `pvxr` opens it lazily.
         let Some(full) = strip_scheme(name) else {
             return false;
         };
@@ -1170,7 +1137,7 @@ impl LinkSet for PvaLinkResolver {
         }
     }
 
-    fn get_value(&self, name: &str) -> Option<EpicsValue> {
+    async fn get_value(&self, name: &str) -> Option<EpicsValue> {
         if !self.is_enabled() {
             return None;
         }
@@ -1201,18 +1168,17 @@ impl LinkSet for PvaLinkResolver {
         // keeps its options (`sevr`, `Q`, `pipeline`, `monorder`);
         // `default_inp_cfg` would discard them.
         let field = cfg.field.clone();
-        let value = block_in_place_or_warn(|| {
-            self.handle.block_on(async {
-                let link = self.registry.get_or_open(cfg).await.ok()?;
-                link.read_with_field(&field).await.ok()
-            })
-        })?;
+        let value = async {
+            let link = self.registry.get_or_open(cfg).await.ok()?;
+            link.read_with_field(&field).await.ok()
+        }
+        .await?;
         self.reads
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         pvfield_to_epics_value(&value)
     }
 
-    fn put_value(&self, name: &str, value: EpicsValue, op: LinkPutOp) -> Result<(), String> {
+    async fn put_value(&self, name: &str, value: EpicsValue, op: LinkPutOp) -> Result<(), String> {
         if !self.is_enabled() {
             return Err("pvalink disabled".into());
         }
@@ -1247,42 +1213,41 @@ impl LinkSet for PvaLinkResolver {
         // through the string PUT path where the bracketed `Display`
         // text is unparseable.
         let array_path = is_array_value(&value);
-        block_in_place_or_warn(|| {
-            self.handle.block_on(async {
-                // `local`-admission gate on the lazy write path: a
-                // `local=true` OUT link must never open — or reuse a
-                // sibling's already-open — remote channel. Checked before
-                // `get_or_open` so even a cache hit is gated (pvxs
-                // `pvaOpenLink`, direction-agnostic).
-                self.check_local_admission(&cfg)
+        async {
+            // `local`-admission gate on the lazy write path: a
+            // `local=true` OUT link must never open — or reuse a
+            // sibling's already-open — remote channel. Checked before
+            // `get_or_open` so even a cache hit is gated (pvxs
+            // `pvaOpenLink`, direction-agnostic).
+            self.check_local_admission(&cfg)
+                .await
+                .map_err(|e| e.to_string())?;
+            // Resolve the SHARED channel owner for this PV (the
+            // registry no longer keys on the per-link OUT options),
+            // then stage THIS link's write with its own
+            // `field`/`proc`/`defer`/`retry` so sibling fields
+            // coalesce into one upstream PUT.
+            let link = self
+                .registry
+                .get_or_open(cfg.clone())
+                .await
+                .map_err(|e| e.to_string())?;
+            if array_path {
+                let pv_field = crate::convert::epics_to_pv_field(&value);
+                link.put_out_field(&cfg, &pv_field, block)
                     .await
-                    .map_err(|e| e.to_string())?;
-                // Resolve the SHARED channel owner for this PV (the
-                // registry no longer keys on the per-link OUT options),
-                // then stage THIS link's write with its own
-                // `field`/`proc`/`defer`/`retry` so sibling fields
-                // coalesce into one upstream PUT.
-                let link = self
-                    .registry
-                    .get_or_open(cfg.clone())
+                    .map_err(|e| e.to_string())
+            } else {
+                let value_str = value.to_string();
+                link.put_out_str(&cfg, &value_str, block)
                     .await
-                    .map_err(|e| e.to_string())?;
-                if array_path {
-                    let pv_field = crate::convert::epics_to_pv_field(&value);
-                    link.put_out_field(&cfg, &pv_field, block)
-                        .await
-                        .map_err(|e| e.to_string())
-                } else {
-                    let value_str = value.to_string();
-                    link.put_out_str(&cfg, &value_str, block)
-                        .await
-                        .map_err(|e| e.to_string())
-                }
-            })
-        })
+                    .map_err(|e| e.to_string())
+            }
+        }
+        .await
     }
 
-    fn scan_forward(&self, name: &str) -> Result<(), String> {
+    async fn scan_forward(&self, name: &str) -> Result<(), String> {
         if !self.is_enabled() {
             return Err("pvalink disabled".into());
         }
@@ -1298,22 +1263,21 @@ impl LinkSet for PvaLinkResolver {
             lazy_register_inp_opts(&self.link_options, full);
         }
         let cfg = self.inp_cfg_for(full);
-        block_in_place_or_warn(|| {
-            self.handle.block_on(async {
-                // Open / reuse the shared channel so the forward link
-                // tracks connection the way pvxs's shared channel does,
-                // then fire `pvaScanForward` (process-only, no value).
-                let link = self
-                    .registry
-                    .get_or_open(cfg)
-                    .await
-                    .map_err(|e| e.to_string())?;
-                link.scan_forward().await.map_err(|e| e.to_string())
-            })
-        })
+        async {
+            // Open / reuse the shared channel so the forward link
+            // tracks connection the way pvxs's shared channel does,
+            // then fire `pvaScanForward` (process-only, no value).
+            let link = self
+                .registry
+                .get_or_open(cfg)
+                .await
+                .map_err(|e| e.to_string())?;
+            link.scan_forward().await.map_err(|e| e.to_string())
+        }
+        .await
     }
 
-    fn flush_puts(&self) {
+    async fn flush_puts(&self) {
         if !self.is_enabled() {
             return;
         }
@@ -1327,16 +1291,15 @@ impl LinkSet for PvaLinkResolver {
         if links.is_empty() {
             return;
         }
-        block_in_place_or_warn(|| {
-            self.handle.block_on(async {
-                for link in links {
-                    let _ = link.flush_retry_pending().await;
-                }
-            })
-        });
+        async {
+            for link in links {
+                let _ = link.flush_retry_pending().await;
+            }
+        }
+        .await;
     }
 
-    fn alarm_message(&self, name: &str) -> Option<String> {
+    async fn alarm_message(&self, name: &str) -> Option<String> {
         // parse the caller's full link config and apply the
         // caller's own `sevr` mode — `get_or_open` may return a
         // previously cached INP link whose `config.sevr` belongs to a
@@ -1351,14 +1314,11 @@ impl LinkSet for PvaLinkResolver {
         let cfg = self.inp_cfg_for(full);
         let sevr = cfg.sevr;
         let field = cfg.field.clone();
-        let link = block_in_place_or_warn(|| {
-            self.handle
-                .block_on(async { self.registry.get_or_open(cfg).await.ok() })
-        })?;
+        let link = async { self.registry.get_or_open(cfg).await.ok() }.await?;
         link.alarm_message_with(&field, sevr)
     }
 
-    fn alarm_severity(&self, name: &str) -> Option<i32> {
+    async fn alarm_severity(&self, name: &str) -> Option<i32> {
         // B2: surface the gated link-alarm severity so the owning
         // record's `LINK_ALARM` actually reflects the remote PV's
         // alarm. The `MS`/`NMS`/`MSI` gate is applied here.
@@ -1374,14 +1334,14 @@ impl LinkSet for PvaLinkResolver {
         let cfg = self.inp_cfg_for(full);
         let sevr = cfg.sevr;
         let field = cfg.field.clone();
-        let link = block_in_place_or_warn(|| {
-            self.handle
-                .block_on(async { self.registry.get_or_open(cfg).await.ok() })
-        })?;
+        let link = async { self.registry.get_or_open(cfg).await.ok() }.await?;
         link.link_alarm_severity_with(&field, sevr)
     }
 
-    fn remote_alarm(&self, name: &str) -> Option<epics_base_rs::server::database::RemoteAlarm> {
+    async fn remote_alarm(
+        &self,
+        name: &str,
+    ) -> Option<epics_base_rs::server::database::RemoteAlarm> {
         // Ungated remote alarm snapshot for DB-link inspection
         // (`dbGetAlarm`/`dbGetAlarmMsg`). Unlike `alarm_severity`, this
         // applies NO `sevr` gate — a default `NMS` link still reports
@@ -1396,14 +1356,11 @@ impl LinkSet for PvaLinkResolver {
         }
         let cfg = self.inp_cfg_for(full);
         let field = cfg.field.clone();
-        let link = block_in_place_or_warn(|| {
-            self.handle
-                .block_on(async { self.registry.get_or_open(cfg).await.ok() })
-        })?;
+        let link = async { self.registry.get_or_open(cfg).await.ok() }.await?;
         link.remote_alarm_snapshot(&field)
     }
 
-    fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
+    async fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
         let full = strip_scheme(name)?;
         let bare = link_pv_name(full);
         if full != bare {
@@ -1423,10 +1380,7 @@ impl LinkSet for PvaLinkResolver {
         let cfg = self.inp_cfg_for(full);
         let want_time = cfg.time;
         let field = cfg.field.clone();
-        let link = block_in_place_or_warn(|| {
-            self.handle
-                .block_on(async { self.registry.get_or_open(cfg).await.ok() })
-        })?;
+        let link = async { self.registry.get_or_open(cfg).await.ok() }.await?;
         // only adopt the upstream timestamp when this caller's
         // link was configured with `time=true`. pvxs
         // `pvalink_lset.cpp:427` copies the latched remote NT
@@ -1439,7 +1393,10 @@ impl LinkSet for PvaLinkResolver {
         link.time_stamp(&field)
     }
 
-    fn link_metadata(&self, name: &str) -> Option<epics_base_rs::server::database::LinkMetadata> {
+    async fn link_metadata(
+        &self,
+        name: &str,
+    ) -> Option<epics_base_rs::server::database::LinkMetadata> {
         // surface the remote display/control/valueAlarm
         // metadata, DBF type and element count through the DB link
         // API, mirroring the pvxs pvalink lset metadata getter set
@@ -1462,14 +1419,11 @@ impl LinkSet for PvaLinkResolver {
         }
         let cfg = self.inp_cfg_for(full);
         let field = cfg.field.clone();
-        let link = block_in_place_or_warn(|| {
-            self.handle
-                .block_on(async { self.registry.get_or_open(cfg).await.ok() })
-        })?;
+        let link = async { self.registry.get_or_open(cfg).await.ok() }.await?;
         link.link_metadata_with(&field)
     }
 
-    fn link_names(&self) -> Vec<String> {
+    async fn link_names(&self) -> Vec<String> {
         // The [`LinkSet::link_names`] enumeration contract: surface one
         // identity per opened INP monitor variant, for link introspection.
         // NOT consumed by the iocInit external-link wait — that wait is
@@ -2834,7 +2788,7 @@ mod tests {
         assert_eq!(resolver.inp_cfg_for("UNSEEN").sevr, SevrMode::Nms);
     }
 
-    /// `LinkSet::link_names()` must surface the opened INP upstream PV
+    /// `LinkSet::link_names().await` must surface the opened INP upstream PV
     /// names (the lset enumeration contract), each landing on the right
     /// link when fed back through its `is_connected` companion query; OUT
     /// links are excluded (no monitor connection signal). These names are
@@ -2866,7 +2820,7 @@ mod tests {
             .registry
             .insert_for_test(&out_cfg, Arc::new(PvaLink::for_test(out_cfg.clone(), None)));
 
-        let mut names = LinkSet::link_names(&resolver);
+        let mut names = LinkSet::link_names(&resolver).await;
         names.sort();
         assert_eq!(
             names,
@@ -2877,11 +2831,11 @@ mod tests {
         // Each returned name is queryable via is_connected — the
         // round-trip identity the enumeration contract guarantees.
         assert!(
-            LinkSet::is_connected(&resolver, "FR15:CONNECTED"),
+            LinkSet::is_connected(&resolver, "FR15:CONNECTED").await,
             "cached INP link reports connected"
         );
         assert!(
-            !LinkSet::is_connected(&resolver, "FR15:PENDING"),
+            !LinkSet::is_connected(&resolver, "FR15:PENDING").await,
             "INP link with no value yet reports not connected"
         );
     }
@@ -3182,10 +3136,6 @@ mod tests {
     /// opening/queuing, not send or stage a remote PUT. Asserts the error
     /// is the `local` gate (`NotLocal` Display) rather than an incidental
     /// disconnected-write failure, so removing the gate truly fails this.
-    ///
-    /// Multi-thread runtime: `put_value` drives the async open through
-    /// `block_in_place` + `block_on`, which a current-thread runtime
-    /// rejects (matching the typed-array OUT tests below).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn b4_local_out_put_value_rejects_non_local_pv() {
         let db = Arc::new(PvDatabase::new());
@@ -3195,7 +3145,8 @@ mod tests {
             "pva://NOT:A:LOCAL:RECORD?local=true",
             EpicsValue::Double(1.0),
             LinkPutOp::Plain,
-        );
+        )
+        .await;
         let err = r.expect_err("local=true OUT put to a non-local PV must fail");
         assert!(
             err.contains("has no matching local record"),
@@ -3776,42 +3727,43 @@ mod tests {
             .open_link_for_record("pva://VAR:PV?proc=CP&Q=64", "REC:Q64")
             .await;
 
-        let targets = resolver.scan_targets.read();
-        let key_q1 = MonitorKey {
-            pv_name: "VAR:PV".to_string(),
-            pipeline: false,
-            queue_size: 1,
-        };
-        let key_q64 = MonitorKey {
-            pv_name: "VAR:PV".to_string(),
-            pipeline: false,
-            queue_size: 64,
-        };
-        let fan_q1 = targets
-            .get(&key_q1)
-            .expect("Q=1 variant must have its own scan fan-out");
-        let fan_q64 = targets
-            .get(&key_q64)
-            .expect("Q=64 variant must have its own scan fan-out");
-        assert_eq!(
-            fan_q1.records.len(),
-            1,
-            "Q=1 fan-out must hold only its own record"
-        );
-        assert_eq!(fan_q1.records[0].record, "REC:Q1");
-        assert_eq!(
-            fan_q64.records.len(),
-            1,
-            "Q=64 fan-out must not inherit the Q=1 record"
-        );
-        assert_eq!(fan_q64.records[0].record, "REC:Q64");
-        drop(targets);
+        {
+            let targets = resolver.scan_targets.read();
+            let key_q1 = MonitorKey {
+                pv_name: "VAR:PV".to_string(),
+                pipeline: false,
+                queue_size: 1,
+            };
+            let key_q64 = MonitorKey {
+                pv_name: "VAR:PV".to_string(),
+                pipeline: false,
+                queue_size: 64,
+            };
+            let fan_q1 = targets
+                .get(&key_q1)
+                .expect("Q=1 variant must have its own scan fan-out");
+            let fan_q64 = targets
+                .get(&key_q64)
+                .expect("Q=64 variant must have its own scan fan-out");
+            assert_eq!(
+                fan_q1.records.len(),
+                1,
+                "Q=1 fan-out must hold only its own record"
+            );
+            assert_eq!(fan_q1.records[0].record, "REC:Q1");
+            assert_eq!(
+                fan_q64.records.len(),
+                1,
+                "Q=64 fan-out must not inherit the Q=1 record"
+            );
+            assert_eq!(fan_q64.records[0].record, "REC:Q64");
+        }
 
         // Both monitor variants must appear in the iocInit wait set,
         // each rendered as an identity that round-trips back to its own
         // variant; the default-Q form is bare, non-default carries the
         // query.
-        let mut names = resolver.link_names();
+        let mut names = resolver.link_names().await;
         names.sort();
         assert_eq!(
             names,
@@ -4108,18 +4060,18 @@ mod tests {
         // MAJOR severity propagate.
         let nms_name = "pva://MR_R15:PV";
         assert_eq!(
-            LinkSet::alarm_severity(&resolver, nms_name),
+            LinkSet::alarm_severity(&resolver, nms_name).await,
             None,
             "an NMS caller must not propagate the remote alarm"
         );
         let ms_name = "pva://MR_R15:PV?sevr=MS";
         assert_eq!(
-            LinkSet::alarm_severity(&resolver, ms_name),
+            LinkSet::alarm_severity(&resolver, ms_name).await,
             Some(2),
             "an MS caller must see MAJOR even though the cached link is NMS"
         );
         assert_eq!(
-            LinkSet::alarm_message(&resolver, ms_name),
+            LinkSet::alarm_message(&resolver, ms_name).await,
             Some("HIGH".to_string()),
             "an MS caller must get the remote alarm message"
         );
@@ -4139,6 +4091,7 @@ mod tests {
         // `alarm_severity` calls read the cached value live and do NOT
         // latch, so the snapshot is still INVALID here.
         let pre = LinkSet::remote_alarm(&resolver, nms_name)
+            .await
             .expect("connected link reports the initial INVALID snapshot");
         assert_eq!(pre.severity, 3, "pre-read snapshot is INVALID_ALARM");
         assert_eq!(pre.status, 14, "LINK_ALARM status");
@@ -4147,7 +4100,7 @@ mod tests {
         // A value read (the LinkSet `get_value` path = pvxs `dbGetLink` /
         // `pvaGetValue`) latches the snapshot.
         assert!(
-            LinkSet::get_value(&resolver, nms_name).is_some(),
+            LinkSet::get_value(&resolver, nms_name).await.is_some(),
             "the cached value read must succeed and latch the snapshot"
         );
 
@@ -4156,6 +4109,7 @@ mod tests {
         // LINK_ALARM(14) status, and message. The `sevr` mode does not
         // gate this path.
         let snap = LinkSet::remote_alarm(&resolver, nms_name)
+            .await
             .expect("NMS caller still gets the ungated remote alarm snapshot");
         assert_eq!(snap.severity, 2, "ungated snapshot reports remote MAJOR");
         assert_eq!(snap.status, 14, "LINK_ALARM status derived from severity");
@@ -4164,12 +4118,12 @@ mod tests {
         // The shared cached link is time=false → a bare caller adopts
         // no timestamp. A caller asking `?time=true` must adopt it.
         assert_eq!(
-            LinkSet::time_stamp(&resolver, nms_name),
+            LinkSet::time_stamp(&resolver, nms_name).await,
             None,
             "a time=false caller must not adopt the upstream timestamp"
         );
         assert_eq!(
-            LinkSet::time_stamp(&resolver, "pva://MR_R15:PV?time=true"),
+            LinkSet::time_stamp(&resolver, "pva://MR_R15:PV?time=true").await,
             Some((1_700_000_000, 42, 0x0000_0000_9000_0000)),
             "a time=true caller must adopt the upstream timestamp and the \
              zero-extended userTag"
@@ -4274,6 +4228,7 @@ mod tests {
         // Drive the OUT path through the resolver's LinkSet impl.
         let scheme_name = format!("pva://{pv_name}");
         LinkSet::put_value(&resolver, &scheme_name, value, LinkPutOp::Plain)
+            .await
             .expect("typed array OUT write must succeed");
 
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;

--- a/crates/epics-ca-rs/src/calink/iocsh.rs
+++ b/crates/epics-ca-rs/src/calink/iocsh.rs
@@ -91,12 +91,24 @@ pub fn db_dbcaxr_command(resolver: CaLinkResolver) -> CommandDef {
                     for (field, raw, parsed) in links {
                         if let epics_base_rs::server::record::ParsedLink::Ca(ca) = parsed {
                             let name = ca.pv;
-                            let connected =
-                                <CaLinkResolver as LinkSet>::is_connected(&resolver, &name);
-                            let value = <CaLinkResolver as LinkSet>::get_value(&resolver, &name);
-                            let alarm =
-                                <CaLinkResolver as LinkSet>::alarm_severity(&resolver, &name);
-                            let ts = <CaLinkResolver as LinkSet>::time_stamp(&resolver, &name);
+                            // The lset is async; this iocsh command is sync, so
+                            // its state is read through the same off-runtime
+                            // thread the record-field lookup above uses.
+                            let r = resolver.clone();
+                            let n = name.clone();
+                            let h = ctx.runtime_handle().clone();
+                            let (connected, value, alarm, ts) = std::thread::spawn(move || {
+                                h.block_on(async move {
+                                    (
+                                        <CaLinkResolver as LinkSet>::is_connected(&r, &n).await,
+                                        <CaLinkResolver as LinkSet>::get_value(&r, &n).await,
+                                        <CaLinkResolver as LinkSet>::alarm_severity(&r, &n).await,
+                                        <CaLinkResolver as LinkSet>::time_stamp(&r, &n).await,
+                                    )
+                                })
+                            })
+                            .join()
+                            .unwrap_or((false, None, None, None));
                             ctx.println(&format!(
                                 "    {field}={raw:?}  ca://{name}  connected={connected}"
                             ));

--- a/crates/epics-ca-rs/src/calink/resolver.rs
+++ b/crates/epics-ca-rs/src/calink/resolver.rs
@@ -444,17 +444,14 @@ impl CaLinkResolver {
         self.links.read().len()
     }
 
-    /// Lazily resolve `name` to its cached [`CaLink`]. Opens the link
-    /// (blocking the worker thread on the runtime) when it is not yet
-    /// in the registry — the first-access slow path. Steady-state
-    /// reads hit the registry directly.
-    fn link_for(&self, name: &str) -> Option<Arc<CaLink>> {
+    /// Lazily resolve `name` to its cached [`CaLink`]. Opens the link when
+    /// it is not yet in the registry — the first-access slow path.
+    /// Steady-state reads hit the registry directly.
+    async fn link_for(&self, name: &str) -> Option<Arc<CaLink>> {
         if let Some(existing) = self.links.read().get(name).cloned() {
             return Some(existing);
         }
-        let resolver = self.clone();
-        let name = name.to_string();
-        block_in_place_or_warn(move || resolver.handle.block_on(resolver.open(&name)).ok())
+        self.open(name).await.ok()
     }
 }
 
@@ -709,8 +706,9 @@ fn map_dbf_type(t: DbFieldType) -> LinkDbfType {
     }
 }
 
+#[async_trait::async_trait]
 impl LinkSet for CaLinkResolver {
-    fn is_connected(&self, name: &str) -> bool {
+    async fn is_connected(&self, name: &str) -> bool {
         let name = strip_ca_scheme(name);
         match self.links.read().get(name) {
             Some(link) => link.is_connected(),
@@ -720,12 +718,12 @@ impl LinkSet for CaLinkResolver {
         }
     }
 
-    fn get_value(&self, name: &str) -> Option<EpicsValue> {
+    async fn get_value(&self, name: &str) -> Option<EpicsValue> {
         let name = strip_ca_scheme(name);
-        self.link_for(name)?.value()
+        self.link_for(name).await?.value()
     }
 
-    fn put_value(&self, name: &str, value: EpicsValue, op: LinkPutOp) -> Result<(), String> {
+    async fn put_value(&self, name: &str, value: EpicsValue, op: LinkPutOp) -> Result<(), String> {
         // Honour the C dbCore split between a plain link put and a
         // put-notify-aware put. `dbCaPutLink` (no callback) sets
         // `putType = CA_PUT`, and the CA task later issues a
@@ -746,44 +744,40 @@ impl LinkSet for CaLinkResolver {
         let name = strip_ca_scheme(name);
         let link = self
             .link_for(name)
+            .await
             .ok_or_else(|| format!("CA link {name} not open"))?;
         let channel = link.channel.clone();
-        block_in_place_or_warn(move || {
-            self.handle
-                .block_on(async move {
-                    match op {
-                        LinkPutOp::Plain => channel.put_nowait(&value).await,
-                        LinkPutOp::Async => channel.put(&value).await,
-                    }
-                })
-                .map_err(|e| e.to_string())
-        })
+        match op {
+            LinkPutOp::Plain => channel.put_nowait(&value).await,
+            LinkPutOp::Async => channel.put(&value).await,
+        }
+        .map_err(|e| e.to_string())
     }
 
-    fn alarm_severity(&self, name: &str) -> Option<i32> {
+    async fn alarm_severity(&self, name: &str) -> Option<i32> {
         let name = strip_ca_scheme(name);
-        let sev = self.link_for(name)?.alarm_severity()?;
+        let sev = self.link_for(name).await?.alarm_severity()?;
         // Mirror the lset contract: only a non-zero severity is a
         // contribution worth propagating into the owning record's
         // LINK_ALARM. `0` (NO_ALARM) means "do not propagate".
         if sev > 0 { Some(sev) } else { None }
     }
 
-    fn alarm_status(&self, name: &str) -> Option<i32> {
+    async fn alarm_status(&self, name: &str) -> Option<i32> {
         // surface the remote STAT for `MSS` propagation.
         // Record processing only consults this when the alarm is
         // actually propagated (severity > 0 via `alarm_severity`), so
         // no severity gate is needed here.
         let name = strip_ca_scheme(name);
-        self.link_for(name)?.alarm_status()
+        self.link_for(name).await?.alarm_status()
     }
 
-    fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
+    async fn time_stamp(&self, name: &str) -> Option<(i64, i32, u64)> {
         let name = strip_ca_scheme(name);
-        self.link_for(name)?.time_stamp()
+        self.link_for(name).await?.time_stamp()
     }
 
-    fn link_metadata(&self, name: &str) -> Option<LinkMetadata> {
+    async fn link_metadata(&self, name: &str) -> Option<LinkMetadata> {
         // surface the remote display/control/alarm limits,
         // precision, units, DBF type and element count through the DB
         // link API so a record with a CA INP link inherits them, matching
@@ -791,10 +785,10 @@ impl LinkSet for CaLinkResolver {
         // no fresh GET — exactly as C `getControlLimits` &c. read
         // `pca->controlLimits`.
         let name = strip_ca_scheme(name);
-        self.link_for(name)?.link_metadata()
+        self.link_for(name).await?.link_metadata()
     }
 
-    fn link_names(&self) -> Vec<String> {
+    async fn link_names(&self) -> Vec<String> {
         self.links.read().keys().cloned().collect()
     }
 }
@@ -805,26 +799,6 @@ impl LinkSet for CaLinkResolver {
 /// so the resolver normalises to the bare PV name.
 fn strip_ca_scheme(name: &str) -> &str {
     name.strip_prefix("ca://").unwrap_or(name)
-}
-
-/// Run `f`, parking the tokio worker thread for the duration when on a
-/// multi-threaded runtime so an inner `block_on` does not deadlock the
-/// runtime. Mirrors the helper in the bridge `pvalink`'s integration
-/// module — the lset trait is synchronous but is invoked from inside
-/// `PvDatabase::resolve_external_pv`'s async context.
-fn block_in_place_or_warn<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    use tokio::runtime::{Handle, RuntimeFlavor};
-    if let Ok(handle) = Handle::try_current() {
-        match handle.runtime_flavor() {
-            RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
-            _ => f(),
-        }
-    } else {
-        f()
-    }
 }
 
 /// Install a [`CaLinkResolver`] on `db`, registered under the `"ca"`

--- a/crates/epics-ca-rs/tests/calink.rs
+++ b/crates/epics-ca-rs/tests/calink.rs
@@ -75,14 +75,14 @@ async fn ca_link_resolves_remote_value() {
 
     // The monitor-backed cache now serves the remote value.
     use epics_base_rs::server::database::LinkSet;
-    let value = LinkSet::get_value(&resolver, "CALINK:SRC");
+    let value = LinkSet::get_value(&resolver, "CALINK:SRC").await;
     assert_eq!(
         value.and_then(|v| v.to_f64()),
         Some(73.5),
         "CA link must return the upstream PV's value"
     );
     assert!(
-        LinkSet::is_connected(&resolver, "CALINK:SRC"),
+        LinkSet::is_connected(&resolver, "CALINK:SRC").await,
         "CA link must report connected once a value is cached"
     );
     assert_eq!(resolver.link_count(), 1);
@@ -114,7 +114,9 @@ async fn ca_link_resolves_with_scheme_prefix() {
 
     use epics_base_rs::server::database::LinkSet;
     assert_eq!(
-        LinkSet::get_value(&resolver, "ca://CALINK:SCHEME").and_then(|v| v.to_f64()),
+        LinkSet::get_value(&resolver, "ca://CALINK:SCHEME")
+            .await
+            .and_then(|v| v.to_f64()),
         Some(404.0),
         "scheme-prefixed CA link must resolve to the upstream value"
     );
@@ -332,13 +334,18 @@ async fn ca_link_out_write_updates_remote_pv() {
         EpicsValue::Double(88.0),
         LinkPutOp::Plain,
     )
+    .await
     .expect("CA-link OUT write must succeed");
 
     // The resolver's monitor sees the server-side change — poll the
     // monitor-backed cache until the write propagates back.
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     loop {
-        if LinkSet::get_value(&resolver, "CALINK:OUT:DST").and_then(|v| v.to_f64()) == Some(88.0) {
+        if LinkSet::get_value(&resolver, "CALINK:OUT:DST")
+            .await
+            .and_then(|v| v.to_f64())
+            == Some(88.0)
+        {
             break;
         }
         assert!(
@@ -403,6 +410,7 @@ async fn ca_link_out_write_async_waits_for_completion() {
         EpicsValue::Double(42.0),
         LinkPutOp::Async,
     )
+    .await
     .expect("completion-aware CA-link OUT write must succeed");
 
     // An independent CA client GET reads the committed value back —
@@ -451,11 +459,14 @@ async fn ca_link_out_write_accepts_scheme_prefix() {
         EpicsValue::Long(123),
         LinkPutOp::Plain,
     )
+    .await
     .expect("scheme-prefixed CA-link OUT write must succeed");
 
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     loop {
-        if LinkSet::get_value(&resolver, "ca://CALINK:OUT:SCHEME").and_then(|v| v.to_f64())
+        if LinkSet::get_value(&resolver, "ca://CALINK:OUT:SCHEME")
+            .await
+            .and_then(|v| v.to_f64())
             == Some(123.0)
         {
             break;
@@ -506,7 +517,7 @@ async fn ca_link_exposes_remote_metadata() {
     // so poll until the cached metadata lands.
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     let md = loop {
-        if let Some(md) = LinkSet::link_metadata(&resolver, "CALINK:META:SRC") {
+        if let Some(md) = LinkSet::link_metadata(&resolver, "CALINK:META:SRC").await {
             // Wait for the CTRL get to fill the limits, not just the
             // channel-info type/count from a partial first store.
             if md.graphic_limits.is_some() {
@@ -541,7 +552,7 @@ async fn ca_link_exposes_remote_metadata() {
 
     // While connected the metadata is served; the read path gates on the
     // connection flag exactly like the value/alarm getters.
-    assert!(LinkSet::is_connected(&resolver, "CALINK:META:SRC"));
+    assert!(LinkSet::is_connected(&resolver, "CALINK:META:SRC").await);
 }
 
 /// `install_calink_resolver` registers under the `ca` scheme so the

--- a/crates/epics-ca-rs/tests/calink_lset_contexts.rs
+++ b/crates/epics-ca-rs/tests/calink_lset_contexts.rs
@@ -1,0 +1,22 @@
+//! The `ca://` lset must answer link reads on any runtime flavor.
+
+use epics_base_rs::server::database::LinkSet;
+use epics_ca_rs::calink::CaLinkResolver;
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_value_of_an_unconnected_link_on_current_thread_runtime() {
+    let resolver = CaLinkResolver::new(tokio::runtime::Handle::current());
+    assert!(
+        resolver.get_value("NO:SUCH:PV:CALINK").await.is_none(),
+        "an unconnected link reads as no value"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_value_of_an_unconnected_link_on_multi_thread_runtime() {
+    let resolver = CaLinkResolver::new(tokio::runtime::Handle::current());
+    assert!(
+        resolver.get_value("NO:SUCH:PV:CALINK").await.is_none(),
+        "an unconnected link reads as no value"
+    );
+}


### PR DESCRIPTION
An lset's state is async state: pvalink and calink both open links, and cache them, on a tokio runtime. But the `LinkSet` trait (`crates/epics-base-rs/src/server/database/link_set.rs`) and the legacy `ExternalPvResolver` closure were **sync** — its module doc even instructed implementers to "keep a `tokio::runtime::Handle` and `block_on` internally". Both production lsets did exactly that, through the same helper, duplicated verbatim in two crates (`epics-bridge-rs/src/pvalink/integration.rs:38`, `epics-ca-rs/src/calink/resolver.rs:815`):

```rust
fn block_in_place_or_warn<F, R>(f: F) -> R {
    if let Ok(handle) = Handle::try_current() {
        match handle.runtime_flavor() {
            RuntimeFlavor::MultiThread => tokio::task::block_in_place(f),
            _ => f(),      // <-- current-thread: the inner Handle::block_on panics
        }
    } else { f() }
}
```

On a current-thread runtime `block_in_place` cannot park a worker, so the helper calls `f` directly — and `f` is `handle.block_on(...)`, which panics inside *any* runtime. The pvalink copy's own comment conceded it: *"the caller will likely call Handle::block_on which panics on current_thread"*. So **every** lset entry point — link read, write, forward scan, alarm severity/status/message, timestamp, metadata — panics on a current-thread runtime. That is the runtime `#[epics::test]` builds (`epics-macros-rs/src/lib.rs:170`) and the one every asyn port actor runs (`asyn-rs/src/port_actor.rs:146`).

## Fix — delete the bridge, don't fix it

The sync boundary was **gratuitous**: every caller of these methods is already an `async fn` (`PvDatabase::resolve_external_pv`, `external_link_alarm`, `external_link_time`, `external_link_metadata`, `write_external_pv`, `scan_forward_external_pv`, `wait_for_external_links`). Record `process()` never touches links. So:

* `LinkSet` becomes `#[async_trait]` — all 12 methods `async fn`.
* `ExternalPvResolver` returns a boxed future instead of a value.
* **Both copies of `block_in_place_or_warn` are deleted**, along with every `handle.block_on` inside the two resolvers. `CaLinkResolver::link_for` is now an `async fn` that awaits `open`; `PvaLinkResolver`'s slow paths await `registry.get_or_open` directly.
* `PvDatabase::registered_link_sets` is the single owner of "snapshot the lset registry, release its lock, then await" — the bare-name link paths no longer iterate the registry under its read guard now that every lset call is an await.

With no blocking bridge there is no runtime flavor to be wrong about.

## API change (stated explicitly)

* **Breaking for out-of-tree lsets:** `LinkSet` is `#[async_trait]`. An impl gains `#[epics_base_rs::async_trait]` and `async fn`; `async_trait` is re-exported from `epics_base_rs` so no new dependency is needed.
* **Breaking for out-of-tree resolver closures:** `ExternalPvResolver` is now `Arc<dyn for<'a> Fn(&'a str) -> Pin<Box<dyn Future<Output = Option<EpicsValue>> + Send + 'a>> + Send + Sync>`; a closure body becomes `Box::pin(async move { ... })`.
* `PvDatabase::unconnected_external_links` / `wait_for_external_links` keep their signatures (already async).
* The one sync in-tree consumer, the `dbpvxr` iocsh command (`epics-ca-rs/src/calink/iocsh.rs`), reads lset state through the same off-runtime `std::thread` + `block_on` bridge it already used for the record-field lookup.
* New dependency: `async-trait` on `epics-base-rs`. The trait is `dyn`-erased (`Arc<dyn LinkSet>`), so native AFIT is not usable.

## Regression test — verified to fail on unfixed main

`crates/epics-ca-rs/tests/calink_lset_contexts.rs`: read a `ca://` link through the lset on a current-thread runtime and on a multi-thread runtime. Both must answer (an unconnected link reads as no value); neither may panic.

On unfixed main (`56a6dbf8`), with the calls in their pre-fix sync form:

```
running 2 tests
test get_value_of_an_unconnected_link_on_current_thread_runtime ... FAILED
test get_value_of_an_unconnected_link_on_multi_thread_runtime ... ok

---- get_value_of_an_unconnected_link_on_current_thread_runtime stdout ----
thread 'get_value_of_an_unconnected_link_on_current_thread_runtime' panicked at
crates/epics-ca-rs/src/calink/resolver.rs:457:56:
Cannot start a runtime from within a runtime. This happens because a function
(like `block_on`) attempted to block the current thread while the thread is being
used to drive asynchronous tasks.

test result: FAILED. 1 passed; 1 failed
```

With the fix: `2 passed; 0 failed`.

## Gates

* `cargo fmt --all` — clean
* `cargo clippy --workspace --all-targets -- -D warnings` — clean
* `cargo nextest run --workspace` — 7426 passed, 2 skipped
* `cargo test --doc --workspace` — clean

## Relation to #18 / #21 / #22

Last two sites from #18's UNFIXED list (`pvalink/integration.rs:38` and — not on that list, found by searching the helper rather than the cited line — `epics-ca-rs/src/calink/resolver.rs:815`, the same helper copy-pasted). Same root cause as #21 and #22: a sync bridge over async state that only works on one runtime flavor. The three remaining `block_in_place` call sites in the workspace are the ones #18 (`asyn-rs/src/port_handle.rs:165`), #21 (`epics-base-rs/src/server/database/field_io.rs:49`) and #22 (`epics-bridge-rs/src/qsrv/provider.rs:178`) address; with all four merged, no sync-over-async bridge is left that a runtime flavor can break.
