### PR TITLE
fix(ca): bind CaServer sockets at construction — kill the CI startup-race flake family

### DIFF
--- a/crates/asyn-rs/tests/process_gate_tests.rs
+++ b/crates/asyn-rs/tests/process_gate_tests.rs
@@ -32,6 +32,7 @@ record(calc, "TEST:ACNT") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("asyn", || {
             Box::new(asyn_rs::asyn_record::AsynRecord::default())
         })

--- a/crates/epics-base-rs/src/net/async_udp_v4.rs
+++ b/crates/epics-base-rs/src/net/async_udp_v4.rs
@@ -1238,10 +1238,21 @@ fn bind_one_at(
     // releases ports immediately on close anyway, so the flag is
     // skipped on Windows. The Windows-idiomatic alternative is
     // SO_EXCLUSIVEADDRUSE, but plain bind() already prevents reuse.
+    //
+    // Only for a *well-known* port — the co-bind case the flags exist
+    // for. A client socket asking for an ephemeral port (0) has nothing
+    // to share, and the flags then do harm: Linux may satisfy bind(0)
+    // with a port already held by a reuse-compatible socket, joining its
+    // SO_REUSEPORT group, after which the kernel load-balances arriving
+    // datagrams across the group — this socket's search replies can be
+    // delivered to the unrelated socket and dropped. With the flags off,
+    // bind(0) yields a port this socket exclusively owns.
     #[cfg(not(windows))]
-    sock.set_reuse_address(true)?;
-    #[cfg(unix)]
-    sock.set_reuse_port(true)?;
+    if port != 0 {
+        sock.set_reuse_address(true)?;
+        #[cfg(unix)]
+        sock.set_reuse_port(true)?;
+    }
     if broadcast {
         sock.set_broadcast(true)?;
     }

--- a/crates/epics-base-rs/src/net/loopback_mcast.rs
+++ b/crates/epics-base-rs/src/net/loopback_mcast.rs
@@ -56,6 +56,14 @@ pub fn bind_loopback_mcast(port: u16) -> io::Result<UdpSocket> {
     // server and client on the same host can both join the group.
     // Windows: skip — its REUSEADDR has socket-hijack semantics and
     // bind() releases on close anyway. (libcom commit 19146a5.)
+    //
+    // Set unconditionally here, including for an ephemeral port —
+    // unlike the unicast sockets in `async_udp_v4`. Co-binding *is* the
+    // purpose of this helper (one listener takes an ephemeral port and
+    // publishes it, the others join that same port), and multicast group
+    // traffic is delivered to every joined socket rather than
+    // load-balanced across the reuse group, so sharing costs nothing
+    // here.
     #[cfg(not(windows))]
     sock.set_reuse_address(true)?;
     #[cfg(unix)]

--- a/crates/epics-base-rs/tests/busy_test.rs
+++ b/crates/epics-base-rs/tests/busy_test.rs
@@ -6,8 +6,9 @@ use std::collections::HashMap;
 
 #[test]
 fn test_register_record_type() {
-    let builder =
-        CaServerBuilder::new().register_record_type("busy", || Box::new(BusyRecord::default()));
+    let builder = CaServerBuilder::new()
+        .port(0)
+        .register_record_type("busy", || Box::new(BusyRecord::default()));
     // Registration succeeds — builder is valid
     drop(builder);
 }
@@ -23,6 +24,7 @@ record(busy, "TEST:BUSY") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("busy", || Box::new(BusyRecord::default()))
         .db_string(db, &macros)
         .unwrap()

--- a/crates/epics-base-rs/tests/client_server.rs
+++ b/crates/epics-base-rs/tests/client_server.rs
@@ -25,12 +25,6 @@ use epics_base_rs::server::snapshot::DbrClass;
 use epics_base_rs::types::{DbFieldType, EpicsValue};
 use serial_test::serial;
 
-/// Pick a free ephemeral port by briefly binding and releasing.
-fn free_port() -> u16 {
-    let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
-    sock.local_addr().unwrap().port()
-}
-
 /// Spin up an ephemeral-port server with the given PVs, return
 /// a connected `CaClient` whose ADDR_LIST points at that server.
 async fn setup(pvs: Vec<(&str, EpicsValue)>) -> CaResult<epics_ca_rs::client::CaClient> {
@@ -69,16 +63,18 @@ async fn setup(pvs: Vec<(&str, EpicsValue)>) -> CaResult<epics_ca_rs::client::Ca
         .await;
     });
 
-    // Bind the UDP search responder on a known free port. Bound here,
-    // so a SEARCH sent immediately below is queued by the kernel rather
-    // than lost — no sleep needed.
-    let udp_port = free_port();
+    // Bind the UDP search responder on a kernel-assigned port and read the
+    // port back — never probe a port and re-bind the number, which races
+    // any other socket in this process. Bound here, so a SEARCH sent
+    // immediately below is queued by the kernel rather than lost — no
+    // sleep needed.
     let responders = epics_ca_rs::server::udp::bind_udp_responders(
-        udp_port,
+        0,
         vec![std::net::Ipv4Addr::UNSPECIFIED],
         &[],
     )
     .expect("UDP responder bound");
+    let udp_port = responders.port();
     let db_udp = db.clone();
     tokio::spawn(async move {
         let _ = epics_ca_rs::server::udp::run_udp_search_responder(

--- a/crates/epics-base-rs/tests/client_server.rs
+++ b/crates/epics-base-rs/tests/client_server.rs
@@ -41,8 +41,12 @@ async fn setup(pvs: Vec<(&str, EpicsValue)>) -> CaResult<epics_ca_rs::client::Ca
 
     let acf = Arc::new(tokio::sync::RwLock::new(None));
 
-    // Start TCP on port 0, get the real port via oneshot.
-    let (tcp_tx, tcp_rx) = tokio::sync::oneshot::channel();
+    // Bind TCP on port 0 — the listener is accepting from here on, and
+    // the chosen port is known without a start-up handshake.
+    let bound_tcp = epics_ca_rs::server::tcp::bind_tcp_listeners(0)
+        .await
+        .expect("TCP listener bound");
+    let tcp_port = bound_tcp.port();
     let db_tcp = db.clone();
     let acf_clone = acf.clone();
     tokio::spawn(async move {
@@ -51,10 +55,9 @@ async fn setup(pvs: Vec<(&str, EpicsValue)>) -> CaResult<epics_ca_rs::client::Ca
         let (acf_reload_tx, _) = tokio::sync::broadcast::channel::<()>(16);
         let _ = epics_ca_rs::server::tcp::run_tcp_listener(
             db_tcp,
-            0,
+            bound_tcp,
             acf_clone,
             acf_reload_tx,
-            tcp_tx,
             beacon_reset,
             None, // conn_events: not subscribed in this test
             None, // audit
@@ -65,24 +68,27 @@ async fn setup(pvs: Vec<(&str, EpicsValue)>) -> CaResult<epics_ca_rs::client::Ca
         )
         .await;
     });
-    let tcp_port = tcp_rx.await.expect("TCP listener started");
 
-    // Start UDP search responder on a known free port.
+    // Bind the UDP search responder on a known free port. Bound here,
+    // so a SEARCH sent immediately below is queued by the kernel rather
+    // than lost — no sleep needed.
     let udp_port = free_port();
+    let responders = epics_ca_rs::server::udp::bind_udp_responders(
+        udp_port,
+        vec![std::net::Ipv4Addr::UNSPECIFIED],
+        &[],
+    )
+    .expect("UDP responder bound");
     let db_udp = db.clone();
     tokio::spawn(async move {
         let _ = epics_ca_rs::server::udp::run_udp_search_responder(
             db_udp,
-            udp_port,
+            responders,
             tcp_port,
-            vec![std::net::Ipv4Addr::UNSPECIFIED],
-            Vec::new(),
             Vec::new(),
         )
         .await;
     });
-    // Give UDP socket a moment to bind
-    tokio::time::sleep(Duration::from_millis(50)).await;
 
     // Point the client at our server's UDP port.
     unsafe {

--- a/crates/epics-bridge-rs/src/bin/dual_ioc_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/dual_ioc_rs.rs
@@ -173,7 +173,14 @@ async fn main() -> ExitCode {
     let ca_handle = if args.no_ca {
         None
     } else {
-        let server = CaServer::from_parts(db.clone(), args.ca_port, None, None, None, None);
+        let server =
+            match CaServer::from_parts(db.clone(), args.ca_port, None, None, None, None).await {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("error binding CA server on port {}: {e}", args.ca_port);
+                    return ExitCode::FAILURE;
+                }
+            };
         Some(tokio::spawn(async move {
             tracing::info!(port = args.ca_port, "CA listener starting");
             server.run().await

--- a/crates/epics-bridge-rs/src/ca_gateway/downstream.rs
+++ b/crates/epics-bridge-rs/src/ca_gateway/downstream.rs
@@ -23,6 +23,7 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
+use epics_base_rs::error::CaResult;
 use epics_base_rs::server::database::PvDatabase;
 use epics_ca_rs::server::{AccessRightsNotifier, CaServer, ServerConnectionEvent, ServerStats};
 use tokio::sync::Mutex;
@@ -301,13 +302,18 @@ struct ReplayState {
 impl DownstreamServer {
     /// Create a new downstream server bound to `port`, serving from
     /// the given shadow database.
-    pub fn new(shadow_db: Arc<PvDatabase>, port: u16) -> Self {
-        let server = CaServer::from_parts(shadow_db.clone(), port, None, None, None, None);
-        Self {
+    ///
+    /// The CA listener is bound here — a client may connect as soon as
+    /// this returns, before [`Self::run`] is spawned. A port that
+    /// cannot be bound is reported now rather than from inside the
+    /// gateway's server task.
+    pub async fn new(shadow_db: Arc<PvDatabase>, port: u16) -> CaResult<Self> {
+        let server = CaServer::from_parts(shadow_db.clone(), port, None, None, None, None).await?;
+        Ok(Self {
             server: Mutex::new(Some(server)),
             shadow_db,
             replay_state: Mutex::new(None),
-        }
+        })
     }
 
     /// Variant of [`Self::new`] that also wraps every accepted
@@ -317,18 +323,19 @@ impl DownstreamServer {
     /// `UpstreamManager::new`. Available with the `ca-gateway-tls`
     /// feature.
     #[cfg(feature = "ca-gateway-tls")]
-    pub fn new_with_tls(
+    pub async fn new_with_tls(
         shadow_db: Arc<PvDatabase>,
         port: u16,
         tls: std::sync::Arc<epics_ca_rs::tls::ServerConfig>,
-    ) -> Self {
-        let mut server = CaServer::from_parts(shadow_db.clone(), port, None, None, None, None);
+    ) -> CaResult<Self> {
+        let mut server =
+            CaServer::from_parts(shadow_db.clone(), port, None, None, None, None).await?;
         server.set_tls(tls);
-        Self {
+        Ok(Self {
             server: Mutex::new(Some(server)),
             shadow_db,
             replay_state: Mutex::new(None),
-        }
+        })
     }
 
     /// Get the underlying shadow database.
@@ -540,7 +547,9 @@ mod tests {
     #[tokio::test]
     async fn construct_downstream() {
         let db = Arc::new(PvDatabase::new());
-        let downstream = DownstreamServer::new(db.clone(), 0);
+        let downstream = DownstreamServer::new(db.clone(), 0)
+            .await
+            .expect("bind downstream");
         // Just verify it constructs without panicking
         assert!(Arc::ptr_eq(downstream.database(), &db));
     }
@@ -548,7 +557,7 @@ mod tests {
     #[tokio::test]
     async fn connection_events_subscribe() {
         let db = Arc::new(PvDatabase::new());
-        let downstream = DownstreamServer::new(db, 0);
+        let downstream = DownstreamServer::new(db, 0).await.expect("bind downstream");
         let rx = downstream.connection_events().await;
         assert!(rx.is_some(), "expected receiver");
         downstream.stop_connection_events().await;
@@ -760,7 +769,7 @@ mod tests {
     #[tokio::test]
     async fn connection_events_seeds_late_subscriber_from_high_water() {
         let db = Arc::new(PvDatabase::new());
-        let downstream = DownstreamServer::new(db, 0);
+        let downstream = DownstreamServer::new(db, 0).await.expect("bind downstream");
 
         // First subscriber installs the forwarder + replay state.
         let _first = downstream

--- a/crates/epics-bridge-rs/src/ca_gateway/server.rs
+++ b/crates/epics-bridge-rs/src/ca_gateway/server.rs
@@ -516,13 +516,14 @@ impl GatewayServer {
                         config.server_port,
                         tls.clone(),
                     )
+                    .await?
                 } else {
-                    DownstreamServer::new(shadow_db.clone(), config.server_port)
+                    DownstreamServer::new(shadow_db.clone(), config.server_port).await?
                 }
             }
             #[cfg(not(feature = "ca-gateway-tls"))]
             {
-                DownstreamServer::new(shadow_db.clone(), config.server_port)
+                DownstreamServer::new(shadow_db.clone(), config.server_port).await?
             }
         });
 

--- a/crates/epics-bridge-rs/src/ca_gateway/upstream.rs
+++ b/crates/epics-bridge-rs/src/ca_gateway/upstream.rs
@@ -2335,15 +2335,14 @@ ASG(NewGroup) {
     #[serial(epics_env)]
     async fn br_2026_111_reload_updates_live_acl_on_admitted_pv() {
         let name = "AS:reload:pv";
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(1.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2395,13 +2394,13 @@ ASG(NewGroup) {
         use epics_base_rs::server::snapshot::{DisplayInfo, Snapshot};
 
         let name = "GW23:seed:pv";
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(1.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
 
         // Grab the upstream db before `server` moves into the run task, so
         // we can give the UPSTREAM PV real display metadata (units="mm").
@@ -2409,7 +2408,6 @@ ASG(NewGroup) {
         // negotiation GET seeds only value, never display (upstream.rs:577).
         let up_db = server.database().clone();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         let mut ctrl = Snapshot::new(
             EpicsValue::Double(1.0),
@@ -2499,15 +2497,14 @@ ASG(NewGroup) {
         let served = "Beam:current";
         let real = "SR:DCCT:current";
 
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(real, EpicsValue::Double(1.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2550,15 +2547,14 @@ ASG(NewGroup) {
     async fn br_fr2_non_alias_keys_shadow_pv_by_same_name() {
         let name = "Plain:pv";
 
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(2.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2624,15 +2620,14 @@ ASG(NewGroup) {
         const UPSTREAM: f64 = 3.0;
         const SENTINEL: f64 = 999.0;
 
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(UPSTREAM))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2678,15 +2673,14 @@ ASG(NewGroup) {
         let name = "C:get";
         const SENTINEL: f64 = 999.0;
 
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(3.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2719,15 +2713,14 @@ ASG(NewGroup) {
     async fn br24_no_cache_monitor_is_lazy() {
         let name = "NC:mon";
 
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(1.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2801,15 +2794,14 @@ ASG(NewGroup) {
     async fn br24_cached_monitor_eager_ensure_release_noop() {
         let name = "C:mon";
 
-        let port = free_port();
         let server = CaServer::builder()
-            .port(port)
+            .port(0)
             .pv(name, EpicsValue::Double(1.0))
             .build()
             .await
             .expect("CA server");
+        let port = server.udp_port();
         let _server = tokio::spawn(async move { server.run().await });
-        tokio::time::sleep(Duration::from_millis(300)).await;
 
         pin_env(port);
         let db = Arc::new(PvDatabase::new());
@@ -2864,6 +2856,8 @@ ASG(NewGroup) {
     #[tokio::test(flavor = "multi_thread")]
     #[serial(epics_env)]
     async fn br_2026_22_lazy_connect_honors_configured_timeout() {
+        // Deliberately a dead port: nothing is served here, so the
+        // configured connect timeout is what ends the search.
         let port = free_port();
         pin_env(port);
         let db = Arc::new(PvDatabase::new());

--- a/crates/epics-bridge-rs/src/error.rs
+++ b/crates/epics-bridge-rs/src/error.rs
@@ -28,6 +28,12 @@ pub enum BridgeError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// A Channel Access error surfaced by the embedded CA client or
+    /// server — e.g. the downstream `CaServer` failing to bind its
+    /// port when the gateway starts.
+    #[error("channel access error: {0}")]
+    Ca(#[from] epics_base_rs::error::CaError),
 }
 
 pub type BridgeResult<T> = Result<T, BridgeError>;

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -1235,7 +1235,8 @@ pub async fn run_ca_pva_qsrv_ioc(
         config.acf.clone(),
         config.autosave_config.clone(),
         config.autosave_manager.clone(),
-    );
+    )
+    .await?;
     epics_base_rs::runtime::task::spawn(async move {
         if let Err(e) = ca_server.run().await {
             eprintln!("CA server error: {e}");

--- a/crates/epics-ca-rs/benches/end_to_end_bench.rs
+++ b/crates/epics-ca-rs/benches/end_to_end_bench.rs
@@ -35,38 +35,24 @@ fn make_runtime() -> Runtime {
         .expect("tokio runtime")
 }
 
-/// Spin up a softioc populated with N PVs of the given type. Returns
-/// `(server_handle, port)`. Server runs forever; the bench drops the
-/// handle when done so the runtime cleans up.
-async fn boot_softioc(n_pvs: usize, port: u16) -> tokio::task::JoinHandle<()> {
+/// Spin up a softioc populated with N PVs of the given type on a
+/// kernel-assigned port. Returns `(server_handle, udp_port)`. The
+/// server is bound and accepting by the time this returns; it runs
+/// forever, and the bench drops the handle when done so the runtime
+/// cleans up.
+async fn boot_softioc(n_pvs: usize) -> (tokio::task::JoinHandle<()>, u16) {
     let mut builder = CaServer::builder().port(0);
     for i in 0..n_pvs {
         builder = builder.pv(&format!("BENCH:PV:{i}"), EpicsValue::Double(i as f64));
     }
     let server = builder.build().await.expect("server build");
-    // Capture the actual bound port via env scan: CaServer chooses
-    // the port lazily inside run(). We use a static port here for
-    // reproducibility in benchmarks. (Production code would pick a
-    // dynamic port and read it back; bench uses a fixed offset to
-    // avoid collisions when run repeatedly.)
-    // Override port to the fixed value before starting.
-    let server = CaServer::from_parts(server.database().clone(), port, None, None, None, None);
+    let port = server.udp_port();
     let handle = tokio::spawn(async move {
         if let Err(e) = server.run().await {
             eprintln!("CA benchmark server exited: {e}");
         }
     });
-    // Give the listener time to bind.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-    handle
-}
-
-fn unused_local_port() -> u16 {
-    std::net::TcpListener::bind(("127.0.0.1", 0))
-        .expect("reserve benchmark port")
-        .local_addr()
-        .expect("benchmark port addr")
-        .port()
+    (handle, port)
 }
 
 fn point_addr_list_at(port: u16) {
@@ -81,9 +67,8 @@ fn point_addr_list_at(port: u16) {
 
 fn bench_caget(c: &mut Criterion) {
     let rt = make_runtime();
-    let port = unused_local_port();
+    let (_server, port) = rt.block_on(boot_softioc(8));
     point_addr_list_at(port);
-    let _server = rt.block_on(boot_softioc(8, port));
     let client = Arc::new(rt.block_on(async { CaClient::new().await.expect("client") }));
 
     // Warm up — establish channels before timing.
@@ -114,9 +99,8 @@ fn bench_caget(c: &mut Criterion) {
 /// this near the network round-trip floor.
 fn bench_bulk_caget(c: &mut Criterion) {
     let rt = make_runtime();
-    let port = unused_local_port();
+    let (_server, port) = rt.block_on(boot_softioc(20));
     point_addr_list_at(port);
-    let _server = rt.block_on(boot_softioc(20, port));
     let client = Arc::new(rt.block_on(async { CaClient::new().await.expect("client") }));
 
     // Warm up — establish channels before timing so we measure the
@@ -159,9 +143,8 @@ fn bench_bulk_caget(c: &mut Criterion) {
 /// reads, flush once, then collect completions" path.
 fn bench_bulk_get_many(c: &mut Criterion) {
     let rt = make_runtime();
-    let port = unused_local_port();
+    let (_server, port) = rt.block_on(boot_softioc(100));
     point_addr_list_at(port);
-    let _server = rt.block_on(boot_softioc(100, port));
     let client = Arc::new(rt.block_on(async { CaClient::new().await.expect("client") }));
 
     let channels = rt.block_on(async {
@@ -200,9 +183,8 @@ fn bench_bulk_get_many(c: &mut Criterion) {
 /// `bench_bulk_get_many` so the only difference is N.
 fn bench_bulk_get_many_scaling(c: &mut Criterion) {
     let rt = make_runtime();
-    let port = unused_local_port();
+    let (_server, port) = rt.block_on(boot_softioc(100));
     point_addr_list_at(port);
-    let _server = rt.block_on(boot_softioc(100, port));
     let client = Arc::new(rt.block_on(async { CaClient::new().await.expect("client") }));
 
     let channels = rt.block_on(async {
@@ -245,9 +227,8 @@ fn bench_bulk_get_many_scaling(c: &mut Criterion) {
 /// hot batched-read path as `get_many`.
 fn bench_bulk_caget_many(c: &mut Criterion) {
     let rt = make_runtime();
-    let port = unused_local_port();
+    let (_server, port) = rt.block_on(boot_softioc(100));
     point_addr_list_at(port);
-    let _server = rt.block_on(boot_softioc(100, port));
     let client = Arc::new(rt.block_on(async { CaClient::new().await.expect("client") }));
     let names: Vec<String> = (0..100).map(|i| format!("BENCH:PV:{i}")).collect();
 
@@ -275,9 +256,8 @@ fn bench_bulk_caget_many(c: &mut Criterion) {
 
 fn bench_caput(c: &mut Criterion) {
     let rt = make_runtime();
-    let port = unused_local_port();
+    let (_server, port) = rt.block_on(boot_softioc(1));
     point_addr_list_at(port);
-    let _server = rt.block_on(boot_softioc(1, port));
     let client = Arc::new(rt.block_on(async { CaClient::new().await.expect("client") }));
     rt.block_on(async {
         let _ = client.caput("BENCH:PV:0", "1.0").await;

--- a/crates/epics-ca-rs/src/server/ca_server.rs
+++ b/crates/epics-ca-rs/src/server/ca_server.rs
@@ -266,6 +266,13 @@ impl CaServerBuilder {
     }
 
     /// Build the server.
+    ///
+    /// The TCP listeners and UDP search-responder sockets are bound
+    /// here, so a returned `CaServer` is already listening: a client
+    /// may connect (or SEARCH) the instant `build()` returns, before
+    /// [`CaServer::run`] has been spawned or polled. Callers therefore
+    /// never need to sleep for a startup window — see
+    /// [`CaServer::tcp_port`] for the port actually bound.
     pub async fn build(self) -> CaResult<CaServer> {
         let (db, autosave_config) = self.ioc.build().await?;
         let acf = Arc::new(tokio::sync::RwLock::new(self.acf));
@@ -286,10 +293,13 @@ impl CaServerBuilder {
         // `EPICS_CAS_SERVER_PORT > EPICS_CA_SERVER_PORT` precedence
         // via cas_server_port() at builder construction.
         let tcp_port = self.tcp_port.unwrap_or(self.port);
+        let (tcp, udp) = bind_sockets(self.port, tcp_port).await?;
         Ok(CaServer {
             db,
-            port: self.port,
-            tcp_port,
+            port: udp.port(),
+            tcp_port: tcp.port(),
+            tcp,
+            udp,
             stats: Arc::new(ServerStats::default()),
             acf,
             acf_source_path: std::sync::Mutex::new(self.acf_path),
@@ -448,15 +458,44 @@ impl AccessRightsNotifier {
     }
 }
 
+/// Bind every socket the server serves on: the TCP listeners and the
+/// UDP search responders.
+///
+/// The single place a `CaServer`'s sockets come into existence — both
+/// construction paths ([`CaServerBuilder::build`] and
+/// [`CaServer::from_parts`]) go through it, so "a `CaServer` exists"
+/// implies "its ports are bound and listening". Binding is what makes
+/// a client's `connect()` / SEARCH succeed; `run()` only services what
+/// the kernel has already accepted or queued. There is consequently no
+/// window between construction and `run()` in which a client is
+/// refused, and no readiness sleep for a caller to guess at.
+async fn bind_sockets(
+    udp_port: u16,
+    tcp_port: u16,
+) -> CaResult<(crate::server::tcp::BoundTcp, crate::server::udp::BoundUdp)> {
+    let tcp = crate::server::tcp::bind_tcp_listeners(tcp_port).await?;
+    let cfg = addr_list::from_env()?;
+    let udp = crate::server::udp::bind_udp_responders(udp_port, cfg.intf_addrs, &cfg.mcast_addrs)?;
+    Ok((tcp, udp))
+}
+
 pub struct CaServer {
     db: Arc<PvDatabase>,
-    /// UDP discovery port. Bound by the search responder.
+    /// UDP discovery port actually bound by the search responders in
+    /// `udp` — the port clients SEARCH on. Equal to the configured port,
+    /// or the kernel-assigned one when 0 was requested.
     port: u16,
-    /// TCP listen port. Equal to `port` unless explicitly split via
-    /// [`CaServerBuilder::tcp_port`] or `EPICS_CAS_SERVER_PORT`
-    /// (epics-base PR #69). The UDP responder advertises this port in
-    /// SEARCH_REPLY frames so clients connect to the right listener.
+    /// TCP port actually bound by the listeners in `tcp` — the value
+    /// SEARCH replies and beacons advertise. Equal to the configured
+    /// port unless it was split via [`CaServerBuilder::tcp_port`] /
+    /// `EPICS_CAS_SERVER_PORT` (epics-base PR #69), or the configured
+    /// port was in use and the ephemeral fallback fired.
     tcp_port: u16,
+    /// TCP listeners, bound at construction. See [`tcp::BoundTcp`].
+    tcp: crate::server::tcp::BoundTcp,
+    /// UDP search responders, bound at construction. See
+    /// [`udp::BoundUdp`].
+    udp: crate::server::udp::BoundUdp,
     /// Shared stats counter — incremented by a task spawned in
     /// `start()` that subscribes to `conn_events`. Surfaced via
     /// [`Self::stats`] and the `casr` iocsh command.
@@ -564,14 +603,19 @@ impl CaServer {
     /// device support wiring. `tcp_port` carries the optional split-port
     /// TCP override (`EPICS_CAS_SERVER_PORT`); pass `None` to share the
     /// UDP discovery port with the TCP listener.
-    pub fn from_parts(
+    ///
+    /// Binds the TCP and UDP sockets, exactly as
+    /// [`CaServerBuilder::build`] does — the returned server is already
+    /// listening, and a bind failure is reported here rather than from
+    /// inside a spawned [`Self::run`] task.
+    pub async fn from_parts(
         db: Arc<PvDatabase>,
         port: u16,
         tcp_port: Option<u16>,
         acf: Option<access_security::AccessSecurityConfig>,
         autosave_config: Option<autosave::SaveSetConfig>,
         autosave_manager: Option<Arc<autosave::AutosaveManager>>,
-    ) -> Self {
+    ) -> CaResult<Self> {
         let stats = Arc::new(ServerStats::default());
         // Always-on connection broadcast so the stats counter task in
         // `run()` (and any external `connection_events()` subscriber)
@@ -580,10 +624,13 @@ impl CaServer {
         let (conn_tx, _) = tokio::sync::broadcast::channel(64);
         let (acf_reload_tx, _) = tokio::sync::broadcast::channel(16);
         let tcp_port = tcp_port.unwrap_or(port);
-        Self {
+        let (tcp, udp) = bind_sockets(port, tcp_port).await?;
+        Ok(Self {
             db,
-            port,
-            tcp_port,
+            port: udp.port(),
+            tcp_port: tcp.port(),
+            tcp,
+            udp,
             stats,
             acf: Arc::new(tokio::sync::RwLock::new(acf)),
             acf_source_path: std::sync::Mutex::new(None),
@@ -606,7 +653,22 @@ impl CaServer {
             #[cfg(feature = "cap-tokens")]
             cap_token_verifier: None,
             beacon_reset: Arc::new(tokio::sync::Notify::new()),
-        }
+        })
+    }
+
+    /// The TCP port the server is listening on.
+    ///
+    /// Known from construction (the listener is already bound), so a
+    /// caller that passed port 0 — or whose configured port was taken
+    /// and hit the ephemeral fallback — can read the real port without
+    /// waiting for [`Self::run`].
+    pub fn tcp_port(&self) -> u16 {
+        self.tcp_port
+    }
+
+    /// The UDP port the search responders are bound to.
+    pub fn udp_port(&self) -> u16 {
+        self.port
     }
 
     /// Re-read the ACF file the server was originally configured with
@@ -954,9 +1016,13 @@ impl CaServer {
         let db_scan = self.db.clone();
         let acf = self.acf.clone();
         let port = self.port;
-        // TCP listen port — equal to `port` unless split via
-        // EPICS_CAS_SERVER_PORT / `.tcp_port()` (epics-base PR #69).
-        let tcp_listen_port = self.tcp_port;
+        // Sockets were bound at construction (`bind_sockets`), so the
+        // TCP port is already final — no start-up handshake back from
+        // the listener task, and nothing downstream (beacon, SEARCH
+        // replies, mDNS, introspection) has to wait to learn it.
+        let tcp_port = self.tcp_port;
+        let bound_tcp = self.tcp.clone();
+        let bound_udp = self.udp.clone();
 
         let scanner = ScanScheduler::new(db_scan);
 
@@ -982,7 +1048,6 @@ impl CaServer {
             None
         };
 
-        let (tcp_tx, tcp_rx) = tokio::sync::oneshot::channel();
         // Use the externally-pulse-able handle held on the struct.
         // Bridge ca_gateway captures `beacon_anomaly_handle()` BEFORE
         // calling run() (which consumes self) and pulses it on
@@ -1037,10 +1102,9 @@ impl CaServer {
             {
                 tcp::run_tcp_listener(
                     db_tcp,
-                    tcp_listen_port,
+                    bound_tcp,
                     acf,
                     acf_reload_tx,
-                    tcp_tx,
                     beacon_reset_tcp,
                     conn_events,
                     audit_for_tcp,
@@ -1056,10 +1120,9 @@ impl CaServer {
             {
                 tcp::run_tcp_listener(
                     db_tcp,
-                    tcp_listen_port,
+                    bound_tcp,
                     acf,
                     acf_reload_tx,
-                    tcp_tx,
                     beacon_reset_tcp,
                     conn_events,
                     audit_for_tcp,
@@ -1149,13 +1212,6 @@ impl CaServer {
         #[cfg(not(unix))]
         let signal_handle: Option<tokio::task::JoinHandle<()>> = None;
         let tcp_abort = tcp_handle.abort_handle();
-
-        let tcp_port = tcp_rx.await.map_err(|_| {
-            CaError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "TCP listener failed to start",
-            ))
-        })?;
 
         let udp_cfg = addr_list::from_env()?;
         eprintln!(
@@ -1313,19 +1369,9 @@ impl CaServer {
         // Spawn UDP responder as its own task so its waker isn't multiplexed
         // through a select! branch (which can drop/replace wakers between polls
         // and miss edge-triggered epoll events).
-        let intf_addrs = udp_cfg.intf_addrs.clone();
         let ignore_addrs = udp_cfg.ignore_addrs.clone();
-        let mcast_addrs = udp_cfg.mcast_addrs.clone();
         let udp_handle = epics_base_rs::runtime::task::spawn(async move {
-            udp::run_udp_search_responder(
-                db_udp,
-                port,
-                tcp_port,
-                intf_addrs,
-                ignore_addrs,
-                mcast_addrs,
-            )
-            .await
+            udp::run_udp_search_responder(db_udp, bound_udp, tcp_port, ignore_addrs).await
         });
         let udp_abort = udp_handle.abort_handle();
 
@@ -1466,9 +1512,11 @@ fn drain_grace_from_env() -> u64 {
 mod access_notifier_tests {
     use super::*;
 
-    fn empty_server() -> CaServer {
+    async fn empty_server() -> CaServer {
         let db = Arc::new(PvDatabase::new());
         CaServer::from_parts(db, 0, None, None, None, None)
+            .await
+            .expect("bind ephemeral server")
     }
 
     // The detachable handle must keep firing after the CaServer value is
@@ -1476,7 +1524,7 @@ mod access_notifier_tests {
     // it long after `run()` has consumed the server.
     #[tokio::test]
     async fn access_rights_notifier_fires_after_server_dropped() {
-        let server = empty_server();
+        let server = empty_server().await;
         let mut rx = server.acf_reload_tx.subscribe();
         let notifier = server.access_rights_notifier();
         drop(server);
@@ -1491,7 +1539,7 @@ mod access_notifier_tests {
     // broadcast, so both re-push CA_PROTO_ACCESS_RIGHTS identically.
     #[tokio::test]
     async fn notify_access_change_and_handle_share_one_channel() {
-        let server = empty_server();
+        let server = empty_server().await;
         let mut rx = server.acf_reload_tx.subscribe();
         server.notify_access_change();
         assert!(rx.try_recv().is_ok(), "notify_access_change must send");

--- a/crates/epics-ca-rs/src/server/mod.rs
+++ b/crates/epics-ca-rs/src/server/mod.rs
@@ -121,7 +121,8 @@ pub async fn run_ca_ioc(config: IocRunConfig) -> CaResult<()> {
         config.acf,
         config.autosave_config,
         config.autosave_manager,
-    );
+    )
+    .await?;
     server.set_after_init_hooks(config.after_init_hooks);
     let casr = iocsh::casr_command(server.stats());
     server

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -771,49 +771,49 @@ impl ClientState {
     }
 }
 
-/// Run the TCP listener for CA connections.
-/// Tries to bind to the configured port first; falls back to an ephemeral port
-/// (port 0) if the configured port is already in use.
+/// TCP listeners that are already bound and listening, one per
+/// `EPICS_CAS_INTF_ADDR_LIST` entry, all sharing one port.
 ///
-/// Notifies `beacon_reset` on each client connect/disconnect so the beacon
-/// emitter restarts its fast beacon cycle. This is a Rust enhancement, NOT
-/// C parity: C `rsrv` resets the beacon interval only on `ctlPause`, never
-/// on connect/disconnect. The extra fast beacons are benign and help
-/// clients notice server state changes promptly.
-#[allow(clippy::too_many_arguments)]
-pub async fn run_tcp_listener(
-    db: Arc<PvDatabase>,
+/// This type is the server's readiness guarantee: it can only be
+/// produced by [`bind_tcp_listeners`], and every `CaServer`
+/// construction path produces one before handing the server back. A
+/// bound-and-listening socket already completes TCP handshakes in the
+/// kernel, so a client that connects before `CaServer::run()` is even
+/// polled is queued rather than refused — owning a `CaServer` implies
+/// "listening", with no readiness handshake for the caller to get
+/// wrong.
+#[derive(Clone)]
+pub struct BoundTcp {
+    listeners: Vec<(Arc<TcpListener>, std::net::Ipv4Addr)>,
     port: u16,
-    acf: Arc<tokio::sync::RwLock<Option<AccessSecurityConfig>>>,
-    acf_reload_tx: broadcast::Sender<()>,
-    tcp_port_tx: tokio::sync::oneshot::Sender<u16>,
-    beacon_reset: std::sync::Arc<tokio::sync::Notify>,
-    conn_events: Option<broadcast::Sender<ServerConnectionEvent>>,
-    audit: Option<crate::audit::AuditLogger>,
-    drain: Arc<std::sync::atomic::AtomicBool>,
-    // PR #592 dbServerStats: per-connection byte counters feed the
-    // `casr` iocsh command's `bytes in=… out=…` line. Optional so unit
-    // tests of the TCP path don't need a full ServerStats wired up.
-    stats: Option<Arc<super::ca_server::ServerStats>>,
-    #[cfg(feature = "experimental-rust-tls")] tls: Option<
-        Arc<std::sync::RwLock<Arc<tokio_rustls::rustls::ServerConfig>>>,
-    >,
-    #[cfg(feature = "cap-tokens")] cap_token_verifier: Option<Arc<crate::cap_token::TokenVerifier>>,
-) -> CaResult<()> {
-    // honour every interface in `EPICS_CAS_INTF_ADDR_LIST`,
-    // not just the first. C `rsrv_init` (caservertask.c:603-712) iterates
-    // `casIntfAddrList` and spawns one `CAS-TCP` accept thread per
-    // entry, all bound to the same TCP port. Binding to a *specific*
-    // interface IP (vs `INADDR_ANY`) and binding to a *different*
-    // specific IP on the same port is allowed by POSIX; only two
-    // 0.0.0.0 binds collide. Empty list → single `0.0.0.0` listener
-    // (default), preserving the current single-NIC behaviour.
-    //
-    // First successful bind decides `actual_port` (honouring the
-    // existing AddrInUse → ephemeral-fallback path). All subsequent
-    // binds must use that same port; if a per-interface bind fails
-    // it is logged and skipped (matches C `cleanup:` / `continue;` in
-    // `caservertask.c:744-749`, which frees the conf and proceeds).
+}
+
+impl BoundTcp {
+    /// The port every listener in this set is bound to. This is the
+    /// port SEARCH replies and beacons advertise — it differs from the
+    /// requested port when the ephemeral fallback fired.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+/// Bind one TCP listener per `EPICS_CAS_INTF_ADDR_LIST` interface.
+///
+/// Tries the configured port first; falls back to an ephemeral port
+/// (port 0) if it is already in use.
+///
+/// C `rsrv_init` (caservertask.c:603-712) iterates `casIntfAddrList`
+/// and spawns one `CAS-TCP` accept thread per entry, all bound to the
+/// same TCP port. Binding to a *specific* interface IP (vs
+/// `INADDR_ANY`) and binding to a *different* specific IP on the same
+/// port is allowed by POSIX; only two 0.0.0.0 binds collide. Empty
+/// list → single `0.0.0.0` listener (default).
+///
+/// The first successful bind decides the port. All subsequent binds
+/// must use that same port; if a per-interface bind fails it is logged
+/// and skipped (matches C `cleanup:` / `continue;` in
+/// `caservertask.c:744-749`, which frees the conf and proceeds).
+pub async fn bind_tcp_listeners(port: u16) -> CaResult<BoundTcp> {
     let intf_addrs: Vec<std::net::Ipv4Addr> = {
         let cfg = super::addr_list::from_env()?;
         if cfg.intf_addrs.is_empty() {
@@ -823,7 +823,7 @@ pub async fn run_tcp_listener(
         }
     };
 
-    let mut listeners: Vec<(TcpListener, std::net::Ipv4Addr)> = Vec::new();
+    let mut listeners: Vec<(Arc<TcpListener>, std::net::Ipv4Addr)> = Vec::new();
     let mut actual_port: Option<u16> = None;
     for ip in &intf_addrs {
         let target_port = actual_port.unwrap_or(port);
@@ -858,22 +858,54 @@ pub async fn run_tcp_listener(
         if actual_port.is_none() {
             actual_port = Some(chosen);
         }
-        listeners.push((listener, *ip));
+        listeners.push((Arc::new(listener), *ip));
     }
 
-    let actual_port = match actual_port {
-        Some(p) => p,
+    match actual_port {
+        Some(port) => Ok(BoundTcp { listeners, port }),
         None => {
             // C `cantProceed("CAS: No TCP server started\n")` at
             // `caservertask.c:752`. Every configured interface failed
             // to bind — there's nothing to serve.
-            return Err(epics_base_rs::error::CaError::Io(std::io::Error::new(
+            Err(epics_base_rs::error::CaError::Io(std::io::Error::new(
                 std::io::ErrorKind::AddrNotAvailable,
                 "CAS: No TCP server started — all configured interfaces failed to bind",
-            )));
+            )))
         }
-    };
-    let _ = tcp_port_tx.send(actual_port);
+    }
+}
+
+/// Serve CA connections on listeners already bound by
+/// [`bind_tcp_listeners`].
+///
+/// Notifies `beacon_reset` on each client connect/disconnect so the beacon
+/// emitter restarts its fast beacon cycle. This is a Rust enhancement, NOT
+/// C parity: C `rsrv` resets the beacon interval only on `ctlPause`, never
+/// on connect/disconnect. The extra fast beacons are benign and help
+/// clients notice server state changes promptly.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_tcp_listener(
+    db: Arc<PvDatabase>,
+    bound: BoundTcp,
+    acf: Arc<tokio::sync::RwLock<Option<AccessSecurityConfig>>>,
+    acf_reload_tx: broadcast::Sender<()>,
+    beacon_reset: std::sync::Arc<tokio::sync::Notify>,
+    conn_events: Option<broadcast::Sender<ServerConnectionEvent>>,
+    audit: Option<crate::audit::AuditLogger>,
+    drain: Arc<std::sync::atomic::AtomicBool>,
+    // PR #592 dbServerStats: per-connection byte counters feed the
+    // `casr` iocsh command's `bytes in=… out=…` line. Optional so unit
+    // tests of the TCP path don't need a full ServerStats wired up.
+    stats: Option<Arc<super::ca_server::ServerStats>>,
+    #[cfg(feature = "experimental-rust-tls")] tls: Option<
+        Arc<std::sync::RwLock<Arc<tokio_rustls::rustls::ServerConfig>>>,
+    >,
+    #[cfg(feature = "cap-tokens")] cap_token_verifier: Option<Arc<crate::cap_token::TokenVerifier>>,
+) -> CaResult<()> {
+    let BoundTcp {
+        listeners,
+        port: actual_port,
+    } = bound;
 
     // One accept-loop task per bound interface. When the parent
     // `run_tcp_listener` future is dropped (CaServer shutdown via
@@ -990,10 +1022,10 @@ pub async fn run_tcp_listener(
 /// `intf` is the bound interface IP; recorded on accept-error logs so
 /// multi-NIC hosts can tell which listener saw the failure. The
 /// `actual_port` parameter is the TCP port shared across all
-/// listeners (decided in `run_tcp_listener`).
+/// listeners (decided in `bind_tcp_listeners`).
 #[allow(clippy::too_many_arguments)]
 async fn accept_loop(
-    listener: TcpListener,
+    listener: Arc<TcpListener>,
     intf: std::net::Ipv4Addr,
     actual_port: u16,
     db: Arc<PvDatabase>,
@@ -5620,25 +5652,26 @@ mod multi_nic_listener_tests {
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;
     use tokio::net::TcpStream;
-    use tokio::sync::{Notify, broadcast, oneshot};
+    use tokio::sync::{Notify, broadcast};
 
-    /// Spawn `run_tcp_listener` against a per-test database, return the
-    /// (port, abort-handle). Honours whatever EPICS_CAS_INTF_ADDR_LIST
-    /// is currently set in the process env (caller manages it).
+    /// Bind an ephemeral listener set and spawn `run_tcp_listener` on it
+    /// against a per-test database; return the (port, abort-handle).
+    /// Honours whatever EPICS_CAS_INTF_ADDR_LIST is currently set in the
+    /// process env (caller manages it).
     async fn start_listener() -> (u16, tokio::task::JoinHandle<()>) {
         let db = Arc::new(PvDatabase::new());
         let acf = Arc::new(tokio::sync::RwLock::new(None));
         let (acf_reload_tx, _) = broadcast::channel::<()>(4);
-        let (tcp_tx, tcp_rx) = oneshot::channel::<u16>();
         let beacon_reset = Arc::new(Notify::new());
         let drain = Arc::new(AtomicBool::new(false));
+        let bound = bind_tcp_listeners(0).await.expect("listener bound");
+        let port = bound.port();
         let handle = tokio::spawn(async move {
             let _ = run_tcp_listener(
                 db,
-                0, // ephemeral
+                bound,
                 acf,
                 acf_reload_tx,
-                tcp_tx,
                 beacon_reset,
                 None,
                 None,
@@ -5651,7 +5684,6 @@ mod multi_nic_listener_tests {
             )
             .await;
         });
-        let port = tcp_rx.await.expect("listener bound");
         (port, handle)
     }
 

--- a/crates/epics-ca-rs/src/server/udp.rs
+++ b/crates/epics-ca-rs/src/server/udp.rs
@@ -50,30 +50,99 @@ fn plan_responder_specs(
         .collect()
 }
 
-/// Run UDP search responders bound to one or more local interfaces.
+/// A UDP search responder whose sockets are already bound (and whose
+/// multicast groups are already joined).
 ///
-/// Each interface gets its own task — having a dedicated socket per
+/// Counterpart of [`super::tcp::BoundTcp`]: only [`bind_udp_responders`]
+/// can produce one, and every `CaServer` construction path does so
+/// before returning the server. A bound UDP socket already queues
+/// datagrams in the kernel, so a SEARCH that arrives before
+/// `CaServer::run()` is polled is answered once the recv loop starts
+/// rather than dropped.
+#[derive(Clone)]
+pub struct BoundResponder {
+    bind_ip: Ipv4Addr,
+    /// Primary socket, bound to the interface entry's address.
+    socket: Arc<UdpSocket>,
+    /// Secondary socket bound to the interface's broadcast address —
+    /// see the comment in [`bind_udp_responders`]. `None` on Windows
+    /// and for wildcard interfaces.
+    bcast: Option<Arc<UdpSocket>>,
+}
+
+/// The UDP search responders of one server, all bound to one port.
+#[derive(Clone)]
+pub struct BoundUdp {
+    responders: Vec<BoundResponder>,
+    port: u16,
+}
+
+impl BoundUdp {
+    /// The UDP port every responder is bound to. With a requested port
+    /// of 0 this is the ephemeral port the kernel chose — the value a
+    /// client must put in `EPICS_CA_ADDR_LIST` to reach this server.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+/// Bind one UDP search responder per `EPICS_CAS_INTF_ADDR_LIST`
+/// interface, joining every configured multicast group on it.
+///
+/// Each interface gets its own socket — having a dedicated socket per
 /// interface lets the OS keep the broadcast routing straight on multi-NIC
 /// hosts (matching C EPICS osiSockDiscoverInterfaces behaviour).
+///
+/// A requested `port` of 0 means "any free UDP port": the first
+/// responder's kernel-assigned port is then imposed on the remaining
+/// interfaces, since a CA server answers SEARCHes on one port and its
+/// clients are pointed at exactly one. This is the race-free way to
+/// take a port — a caller that probes for a free port first and passes
+/// the number can still lose it to another socket in between.
+pub fn bind_udp_responders(
+    port: u16,
+    intf_addrs: Vec<Ipv4Addr>,
+    mcast_addrs: &[Ipv4Addr],
+) -> CaResult<BoundUdp> {
+    let mut responders = Vec::new();
+    let mut actual_port = if port == 0 { None } else { Some(port) };
+    for (bind_ip, mcast_groups) in plan_responder_specs(intf_addrs, mcast_addrs) {
+        let responder = bind_single_responder(bind_ip, actual_port.unwrap_or(0), &mcast_groups)?;
+        if actual_port.is_none() {
+            actual_port = Some(responder.socket.local_addr()?.port());
+        }
+        responders.push(responder);
+    }
+    // `plan_responder_specs` always yields at least one spec (an empty
+    // interface list becomes the wildcard entry), so the port is set.
+    let port = actual_port.ok_or_else(|| {
+        epics_base_rs::error::CaError::Io(std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            "CAS: no UDP search responder bound",
+        ))
+    })?;
+    Ok(BoundUdp { responders, port })
+}
+
+/// Run the recv loops of responders already bound by
+/// [`bind_udp_responders`].
 ///
 /// `ignore_addrs` filters out source addresses that should never receive
 /// search replies (EPICS_CAS_IGNORE_ADDR_LIST).
 pub async fn run_udp_search_responder(
     db: Arc<PvDatabase>,
-    port: u16,
+    bound: BoundUdp,
     tcp_port: u16,
-    intf_addrs: Vec<Ipv4Addr>,
     ignore_addrs: Vec<Ipv4Addr>,
-    mcast_addrs: Vec<Ipv4Addr>,
 ) -> CaResult<()> {
-    let specs = plan_responder_specs(intf_addrs, &mcast_addrs);
-    let mut handles = Vec::with_capacity(specs.len());
+    let responders = bound.responders;
+    let mut handles = Vec::with_capacity(responders.len());
 
-    for (bind_ip, mcast_for_intf) in specs {
+    for responder in responders {
         let db_t = db.clone();
         let ignore_t = ignore_addrs.clone();
         let handle = epics_base_rs::runtime::task::spawn(async move {
-            run_single_responder(db_t, bind_ip, port, tcp_port, ignore_t, mcast_for_intf).await
+            run_single_responder(db_t, responder, tcp_port, ignore_t).await
         });
         handles.push(handle);
     }
@@ -97,15 +166,17 @@ pub async fn run_udp_search_responder(
     result
 }
 
-async fn run_single_responder(
-    db: Arc<PvDatabase>,
+fn bind_single_responder(
     bind_ip: Ipv4Addr,
     port: u16,
-    tcp_port: u16,
-    ignore_addrs: Vec<Ipv4Addr>,
-    mcast_groups: Vec<Ipv4Addr>,
-) -> CaResult<()> {
+    mcast_groups: &[Ipv4Addr],
+) -> CaResult<BoundResponder> {
     let socket = bind_responder_socket(bind_ip, port)?;
+    // The port the primary actually took — identical to `port`, except
+    // for an ephemeral (0) request, where the kernel chose it. Every
+    // other socket of this responder must bind that same port: a CA
+    // server answers SEARCHes on exactly one port.
+    let port = socket.local_addr()?.port();
     // Join each multicast group on this
     // responder's own socket via `IP_ADD_MEMBERSHIP` with
     // `imr_interface = bind_ip`. C `caservertask.c:633-665` joins
@@ -120,7 +191,7 @@ async fn run_single_responder(
     // request is answered exactly once. Per-(intf, group) failures
     // are logged and skipped — `caservertask.c:659-660`
     // `errlogPrintf`s and continues; the IOC stays up.
-    for group in &mcast_groups {
+    for group in mcast_groups {
         match socket.join_multicast_v4(*group, bind_ip) {
             Ok(()) => tracing::debug!(
                 target: "epics_ca_rs::server::udp",
@@ -158,7 +229,7 @@ async fn run_single_responder(
     // socket receives broadcasts), so C `caservertask.c:670, 728`
     // guards the secondary socket with `#if !(_WIN32 || __CYGWIN__)`.
     // Mirror that gate.
-    let bcast_socket: Option<Arc<UdpSocket>> = {
+    let bcast: Option<Arc<UdpSocket>> = {
         #[cfg(any(windows, target_os = "windows"))]
         {
             None
@@ -184,9 +255,27 @@ async fn run_single_responder(
         }
     };
 
+    Ok(BoundResponder {
+        bind_ip,
+        socket,
+        bcast,
+    })
+}
+
+async fn run_single_responder(
+    db: Arc<PvDatabase>,
+    responder: BoundResponder,
+    tcp_port: u16,
+    ignore_addrs: Vec<Ipv4Addr>,
+) -> CaResult<()> {
+    let BoundResponder {
+        bind_ip,
+        socket,
+        bcast,
+    } = responder;
     let udp_rl = Arc::new(UdpRateLimiter::from_env());
     let primary = recv_loop(
-        socket.clone(),
+        socket,
         db.clone(),
         bind_ip,
         tcp_port,
@@ -194,7 +283,7 @@ async fn run_single_responder(
         udp_rl.clone(),
     );
 
-    match bcast_socket {
+    match bcast {
         Some(bsock) => {
             let secondary = recv_loop(bsock, db, bind_ip, tcp_port, ignore_addrs, udp_rl);
             // First task to error wins; the other is dropped when this
@@ -217,8 +306,17 @@ fn bind_responder_socket(bind_ip: Ipv4Addr, port: u16) -> CaResult<UdpSocket> {
     // requires BOTH SO_REUSEADDR and SO_REUSEPORT (different reuse classes
     // don't share); BSD/macOS need SO_REUSEPORT. Mirror libcom
     // epicsSocketEnableAddressUseForDatagramFanout and set both on Unix.
+    //
+    // Only for a *well-known* port, which is the case the fanout exists
+    // for. On an ephemeral bind (port 0) there is nothing to share, and
+    // the flags are actively harmful: Linux may hand bind(0) a port that
+    // already belongs to a reuse-compatible socket, silently joining its
+    // SO_REUSEPORT group — the kernel then load-balances arriving
+    // datagrams across the group, so SEARCHes for this server land on an
+    // unrelated socket and go unanswered. Leaving the flags off makes the
+    // kernel pick a port this socket exclusively owns.
     #[cfg(not(windows))]
-    {
+    if port != 0 {
         sock.set_reuse_address(true)?;
         #[cfg(unix)]
         sock.set_reuse_port(true)?;
@@ -232,7 +330,16 @@ fn bind_responder_socket(bind_ip: Ipv4Addr, port: u16) -> CaResult<UdpSocket> {
         let _ = sock.set_multicast_all_v4(false);
     }
     sock.set_nonblocking(true)?;
-    sock.bind(&std::net::SocketAddrV4::new(bind_ip, port).into())?;
+    // Name the socket in the error: a CA server binds several, and
+    // "Address already in use" with no address is unactionable for an
+    // operator whose UDP search port is taken by another process.
+    sock.bind(&std::net::SocketAddrV4::new(bind_ip, port).into())
+        .map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!("CA server UDP search responder bind {bind_ip}:{port}: {e}"),
+            )
+        })?;
     let socket = UdpSocket::from_std(sock.into())?;
     socket.set_broadcast(true)?;
     // EPICS_CA_MCAST_TTL (epics-base 3.16, f2a1834d). Only consulted by
@@ -889,5 +996,73 @@ mod mr_r8_responder_plan_tests {
         assert_eq!(specs.len(), 1);
         assert_eq!(specs[0].0, Ipv4Addr::UNSPECIFIED);
         assert!(specs[0].1.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod responder_bind_tests {
+    use super::*;
+
+    /// Boundary — port 0: an ephemeral responder must own its port
+    /// exclusively. The reuse flags exist so a well-known CA port can be
+    /// co-bound (caRepeater, a second IOC); on an ephemeral bind they let
+    /// Linux hand out a port already held by a reuse-compatible socket,
+    /// joining its SO_REUSEPORT group. The kernel then load-balances
+    /// arriving datagrams across the group and SEARCHes for this server
+    /// vanish into the other socket. A second bind of the same port must
+    /// therefore be refused.
+    #[test]
+    fn ephemeral_responder_port_cannot_be_co_bound() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let _g = rt.enter();
+
+        let bound = bind_udp_responders(0, vec![Ipv4Addr::LOCALHOST], &[]).expect("bind ephemeral");
+        assert_ne!(bound.port(), 0, "an ephemeral bind reports its real port");
+
+        // A reuse-enabled datagram socket — exactly the kind the CA
+        // client and caRepeater open — must NOT be able to join it.
+        let intruder = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).expect("socket");
+        intruder.set_reuse_address(true).expect("reuse addr");
+        #[cfg(unix)]
+        intruder.set_reuse_port(true).expect("reuse port");
+        let addr = std::net::SocketAddrV4::new(Ipv4Addr::LOCALHOST, bound.port());
+        assert!(
+            intruder.bind(&addr.into()).is_err(),
+            "the responder's ephemeral port must be exclusively owned; a \
+             second socket co-binding it would steal half its SEARCHes"
+        );
+    }
+
+    /// Boundary — a fixed port keeps the datagram-fanout reuse flags, so
+    /// the well-known CA port can still be co-bound (caRepeater parity).
+    #[test]
+    fn fixed_responder_port_still_allows_datagram_fanout() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let _g = rt.enter();
+
+        // Take an ephemeral port first, then re-bind that same number as
+        // a *fixed* port so the test never guesses at a free one.
+        let probe = bind_udp_responders(0, vec![Ipv4Addr::LOCALHOST], &[]).expect("probe bind");
+        let port = probe.port();
+        drop(probe);
+
+        let bound = bind_udp_responders(port, vec![Ipv4Addr::LOCALHOST], &[]).expect("fixed bind");
+        assert_eq!(bound.port(), port);
+
+        let peer = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).expect("socket");
+        peer.set_reuse_address(true).expect("reuse addr");
+        #[cfg(unix)]
+        peer.set_reuse_port(true).expect("reuse port");
+        let addr = std::net::SocketAddrV4::new(Ipv4Addr::LOCALHOST, port);
+        assert!(
+            peer.bind(&addr.into()).is_ok(),
+            "a well-known CA port must stay co-bindable (caRepeater fanout)"
+        );
     }
 }

--- a/crates/epics-ca-rs/src/server/udp.rs
+++ b/crates/epics-ca-rs/src/server/udp.rs
@@ -1038,6 +1038,12 @@ mod responder_bind_tests {
 
     /// Boundary — a fixed port keeps the datagram-fanout reuse flags, so
     /// the well-known CA port can still be co-bound (caRepeater parity).
+    ///
+    /// Unix only: `bind_responder_socket` sets no reuse flag at all on
+    /// Windows (its `SO_REUSEADDR` has socket-hijack semantics — see the
+    /// `cfg(not(windows))` gate there), so co-binding is *correctly*
+    /// refused on Windows and there is no fanout to assert.
+    #[cfg(unix)]
     #[test]
     fn fixed_responder_port_still_allows_datagram_fanout() {
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/crates/epics-ca-rs/tests/acf_hot_reload.rs
+++ b/crates/epics-ca-rs/tests/acf_hot_reload.rs
@@ -34,7 +34,9 @@ async fn reload_acf_swaps_in_new_rules() {
 
     // No source path → reload_acf_from must work but reload_acf would
     // fail on a server constructed without acf_file.
-    let bare = CaServer::from_parts(server.database().clone(), 0, None, None, None, None);
+    let bare = CaServer::from_parts(server.database().clone(), 0, None, None, None, None)
+        .await
+        .expect("build bare server");
     assert!(bare.reload_acf().await.is_err());
     assert!(
         bare.reload_acf_from(acf_path.to_str().unwrap())

--- a/crates/epics-ca-rs/tests/acf_hot_reload.rs
+++ b/crates/epics-ca-rs/tests/acf_hot_reload.rs
@@ -13,6 +13,7 @@ async fn reload_acf_swaps_in_new_rules() {
     std::fs::write(&acf_path, "ASG(DEFAULT) { RULE(1, READ) }").expect("write acf v1");
 
     let server = CaServer::builder()
+        .port(0)
         .pv("HOT:VAL", epics_base_rs::types::EpicsValue::Long(0))
         .acf_file(acf_path.to_str().unwrap())
         .expect("acf v1")

--- a/crates/epics-ca-rs/tests/caget_dbr_type.rs
+++ b/crates/epics-ca-rs/tests/caget_dbr_type.rs
@@ -30,15 +30,6 @@ use epics_ca_rs::client::{CaClient, EnumReadback};
 use epics_ca_rs::server::CaServer;
 use serial_test::serial;
 
-/// Reserve and immediately release a free localhost TCP port so the
-/// `CaServer` can bind it.
-fn free_port() -> u16 {
-    let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-    let p = probe.local_addr().unwrap().port();
-    drop(probe);
-    p
-}
-
 /// Point a soon-to-be-constructed `CaClient` at exactly this server so
 /// it skips UDP search.
 ///
@@ -59,16 +50,15 @@ async fn server_with_double_waveform(
     pv: &'static str,
     seed: Vec<f64>,
 ) -> (CaClient, epics_ca_rs::client::CaChannel) {
-    let port = free_port();
     let len = seed.len() as i32;
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record(pv, WaveformRecord::new(len, DbFieldType::Double))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -90,18 +80,17 @@ async fn server_with_bi(
     znam: &str,
     onam: &str,
 ) -> (CaClient, epics_ca_rs::client::CaChannel) {
-    let port = free_port();
     let mut rec = BiRecord::new(val);
     rec.znam = znam.into();
     rec.onam = onam.into();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record(pv, rec)
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -325,15 +314,14 @@ async fn caget_dbr_type_reaches_class_name() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn long_string_autosize_returns_40_nul_padded() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("R55:LS:AUTO", StringinRecord::new("hello"))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -375,15 +363,14 @@ async fn long_string_autosize_returns_40_nul_padded() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn long_string_count_clamp_trims_char_array() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("R55:LS:CLAMP", StringinRecord::new("hello"))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -422,17 +409,16 @@ async fn long_string_count_clamp_trims_char_array() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn printf_val_native_type_is_scalar_dbr_string() {
-    let port = free_port();
     let mut rec = PrintfRecord::default();
     rec.val = "log: 42".to_string();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("R3C2:PF:VAL", rec)
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -473,17 +459,16 @@ async fn printf_val_native_type_is_scalar_dbr_string() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn lsi_val_native_type_is_scalar_dbr_string_and_clips() {
-    let port = free_port();
     // 45 chars: longer than MAX_STRING_SIZE (40) so the DBR_STRING slot clips.
     let long = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHI";
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("R3C2:LSI:VAL", LsiRecord::new(long))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");

--- a/crates/epics-ca-rs/tests/calink.rs
+++ b/crates/epics-ca-rs/tests/calink.rs
@@ -18,7 +18,10 @@ use epics_ca_rs::client::{CaClient, CaClientConfig};
 use epics_ca_rs::server::CaServer;
 use serial_test::serial;
 
-/// Reserve a free TCP port by binding ephemeral then dropping.
+/// A port with nothing bound to it — for the tests that want an
+/// unreachable upstream. A test that *hosts* a server must not use this:
+/// it asks the server for port 0 and reads back the port it bound, so
+/// the port cannot be taken between the probe and the bind.
 fn free_port() -> u16 {
     let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA port");
     probe.local_addr().unwrap().port()
@@ -53,15 +56,14 @@ fn pin_env(port: u16) {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_link_resolves_remote_value() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:SRC", EpicsValue::Double(73.5))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let resolver = CaLinkResolver::with_client(client, tokio::runtime::Handle::current());
@@ -94,15 +96,14 @@ async fn ca_link_resolves_remote_value() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_link_resolves_with_scheme_prefix() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:SCHEME", EpicsValue::Long(404))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let resolver = CaLinkResolver::with_client(client, tokio::runtime::Handle::current());
@@ -129,15 +130,14 @@ async fn ca_link_resolves_with_scheme_prefix() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn record_with_ca_inp_link_reads_remote_value() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:INP:SRC", EpicsValue::Double(19.25))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let db = PvDatabase::new();
@@ -200,15 +200,14 @@ async fn record_with_ca_inp_link_reads_remote_value() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_cp_holder_processes_on_remote_change() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:CP:SRC", EpicsValue::Double(5.0))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     pin_env(port);
     let db = PvDatabase::new();
@@ -305,15 +304,14 @@ async fn ca_cp_holder_processes_on_remote_change() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_link_out_write_updates_remote_pv() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:OUT:DST", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let resolver = CaLinkResolver::with_client(client, tokio::runtime::Handle::current());
@@ -382,15 +380,14 @@ async fn ca_link_out_write_updates_remote_pv() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_link_out_write_async_waits_for_completion() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:OUT:ASYNC", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let resolver = CaLinkResolver::with_client(client, tokio::runtime::Handle::current());
@@ -434,15 +431,14 @@ async fn ca_link_out_write_async_waits_for_completion() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_link_out_write_accepts_scheme_prefix() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:OUT:SCHEME", EpicsValue::Long(7))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let resolver = CaLinkResolver::with_client(client, tokio::runtime::Handle::current());
@@ -487,7 +483,6 @@ async fn ca_link_out_write_accepts_scheme_prefix() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial(epics_env)]
 async fn ca_link_exposes_remote_metadata() {
-    let port = free_port();
     // ai record with real display/control metadata so the upstream CTRL
     // get returns non-default limits/precision/units.
     let mut src = AiRecord::new(50.0);
@@ -496,13 +491,13 @@ async fn ca_link_exposes_remote_metadata() {
     src.lopr = -50.0;
     src.prec = 3;
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("CALINK:META:SRC", src)
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     let client = Arc::new(pinned_client(port).await);
     let resolver = CaLinkResolver::with_client(client, tokio::runtime::Handle::current());
@@ -607,15 +602,14 @@ fn ca_modifier_link_classifies_as_ca() {
 async fn calink_warms_cp_holder_via_iocapplication_run_seam() {
     use epics_base_rs::server::ioc_app::IocApplication;
 
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CALINK:SEAM:SRC", EpicsValue::Double(5.0))
         .build()
         .await
         .expect("CA server");
+    let port = server.udp_port();
     let _server = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     pin_env(port);
 

--- a/crates/epics-ca-rs/tests/channel_filters.rs
+++ b/crates/epics-ca-rs/tests/channel_filters.rs
@@ -25,16 +25,6 @@ use epics_ca_rs::client::{CaClient, MonitorHandle};
 use epics_ca_rs::server::CaServer;
 use serial_test::serial;
 
-/// Reserve and immediately release a free localhost TCP port so the
-/// `CaServer` can bind it. Mirrors the pattern used across
-/// `protocol_tests.rs`.
-fn free_port() -> u16 {
-    let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-    let p = probe.local_addr().unwrap().port();
-    drop(probe);
-    p
-}
-
 /// Point a soon-to-be-constructed `CaClient` at exactly this server so
 /// it skips UDP search.
 ///
@@ -98,15 +88,14 @@ async fn recv_value(mon: &mut MonitorHandle) -> EpicsValue {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn ca_fr_8_record_field_read_notify_applies_arr() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("CAFR8:WF:R1", WaveformRecord::new(10, DbFieldType::Double))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -163,15 +152,14 @@ async fn ca_fr_8_record_field_read_notify_applies_arr() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn ca_fr_8_record_field_monitor_applies_arr_on_updates() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("CAFR8:WF:R2", WaveformRecord::new(10, DbFieldType::Double))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -217,15 +205,14 @@ async fn ca_fr_8_record_field_monitor_applies_arr_on_updates() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn ca_fr_8_simplepv_monitor_applies_arr() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CAFR8:SP:R3", EpicsValue::DoubleArray(ramp(0.0, 10)))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -276,15 +263,14 @@ async fn ca_fr_8_simplepv_monitor_applies_arr() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn ca_fr_8_arr_on_scalar_channel_is_noop() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CAFR8:SP:SCALAR", EpicsValue::Double(42.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -319,15 +305,14 @@ async fn ca_fr_8_arr_on_scalar_channel_is_noop() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn ca_fr_8_malformed_suffix_rejects_channel_create() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("CAFR8:WF:R4", WaveformRecord::new(10, DbFieldType::Double))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");
@@ -385,15 +370,14 @@ async fn ca_fr_8_malformed_suffix_rejects_channel_create() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn ca_fr_8_dotted_filter_suffix_resolves_at_search() {
-    let port = free_port();
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .record("CAFR8:DOT:R5", WaveformRecord::new(10, DbFieldType::Double))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _h = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     point_client_at(port);
     let client = CaClient::new().await.expect("client");

--- a/crates/epics-ca-rs/tests/differential_libca.rs
+++ b/crates/epics-ca-rs/tests/differential_libca.rs
@@ -136,8 +136,10 @@ impl DefaultExt for Option<(String, String, String)> {
 // well-known-but-unlikely ports avoids the issue at the cost of
 // requiring `--test-threads=1` (already documented in the module
 // header).
-fn free_port_pair() -> (u16, u16) {
-    (49997, 49998)
+/// Port for the C `softIoc` side. The Rust server no longer needs one
+/// chosen up front — it binds port 0 and reports what it got.
+fn c_softioc_port() -> u16 {
+    49998
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -149,21 +151,17 @@ async fn caget_double_matches_libca() {
         eprintln!("skipping: libca not on PATH");
         return;
     };
-    let (rs_port, c_port) = free_port_pair();
+    let c_port = c_softioc_port();
 
     // Rust side
     let server = epics_ca_rs::server::CaServer::builder()
-        .port(rs_port)
+        .port(0)
         .pv("DIFF:VAL", epics_base_rs::types::EpicsValue::Double(3.14))
         .build()
         .await
         .expect("rust server");
+    let rs_port = server.udp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    // Give the listener time to bind and become reachable. cold-start
-    // races with cargo build noise can stretch this — 3 s is the
-    // safer floor for #[ignore] tests that occasionally run against
-    // a freshly-rebuilt softioc binary.
-    tokio::time::sleep(Duration::from_secs(3)).await;
 
     // C side
     let mut c_child = start_c_softioc(
@@ -195,20 +193,16 @@ async fn caput_then_caget_matches_libca() {
         eprintln!("skipping: libca not on PATH");
         return;
     };
-    let (rs_port, c_port) = free_port_pair();
+    let c_port = c_softioc_port();
 
     let server = epics_ca_rs::server::CaServer::builder()
-        .port(rs_port)
+        .port(0)
         .pv("DIFF:WRITE", epics_base_rs::types::EpicsValue::Double(0.0))
         .build()
         .await
         .expect("rust server");
+    let rs_port = server.udp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    // Give the listener time to bind and become reachable. cold-start
-    // races with cargo build noise can stretch this — 3 s is the
-    // safer floor for #[ignore] tests that occasionally run against
-    // a freshly-rebuilt softioc binary.
-    tokio::time::sleep(Duration::from_secs(3)).await;
 
     let mut c_child = start_c_softioc(
         c_port,

--- a/crates/epics-ca-rs/tests/discovery_mdns.rs
+++ b/crates/epics-ca-rs/tests/discovery_mdns.rs
@@ -15,13 +15,6 @@ use epics_ca_rs::client::{CaClient, CaClientConfig};
 use epics_ca_rs::discovery::DiscoveryConfig;
 use epics_ca_rs::server::CaServer;
 
-fn free_port() -> u16 {
-    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let p = l.local_addr().unwrap().port();
-    drop(l);
-    p
-}
-
 /// Smoke test that may be flaky on hosts without working multicast
 /// (some CI containers) — annotated `#[ignore]` so it's opt-in via
 /// `cargo test -- --ignored`. Real LAN hosts run it cleanly.
@@ -38,17 +31,16 @@ async fn mdns_server_announce_to_client_discover() {
             .unwrap()
             .as_micros()
     );
-    let port = free_port();
-
     let server = CaServer::builder()
         .pv("MDNS:VAL", epics_base_rs::types::EpicsValue::Long(7777))
-        .port(port)
+        .port(0)
         .announce_mdns(&instance)
         .announce_txt("version", "test")
         .build()
         .await
         .expect("build");
 
+    let port = server.udp_port();
     let server_arc = Arc::new(server);
     let server_clone = server_arc.clone();
     let server_task = tokio::spawn(async move {

--- a/crates/epics-ca-rs/tests/protocol_tests.rs
+++ b/crates/epics-ca-rs/tests/protocol_tests.rs
@@ -352,25 +352,15 @@ async fn server_get_nonexistent_pv_returns_error() {
 async fn server_stats_bytes_in_out_track_real_traffic() {
     use std::time::Duration;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("STATS:BYTES", EpicsValue::Double(7.5))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let stats = server.stats();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-
-    // Let the listener bind + accept loop spin up.
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Drive a real CA caget through the local TCP listener. Tell the
     // client exactly where to find this server so it skips UDP search.
@@ -426,23 +416,15 @@ async fn server_stats_bytes_in_out_track_real_traffic() {
 async fn server_stats_subscription_counters_track_camonitor_lifecycle() {
     use std::time::Duration;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("STATS:SUB:PV", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let stats = server.stats();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     unsafe {
         std::env::set_var("EPICS_CA_ADDR_LIST", format!("127.0.0.1:{port}"));
@@ -812,22 +794,14 @@ async fn server_echo_round_trips_request_header_and_payload() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("ECHO:PV", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -937,22 +911,14 @@ async fn server_event_cancel_unknown_sid_replies_eca_internal_and_disconnects() 
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("BADMONID:PV", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Connect a raw TCP socket and complete the CA handshake.
     let mut sock = TcpStream::connect(("127.0.0.1", port))
@@ -1069,22 +1035,14 @@ async fn server_unknown_tcp_command_replies_error_and_disconnects() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("BAD:CMD", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -1181,22 +1139,14 @@ async fn server_tcp_version_below_minimum_drops_connection() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("VER:OLD", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -1256,22 +1206,14 @@ async fn server_write_notify_bad_type_replies_error_and_disconnects() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("WRBAD:PV", EpicsValue::Double(0.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -1436,22 +1378,14 @@ async fn server_deprecated_read_class_name_count0_follows_c_m_count() {
     // literal to match this file's wire-level convention (no types import).
     const DBR_CLASS_NAME: u16 = 38;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("CLSNM:PV", EpicsValue::Double(0.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -1657,25 +1591,17 @@ async fn server_deprecated_read_string_shortens_to_nul_length() {
     // DBR_STRING = 0 (epics_base_rs::types::DBR_STRING).
     const DBR_STRING: u16 = 0;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     // STR:SHORT = "OK"; STR:LONG = 40 'A's (encoder clamps to 39 chars +
     // a NUL at byte 39, so epicsStrnLen == 39 and the trimmed size is 40).
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("STR:SHORT", EpicsValue::String("OK".into()))
         .pv("STR:LONG", EpicsValue::String("A".repeat(40).into()))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -1857,21 +1783,16 @@ async fn mr_r7_rejected_queued_datagram_does_not_reparse_stale_buffer() {
     use std::time::Duration;
     use tokio::net::UdpSocket;
 
-    let port = {
-        let probe = std::net::UdpSocket::bind(("127.0.0.1", 0)).expect("reserve free CA UDP port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("MR7:PV", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    // This test speaks UDP SEARCH straight at the responder, so it needs
+    // the UDP port, not the TCP one.
+    let port = server.udp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(250)).await;
 
     // Build a CA_PROTO_SEARCH UDP datagram for MR7:PV. The server's
     // SEARCH reply echoes `m_available` (the client cid), so a unique
@@ -2028,22 +1949,14 @@ async fn server_read_notify_bad_type_closes_silently() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("RDBAD:PV", EpicsValue::Double(0.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -2162,22 +2075,14 @@ async fn server_read_sync_echoes_request_header() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("SYNC:PV", EpicsValue::Double(0.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.tcp_port();
     let _rs_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut sock = TcpStream::connect(("127.0.0.1", port))
         .await
@@ -2253,22 +2158,14 @@ async fn first_connect_does_not_emit_native_type_changed() {
 
     use epics_ca_rs::client::{CaClient, ConnectionEvent};
 
-    let port = {
-        let probe =
-            std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free CA server port");
-        let p = probe.local_addr().unwrap().port();
-        drop(probe);
-        p
-    };
-
     let server = CaServer::builder()
-        .port(port)
+        .port(0)
         .pv("NTC:FIRST:PV", EpicsValue::Double(1.0))
         .build()
         .await
         .expect("build CA server");
+    let port = server.udp_port();
     let _server_handle = tokio::spawn(async move { server.run().await });
-    tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Target the in-process server directly (no process-global env mutation),
     // so this test needs no `#[serial]` and cannot race the env other tests set.

--- a/crates/epics-ca-rs/tests/protocol_tests.rs
+++ b/crates/epics-ca-rs/tests/protocol_tests.rs
@@ -198,6 +198,7 @@ fn header_set_payload_count_boundary_at_0xffff() {
 #[tokio::test]
 async fn server_builder_with_simple_pvs() {
     let server = CaServer::builder()
+        .port(0)
         .pv("TEST:DOUBLE", EpicsValue::Double(3.15))
         .pv("TEST:STRING", EpicsValue::String("hello".into()))
         .pv("TEST:SHORT", EpicsValue::Short(42))
@@ -229,6 +230,7 @@ async fn server_builder_with_simple_pvs() {
 #[tokio::test]
 async fn server_put_and_get_double() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:D", EpicsValue::Double(0.0))
         .build()
         .await
@@ -241,6 +243,7 @@ async fn server_put_and_get_double() {
 #[tokio::test]
 async fn server_put_and_get_string() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:S", EpicsValue::String("initial".into()))
         .build()
         .await
@@ -259,6 +262,7 @@ async fn server_put_and_get_string() {
 #[tokio::test]
 async fn server_put_and_get_short() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:I", EpicsValue::Short(0))
         .build()
         .await
@@ -271,6 +275,7 @@ async fn server_put_and_get_short() {
 #[tokio::test]
 async fn server_put_and_get_enum() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:E", EpicsValue::Enum(0))
         .build()
         .await
@@ -283,6 +288,7 @@ async fn server_put_and_get_enum() {
 #[tokio::test]
 async fn server_put_and_get_float() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:F", EpicsValue::Float(0.0))
         .build()
         .await
@@ -295,6 +301,7 @@ async fn server_put_and_get_float() {
 #[tokio::test]
 async fn server_put_and_get_long() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:L", EpicsValue::Long(0))
         .build()
         .await
@@ -313,6 +320,7 @@ async fn server_put_and_get_long() {
 #[tokio::test]
 async fn server_put_and_get_char() {
     let server = CaServer::builder()
+        .port(0)
         .pv("SRV:C", EpicsValue::Char(0))
         .build()
         .await
@@ -329,6 +337,7 @@ async fn server_put_and_get_char() {
 #[tokio::test]
 async fn server_get_nonexistent_pv_returns_error() {
     let server = CaServer::builder()
+        .port(0)
         .pv("REAL:PV", EpicsValue::Double(1.0))
         .build()
         .await
@@ -473,6 +482,7 @@ async fn server_stats_subscription_counters_track_camonitor_lifecycle() {
 #[tokio::test]
 async fn server_put_nonexistent_pv_returns_error() {
     let server = CaServer::builder()
+        .port(0)
         .pv("REAL:PV", EpicsValue::Double(1.0))
         .build()
         .await
@@ -488,7 +498,7 @@ async fn server_put_nonexistent_pv_returns_error() {
 
 #[tokio::test]
 async fn server_add_pv_at_runtime() {
-    let server = CaServer::builder().build().await.unwrap();
+    let server = CaServer::builder().port(0).build().await.unwrap();
 
     // PV does not exist yet
     assert!(server.get("RUNTIME:PV").await.is_err());
@@ -513,6 +523,7 @@ async fn server_add_pv_at_runtime() {
 #[tokio::test]
 async fn server_multiple_pv_types_coexist() {
     let server = CaServer::builder()
+        .port(0)
         .pv("MULTI:D", EpicsValue::Double(1.1))
         .pv("MULTI:S", EpicsValue::String("abc".into()))
         .pv("MULTI:I", EpicsValue::Short(7))
@@ -552,6 +563,7 @@ record(ai, "TEMP:READING") {
 "#;
     let macros = HashMap::new();
     let server = CaServer::builder()
+        .port(0)
         .db_string(db_text, &macros)
         .unwrap()
         .build()
@@ -572,6 +584,7 @@ record(ai, "$(PREFIX):SETPOINT") {
     let mut macros = HashMap::new();
     macros.insert("PREFIX".to_string(), "MTR01".to_string());
     let server = CaServer::builder()
+        .port(0)
         .db_string(db_text, &macros)
         .unwrap()
         .build()
@@ -597,6 +610,7 @@ record(ai, "SENSOR:TEMP") {
 "#;
     let macros = HashMap::new();
     let server = CaServer::builder()
+        .port(0)
         .db_string(db_text, &macros)
         .unwrap()
         .build()
@@ -654,6 +668,7 @@ record(stringout, "SO:VAL") {
 "#;
     let macros = HashMap::new();
     let server = CaServer::builder()
+        .port(0)
         .db_string(db_text, &macros)
         .unwrap()
         .build()
@@ -687,6 +702,7 @@ record(ao, "CTRL:SP") {
 "#;
     let macros = HashMap::new();
     let server = CaServer::builder()
+        .port(0)
         .db_string(db_text, &macros)
         .unwrap()
         .build()
@@ -723,6 +739,7 @@ record(ai, "REC:AI") {
 "#;
     let macros = HashMap::new();
     let server = CaServer::builder()
+        .port(0)
         .pv("SIMPLE:PV", EpicsValue::Double(20.0))
         .db_string(db_text, &macros)
         .unwrap()
@@ -768,6 +785,7 @@ async fn server_builder_custom_port() {
 #[tokio::test]
 async fn server_database_accessor() {
     let server = CaServer::builder()
+        .port(0)
         .pv("DB:ACCESS", EpicsValue::Double(7.7))
         .build()
         .await

--- a/crates/epics-ca-rs/tests/tls_end_to_end.rs
+++ b/crates/epics-ca-rs/tests/tls_end_to_end.rs
@@ -11,7 +11,6 @@ use epics_ca_rs::client::{CaClient, CaClientConfig};
 use epics_ca_rs::server::CaServer;
 use epics_ca_rs::tls;
 use std::time::Duration;
-use tokio::sync::oneshot;
 
 fn fresh_cert_and_key() -> (
     Vec<rustls_pki_types::CertificateDer<'static>>,
@@ -48,33 +47,23 @@ async fn rust_client_tls_to_rust_server() {
     let roots = tls::load_root_store(cert_file.path()).unwrap();
     let client_tls = tls::TlsConfig::client_from_roots(roots);
 
-    // Pick a free port for the IOC.
-    let port = {
-        let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let p = l.local_addr().unwrap().port();
-        drop(l);
-        p
-    };
-
-    // Bring up the IOC with TLS enabled.
+    // Bring up the IOC with TLS enabled on a kernel-assigned port.
     let server = CaServer::builder()
         .pv("TLS:VAL", epics_base_rs::types::EpicsValue::Long(7777))
-        .port(port)
+        .port(0)
         .with_tls(server_tls)
         .build()
         .await
         .expect("build");
 
+    // `build()` bound the listener, so the server is accepting TLS
+    // connections already — nothing to wait for.
+    let port = server.udp_port();
     let server_arc = std::sync::Arc::new(server);
     let server_clone = server_arc.clone();
-    let (ready_tx, ready_rx) = oneshot::channel::<()>();
     let server_task = tokio::spawn(async move {
-        // Give caller a chance to know the listener is up
-        let _ = ready_tx.send(());
         let _ = server_clone.run().await;
     });
-    let _ = ready_rx.await;
-    tokio::time::sleep(Duration::from_millis(800)).await;
 
     // Set up the client to talk to that port over TLS.
     unsafe {

--- a/crates/optics-rs/tests/integration_tests.rs
+++ b/crates/optics-rs/tests/integration_tests.rs
@@ -33,6 +33,7 @@ record(calc, "TEST:TCNT") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("table", || Box::new(TableRecord::default()))
         .register_record_type("calc", || {
             Box::new(epics_base_rs::server::records::calc::CalcRecord::new("A+1"))

--- a/crates/scaler-rs/tests/integration_tests.rs
+++ b/crates/scaler-rs/tests/integration_tests.rs
@@ -17,6 +17,7 @@ record(scaler, "TEST:SC") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(ScalerRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -77,6 +78,7 @@ record(scaler, "TEST:SC2") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(ScalerRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -104,6 +106,7 @@ record(scaler, "TEST:SC3") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(ScalerRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -158,6 +161,7 @@ record(scaler, "TEST:SC4") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(ScalerRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -194,6 +198,7 @@ record(scaler, "TEST:SC5") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(ScalerRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -600,6 +605,7 @@ record(scaler, "TEST:SCNP") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(ScalerRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()

--- a/crates/std-rs/tests/e2e_tests.rs
+++ b/crates/std-rs/tests/e2e_tests.rs
@@ -26,6 +26,7 @@ record(throttle, "THR") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -68,6 +69,7 @@ record(throttle, "THR2") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -134,6 +136,7 @@ record(scaler, "SC") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("scaler", || Box::new(scaler_rs::ScalerRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -330,6 +333,7 @@ record(epid, "TEST:PID") {
 }
 "#;
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .db_string(db_str, &HashMap::new())
         .unwrap()
@@ -433,6 +437,7 @@ record(epid, "PID") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -517,6 +522,7 @@ record(epid, "PID") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .register_device_support("Epid Async Soft", || {

--- a/crates/std-rs/tests/integration_tests.rs
+++ b/crates/std-rs/tests/integration_tests.rs
@@ -23,6 +23,7 @@ record(throttle, "TEST:THR") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -115,6 +116,7 @@ record(throttle, "TEST:THR2") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -160,6 +162,7 @@ record(throttle, "TEST:THR3") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -219,6 +222,7 @@ record(epid, "TEST:PID") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -289,6 +293,7 @@ record(epid, "TEST:PID2") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -354,6 +359,7 @@ record(epid, "TEST:PIDSUP") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -432,6 +438,7 @@ record(epid, "TEST:PIDCL") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -516,6 +523,7 @@ record(epid, "TEST:PIDCLF") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -567,6 +575,7 @@ record(timestamp, "TEST:TS") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("timestamp", || Box::new(std_rs::TimestampRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -620,6 +629,7 @@ record(timestamp, "TEST:TSNP") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("timestamp", || Box::new(std_rs::TimestampRecord::default()))
         .db_string(db_str, &macros)
         .unwrap()
@@ -705,6 +715,7 @@ record(epid, "PID") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .register_record_type("calc", || {
             Box::new(epics_base_rs::server::records::calc::CalcRecord::new("A+1"))
@@ -772,6 +783,7 @@ record(throttle, "TEST:THRSYNC") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -851,6 +863,7 @@ record(throttle, "TEST:THROV2") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -905,6 +918,7 @@ record(throttle, "TEST:THRPP") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("throttle", || Box::new(std_rs::ThrottleRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)
@@ -971,6 +985,7 @@ record(epid, "TEST:PIDNV") {
 "#;
     let macros = HashMap::new();
     let server = CaServerBuilder::new()
+        .port(0)
         .register_record_type("epid", || Box::new(std_rs::EpidRecord::default()))
         .register_record_type("ao", || Box::new(AoRecord::default()))
         .db_string(db_str, &macros)

--- a/examples/qsrv-ioc/src/main.rs
+++ b/examples/qsrv-ioc/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> CaResult<()> {
     spawn_simulator(db.clone());
 
     // ── Build both servers from the same database ──
-    let ca_server = CaServer::from_parts(db.clone(), ca_port, None, None, None, None);
+    let ca_server = CaServer::from_parts(db.clone(), ca_port, None, None, None, None).await?;
     let pva_server = PvaServer::from_parts(db, pva_port, None, None, None);
 
     // CA runs in background, PVA runs with iocsh (shell exit stops everything)

--- a/examples/regression-ioc/src/lib.rs
+++ b/examples/regression-ioc/src/lib.rs
@@ -109,9 +109,11 @@ impl RegressionIoc {
         // Arm motor polling after iocInit (C arms the poller post-PINI).
         let _ = poll_cmd_tx.try_send(PollCommand::StartPolling);
 
-        // CA server on a reserved free port; run() spawns the SCAN scheduler.
-        let ca_port = free_loopback_port();
-        let ca_server = CaServer::from_parts(db.clone(), ca_port, None, None, None, None);
+        // CA server on a kernel-assigned port: `from_parts` binds the
+        // sockets and reports the port it got, so nothing can take the
+        // number in between. run() spawns the SCAN scheduler.
+        let ca_server = CaServer::from_parts(db.clone(), 0, None, None, None, None).await?;
+        let ca_port = ca_server.udp_port();
         let _ca_task = tokio::spawn(async move { ca_server.run().await });
 
         // Native PVA server on an ephemeral loopback port; serves the same db.
@@ -148,17 +150,6 @@ impl RegressionIoc {
             .server_addr(self.pva_addr)
             .build()
     }
-}
-
-/// Reserve then release a free loopback TCP port, returning its number.
-///
-/// `CaServer` cannot read back a kernel-assigned port-0 binding, so the
-/// verified idiom is reserve-then-bind-that-number.
-pub fn free_loopback_port() -> u16 {
-    let probe = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("reserve free port");
-    let port = probe.local_addr().expect("local_addr").port();
-    drop(probe);
-    port
 }
 
 /// Point the next `CaClient::new()` at exactly `127.0.0.1:port`.


### PR DESCRIPTION
## The defect

main's CI is red intermittently across the whole client/server test family — `ConnectionRefused`, `ChannelNotFound`, and `Io(AddrInUse)` from `CaServer::builder().build()` — and it gets worse the more loaded the runner is.

`CaServer::run()` bound its TCP listener and UDP search responders **inside the tasks it spawned**. Every test did:

```rust
tokio::spawn(server.run());
sleep(Duration::from_millis(50)).await;   // "wait for the server"
CaClient::new().await?.caget("X").await   // race
```

The sleep proved nothing: it waits for wall-clock, not for a bind. On a 2-core runner the spawned task regularly had not reached its `bind()` yet. Worse, a bind error inside those tasks killed the whole server, so a lost port race surfaced much later as a refused connection with no bind error anywhere in the log.

## Fix 1 — readiness by construction

Bind is now a construction-time step, so **owning a `CaServer` implies its sockets are listening**.

- `tcp::bind_tcp_listeners(port) -> BoundTcp` and `udp::bind_udp_responders(port, ..) -> BoundUdp` split bind from serve; `run_tcp_listener` / `run_udp_search_responder` take already-bound sockets (`Arc`'d, since `run(&self)` shares them).
- `CaServer::bind_sockets` is the **single owner** of socket creation, called by both construction paths — `builder().build()` and `from_parts()` (now `async` + fallible). A bind failure reaches the caller instead of being swallowed by a spawned task.
- `run()` loses its TCP-port `oneshot` and its "TCP listener failed to start" path: the port is known before `run()` is ever polled.

A bound-and-listening TCP socket completes handshakes in the kernel, and a bound UDP socket queues datagrams — so a client that connects or SEARCHes before the server task is first polled is served, not refused. **The 45 fixed readiness `sleep()`s are therefore deleted.** (The two sleeps that wait for something real — mDNS propagation, a connection timeout — are kept.)

## Fix 2 — take ports by binding, not by guessing

Exposed by fix 1: tests probed a free **TCP** port and then had the server bind **UDP** on the same number. Nothing owned that port in between, and ephemeral UDP sockets elsewhere in the process (repeater, beacon, asyn/PVA clients) could already hold it — that is the `Io(AddrInUse)` from `build()`.

Ports are now taken by binding. Tests pass `.port(0)` and read the real port back via the new `CaServer::udp_port()` / `tcp_port()`. The server *holds* the port from bind onward, so nothing can take it. `free_port()` survives only where a test genuinely wants an address with **no** server on it (dead-upstream, connect-timeout cases), and is documented as such.

## Fix 3 — `SO_REUSE*` only for well-known ports (separate commit)

An ephemeral bind with `SO_REUSEADDR`/`SO_REUSEPORT` already set may be handed a port a reuse-compatible socket already owns: the kernel silently joins that `SO_REUSEPORT` group instead of failing, then **load-balances arriving datagrams across the group** — so an unrelated socket eats a share of our SEARCHes. The flags exist for the well-known-port co-bind case, so they are now set only when the caller asked for a specific port.

`loopback_mcast` is exempt and keeps them unconditionally: co-binding is that helper's purpose, and multicast is delivered to *every* joined socket rather than load-balanced. Documented in place.

Boundary tests in `server/udp.rs` pin both sides: an ephemeral responder port cannot be co-bound; a well-known one still can (caRepeater parity).

## API change

- `CaServer::from_parts(..)` is now `async` and returns `CaResult<Self>`. All in-tree callers updated.
- New: `CaServer::tcp_port()` / `CaServer::udp_port()`.
- epics-bridge-rs: `DownstreamServer::new{,_with_tls}` are `async` + fallible; `BridgeError` gained a `Ca` variant so the bind error propagates.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --doc --workspace` — pass
- `cargo nextest run --workspace --no-fail-fast` — **7441 passed, 2 skipped, 6 consecutive runs**
- `taskset -c 0,1 cargo nextest run --workspace --no-fail-fast` — the 2-core condition that reproduced the failure: **7441 passed, 4 consecutive runs**