### PR TITLE
fix(asyn): carry the record's asyn interface into drv_user_create

### DIFF
--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -9,6 +9,7 @@ use epics_base_rs::types::EpicsValue;
 use crate::error::AsynError;
 use crate::interfaces::InterfaceType;
 use crate::interrupt::{InterruptFilter, InterruptSubscription};
+use crate::port::DrvUserRequest;
 use crate::port_handle::{AsyncCompletionHandle, PortHandle};
 use crate::request::{RequestOp, RequestResult};
 use crate::user::AsynUser;
@@ -1612,11 +1613,12 @@ impl DeviceSupport for AsynDeviceSupport {
         if !self.reason_set {
             // Pass the record's asyn `addr`: a multi-device driver (e.g. modbus)
             // rejects an out-of-range offset here at bind time (C `drvUserCreate`
-            // `checkOffset`) instead of alarming on every I/O.
-            match self
-                .handle
-                .drv_user_create_blocking(&self.drv_info, self.addr)
-            {
+            // `checkOffset`) instead of alarming on every I/O. Pass the record's
+            // interface (from its DTYP): an on-demand driver must create the
+            // parameter with the type this record will read it as — C
+            // `adsAsynPortDriver::getRecordInfoFromDrvInfo`.
+            let req = DrvUserRequest::new(&self.drv_info, self.addr).with_iface(self.iface);
+            match self.handle.drv_user_create_blocking(&req) {
                 Ok(info) => {
                     self.reason = info.reason;
                     // Per-record octet cap (C `modbusDrvUser_t.len`); applied to
@@ -5400,8 +5402,7 @@ mod tests {
             }
             fn drv_user_create(
                 &mut self,
-                _drv_info: &str,
-                _addr: i32,
+                _req: &DrvUserRequest,
             ) -> crate::error::AsynResult<crate::port::DrvUserInfo> {
                 Ok(crate::port::DrvUserInfo {
                     reason: 0,
@@ -5455,6 +5456,117 @@ mod tests {
         let mut rec = LsiRecord::new("");
         ads.init(&mut rec).unwrap();
         assert_eq!(ads.octet_max_size, 256);
+    }
+
+    /// A record's bind carries the asyn interface it will read the parameter
+    /// through (from its DTYP), so an on-demand driver creates the parameter
+    /// with that type instead of guessing.
+    ///
+    /// C parity: `adsAsynPortDriver::getRecordInfoFromDrvInfo` derives each
+    /// parameter's asyn type from the bound record's DTYP — the same PLC symbol
+    /// may bind as `asynInt32` from one record and `asynFloat64` from another.
+    /// Without the interface at bind, a lazily-created parameter can only be
+    /// guessed from the drvInfo string, and a wrong guess feeds the record a
+    /// value of the wrong `ParamValue` variant on every I/O Intr callback.
+    #[test]
+    fn drv_user_create_receives_the_records_interface() {
+        /// What the driver saw and what it therefore created, per bind.
+        type Binds = Arc<std::sync::Mutex<Vec<(String, Option<InterfaceType>, ParamType)>>>;
+
+        /// An on-demand driver (C Autoparam lazy creation): it holds no
+        /// parameters up front and creates one per drvInfo as records bind,
+        /// typed by the interface the record announced.
+        struct OnDemandPort {
+            base: PortDriverBase,
+            binds: Binds,
+        }
+        impl PortDriver for OnDemandPort {
+            fn base(&self) -> &PortDriverBase {
+                &self.base
+            }
+            fn base_mut(&mut self) -> &mut PortDriverBase {
+                &mut self.base
+            }
+            fn drv_user_create(
+                &mut self,
+                req: &DrvUserRequest,
+            ) -> crate::error::AsynResult<crate::port::DrvUserInfo> {
+                let param_type = match req.iface {
+                    Some(InterfaceType::Float64) => ParamType::Float64,
+                    Some(InterfaceType::Int32) => ParamType::Int32,
+                    Some(InterfaceType::Octet) => ParamType::Octet,
+                    // No interface announced: the driver has nothing to honour.
+                    _ => ParamType::Int32,
+                };
+                self.binds
+                    .lock()
+                    .unwrap()
+                    .push((req.drv_info.clone(), req.iface, param_type));
+                let reason = self.base_mut().create_param(&req.drv_info, param_type)?;
+                Ok(crate::port::DrvUserInfo::from_reason(reason))
+            }
+        }
+
+        /// Bind one record on `iface_type` to the drvInfo `SYMBOL` and return
+        /// what the driver was told at bind.
+        fn bind(iface_type: &str, init: impl FnOnce(&mut AsynDeviceSupport)) -> Binds {
+            let binds: Binds = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let driver = OnDemandPort {
+                base: PortDriverBase::new("ondemand", 1, PortFlags::default()),
+                binds: Arc::clone(&binds),
+            };
+            let interrupts = Arc::new(InterruptManager::new(256));
+            let (tx, rx) = tokio::sync::mpsc::channel(256);
+            let actor = PortActor::new(Box::new(driver), rx);
+            let actor_id = actor.id();
+            std::thread::Builder::new()
+                .name("ondemand-actor".into())
+                .spawn(move || actor.run())
+                .unwrap();
+            let handle = PortHandle::new(tx, "ondemand".into(), interrupts, actor_id);
+            let link = AsynLink {
+                port_name: "ondemand".into(),
+                addr: 0,
+                timeout: Duration::from_secs(1),
+                drv_info: "SYMBOL".into(),
+            };
+            let mut ads = AsynDeviceSupport::from_handle(handle, link, iface_type);
+            ads.set_record_info("TEST:SYMBOL", ScanType::Passive);
+            init(&mut ads);
+            binds
+        }
+
+        use epics_base_rs::server::records::ai::AiRecord;
+        use epics_base_rs::server::records::longin::LonginRecord;
+
+        // The same drvInfo bound by an `ai` with DTYP=asynFloat64: the driver
+        // must be told Float64 and create a Float64 parameter.
+        let binds = bind("asynFloat64", |ads| {
+            let mut rec = AiRecord::new(0.0);
+            ads.init(&mut rec).unwrap();
+        });
+        assert_eq!(
+            binds.lock().unwrap().as_slice(),
+            [(
+                "SYMBOL".to_string(),
+                Some(InterfaceType::Float64),
+                ParamType::Float64
+            )]
+        );
+
+        // The same drvInfo bound by a `longin` with DTYP=asynInt32: Int32.
+        let binds = bind("asynInt32", |ads| {
+            let mut rec = LonginRecord::new(0);
+            ads.init(&mut rec).unwrap();
+        });
+        assert_eq!(
+            binds.lock().unwrap().as_slice(),
+            [(
+                "SYMBOL".to_string(),
+                Some(InterfaceType::Int32),
+                ParamType::Int32
+            )]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -6667,8 +6779,7 @@ mod tests {
         // the test need not pre-register params on the mock.
         fn drv_user_create(
             &mut self,
-            _drv_info: &str,
-            _addr: i32,
+            _req: &DrvUserRequest,
         ) -> AsynResult<crate::port::DrvUserInfo> {
             Ok(crate::port::DrvUserInfo::from_reason(0))
         }

--- a/crates/asyn-rs/src/asyn_record/mod.rs
+++ b/crates/asyn-rs/src/asyn_record/mod.rs
@@ -68,6 +68,18 @@ impl InterfaceType {
             _ => Self::Octet,
         }
     }
+
+    /// The asyn interface this IFACE selection performs I/O through — what the
+    /// driver must create the parameter as when it resolves this record's
+    /// drvInfo on demand.
+    fn as_asyn_iface(self) -> crate::interfaces::InterfaceType {
+        match self {
+            Self::Octet => crate::interfaces::InterfaceType::Octet,
+            Self::Int32 => crate::interfaces::InterfaceType::Int32,
+            Self::UInt32Digital => crate::interfaces::InterfaceType::UInt32Digital,
+            Self::Float64 => crate::interfaces::InterfaceType::Float64,
+        }
+    }
 }
 
 // ===== Baud rate menu mapping =====
@@ -1782,10 +1794,12 @@ impl AsynRecord {
             Some(entry) => {
                 // Resolve drvinfo → reason if specified
                 if !self.drvinfo.is_empty() {
-                    match entry
-                        .handle
-                        .drv_user_create_blocking(&self.drvinfo, self.addr)
-                    {
+                    // Forward the interface this record performs I/O through
+                    // (its IFACE field) so an on-demand driver creates the
+                    // parameter with the type this record will read it as.
+                    let req = crate::port::DrvUserRequest::new(&self.drvinfo, self.addr)
+                        .with_iface(InterfaceType::from_u16(self.iface as u16).as_asyn_iface());
+                    match entry.handle.drv_user_create_blocking(&req) {
                         Ok(info) => {
                             self.resolved_reason = info.reason;
                             self.reason = info.reason as i32;

--- a/crates/asyn-rs/src/port.rs
+++ b/crates/asyn-rs/src/port.rs
@@ -883,6 +883,60 @@ impl DrvUserInfo {
     }
 }
 
+/// Everything a binding tells the driver when it resolves a drvInfo string —
+/// the asyn-rs analogue of the `pasynUser` C `drvUserCreate` receives.
+///
+/// This is one carrier rather than a widening argument list because the bind
+/// request has already grown once (`addr`, for C `checkOffset`) and is now
+/// growing again (`iface`): a driver that resolves a drvInfo needs to know
+/// *how the record will use the parameter*, not just its name. The struct is
+/// `#[non_exhaustive]` so the next field is additive — build it with
+/// [`DrvUserRequest::new`] and the builder methods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DrvUserRequest {
+    /// The record's driver-info string (C `pasynUser->drvUser` input).
+    pub drv_info: String,
+    /// The record's asyn `addr`, so a multi-device driver can reject an
+    /// out-of-range address at bind time (C `drvUserCreate` `checkOffset`,
+    /// drvModbusAsyn.cpp:378-384).
+    pub addr: i32,
+    /// The asyn interface the record will actually read and write this
+    /// parameter through, derived from its DTYP (`asynFloat64` → [`InterfaceType::Float64`]).
+    ///
+    /// An on-demand driver (C Autoparam lazy creation) must create the
+    /// parameter with the type the record will read it as, or every value the
+    /// record takes from it is a coerced type mismatch: C
+    /// `adsAsynPortDriver::getRecordInfoFromDrvInfo` derives the parameter's
+    /// asyn type from the bound record's DTYP for exactly this reason — the
+    /// same PLC symbol may bind as `asynInt32` from one record and
+    /// `asynFloat64` from another.
+    ///
+    /// `None` when the bind has no record behind it (a port-level
+    /// [`crate::sync_io`] resolve, a driver-to-driver handle call): the driver
+    /// then has no record type to honour and falls back to its own default.
+    pub iface: Option<InterfaceType>,
+}
+
+impl DrvUserRequest {
+    /// A bind request for `drv_info` at `addr` with no record interface — the
+    /// port-level resolve.
+    pub fn new(drv_info: impl Into<String>, addr: i32) -> Self {
+        Self {
+            drv_info: drv_info.into(),
+            addr,
+            iface: None,
+        }
+    }
+
+    /// Attach the bound record's asyn interface. Accepts an
+    /// [`InterfaceType`] or an `Option<InterfaceType>`.
+    pub fn with_iface(mut self, iface: impl Into<Option<InterfaceType>>) -> Self {
+        self.iface = iface.into();
+        self
+    }
+}
+
 /// Port driver trait. All methods have default implementations that operate
 /// on the parameter cache (no actual I/O).
 ///
@@ -1393,22 +1447,28 @@ pub trait PortDriver: Send + Sync + 'static {
 
     // --- drvUser ---
 
-    /// Resolve a record's driver-info string (and its asyn `addr`) to a
-    /// [`DrvUserInfo`] at bind time — the asyn-rs analogue of C `drvUserCreate`.
+    /// Resolve a record's bind request ([`DrvUserRequest`]: drvInfo string, asyn
+    /// `addr`, and the record's asyn interface) to a [`DrvUserInfo`] — the
+    /// asyn-rs analogue of C `drvUserCreate`.
     ///
     /// Takes `&mut self` so a driver can register a parameter on demand from the
     /// resolved drvInfo (C Autoparam lazy creation) rather than requiring it be
-    /// declared up front, and `addr` so a multi-device driver can reject an
+    /// declared up front. Such a driver must create the parameter with the type
+    /// the record will read it as — [`DrvUserRequest::iface`] — the way C
+    /// `adsAsynPortDriver::getRecordInfoFromDrvInfo` derives the parameter's
+    /// asyn type from the bound record's DTYP.
+    ///
+    /// [`DrvUserRequest::addr`] lets a multi-device driver reject an
     /// out-of-range address at bind time (C `drvUserCreate` runs `checkOffset`,
     /// drvModbusAsyn.cpp:378-384) instead of alarming on every I/O.
     ///
-    /// Default: look up the shared reason by parameter name; ignore `addr`.
-    fn drv_user_create(&mut self, drv_info: &str, _addr: i32) -> AsynResult<DrvUserInfo> {
+    /// Default: look up the shared reason by parameter name; ignore the rest.
+    fn drv_user_create(&mut self, req: &DrvUserRequest) -> AsynResult<DrvUserInfo> {
         let reason = self
             .base()
             .params
-            .find_param(drv_info)
-            .ok_or_else(|| AsynError::ParamNotFound(drv_info.to_string()))?;
+            .find_param(&req.drv_info)
+            .ok_or_else(|| AsynError::ParamNotFound(req.drv_info.clone()))?;
         Ok(DrvUserInfo::from_reason(reason))
     }
 
@@ -1509,9 +1569,22 @@ mod tests {
     #[test]
     fn test_drv_user_create() {
         let mut drv = TestDriver::new();
-        assert_eq!(drv.drv_user_create("VAL", 0).unwrap().reason, 0);
-        assert_eq!(drv.drv_user_create("TEMP", 0).unwrap().reason, 1);
-        assert!(drv.drv_user_create("NOPE", 0).is_err());
+        assert_eq!(
+            drv.drv_user_create(&DrvUserRequest::new("VAL", 0))
+                .unwrap()
+                .reason,
+            0
+        );
+        assert_eq!(
+            drv.drv_user_create(&DrvUserRequest::new("TEMP", 0))
+                .unwrap()
+                .reason,
+            1
+        );
+        assert!(
+            drv.drv_user_create(&DrvUserRequest::new("NOPE", 0))
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -698,8 +698,8 @@ impl PortActor {
                 }
                 Ok(RequestResult::write_ok())
             }
-            RequestOp::DrvUserCreate { drv_info, addr } => {
-                let info = self.driver.drv_user_create(drv_info, *addr)?;
+            RequestOp::DrvUserCreate(req) => {
+                let info = self.driver.drv_user_create(req)?;
                 Ok(RequestResult::drv_user_create(
                     info.reason,
                     info.max_octet_len,

--- a/crates/asyn-rs/src/port_handle.rs
+++ b/crates/asyn-rs/src/port_handle.rs
@@ -14,7 +14,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::error::{AsynError, AsynResult, AsynStatus};
 use crate::interrupt::InterruptManager;
-use crate::port::DrvUserInfo;
+use crate::port::{DrvUserInfo, DrvUserRequest};
 use crate::port_actor::{ActorId, ActorMessage};
 use crate::request::{CancelToken, RequestOp, RequestResult};
 use crate::user::AsynUser;
@@ -460,20 +460,14 @@ impl PortHandle {
         Ok(())
     }
 
-    /// Resolve a drvInfo (and asyn `addr`) to its shared reason index. The async
-    /// port-handle path needs only the reason; the per-record [`DrvUserInfo`]
+    /// Resolve a bind request ([`DrvUserRequest`]) to its shared reason index. The
+    /// async port-handle path needs only the reason; the per-record [`DrvUserInfo`]
     /// (string-length cap etc.) is surfaced on the record-binding blocking path
     /// [`drv_user_create_blocking`](Self::drv_user_create_blocking).
-    pub async fn drv_user_create(&self, drv_info: &str, addr: i32) -> AsynResult<usize> {
-        let user = AsynUser::default().with_addr(addr);
+    pub async fn drv_user_create(&self, req: &DrvUserRequest) -> AsynResult<usize> {
+        let user = AsynUser::default().with_addr(req.addr);
         let result = self
-            .submit_async(
-                RequestOp::DrvUserCreate {
-                    drv_info: drv_info.to_string(),
-                    addr,
-                },
-                user,
-            )
+            .submit_async(RequestOp::DrvUserCreate(req.clone()), user)
             .await?;
         result.reason.ok_or_else(|| AsynError::Status {
             status: AsynStatus::Error,
@@ -569,15 +563,9 @@ impl PortHandle {
 
     // --- Sync convenience methods ---
 
-    pub fn drv_user_create_blocking(&self, drv_info: &str, addr: i32) -> AsynResult<DrvUserInfo> {
-        let user = AsynUser::default().with_addr(addr);
-        let result = self.submit_blocking(
-            RequestOp::DrvUserCreate {
-                drv_info: drv_info.to_string(),
-                addr,
-            },
-            user,
-        )?;
+    pub fn drv_user_create_blocking(&self, req: &DrvUserRequest) -> AsynResult<DrvUserInfo> {
+        let user = AsynUser::default().with_addr(req.addr);
+        let result = self.submit_blocking(RequestOp::DrvUserCreate(req.clone()), user)?;
         let reason = result.reason.ok_or_else(|| AsynError::Status {
             status: AsynStatus::Error,
             message: "drv_user_create returned no reason".into(),

--- a/crates/asyn-rs/src/protocol/command.rs
+++ b/crates/asyn-rs/src/protocol/command.rs
@@ -117,6 +117,12 @@ pub enum PortCommand {
         drv_info: String,
         /// The record's asyn `addr` (C `drvUserCreate` `checkOffset` input).
         addr: i32,
+        /// The bound record's asyn interface name (`"asynFloat64"`, …), so a
+        /// remote on-demand driver can create the parameter with the type the
+        /// record will read it as. `None` for a port-level resolve with no
+        /// record behind it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        iface: Option<String>,
     },
     CallParamCallbacks {
         addr: i32,
@@ -199,6 +205,7 @@ mod tests {
             PortCommand::DrvUserCreate {
                 drv_info: "MOTOR_STATUS".into(),
                 addr: 0,
+                iface: Some("asynFloat64".into()),
             },
             PortCommand::CallParamCallbacks { addr: 0 },
             PortCommand::GetOption { key: "baud".into() },

--- a/crates/asyn-rs/src/protocol/convert.rs
+++ b/crates/asyn-rs/src/protocol/convert.rs
@@ -85,9 +85,10 @@ impl From<&RequestOp> for PortCommand {
             RequestOp::GetAutoConnect => Self::GetAutoConnect,
             RequestOp::BlockProcess => Self::BlockProcess,
             RequestOp::UnblockProcess => Self::UnblockProcess,
-            RequestOp::DrvUserCreate { drv_info, addr } => Self::DrvUserCreate {
-                drv_info: drv_info.clone(),
-                addr: *addr,
+            RequestOp::DrvUserCreate(req) => Self::DrvUserCreate {
+                drv_info: req.drv_info.clone(),
+                addr: req.addr,
+                iface: req.iface.map(|i| i.asyn_name().to_string()),
             },
             RequestOp::CallParamCallbacks { addr, .. } => Self::CallParamCallbacks { addr: *addr },
             RequestOp::GetOption { key } => Self::GetOption { key: key.clone() },
@@ -185,10 +186,17 @@ impl From<&PortCommand> for RequestOp {
             PortCommand::GetAutoConnect => Self::GetAutoConnect,
             PortCommand::BlockProcess => Self::BlockProcess,
             PortCommand::UnblockProcess => Self::UnblockProcess,
-            PortCommand::DrvUserCreate { drv_info, addr } => Self::DrvUserCreate {
-                drv_info: drv_info.clone(),
-                addr: *addr,
-            },
+            PortCommand::DrvUserCreate {
+                drv_info,
+                addr,
+                iface,
+            } => Self::DrvUserCreate(
+                crate::port::DrvUserRequest::new(drv_info.clone(), *addr).with_iface(
+                    iface
+                        .as_deref()
+                        .and_then(crate::interfaces::InterfaceType::from_asyn_name),
+                ),
+            ),
             PortCommand::CallParamCallbacks { addr } => Self::CallParamCallbacks {
                 addr: *addr,
                 updates: vec![],
@@ -343,10 +351,10 @@ mod tests {
             RequestOp::Disconnect,
             RequestOp::BlockProcess,
             RequestOp::UnblockProcess,
-            RequestOp::DrvUserCreate {
-                drv_info: "INFO".into(),
-                addr: 0,
-            },
+            RequestOp::DrvUserCreate(
+                crate::port::DrvUserRequest::new("INFO", 0)
+                    .with_iface(crate::interfaces::InterfaceType::Float64),
+            ),
             RequestOp::GetOption { key: "baud".into() },
             RequestOp::SetOption {
                 key: "baud".into(),

--- a/crates/asyn-rs/src/request.rs
+++ b/crates/asyn-rs/src/request.rs
@@ -150,13 +150,11 @@ pub enum RequestOp {
     BlockProcess,
     /// Unblock the port.
     UnblockProcess,
-    /// Resolve a driver info string to a parameter reason index.
-    DrvUserCreate {
-        drv_info: String,
-        /// The record's asyn `addr`, so a multi-device driver can reject an
-        /// out-of-range address at bind time (C `drvUserCreate` `checkOffset`).
-        addr: i32,
-    },
+    /// Resolve a record's bind request to a parameter reason index. Carries the
+    /// full [`DrvUserRequest`] — drvInfo, asyn `addr`, and the record's asyn
+    /// interface — so an on-demand driver can create the parameter with the type
+    /// the record will read it as.
+    DrvUserCreate(crate::port::DrvUserRequest),
     /// Read an enum value (index + string choices).
     EnumRead,
     /// Write an enum index.

--- a/crates/asyn-rs/src/sync_io.rs
+++ b/crates/asyn-rs/src/sync_io.rs
@@ -188,10 +188,11 @@ impl SyncIOHandle {
     }
 
     pub fn drv_user_create(&self, drv_info: &str) -> AsynResult<usize> {
-        // Synchronous I/O binds at the port level (no per-record asyn addr); use
-        // addr 0 (C `getAddr` default) and surface only the shared reason.
+        // Synchronous I/O binds at the port level: no per-record asyn addr (use
+        // addr 0, C `getAddr` default) and no record interface behind the bind.
+        // Surface only the shared reason.
         self.handle
-            .drv_user_create_blocking(drv_info, 0)
+            .drv_user_create_blocking(&crate::port::DrvUserRequest::new(drv_info, 0))
             .map(|info| info.reason)
     }
 }

--- a/crates/asyn-rs/tests/port_driver_tests.rs
+++ b/crates/asyn-rs/tests/port_driver_tests.rs
@@ -13,7 +13,7 @@ use asyn_rs::error::{AsynError, AsynResult, AsynStatus};
 use asyn_rs::interrupt::InterruptFilter;
 use asyn_rs::manager::PortManager;
 use asyn_rs::param::{EnumEntry, ParamType, ParamValue};
-use asyn_rs::port::{PortDriver, PortDriverBase, PortFlags};
+use asyn_rs::port::{DrvUserRequest, PortDriver, PortDriverBase, PortFlags};
 use asyn_rs::user::AsynUser;
 
 // ============================================================
@@ -298,7 +298,10 @@ fn setup_error() -> (PortManager, asyn_rs::port_handle::PortHandle) {
 #[tokio::test]
 async fn test_int32_write_and_read() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("Run", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
     h.write_int32(reason, 0, 1).await.unwrap();
     let val = h.read_int32(reason, 0).await.unwrap();
     assert_eq!(val, 1);
@@ -307,7 +310,10 @@ async fn test_int32_write_and_read() {
 #[tokio::test]
 async fn test_float64_write_and_read() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("NoiseAmplitude", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("NoiseAmplitude", 0))
+        .await
+        .unwrap();
     h.write_float64(reason, 0, 0.25).await.unwrap();
     let val = h.read_float64(reason, 0).await.unwrap();
     assert!((val - 0.25).abs() < 1e-10);
@@ -316,8 +322,14 @@ async fn test_float64_write_and_read() {
 #[tokio::test]
 async fn test_float64_array_after_run() {
     let (_mgr, h) = setup_scope();
-    let run = h.drv_user_create("Run", 0).await.unwrap();
-    let wf = h.drv_user_create("Waveform", 0).await.unwrap();
+    let run = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
+    let wf = h
+        .drv_user_create(&DrvUserRequest::new("Waveform", 0))
+        .await
+        .unwrap();
     h.write_int32(run, 0, 1).await.unwrap();
     let data = h.read_float64_array(wf, 0, 256).await.unwrap();
     assert_eq!(data.len(), 128, "Default MaxPoints=128");
@@ -332,10 +344,22 @@ async fn test_float64_array_after_run() {
 #[tokio::test]
 async fn test_computed_statistics() {
     let (_mgr, h) = setup_scope();
-    let run = h.drv_user_create("Run", 0).await.unwrap();
-    let min_r = h.drv_user_create("MinValue", 0).await.unwrap();
-    let max_r = h.drv_user_create("MaxValue", 0).await.unwrap();
-    let mean_r = h.drv_user_create("MeanValue", 0).await.unwrap();
+    let run = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
+    let min_r = h
+        .drv_user_create(&DrvUserRequest::new("MinValue", 0))
+        .await
+        .unwrap();
+    let max_r = h
+        .drv_user_create(&DrvUserRequest::new("MaxValue", 0))
+        .await
+        .unwrap();
+    let mean_r = h
+        .drv_user_create(&DrvUserRequest::new("MeanValue", 0))
+        .await
+        .unwrap();
     h.write_int32(run, 0, 1).await.unwrap();
     let min_val = h.read_float64(min_r, 0).await.unwrap();
     let max_val = h.read_float64(max_r, 0).await.unwrap();
@@ -347,7 +371,10 @@ async fn test_computed_statistics() {
 #[tokio::test]
 async fn test_enum_read_write() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("VoltsPerDivSelect", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("VoltsPerDivSelect", 0))
+        .await
+        .unwrap();
     h.write_enum(reason, 0, 2).await.unwrap();
     let idx = h.read_enum(reason, 0).await.unwrap();
     assert_eq!(idx, 2);
@@ -356,9 +383,18 @@ async fn test_enum_read_write() {
 #[tokio::test]
 async fn test_max_points_controls_waveform_size() {
     let (_mgr, h) = setup_scope();
-    let mp = h.drv_user_create("MaxPoints", 0).await.unwrap();
-    let run = h.drv_user_create("Run", 0).await.unwrap();
-    let wf = h.drv_user_create("Waveform", 0).await.unwrap();
+    let mp = h
+        .drv_user_create(&DrvUserRequest::new("MaxPoints", 0))
+        .await
+        .unwrap();
+    let run = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
+    let wf = h
+        .drv_user_create(&DrvUserRequest::new("Waveform", 0))
+        .await
+        .unwrap();
     h.write_int32(mp, 0, 64).await.unwrap();
     h.write_int32(run, 0, 1).await.unwrap();
     let data = h.read_float64_array(wf, 0, 256).await.unwrap();
@@ -372,7 +408,10 @@ async fn test_max_points_controls_waveform_size() {
 #[tokio::test]
 async fn test_octet_write_read() {
     let (_mgr, h) = setup_echo();
-    let reason = h.drv_user_create("MSG", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("MSG", 0))
+        .await
+        .unwrap();
     h.write_octet(reason, 0, b"Hello, EPICS!".to_vec())
         .await
         .unwrap();
@@ -383,7 +422,10 @@ async fn test_octet_write_read() {
 #[tokio::test]
 async fn test_octet_overwrite() {
     let (_mgr, h) = setup_echo();
-    let reason = h.drv_user_create("MSG", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("MSG", 0))
+        .await
+        .unwrap();
     h.write_octet(reason, 0, b"first".to_vec()).await.unwrap();
     h.write_octet(reason, 0, b"second".to_vec()).await.unwrap();
     let data = h.read_octet(reason, 0, 64).await.unwrap();
@@ -397,7 +439,10 @@ async fn test_octet_overwrite() {
 #[tokio::test]
 async fn test_error_normal_read() {
     let (_mgr, h) = setup_error();
-    let val_r = h.drv_user_create("VAL", 0).await.unwrap();
+    let val_r = h
+        .drv_user_create(&DrvUserRequest::new("VAL", 0))
+        .await
+        .unwrap();
     h.write_int32(val_r, 0, 42).await.unwrap();
     let val = h.read_int32(val_r, 0).await.unwrap();
     assert_eq!(val, 42);
@@ -406,8 +451,14 @@ async fn test_error_normal_read() {
 #[tokio::test]
 async fn test_error_read_failure() {
     let (_mgr, h) = setup_error();
-    let val_r = h.drv_user_create("VAL", 0).await.unwrap();
-    let sts_r = h.drv_user_create("STATUS", 0).await.unwrap();
+    let val_r = h
+        .drv_user_create(&DrvUserRequest::new("VAL", 0))
+        .await
+        .unwrap();
+    let sts_r = h
+        .drv_user_create(&DrvUserRequest::new("STATUS", 0))
+        .await
+        .unwrap();
     h.write_int32(sts_r, 0, 1).await.unwrap();
     let result = h.read_int32(val_r, 0).await;
     assert!(result.is_err(), "Read should fail when STATUS=1");
@@ -416,8 +467,14 @@ async fn test_error_read_failure() {
 #[tokio::test]
 async fn test_error_recovery() {
     let (_mgr, h) = setup_error();
-    let val_r = h.drv_user_create("VAL", 0).await.unwrap();
-    let sts_r = h.drv_user_create("STATUS", 0).await.unwrap();
+    let val_r = h
+        .drv_user_create(&DrvUserRequest::new("VAL", 0))
+        .await
+        .unwrap();
+    let sts_r = h
+        .drv_user_create(&DrvUserRequest::new("STATUS", 0))
+        .await
+        .unwrap();
     h.write_int32(val_r, 0, 99).await.unwrap();
     h.write_int32(sts_r, 0, 1).await.unwrap();
     assert!(h.read_int32(val_r, 0).await.is_err());
@@ -433,7 +490,10 @@ async fn test_error_recovery() {
 #[tokio::test]
 async fn test_interrupt_on_param_change() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("NoiseAmplitude", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("NoiseAmplitude", 0))
+        .await
+        .unwrap();
     let (_sub, mut rx) = h.interrupts().register_interrupt_user(InterruptFilter {
         reason: Some(reason),
         addr: Some(0),
@@ -454,8 +514,14 @@ async fn test_interrupt_on_param_change() {
 #[tokio::test]
 async fn test_interrupt_filter_excludes_other_params() {
     let (_mgr, h) = setup_scope();
-    let noise_r = h.drv_user_create("NoiseAmplitude", 0).await.unwrap();
-    let update_r = h.drv_user_create("UpdateTime", 0).await.unwrap();
+    let noise_r = h
+        .drv_user_create(&DrvUserRequest::new("NoiseAmplitude", 0))
+        .await
+        .unwrap();
+    let update_r = h
+        .drv_user_create(&DrvUserRequest::new("UpdateTime", 0))
+        .await
+        .unwrap();
 
     // Flush initial changed state from constructor
     h.write_float64(noise_r, 0, 0.1).await.unwrap();
@@ -482,7 +548,10 @@ async fn test_interrupt_filter_excludes_other_params() {
 #[tokio::test]
 async fn test_multiple_interrupt_subscribers() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("Run", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
     let (_sub1, mut rx1) = h.interrupts().register_interrupt_user(InterruptFilter {
         reason: Some(reason),
         addr: Some(0),
@@ -513,14 +582,19 @@ async fn test_multiple_interrupt_subscribers() {
 #[tokio::test]
 async fn test_drv_user_known_param() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("Run", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
     assert_eq!(reason, 0);
 }
 
 #[tokio::test]
 async fn test_drv_user_unknown_param() {
     let (_mgr, h) = setup_scope();
-    let result = h.drv_user_create("NonExistent", 0).await;
+    let result = h
+        .drv_user_create(&DrvUserRequest::new("NonExistent", 0))
+        .await;
     assert!(result.is_err());
 }
 
@@ -532,7 +606,10 @@ async fn test_drv_user_unknown_param() {
 fn test_blocking_int32_roundtrip() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let (_mgr, h) = rt.block_on(async { setup_scope() });
-    let reason = h.drv_user_create_blocking("Run", 0).unwrap().reason;
+    let reason = h
+        .drv_user_create_blocking(&DrvUserRequest::new("Run", 0))
+        .unwrap()
+        .reason;
     h.write_int32_blocking(reason, 0, 1).unwrap();
     let val = h.read_int32_blocking(reason, 0).unwrap();
     assert_eq!(val, 1);
@@ -543,7 +620,7 @@ fn test_blocking_float64_roundtrip() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let (_mgr, h) = rt.block_on(async { setup_scope() });
     let reason = h
-        .drv_user_create_blocking("NoiseAmplitude", 0)
+        .drv_user_create_blocking(&DrvUserRequest::new("NoiseAmplitude", 0))
         .unwrap()
         .reason;
     h.write_float64_blocking(reason, 0, 3.15).unwrap();
@@ -558,7 +635,10 @@ fn test_blocking_float64_roundtrip() {
 #[tokio::test]
 async fn test_port_connected_by_default() {
     let (_mgr, h) = setup_scope();
-    let reason = h.drv_user_create("Run", 0).await.unwrap();
+    let reason = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
     assert!(h.read_int32(reason, 0).await.is_ok());
 }
 
@@ -570,7 +650,10 @@ async fn test_port_connected_by_default() {
 async fn test_callback_flushes_multiple_changes() {
     let (_mgr, h) = setup_scope();
     let mut broadcast_rx = h.interrupts().subscribe_async();
-    let run = h.drv_user_create("Run", 0).await.unwrap();
+    let run = h
+        .drv_user_create(&DrvUserRequest::new("Run", 0))
+        .await
+        .unwrap();
     h.write_int32(run, 0, 1).await.unwrap();
 
     let mut received_reasons = std::collections::HashSet::new();

--- a/crates/modbus-rs/src/ioc.rs
+++ b/crates/modbus-rs/src/ioc.rs
@@ -44,7 +44,7 @@ use asyn_rs::error::{AsynError, AsynResult, AsynStatus};
 use asyn_rs::interfaces::InterfaceType;
 use asyn_rs::interpose::EomReason;
 use asyn_rs::param::{ParamType, ParamValue};
-use asyn_rs::port::{DrvUserInfo, PortDriver, PortDriverBase, PortFlags};
+use asyn_rs::port::{DrvUserInfo, DrvUserRequest, PortDriver, PortDriverBase, PortFlags};
 use asyn_rs::runtime::config::RuntimeConfig;
 use asyn_rs::runtime::port::create_port_runtime;
 use asyn_rs::sync_io::SyncIOHandle;
@@ -808,7 +808,12 @@ impl PortDriver for ModbusPortDriver {
         &mut self.base
     }
 
-    fn drv_user_create(&mut self, drv_info: &str, addr: i32) -> AsynResult<DrvUserInfo> {
+    fn drv_user_create(&mut self, req: &DrvUserRequest) -> AsynResult<DrvUserInfo> {
+        // The modbus drvInfo names the data type (`INT16`, `FLOAT32LE`, …), so
+        // the parameter type comes from the drvInfo, not from the bound record's
+        // interface (`req.iface`): a record whose DTYP disagrees with the
+        // configured data type is a configuration error, not a retype request.
+        let (drv_info, addr) = (req.drv_info.as_str(), req.addr);
         // C `drvUserCreate` (drvModbusAsyn.cpp:368-433) strips everything after
         // the first '=' to resolve the data-type name, then validates the
         // optional `=N` string-length suffix: it is legal ONLY for the eight
@@ -1813,24 +1818,70 @@ mod tests {
         )
         .expect("relative config must build");
         // Accepted.
-        assert!(driver.drv_user_create("STRING_HIGH", 0).is_ok());
-        assert!(driver.drv_user_create("STRING_HIGH=5", 0).is_ok());
-        assert!(driver.drv_user_create("STRING_HIGH=0x10", 0).is_ok());
-        assert!(driver.drv_user_create("STRING_HIGH=010", 0).is_ok());
         assert!(
-            driver.drv_user_create("STRING_HIGH=", 0).is_ok(),
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH", 0))
+                .is_ok()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=5", 0))
+                .is_ok()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=0x10", 0))
+                .is_ok()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=010", 0))
+                .is_ok()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=", 0))
+                .is_ok(),
             "empty length parses as 0, which C accepts"
         );
-        assert!(driver.drv_user_create("INT16", 0).is_ok());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("INT16", 0))
+                .is_ok()
+        );
         // Rejected: garbage / negative length on a string type.
-        assert!(driver.drv_user_create("STRING_HIGH=abc", 0).is_err());
-        assert!(driver.drv_user_create("STRING_HIGH=5x", 0).is_err());
-        assert!(driver.drv_user_create("STRING_HIGH=-3", 0).is_err());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=abc", 0))
+                .is_err()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=5x", 0))
+                .is_err()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=-3", 0))
+                .is_err()
+        );
         // Rejected: a length suffix on a non-string type.
-        assert!(driver.drv_user_create("INT16=5", 0).is_err());
-        assert!(driver.drv_user_create("UINT16=0", 0).is_err());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("INT16=5", 0))
+                .is_err()
+        );
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("UINT16=0", 0))
+                .is_err()
+        );
         // Still rejected: an unknown type name.
-        assert!(driver.drv_user_create("NOPE", 0).is_err());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("NOPE", 0))
+                .is_err()
+        );
     }
 
     /// R52: `connect_addr` rejects an out-of-range register offset (the asyn
@@ -1905,17 +1956,29 @@ mod tests {
         )
         .expect("relative config must build");
         // In-range data offset binds.
-        assert!(driver.drv_user_create("INT16", 5).is_ok());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("INT16", 5))
+                .is_ok()
+        );
         // Out-of-range data offset fails at bind, not per-I/O.
         assert!(
-            driver.drv_user_create("INT16", 16).is_err(),
+            driver
+                .drv_user_create(&DrvUserRequest::new("INT16", 16))
+                .is_err(),
             "offset == length is out of range in relative mode"
         );
-        assert!(driver.drv_user_create("INT16", 99).is_err());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("INT16", 99))
+                .is_err()
+        );
         // A non-data (statistics) reason carries no offset → C skips
         // `checkOffset`, so an out-of-range addr must NOT reject it.
         assert!(
-            driver.drv_user_create("READ_OK", 99).is_ok(),
+            driver
+                .drv_user_create(&DrvUserRequest::new("READ_OK", 99))
+                .is_ok(),
             "statistics params fall through to the base class with no offset check"
         );
     }
@@ -1935,21 +1998,21 @@ mod tests {
         .expect("relative config must build");
         assert_eq!(
             driver
-                .drv_user_create("STRING_HIGH=5", 0)
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=5", 0))
                 .unwrap()
                 .max_octet_len,
             Some(5)
         );
         assert_eq!(
             driver
-                .drv_user_create("STRING_HIGH=0x10", 0)
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=0x10", 0))
                 .unwrap()
                 .max_octet_len,
             Some(16)
         );
         assert_eq!(
             driver
-                .drv_user_create("STRING_HIGH", 0)
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH", 0))
                 .unwrap()
                 .max_octet_len,
             None,
@@ -1957,14 +2020,17 @@ mod tests {
         );
         assert_eq!(
             driver
-                .drv_user_create("STRING_HIGH=", 0)
+                .drv_user_create(&DrvUserRequest::new("STRING_HIGH=", 0))
                 .unwrap()
                 .max_octet_len,
             Some(0),
             "TYPE= caps to 0 (C strtol(\"\") == 0)"
         );
         assert_eq!(
-            driver.drv_user_create("INT16", 0).unwrap().max_octet_len,
+            driver
+                .drv_user_create(&DrvUserRequest::new("INT16", 0))
+                .unwrap()
+                .max_octet_len,
             None,
             "a non-string type never carries an octet cap"
         );

--- a/crates/mqtt-rs/src/driver.rs
+++ b/crates/mqtt-rs/src/driver.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use asyn_rs::error::{AsynError, AsynResult};
 use asyn_rs::param::ParamType;
-use asyn_rs::port::{DrvUserInfo, PortDriver, PortDriverBase, PortFlags};
+use asyn_rs::port::{DrvUserInfo, DrvUserRequest, PortDriver, PortDriverBase, PortFlags};
 use asyn_rs::user::AsynUser;
 use tokio::sync::mpsc;
 
@@ -216,7 +216,11 @@ impl PortDriver for MqttDriver {
         &mut self.base
     }
 
-    fn drv_user_create(&mut self, drv_info: &str, _addr: i32) -> AsynResult<DrvUserInfo> {
+    fn drv_user_create(&mut self, req: &DrvUserRequest) -> AsynResult<DrvUserInfo> {
+        // The MQTT drvInfo names the payload type (`FLAT:INT`, `JSON:STRING`, …),
+        // so the on-demand parameter type comes from the drvInfo, not from the
+        // bound record's interface (`req.iface`).
+        let drv_info = req.drv_info.as_str();
         // C parity: `Autoparam::Driver::drvUserCreate` parses the reason into a
         // device address and creates the parameter on demand, reusing the
         // existing one for an equal address (`createParam` dedup by
@@ -390,7 +394,9 @@ mod tests {
         // would (`drv_user_create`).
         let mut driver = MqttDriver::new("TEST", &config, Vec::new(), tx, connected);
         for t in topics {
-            driver.drv_user_create(t, 0).expect("on-demand create");
+            driver
+                .drv_user_create(&DrvUserRequest::new(*t, 0))
+                .expect("on-demand create");
         }
         (driver, rx)
     }
@@ -406,7 +412,7 @@ mod tests {
         let connected = Arc::new(AtomicBool::new(false));
         let mut driver = MqttDriver::new("TEST", &config, Vec::new(), tx, connected.clone());
         let reason = driver
-            .drv_user_create("FLAT:INT test/int_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:INT test/int_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -436,7 +442,7 @@ mod tests {
         let connected = Arc::new(AtomicBool::new(false));
         let mut driver = MqttDriver::new("TEST", &config, Vec::new(), tx, connected.clone());
         let reason = driver
-            .drv_user_create("FLAT:DIGITAL test/digital_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:DIGITAL test/digital_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -483,17 +489,17 @@ mod tests {
         // same drvInfo returns the same reason; a different address gets its own.
         let (mut driver, _rx) = make_driver(&[]);
         let a1 = driver
-            .drv_user_create("FLAT:INT test/int_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:INT test/int_topic", 0))
             .unwrap()
             .reason;
         let a2 = driver
-            .drv_user_create("FLAT:INT test/int_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:INT test/int_topic", 0))
             .unwrap()
             .reason;
         assert_eq!(a1, a2, "same address must reuse the same parameter");
 
         let b = driver
-            .drv_user_create("FLAT:FLOAT test/float_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:FLOAT test/float_topic", 0))
             .unwrap()
             .reason;
         assert_ne!(a1, b, "a distinct address gets its own parameter");
@@ -504,10 +510,18 @@ mod tests {
         // Born-empty driver: a valid topic never pre-registered is created on
         // demand when a record binds (C: `Autoparam::Driver` lazy `createParam`).
         let (mut driver, _rx) = make_driver(&[]);
-        assert!(driver.drv_user_create("FLAT:FLOAT other/topic", 0).is_ok());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("FLAT:FLOAT other/topic", 0))
+                .is_ok()
+        );
         // A drvInfo that is neither a valid topic address nor an internal param
         // name is rejected.
-        assert!(driver.drv_user_create("not a topic address", 0).is_err());
+        assert!(
+            driver
+                .drv_user_create(&DrvUserRequest::new("not a topic address", 0))
+                .is_err()
+        );
     }
 
     #[test]
@@ -524,7 +538,7 @@ mod tests {
         let mut driver = MqttDriver::new("TEST", &config, vec![overlaid], tx, connected);
 
         let on_demand = driver
-            .drv_user_create("JSON:STRING zigbee/x state", 0)
+            .drv_user_create(&DrvUserRequest::new("JSON:STRING zigbee/x state", 0))
             .unwrap()
             .reason;
         assert!(
@@ -537,7 +551,7 @@ mod tests {
 
         // A topic with no overlay entry uses the parsed address verbatim.
         let plain = driver
-            .drv_user_create("JSON:STRING zigbee/y state", 0)
+            .drv_user_create(&DrvUserRequest::new("JSON:STRING zigbee/y state", 0))
             .unwrap()
             .reason;
         assert!(
@@ -565,7 +579,7 @@ mod tests {
     fn write_int32_sends_publish_request() {
         let (mut driver, mut rx) = make_driver(&["FLAT:INT test/int_topic"]);
         let reason = driver
-            .drv_user_create("FLAT:INT test/int_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:INT test/int_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -581,7 +595,7 @@ mod tests {
     fn write_float64_sends_publish_request() {
         let (mut driver, mut rx) = make_driver(&["FLAT:FLOAT test/float_topic"]);
         let reason = driver
-            .drv_user_create("FLAT:FLOAT test/float_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:FLOAT test/float_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -598,7 +612,7 @@ mod tests {
     fn write_octet_sends_publish_request() {
         let (mut driver, mut rx) = make_driver(&["FLAT:STRING test/str_topic"]);
         let reason = driver
-            .drv_user_create("FLAT:STRING test/str_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:STRING test/str_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -617,7 +631,7 @@ mod tests {
     fn write_octet_truncates_published_payload_at_first_nul() {
         let (mut driver, mut rx) = make_driver(&["FLAT:STRING test/str_topic"]);
         let reason = driver
-            .drv_user_create("FLAT:STRING test/str_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:STRING test/str_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -638,7 +652,7 @@ mod tests {
     fn write_octet_flat_publishes_raw_non_utf8_bytes() {
         let (mut driver, mut rx) = make_driver(&["FLAT:STRING test/bin"]);
         let reason = driver
-            .drv_user_create("FLAT:STRING test/bin", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:STRING test/bin", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -661,7 +675,7 @@ mod tests {
     fn masked_digital_write_rejected_when_value_uninitialized() {
         let (mut driver, mut rx) = make_driver(&["FLAT:DIGITAL test/bits"]);
         let reason = driver
-            .drv_user_create("FLAT:DIGITAL test/bits", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:DIGITAL test/bits", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -686,7 +700,7 @@ mod tests {
     fn masked_digital_write_merges_against_inbound_value() {
         let (mut driver, mut rx) = make_driver(&["FLAT:DIGITAL test/bits"]);
         let reason = driver
-            .drv_user_create("FLAT:DIGITAL test/bits", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:DIGITAL test/bits", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -720,7 +734,7 @@ mod tests {
     fn successful_write_does_not_commit_cache() {
         let (mut driver, mut rx) = make_driver(&["FLAT:DIGITAL test/bits"]);
         let reason = driver
-            .drv_user_create("FLAT:DIGITAL test/bits", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:DIGITAL test/bits", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);
@@ -750,7 +764,7 @@ mod tests {
     fn successful_scalar_write_does_not_commit_cache() {
         let (mut driver, mut rx) = make_driver(&["FLAT:INT test/int_topic"]);
         let reason = driver
-            .drv_user_create("FLAT:INT test/int_topic", 0)
+            .drv_user_create(&DrvUserRequest::new("FLAT:INT test/int_topic", 0))
             .unwrap()
             .reason;
         let mut user = AsynUser::new(reason);

--- a/examples/scope-ioc/examples/scope_sim.rs
+++ b/examples/scope-ioc/examples/scope_sim.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use asyn_rs::port::DrvUserRequest;
 use asyn_rs::runtime::sync::Notify;
 
 use asyn_rs::runtime::config::RuntimeConfig;
@@ -90,7 +91,7 @@ async fn main() {
     // 7. Change vertical gain to x10
     println!("\nSwitching vertical gain to x10...");
     let vgs_idx = port_handle
-        .drv_user_create("P_VertGainSelect", 0)
+        .drv_user_create(&DrvUserRequest::new("P_VertGainSelect", 0))
         .await
         .unwrap();
     port_handle.write_int32(vgs_idx, 0, 3).await.unwrap(); // x10


### PR DESCRIPTION
## Defect

A record's bind tells the driver only the drvInfo string and the asyn `addr` — never the interface the record actually reads the parameter through (its DTYP). `AsynDeviceSupport` *has* the resolved interface (`iface: Option<InterfaceType>`, `adapter.rs:279`, from the DTYP string at `:277`) and drops it at the bind call:

```rust
// crates/asyn-rs/src/adapter.rs (before)
self.handle.drv_user_create_blocking(&self.drv_info, self.addr)
```

`RequestOp::DrvUserCreate { drv_info, addr }` has no interface field, so `PortDriver::drv_user_create(&mut self, drv_info: &str, _addr: i32)` cannot receive one.

That hook exists so a driver can create the parameter **on demand** (C Autoparam lazy creation — the doc comment says so). An on-demand driver must therefore *guess* the parameter's type from the drvInfo string. C does not guess: `adsAsynPortDriver::getRecordInfoFromDrvInfo()` derives each parameter's asyn type from the **bound record's DTYP**, precisely because the same PLC symbol may bind as `asynInt32` from one record and `asynFloat64` from another.

### Why this is a defect and not a feature gap: a wrong guess is silent

The I/O-Intr read path does not check the type it hands the record:

`adapter.rs:2188-2199` → `param_value_to_epics_value` (`:923`, dispatches on the **ParamValue variant**) → `store_read_value` (`:1427`, dispatches on the record's `iface_type` **and** pattern-matches the `EpicsValue` variant). A `ParamValue::Int32` delivered to an `asynFloat64` record misses the `EpicsValue::Double` arm, falls out of every conversion arm, and lands on the fallback `let _ = record.set_val(val)` — a raw numeric coercion that bypasses the record's conversions: ai `ASLO`/`AOFF`/`SMOO` (devAsynFloat64.c:595-602), asynInt32 ai `ESLO`/`EOFF` linear convert, bi/mbbi `RVAL` + state-table mapping.

The other two paths through the same mismatch fail *loudly* — `ParamStore::get_int32`/`get_float64`/`set_int32`/`set_float64` return `AsynError::TypeMismatch` — so the polled read and the write paths surface a wrong parameter type immediately. Only the I/O-Intr read degrades silently, which is what makes the missing interface at bind a defect: the driver's only way to be right is a guess, and being wrong is invisible.

## Fix

Carry the record's interface through the bind. `RequestOp::DrvUserCreate` now holds one carrier, `DrvUserRequest { drv_info, addr, iface }`, which the port actor hands to `PortDriver::drv_user_create`. The adapter fills `iface` from the interface it already resolved from the record's DTYP; `asynRecord` fills it from its `IFACE` field (the interface it performs I/O through); `sync_io`'s port-level resolve leaves it `None` — there is no record behind that bind, so there is nothing to honour.

In-tree drivers keep their current typing rules, which are not guesses: both the modbus drvInfo (`INT16`, `FLOAT32LE`, …) and the MQTT drvInfo (`FLAT:INT`, `JSON:STRING`, …) name the type. `req.iface` is for drivers whose drvInfo does not — the twincat-ads case.

## ⚠️ BREAKING API CHANGE

Three signatures change; out-of-tree `PortDriver` implementations that override `drv_user_create`, and any caller of the two `PortHandle` methods, must be updated:

| before | after |
| --- | --- |
| `PortDriver::drv_user_create(&mut self, drv_info: &str, addr: i32)` | `PortDriver::drv_user_create(&mut self, req: &DrvUserRequest)` |
| `PortHandle::drv_user_create(&self, drv_info: &str, addr: i32)` | `PortHandle::drv_user_create(&self, req: &DrvUserRequest)` |
| `PortHandle::drv_user_create_blocking(&self, drv_info: &str, addr: i32)` | `PortHandle::drv_user_create_blocking(&self, req: &DrvUserRequest)` |

Migration is mechanical: `drv_user_create("SYMBOL", 0)` → `drv_user_create(&DrvUserRequest::new("SYMBOL", 0))`; an overriding driver reads `req.drv_info` / `req.addr` and may now consult `req.iface`.

**Why a struct rather than a third parameter.** This bind signature has already widened once — `addr` was added to it to let a multi-device driver run C's `checkOffset` at bind time. Adding `iface` as a third positional parameter would break every override again and leave the next field to break them a third time. `DrvUserRequest` is `#[non_exhaustive]` with a `new` + builder, so the next field is additive and this is the last break of this signature. `PortDriver::drv_user_create` keeps its default body (reason lookup by name), so a driver that does not override it is unaffected.

The wire protocol (`PortCommand::DrvUserCreate`) gains an optional `iface` field carrying the asyn interface name (`"asynFloat64"`, …), `#[serde(default, skip_serializing_if = "Option::is_none")]` — an old peer that omits it decodes as `None`, i.e. today's behaviour.

## Regression test

`crates/asyn-rs/src/adapter.rs::drv_user_create_receives_the_records_interface` — an on-demand driver (no parameters up front) that types each parameter from the interface the record announced. The **same** drvInfo `SYMBOL` is bound once by an `ai` on `asynFloat64` and once by a `longin` on `asynInt32`; the test asserts what the driver was told at bind and what it therefore created.

Verified to fail on unfixed `main` (8d38c5e0). Main cannot express the driver's side of this at all — the hook receives no interface — so on main the same driver records `None` and can only guess:

```
thread 'adapter::tests::drv_user_create_receives_the_records_interface' panicked at crates/asyn-rs/src/adapter.rs:5537:9:
assertion `left == right` failed
  left: [("SYMBOL", None, Int32)]
 right: [("SYMBOL", Some(Float64), Float64)]

Summary [0.011s] 1 test run: 0 passed, 1 failed, 720 skipped
```

With the fix: `PASS [0.005s] asyn-rs adapter::tests::drv_user_create_receives_the_records_interface`.

## Not in this PR

The silent-coercion half — the I/O-Intr read path deriving the record's value from the `ParamValue` **variant** instead of from the record's **interface**, which also means it never applies the `@asynMask` nbits mask/sign-extend that the polled path's `result_to_value`/`apply_int32_mask` applies (C applies it in *both* `processCallbackInput` and `interruptCallbackInput`) — is a separate defect with a separate fix, and gets its own PR.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7445 passed, 2 skipped
- `cargo test --doc --workspace` — clean