### PR TITLE
fix(net): UDP datagram fanout must set SO_REUSEADDR on Windows; drop the PORT_RUNTIMES keep-alive statics

### DIFF
--- a/crates/epics-base-rs/src/net/async_udp_v4.rs
+++ b/crates/epics-base-rs/src/net/async_udp_v4.rs
@@ -1233,21 +1233,25 @@ fn bind_one_at(
     // reach the server, and reconnect after IOC restart silently
     // fails.
     //
-    // libcom commit 19146a5: Windows SO_REUSEADDR has dangerous
-    // socket-hijack semantics (any process can rebind), and Windows
-    // releases ports immediately on close anyway, so the flag is
-    // skipped on Windows. The Windows-idiomatic alternative is
-    // SO_EXCLUSIVEADDRUSE, but plain bind() already prevents reuse.
+    // The fanout helper carries no `#ifdef _WIN32` — it sets SO_REUSEADDR
+    // on every platform, Windows included. (The Windows carve-out in
+    // libcom commit 19146a5 belongs to the *other* helper,
+    // `epicsSocketEnableAddressReuseDuringTimeWaitState`, which guards TCP
+    // time-wait rebinding; WINSOCK's SO_REUSEADDR has port-hijack
+    // semantics, and C accepts that cost for datagram fanout but not for
+    // TCP.) Skipping it on Windows breaks the co-bind this socket exists
+    // to support.
     //
     // Only for a *well-known* port — the co-bind case the flags exist
-    // for. A client socket asking for an ephemeral port (0) has nothing
-    // to share, and the flags then do harm: Linux may satisfy bind(0)
-    // with a port already held by a reuse-compatible socket, joining its
-    // SO_REUSEPORT group, after which the kernel load-balances arriving
-    // datagrams across the group — this socket's search replies can be
-    // delivered to the unrelated socket and dropped. With the flags off,
-    // bind(0) yields a port this socket exclusively owns.
-    #[cfg(not(windows))]
+    // for, and what C does: udpiiu.cpp:248 binds the client search socket
+    // to PORT_ANY and enables no reuse on it. A socket asking for an
+    // ephemeral port has nothing to share, and the flags then do harm:
+    // Linux may satisfy bind(0) with a port already held by a
+    // reuse-compatible socket, joining its SO_REUSEPORT group, after which
+    // the kernel load-balances arriving datagrams across the group — this
+    // socket's search replies can be delivered to the unrelated socket and
+    // dropped. With the flags off, bind(0) yields a port this socket
+    // exclusively owns.
     if port != 0 {
         sock.set_reuse_address(true)?;
         #[cfg(unix)]

--- a/crates/epics-base-rs/src/net/loopback_mcast.rs
+++ b/crates/epics-base-rs/src/net/loopback_mcast.rs
@@ -54,17 +54,22 @@ pub fn bind_loopback_mcast(port: u16) -> io::Result<UdpSocket> {
 
     // Same SO_REUSE* policy as the per-NIC bundle: required so a PVA
     // server and client on the same host can both join the group.
-    // Windows: skip — its REUSEADDR has socket-hijack semantics and
-    // bind() releases on close anyway. (libcom commit 19146a5.)
     //
-    // Set unconditionally here, including for an ephemeral port —
-    // unlike the unicast sockets in `async_udp_v4`. Co-binding *is* the
-    // purpose of this helper (one listener takes an ephemeral port and
-    // publishes it, the others join that same port), and multicast group
-    // traffic is delivered to every joined socket rather than
-    // load-balanced across the reuse group, so sharing costs nothing
-    // here.
-    #[cfg(not(windows))]
+    // On every platform, Windows included: this is the socket pvxs builds
+    // in `UDPCollector` (udp_collector.cpp:124-151), and it hands it to
+    // `epicsSocketEnableAddressUseForDatagramFanout` (:136) — the libcom
+    // helper that sets SO_REUSEPORT then SO_REUSEADDR with no `#ifdef
+    // _WIN32`. (The Windows carve-out of commit 19146a5 belongs to the TCP
+    // time-wait helper, `epicsSocketEnableAddressReuseDuringTimeWaitState`.
+    // Applying it here would stop a second local PVA process from joining
+    // the ORIGIN_TAG channel on Windows.)
+    //
+    // Set unconditionally, including for an ephemeral port — unlike the
+    // unicast sockets in `async_udp_v4`. Co-binding *is* the purpose of
+    // this helper (one listener takes an ephemeral port and publishes it,
+    // the others join that same port), and multicast group traffic is
+    // delivered to every joined socket rather than load-balanced across the
+    // reuse group, so sharing costs nothing here.
     sock.set_reuse_address(true)?;
     #[cfg(unix)]
     sock.set_reuse_port(true)?;

--- a/crates/epics-ca-rs/src/server/udp.rs
+++ b/crates/epics-ca-rs/src/server/udp.rs
@@ -300,22 +300,32 @@ async fn run_single_responder(
 /// sockets share identical socket-option setup.
 fn bind_responder_socket(bind_ip: Ipv4Addr, port: u16) -> CaResult<UdpSocket> {
     let sock = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
-    // libcom commits 19146a5 + 5064931 + 65ef6e9: SO_REUSEADDR has dangerous
-    // hijack semantics on Windows (any process can rebind), so it's POSIX-only.
-    // For UDP datagram fanout (caRepeater + CA server sharing a port) Linux
-    // requires BOTH SO_REUSEADDR and SO_REUSEPORT (different reuse classes
-    // don't share); BSD/macOS need SO_REUSEPORT. Mirror libcom
-    // epicsSocketEnableAddressUseForDatagramFanout and set both on Unix.
+    // This is a *datagram fanout* socket, so it mirrors libcom's
+    // `epicsSocketEnableAddressUseForDatagramFanout`
+    // (osdSockAddrReuse.cpp), which the C CA server applies to exactly
+    // these sockets — the UDP name receiver and its broadcast companion
+    // (caservertask.c:628, :698). That helper sets SO_REUSEPORT (where
+    // it exists) followed by SO_REUSEADDR on *every* platform: it has no
+    // `#ifdef _WIN32`. Windows must set SO_REUSEADDR too, or a second IOC
+    // on the host cannot bind the CA port and never receives a broadcast
+    // SEARCH.
+    //
+    // Do not confuse this with `epicsSocketEnableAddressReuseDuringTimeWaitState`
+    // (the TCP time-wait helper), which *is* a Windows no-op because
+    // WINSOCK's SO_REUSEADDR has port-hijack semantics there. That rule
+    // governs the TCP listener and caRepeater's exclusive bind, not this
+    // socket.
     //
     // Only for a *well-known* port, which is the case the fanout exists
-    // for. On an ephemeral bind (port 0) there is nothing to share, and
-    // the flags are actively harmful: Linux may hand bind(0) a port that
-    // already belongs to a reuse-compatible socket, silently joining its
-    // SO_REUSEPORT group — the kernel then load-balances arriving
-    // datagrams across the group, so SEARCHes for this server land on an
-    // unrelated socket and go unanswered. Leaving the flags off makes the
-    // kernel pick a port this socket exclusively owns.
-    #[cfg(not(windows))]
+    // for — C likewise leaves its PORT_ANY sockets bare (udpiiu.cpp:248
+    // binds the client search socket to PORT_ANY and enables no reuse).
+    // On an ephemeral bind the flags are actively harmful: Linux may hand
+    // bind(0) a port that already belongs to a reuse-compatible socket,
+    // silently joining its SO_REUSEPORT group — the kernel then
+    // load-balances arriving datagrams across the group, so SEARCHes for
+    // this server land on an unrelated socket and go unanswered. Leaving
+    // the flags off makes the kernel pick a port this socket exclusively
+    // owns.
     if port != 0 {
         sock.set_reuse_address(true)?;
         #[cfg(unix)]
@@ -1037,13 +1047,14 @@ mod responder_bind_tests {
     }
 
     /// Boundary — a fixed port keeps the datagram-fanout reuse flags, so
-    /// the well-known CA port can still be co-bound (caRepeater parity).
+    /// the well-known CA port can still be co-bound (multiple IOCs on one
+    /// host must all receive a broadcast SEARCH).
     ///
-    /// Unix only: `bind_responder_socket` sets no reuse flag at all on
-    /// Windows (its `SO_REUSEADDR` has socket-hijack semantics — see the
-    /// `cfg(not(windows))` gate there), so co-binding is *correctly*
-    /// refused on Windows and there is no fanout to assert.
-    #[cfg(unix)]
+    /// Runs on Windows too: libcom's fanout helper sets SO_REUSEADDR on
+    /// every platform, so the co-bind must work there as well. This test
+    /// is what pins that — it failed on Windows while
+    /// `bind_responder_socket` was (wrongly) applying the TCP time-wait
+    /// helper's Windows carve-out.
     #[test]
     fn fixed_responder_port_still_allows_datagram_fanout() {
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/crates/epics-pva-rs/src/client_native/search_engine.rs
+++ b/crates/epics-pva-rs/src/client_native/search_engine.rs
@@ -807,7 +807,13 @@ fn bind_beacon_udp_v6(port: u16) -> Option<Arc<UdpSocket>> {
     // a server v6 SEARCH listener on `[::]:port` and a client v6 beacon
     // listener can coexist. The server emits beacons FROM a separate
     // ephemeral socket, so this REUSEPORT-shared listener only receives.
-    #[cfg(not(windows))]
+    //
+    // SO_REUSEADDR on every platform, Windows included: pvxs puts its UDP
+    // sockets through `epicsSocketEnableAddressUseForDatagramFanout`
+    // (udp_collector.cpp:136), and that libcom helper has no `#ifdef
+    // _WIN32` — the Windows carve-out belongs to the TCP time-wait helper,
+    // not this one. Skipping it here would stop a second PVA process on a
+    // Windows host from co-binding the beacon port.
     if let Err(e) = sock.set_reuse_address(true) {
         debug!("v6 beacon socket: set_reuse_address failed: {e}");
     }

--- a/crates/modbus-rs/src/ioc.rs
+++ b/crates/modbus-rs/src/ioc.rs
@@ -46,7 +46,7 @@ use asyn_rs::interpose::EomReason;
 use asyn_rs::param::{ParamType, ParamValue};
 use asyn_rs::port::{DrvUserInfo, PortDriver, PortDriverBase, PortFlags};
 use asyn_rs::runtime::config::RuntimeConfig;
-use asyn_rs::runtime::port::{PortRuntimeHandle, create_port_runtime};
+use asyn_rs::runtime::port::create_port_runtime;
 use asyn_rs::sync_io::SyncIOHandle;
 use asyn_rs::trace::TraceManager;
 use asyn_rs::user::AsynUser;
@@ -1407,9 +1407,6 @@ impl Default for InterposeSettings {
 /// name, consumed by `drvModbusAsynConfigure`.
 static PENDING_LINKS: Mutex<Option<HashMap<String, InterposeSettings>>> = Mutex::new(None);
 
-/// Port runtime handles — dropping one shuts the actor down, so they are kept.
-static PORT_RUNTIMES: Mutex<Option<Vec<PortRuntimeHandle>>> = Mutex::new(None);
-
 fn record_interpose(octet_port: &str, settings: InterposeSettings) {
     let mut g = PENDING_LINKS.lock().unwrap();
     g.get_or_insert_with(HashMap::new)
@@ -1423,11 +1420,6 @@ fn take_interpose(octet_port: &str) -> InterposeSettings {
         .as_ref()
         .and_then(|m| m.get(octet_port).copied())
         .unwrap_or_default()
-}
-
-fn keep_runtime(handle: PortRuntimeHandle) {
-    let mut g = PORT_RUNTIMES.lock().unwrap();
-    g.get_or_insert_with(Vec::new).push(handle);
 }
 
 /// `modbusInterposeConfig portName linkType timeoutMsec writeDelayMsec` — port
@@ -1660,11 +1652,16 @@ impl CommandHandler for ModbusConfigHandler {
 
         let (runtime, _jh) = create_port_runtime(driver, RuntimeConfig::default());
         let port_handle = runtime.port_handle().clone();
-        // On a duplicate port name the runtime handle drops here, shutting
-        // the just-spawned actor down.
-        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
-            .map_err(|e| e.to_string())?;
-        keep_runtime(runtime);
+        if let Err(e) =
+            asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
+        {
+            // Nothing published this port, so ask the actor to stop.
+            runtime.shutdown();
+            return Err(e.to_string());
+        }
+        // The registry above holds a live `PortHandle` for this port, which is
+        // what keeps its actor alive; the `PortRuntimeHandle` may drop here.
+        drop(runtime);
 
         println!("drvModbusAsynConfigure: port='{port_name}' octet='{octet_port}' link={link:?}");
 

--- a/crates/mqtt-rs/src/ioc.rs
+++ b/crates/mqtt-rs/src/ioc.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use asyn_rs::runtime::config::RuntimeConfig;
-use asyn_rs::runtime::port::{PortRuntimeHandle, create_port_runtime};
+use asyn_rs::runtime::port::create_port_runtime;
 use asyn_rs::trace::TraceManager;
 use epics_base_rs::server::iocsh::registry::*;
 
@@ -21,16 +21,6 @@ use crate::event_loop::mqtt_event_loop;
 /// on-demand creation. Populated by [`register_pending_topic`] (the Z2M
 /// builders), drained once by [`take_pending_topics`] at driver creation.
 static PENDING_TOPICS: Mutex<Option<HashMap<String, Vec<TopicAddress>>>> = Mutex::new(None);
-
-/// Global storage for port runtime handles.
-/// Dropping a PortRuntimeHandle shuts down the actor, so we must keep them alive.
-static PORT_RUNTIMES: Mutex<Option<Vec<PortRuntimeHandle>>> = Mutex::new(None);
-
-fn keep_runtime(handle: PortRuntimeHandle) {
-    let mut guard = PORT_RUNTIMES.lock().unwrap();
-    let vec = guard.get_or_insert_with(Vec::new);
-    vec.push(handle);
-}
 
 pub(crate) fn register_pending_topic(port_name: &str, addr: TopicAddress) {
     let mut guard = PENDING_TOPICS.lock().unwrap();
@@ -161,13 +151,16 @@ impl CommandHandler for MqttConfigHandler {
         let (runtime_handle, _actor_jh) = create_port_runtime(driver, RuntimeConfig::default());
         let port_handle = runtime_handle.port_handle().clone();
 
-        // On a duplicate port name the runtime handle drops here, shutting
-        // the just-spawned actor down.
-        asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
-            .map_err(|e| e.to_string())?;
-
-        // Keep the runtime handle alive — dropping it shuts down the actor
-        keep_runtime(runtime_handle);
+        if let Err(e) =
+            asyn_rs::asyn_record::register_port(&port_name, port_handle.clone(), self.trace.clone())
+        {
+            // Nothing published this port, so ask the actor to stop.
+            runtime_handle.shutdown();
+            return Err(e.to_string());
+        }
+        // The registry above holds a live `PortHandle` for this port, which is
+        // what keeps its actor alive; the `PortRuntimeHandle` may drop here.
+        drop(runtime_handle);
 
         // Create Connected PV if name was provided
         if let Some(pv_name) = conn_pv_name {


### PR DESCRIPTION
Closes the two items left UNFIXED after #24 / #20. Both turned out to be real defects, not accepted limitations.

## 1. UDP fanout wrongly applied the TCP Windows rule (`c8f8c5a2`, `fff4e685`)

libcom has **two** reuse helpers (`osdSockAddrReuse.cpp`) and we applied the wrong one to our UDP sockets:

| helper | for | Windows |
|---|---|---|
| `epicsSocketEnableAddressReuseDuringTimeWaitState` | TCP time-wait rebinding | **no-op** — WINSOCK's `SO_REUSEADDR` has port-hijack semantics |
| `epicsSocketEnableAddressUseForDatagramFanout` | UDP fanout | sets `SO_REUSEPORT` then `SO_REUSEADDR`, **no `#ifdef _WIN32`** |

C accepts the hijack risk for datagram fanout — the fanout *is* the point. The C CA server hands its UDP name receiver and broadcast companion to the fanout helper (`caservertask.c:628`, `:698`), and pvxs hands its `UDPCollector` socket to the same helper (`udp_collector.cpp:136`). The only Windows-guarded reuse in pvxs is on the TCP acceptor (`serverconn.cpp:412`).

Four of our datagram sockets carried the *TCP* helper's `cfg(not(windows))`:

- `epics-ca-rs::server::udp::bind_responder_socket` — the CA server's UDP search responder
- `epics-base-rs::net::async_udp_v4::bind_one_at` — the per-NIC UDP bundle
- `epics-base-rs::net::loopback_mcast` — our port of pvxs's `UDPCollector` socket (224.0.0.128 ORIGIN_TAG channel)
- `epics-pva-rs::client_native::search_engine` — the v6 beacon listener

**Consequence on Windows:** a second IOC on the host cannot bind the CA port, so it never receives a broadcast SEARCH — precisely the co-bind the flags exist to permit. Same for a second local PVA process joining the ORIGIN_TAG channel.

All four now set `SO_REUSEADDR` on every platform; `SO_REUSEPORT` stays Unix-only, as in C.

The `port != 0` gate from #24 is **unchanged** and is itself C parity: `udpiiu.cpp:248` binds the client search socket to `PORT_ANY` and enables no reuse on it. `loopback_mcast` keeps its flags even for an ephemeral port — co-binding is that helper's purpose, and multicast is delivered to every joined socket rather than load-balanced, so it is not exposed to the `bind(0)`-joins-a-reuse-group hazard that gates the unicast sockets.

`fixed_responder_port_still_allows_datagram_fanout` loses its `cfg(unix)` gate: it now runs on Windows, where it is exactly what pins this fix. It is the test that failed on Windows in #24 while the carve-out was in place.

**Distinct, not changed:** `epics-ca-rs::repeater` keeps `cfg(not(windows))`. C's repeater calls `makeSocket` → the *time-wait* helper after an exclusive bind (`repeater.cpp:94-124`, `:513`), never the fanout helper — it matches C already. After this PR it is the only `cfg(not(windows))` reuse left in the workspace.

## 2. `PORT_RUNTIMES` keep-alive statics (`32310e4e`)

`mqtt-rs` and `modbus-rs` each carried a `PORT_RUNTIMES: Mutex<Option<Vec<PortRuntimeHandle>>>` static plus a `keep_runtime()`, documented as *"dropping a PortRuntimeHandle shuts down the actor, so we must keep them alive"*. Since #20 that sentence is **false**: a port stops only when someone asks it to, or when its last `PortHandle` goes. Both crates register the port *before* stashing the handle, so the registry's `PortHandle` has been what keeps the actor alive.

The statics are removed and both call sites take the shape asyn-rs's own port-configure commands now use: on a duplicate port name, `shutdown()` the actor explicitly and return the error; otherwise drop the runtime handle and let reachability keep the port alive. This also deletes the second stale comment at those sites (*"the runtime handle drops here, shutting the just-spawned actor down"*), which #20 likewise made untrue.

No behavior change on the success path; the leak of one handle per port for the life of the process goes away.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace --no-fail-fast` — 7444 passed, 2 skipped

Windows behavior cannot be proven on a Linux host; the un-gated boundary test is what verifies it here, on the Windows CI legs.