### PR TITLE
fix(asyn): derive I/O-Intr values through the record's interface, not the ParamValue variant

### DIFF
--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -919,28 +919,57 @@ fn asyn_error_to_alarm(e: &AsynError) -> (u16, u16) {
     asyn_error_to_alarm_with_default(e, epics_base_rs::server::recgbl::alarm_status::READ_ALARM)
 }
 
-/// Convert an asyn ParamValue to an EpicsValue.
-fn param_value_to_epics_value(pv: &crate::param::ParamValue) -> Option<EpicsValue> {
-    use crate::param::ParamValue;
-    match pv {
-        ParamValue::Int32(v) => Some(EpicsValue::Long(*v)),
-        ParamValue::Int64(v) => Some(EpicsValue::Double(*v as f64)),
-        ParamValue::Float64(v) => Some(EpicsValue::Double(*v)),
-        ParamValue::Octet(s) => Some(EpicsValue::String(s.clone().into())),
-        ParamValue::UInt32Digital(v) => Some(EpicsValue::Long(*v as i32)),
-        ParamValue::Enum { index, .. } => Some(EpicsValue::Enum(*index as u16)),
-        ParamValue::Int8Array(a) => {
-            Some(EpicsValue::CharArray(a.iter().map(|&x| x as u8).collect()))
-        }
-        ParamValue::Int16Array(a) => Some(EpicsValue::ShortArray(a.to_vec())),
-        ParamValue::Int32Array(a) => Some(EpicsValue::LongArray(a.to_vec())),
-        ParamValue::Int64Array(a) => {
-            Some(EpicsValue::LongArray(a.iter().map(|&x| x as i32).collect()))
-        }
-        ParamValue::Float32Array(a) => Some(EpicsValue::FloatArray(a.to_vec())),
-        ParamValue::Float64Array(a) => Some(EpicsValue::DoubleArray(a.to_vec())),
-        _ => None,
+/// Derive the record's value from an interrupt sample **through the interface
+/// the record is bound on** — the I/O-Intr twin of the polled
+/// [`AsynDeviceSupport::result_to_value`], which reads the driver's reply
+/// through that same interface (`asynFloat64` takes `float_val`, `asynInt32`
+/// takes `int_val`, …).
+///
+/// The scalar rules are the interface read rules themselves ([`ParamValue::as_int32`]
+/// and friends), the very ones [`crate::param::ParamList::get_int32`] applies when the
+/// polled path reads the same parameter — one owner, so the two paths cannot
+/// disagree about what an `asynFloat64` record may be handed.
+///
+/// A sample the record's interface cannot read is an [`AsynError::TypeMismatch`],
+/// exactly as it is on the polled path, and the caller alarms the record.
+/// Coercing it instead (what a variant-directed mapping does) hands the record a
+/// value of the wrong `EpicsValue` kind, which then misses its conversion arm in
+/// [`AsynDeviceSupport::store_read_value`] and lands on raw `set_val` — silently
+/// bypassing ai ASLO/AOFF/SMOO, asynInt32 ai ESLO/EOFF, and bi/mbbi RVAL state
+/// tables. C cannot reach that state at all: it keeps one interrupt list per
+/// interface, so a record is only ever handed a value of its own type.
+///
+/// Arrays keep the per-interface `convert` of [`convert_param_array_to_iface`]
+/// (C fires all six array interfaces, each with its own converted copy).
+/// `Ok(None)` for an interface with no value mapping (e.g. `asynGenericPointer`),
+/// which stores nothing — as before.
+fn param_value_for_iface(
+    iface_type: &str,
+    pv: &crate::param::ParamValue,
+) -> Result<Option<EpicsValue>, AsynError> {
+    if let Some(arr) = convert_param_array_to_iface(iface_type, pv) {
+        return Ok(Some(arr));
     }
+    let val = match iface_type {
+        "asynInt32" => EpicsValue::Long(pv.as_int32()?),
+        "asynInt64" => EpicsValue::Double(pv.as_int64()? as f64),
+        "asynFloat64" => EpicsValue::Double(pv.as_float64()?),
+        "asynOctet" => EpicsValue::String(pv.as_octet()?.into()),
+        "asynUInt32Digital" => EpicsValue::Long(pv.as_uint32()? as i32),
+        "asynEnum" => EpicsValue::Enum(pv.as_enum()?.0 as u16),
+        // An array interface reached here only because the sample is not an
+        // array (`convert_param_array_to_iface` handles every array sample):
+        // the record's interface cannot read it, same as the scalar mismatches.
+        "asynInt8Array" | "asynInt16Array" | "asynInt32Array" | "asynInt64Array"
+        | "asynFloat32Array" | "asynFloat64Array" => {
+            return Err(AsynError::TypeMismatch {
+                expected: "Array",
+                actual: pv.type_name(),
+            });
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(val))
 }
 
 /// Convert a native-typed array interrupt to the element type of the consuming
@@ -2186,16 +2215,31 @@ impl DeviceSupport for AsynDeviceSupport {
                 // `skip_convert` stays true so the record skips the RVAL→VAL
                 // convert and keeps its previous value = C return -1.
                 if ci.aux_status == crate::error::AsynStatus::Success {
-                    // Array interrupts carry the native element type; convert to
-                    // this record's interface type so a mismatched FTVL gets the
-                    // same per-type `convert` the polled path applies (C fires
-                    // all six array interfaces, NDPluginStdArrays.cpp:169-197).
-                    // Scalar interfaces fall back to the verbatim mapping.
-                    let val = convert_param_array_to_iface(&self.iface_type, &ci.value)
-                        .or_else(|| param_value_to_epics_value(&ci.value))
-                        .map(|v| self.cap_octet_read_value(v));
-                    if let Some(val) = val {
-                        skip_convert = self.store_read_value(record, val);
+                    // Derive the value through THIS record's interface, the same
+                    // way the polled path does (`result_to_value`): an array
+                    // interrupt gets the per-interface `convert` (C fires all six
+                    // array interfaces, NDPluginStdArrays.cpp:169-197) and a
+                    // scalar gets its interface's read rule.
+                    match param_value_for_iface(&self.iface_type, &ci.value) {
+                        Ok(Some(val)) => {
+                            let val = self.cap_octet_read_value(val);
+                            skip_convert = self.store_read_value(record, val);
+                        }
+                        Ok(None) => {}
+                        // The driver fired a value this record's interface cannot
+                        // read. C cannot deliver that (one interrupt list per
+                        // interface); here it means the parameter's type and the
+                        // record's DTYP disagree. Alarm it — the same
+                        // TypeMismatch the polled read raises through
+                        // `asyn_error_to_alarm` — and keep the prior value.
+                        // Coercing it instead would bypass the record's
+                        // conversions silently.
+                        Err(e) => {
+                            let (status, severity) =
+                                asyn_error_to_alarm_with_default(&e, default_stat);
+                            self.last_alarm_status = status;
+                            self.last_alarm_severity = severity;
+                        }
                     }
                 }
             }
@@ -6460,6 +6504,74 @@ mod tests {
             rec.val(),
             Some(EpicsValue::Double(21.0)),
             "VAL = raw*ASLO + AOFF = 10*2 + 1 = 21"
+        );
+    }
+
+    /// An I/O-Intr sample the record's interface cannot read must alarm the
+    /// record, never be coerced into it.
+    ///
+    /// The driver's parameter is `Float64` (what this `asynFloat64` ai binds),
+    /// but a driver that fires a differently-typed value for the same reason —
+    /// an on-demand driver that created the parameter as Int32, say — used to
+    /// have that value mapped by its *variant*, not by the record's interface:
+    /// `ParamValue::Int32` became `EpicsValue::Long`, which misses every
+    /// `asynFloat64` arm of `store_read_value` and lands on raw `set_val`,
+    /// silently bypassing the ai ASLO/AOFF/SMOO conversion the record is
+    /// configured for.
+    ///
+    /// The polled read of that same mismatched parameter fails loudly
+    /// (`AsynError::TypeMismatch` from `ParamList::get_float64` → READ/INVALID);
+    /// the I/O-Intr read must do the same.
+    #[test]
+    fn io_intr_sample_of_the_wrong_type_alarms_instead_of_coercing() {
+        use epics_base_rs::server::recgbl::alarm_status::READ_ALARM;
+        use epics_base_rs::server::record::AlarmSeverity;
+        use epics_base_rs::server::records::ai::AiRecord;
+
+        let mut ads = make_float64_io_intr_adapter();
+        let mut rec = AiRecord::new(0.0);
+        ads.init(&mut rec).unwrap();
+        ads.set_record_info("TEST:AI", ScanType::IoIntr);
+        rec.aslo = 2.0;
+        rec.aoff = 1.0;
+
+        // A correctly-typed sample: the ai conversion runs. VAL = 5*2 + 1 = 11.
+        push_f64(&ads, 5.0);
+        ads.read(&mut rec).unwrap();
+        assert_eq!(
+            rec.val(),
+            Some(EpicsValue::Double(11.0)),
+            "asynFloat64 ai applies ASLO/AOFF: 5*2 + 1 = 11"
+        );
+        assert_eq!(
+            ads.last_alarm(),
+            None,
+            "a well-typed sample raises no alarm"
+        );
+
+        // Same reason, a value this record's interface cannot read.
+        {
+            let mut g = ads.interrupt_fifo.lock().unwrap();
+            g.push_with_overflow(CachedInterrupt {
+                value: crate::param::ParamValue::Int32(5),
+                timestamp: SystemTime::UNIX_EPOCH,
+                alarm_status: 0,
+                alarm_severity: 0,
+                aux_status: crate::error::AsynStatus::Success,
+            });
+        }
+        ads.read(&mut rec).unwrap();
+        assert_eq!(
+            ads.last_alarm(),
+            Some((READ_ALARM, AlarmSeverity::Invalid as u16)),
+            "an Int32 sample on an asynFloat64 record is a TypeMismatch: READ/INVALID, \
+             the same alarm the polled read raises"
+        );
+        assert_eq!(
+            rec.val(),
+            Some(EpicsValue::Double(11.0)),
+            "the prior value is kept; the raw 5 must NOT be coerced into VAL \
+             (which would bypass ASLO/AOFF and read 5 instead of 11)"
         );
     }
 

--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -920,59 +920,6 @@ fn asyn_error_to_alarm(e: &AsynError) -> (u16, u16) {
     asyn_error_to_alarm_with_default(e, epics_base_rs::server::recgbl::alarm_status::READ_ALARM)
 }
 
-/// Derive the record's value from an interrupt sample **through the interface
-/// the record is bound on** — the I/O-Intr twin of the polled
-/// [`AsynDeviceSupport::result_to_value`], which reads the driver's reply
-/// through that same interface (`asynFloat64` takes `float_val`, `asynInt32`
-/// takes `int_val`, …).
-///
-/// The scalar rules are the interface read rules themselves ([`ParamValue::as_int32`]
-/// and friends), the very ones [`crate::param::ParamList::get_int32`] applies when the
-/// polled path reads the same parameter — one owner, so the two paths cannot
-/// disagree about what an `asynFloat64` record may be handed.
-///
-/// A sample the record's interface cannot read is an [`AsynError::TypeMismatch`],
-/// exactly as it is on the polled path, and the caller alarms the record.
-/// Coercing it instead (what a variant-directed mapping does) hands the record a
-/// value of the wrong `EpicsValue` kind, which then misses its conversion arm in
-/// [`AsynDeviceSupport::store_read_value`] and lands on raw `set_val` — silently
-/// bypassing ai ASLO/AOFF/SMOO, asynInt32 ai ESLO/EOFF, and bi/mbbi RVAL state
-/// tables. C cannot reach that state at all: it keeps one interrupt list per
-/// interface, so a record is only ever handed a value of its own type.
-///
-/// Arrays keep the per-interface `convert` of [`convert_param_array_to_iface`]
-/// (C fires all six array interfaces, each with its own converted copy).
-/// `Ok(None)` for an interface with no value mapping (e.g. `asynGenericPointer`),
-/// which stores nothing — as before.
-fn param_value_for_iface(
-    iface_type: &str,
-    pv: &crate::param::ParamValue,
-) -> Result<Option<EpicsValue>, AsynError> {
-    if let Some(arr) = convert_param_array_to_iface(iface_type, pv) {
-        return Ok(Some(arr));
-    }
-    let val = match iface_type {
-        "asynInt32" => EpicsValue::Long(pv.as_int32()?),
-        "asynInt64" => EpicsValue::Double(pv.as_int64()? as f64),
-        "asynFloat64" => EpicsValue::Double(pv.as_float64()?),
-        "asynOctet" => EpicsValue::String(pv.as_octet()?.into()),
-        "asynUInt32Digital" => EpicsValue::Long(pv.as_uint32()? as i32),
-        "asynEnum" => EpicsValue::Enum(pv.as_enum()?.0 as u16),
-        // An array interface reached here only because the sample is not an
-        // array (`convert_param_array_to_iface` handles every array sample):
-        // the record's interface cannot read it, same as the scalar mismatches.
-        "asynInt8Array" | "asynInt16Array" | "asynInt32Array" | "asynInt64Array"
-        | "asynFloat32Array" | "asynFloat64Array" => {
-            return Err(AsynError::TypeMismatch {
-                expected: "Array",
-                actual: pv.type_name(),
-            });
-        }
-        _ => return Ok(None),
-    };
-    Ok(Some(val))
-}
-
 /// Convert a native-typed array interrupt to the element type of the consuming
 /// record's asyn array interface.
 ///
@@ -1253,6 +1200,67 @@ impl AsynDeviceSupport {
     /// when no nbits was configured (`int32_mask == None`).
     fn apply_int32_mask(&self, value: i32) -> i32 {
         self.int32_mask.map_or(value, |m| m.apply(value))
+    }
+
+    /// Derive the record's value from an interrupt sample **through the interface
+    /// the record is bound on** — the I/O-Intr twin of the polled
+    /// [`AsynDeviceSupport::result_to_value`], which reads the driver's reply
+    /// through that same interface (`asynFloat64` takes `float_val`, `asynInt32`
+    /// takes `int_val`, …).
+    ///
+    /// The scalar rules are the interface read rules themselves ([`ParamValue::as_int32`]
+    /// and friends), the very ones [`crate::param::ParamList::get_int32`] applies when the
+    /// polled path reads the same parameter — one owner, so the two paths cannot
+    /// disagree about what an `asynFloat64` record may be handed.
+    ///
+    /// A sample the record's interface cannot read is an [`AsynError::TypeMismatch`],
+    /// exactly as it is on the polled path, and the caller alarms the record.
+    /// Coercing it instead (what a variant-directed mapping does) hands the record a
+    /// value of the wrong `EpicsValue` kind, which then misses its conversion arm in
+    /// [`AsynDeviceSupport::store_read_value`] and lands on raw `set_val` — silently
+    /// bypassing ai ASLO/AOFF/SMOO, asynInt32 ai ESLO/EOFF, and bi/mbbi RVAL state
+    /// tables. C cannot reach that state at all: it keeps one interrupt list per
+    /// interface, so a record is only ever handed a value of its own type.
+    ///
+    /// Arrays keep the per-interface `convert` of [`convert_param_array_to_iface`]
+    /// (C fires all six array interfaces, each with its own converted copy).
+    /// `Ok(None)` for an interface with no value mapping (e.g. `asynGenericPointer`),
+    /// which stores nothing — as before.
+    ///
+    /// Takes `&self` for the same reason `result_to_value` does: `asynInt32` reads
+    /// are masked and sign-extended by the record's `@asynMask` nbits, and C applies
+    /// that in the interrupt path too (`interruptCallbackInput`, devAsynInt32.c:537-539,
+    /// the same `value &= mask` + bipolar sign-extend as `processCallbackInput` at
+    /// :485-488). A free function could not reach `int32_mask`, and the two paths
+    /// would silently disagree again — this time about the mask instead of the type.
+    fn param_value_for_iface(
+        &self,
+        pv: &crate::param::ParamValue,
+    ) -> Result<Option<EpicsValue>, AsynError> {
+        let iface_type = self.iface_type.as_str();
+        if let Some(arr) = convert_param_array_to_iface(iface_type, pv) {
+            return Ok(Some(arr));
+        }
+        let val = match iface_type {
+            "asynInt32" => EpicsValue::Long(self.apply_int32_mask(pv.as_int32()?)),
+            "asynInt64" => EpicsValue::Double(pv.as_int64()? as f64),
+            "asynFloat64" => EpicsValue::Double(pv.as_float64()?),
+            "asynOctet" => EpicsValue::String(pv.as_octet()?.into()),
+            "asynUInt32Digital" => EpicsValue::Long(pv.as_uint32()? as i32),
+            "asynEnum" => EpicsValue::Enum(pv.as_enum()?.0 as u16),
+            // An array interface reached here only because the sample is not an
+            // array (`convert_param_array_to_iface` handles every array sample):
+            // the record's interface cannot read it, same as the scalar mismatches.
+            "asynInt8Array" | "asynInt16Array" | "asynInt32Array" | "asynInt64Array"
+            | "asynFloat32Array" | "asynFloat64Array" => {
+                return Err(AsynError::TypeMismatch {
+                    expected: "Array",
+                    actual: pv.type_name(),
+                });
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(val))
     }
 
     /// Extract an EpicsValue from a RequestResult based on interface type.
@@ -2222,7 +2230,7 @@ impl DeviceSupport for AsynDeviceSupport {
                     // interrupt gets the per-interface `convert` (C fires all six
                     // array interfaces, NDPluginStdArrays.cpp:169-197) and a
                     // scalar gets its interface's read rule.
-                    match param_value_for_iface(&self.iface_type, &ci.value) {
+                    match self.param_value_for_iface(&ci.value) {
                         Ok(Some(val)) => {
                             let val = self.cap_octet_read_value(val);
                             skip_convert = self.store_read_value(record, val);
@@ -3442,6 +3450,48 @@ mod tests {
             AsynDeviceSupport::from_handle(handle, link, "asynInt32").with_mask((-8i32) as u32);
         let result = RequestResult::int32_read(0xFF);
         assert_eq!(ads.result_to_value(&result), Some(EpicsValue::Long(-1)));
+    }
+
+    /// The I/O-Intr twin of `result_to_value_masks_and_sign_extends_int32`.
+    ///
+    /// C applies `@asynMask` in BOTH input paths — `processCallbackInput`
+    /// (devAsynInt32.c:485-488) and `interruptCallbackInput` (:537-539) run the
+    /// same `value &= mask` + bipolar sign-extend. A mask on one path only is the
+    /// same defect class this module's `param_value_for_iface` exists to close:
+    /// the polled read and the interrupt read of one parameter deriving the
+    /// record's value by different rules.
+    #[test]
+    fn io_intr_masks_and_sign_extends_int32_like_the_polled_read() {
+        use crate::param::ParamValue;
+
+        let interrupts = Arc::new(InterruptManager::new(256));
+        let (tx, _rx) = tokio::sync::mpsc::channel(256);
+        let handle = PortHandle::new(tx, "p".into(), interrupts, ActorId::new());
+        let link = AsynLink {
+            port_name: "p".into(),
+            addr: 0,
+            timeout: Duration::from_secs(1),
+            drv_info: String::new(),
+        };
+        let ads =
+            AsynDeviceSupport::from_handle(handle, link, "asynInt32").with_mask((-8i32) as u32);
+
+        // Same raw sample down both paths of the same adapter: they must agree.
+        let polled = ads.result_to_value(&RequestResult::int32_read(0xF0));
+        let io_intr = ads
+            .param_value_for_iface(&ParamValue::Int32(0xF0))
+            .expect("an Int32 sample is readable through asynInt32");
+
+        assert_eq!(
+            polled,
+            Some(EpicsValue::Long(-16)),
+            "bipolar 8-bit: 0xF0 masks and sign-extends to -16"
+        );
+        assert_eq!(
+            io_intr, polled,
+            "the interrupt read must apply the same @asynMask as the polled read \
+             (C interruptCallbackInput, devAsynInt32.c:537-539)"
+        );
     }
 
     #[test]

--- a/crates/asyn-rs/src/param.rs
+++ b/crates/asyn-rs/src/param.rs
@@ -120,6 +120,84 @@ impl ParamValue {
         }
     }
 
+    /// Read this value through the **asynInt32** interface — the single owner
+    /// of that interface's read rule, shared by the parameter-store getters
+    /// ([`ParamList::get_int32`]) and the device-support I/O-Intr path, so a
+    /// value delivered to a record cannot be typed differently from the same
+    /// value read by a poll.
+    ///
+    /// A parameter whose type the interface cannot read is an
+    /// [`AsynError::TypeMismatch`], never a coercion: C keeps one interrupt
+    /// list per interface, so a record on `asynInt32` is only ever handed an
+    /// int32 (an enum's index included — asynInt32 reads an enum's index
+    /// transparently).
+    pub fn as_int32(&self) -> AsynResult<i32> {
+        match self {
+            Self::Int32(v) => Ok(*v),
+            Self::Enum { index, .. } => Ok(*index as i32),
+            other => Err(AsynError::TypeMismatch {
+                expected: "Int32",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
+    /// Read this value through the **asynInt64** interface. See [`Self::as_int32`].
+    pub fn as_int64(&self) -> AsynResult<i64> {
+        match self {
+            Self::Int64(v) => Ok(*v),
+            other => Err(AsynError::TypeMismatch {
+                expected: "Int64",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
+    /// Read this value through the **asynFloat64** interface. See [`Self::as_int32`].
+    pub fn as_float64(&self) -> AsynResult<f64> {
+        match self {
+            Self::Float64(v) => Ok(*v),
+            other => Err(AsynError::TypeMismatch {
+                expected: "Float64",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
+    /// Read this value through the **asynOctet** interface. See [`Self::as_int32`].
+    pub fn as_octet(&self) -> AsynResult<&str> {
+        match self {
+            Self::Octet(s) => Ok(s),
+            other => Err(AsynError::TypeMismatch {
+                expected: "Octet",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
+    /// Read this value through the **asynUInt32Digital** interface. See
+    /// [`Self::as_int32`].
+    pub fn as_uint32(&self) -> AsynResult<u32> {
+        match self {
+            Self::UInt32Digital(v) => Ok(*v),
+            other => Err(AsynError::TypeMismatch {
+                expected: "UInt32Digital",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
+    /// Read this value through the **asynEnum** interface. See [`Self::as_int32`].
+    pub fn as_enum(&self) -> AsynResult<(usize, Arc<[EnumEntry]>)> {
+        match self {
+            Self::Enum { index, choices } => Ok((*index, choices.clone())),
+            other => Err(AsynError::TypeMismatch {
+                expected: "Enum",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
     /// Whether this is an array or generic-pointer value. C asynPortDriver
     /// fires interrupts for these through the per-type doCallbacks*Array /
     /// doCallbacksGenericPointer paths, NOT `paramList::callCallbacks`
@@ -345,15 +423,7 @@ impl ParamList {
     /// `.unwrap_or(0)` convention used throughout the workspace and
     /// stays callable on never-set params.
     pub fn get_int32(&self, index: usize, addr: i32) -> AsynResult<i32> {
-        match &self.get_entry(index, addr)?.value {
-            ParamValue::Int32(v) => Ok(*v),
-            // C EPICS asyn: asynInt32 interface reads enum index transparently
-            ParamValue::Enum { index: idx, .. } => Ok(*idx as i32),
-            other => Err(AsynError::TypeMismatch {
-                expected: "Int32",
-                actual: other.type_name(),
-            }),
-        }
+        self.get_entry(index, addr)?.value.as_int32()
     }
 
     /// Strict variant of [`Self::get_int32`] — returns
@@ -365,24 +435,12 @@ impl ParamList {
     /// `ParamValNotDefined` to `asynParamUndefined`.
     pub fn get_int32_strict(&self, index: usize, addr: i32) -> AsynResult<i32> {
         let entry = self.get_entry(index, addr)?;
-        match &entry.value {
-            ParamValue::Int32(v) => {
-                if !entry.defined {
-                    return Err(AsynError::ParamUndefined(index));
-                }
-                Ok(*v)
-            }
-            ParamValue::Enum { index: idx, .. } => {
-                if !entry.defined {
-                    return Err(AsynError::ParamUndefined(index));
-                }
-                Ok(*idx as i32)
-            }
-            other => Err(AsynError::TypeMismatch {
-                expected: "Int32",
-                actual: other.type_name(),
-            }),
+        // C order: WrongType first (`as_int32`), then NotDefined.
+        let value = entry.value.as_int32()?;
+        if !entry.defined {
+            return Err(AsynError::ParamUndefined(index));
         }
+        Ok(value)
     }
 
     pub fn set_int32(&mut self, index: usize, addr: i32, value: i32) -> AsynResult<()> {
@@ -432,13 +490,7 @@ impl ParamList {
     /// Lax variant — returns `0.0` for an undefined Float64. Use
     /// [`Self::get_float64_strict`] for C parity.
     pub fn get_float64(&self, index: usize, addr: i32) -> AsynResult<f64> {
-        match &self.get_entry(index, addr)?.value {
-            ParamValue::Float64(v) => Ok(*v),
-            other => Err(AsynError::TypeMismatch {
-                expected: "Float64",
-                actual: other.type_name(),
-            }),
-        }
+        self.get_entry(index, addr)?.value.as_float64()
     }
 
     /// Strict variant — returns [`AsynError::ParamUndefined`] when the
@@ -447,18 +499,11 @@ impl ParamList {
     /// `paramList::getDouble` (`asynPortDriver.cpp:383-401`).
     pub fn get_float64_strict(&self, index: usize, addr: i32) -> AsynResult<f64> {
         let entry = self.get_entry(index, addr)?;
-        match &entry.value {
-            ParamValue::Float64(v) => {
-                if !entry.defined {
-                    return Err(AsynError::ParamUndefined(index));
-                }
-                Ok(*v)
-            }
-            other => Err(AsynError::TypeMismatch {
-                expected: "Float64",
-                actual: other.type_name(),
-            }),
+        let value = entry.value.as_float64()?;
+        if !entry.defined {
+            return Err(AsynError::ParamUndefined(index));
         }
+        Ok(value)
     }
 
     pub fn set_float64(&mut self, index: usize, addr: i32, value: f64) -> AsynResult<()> {
@@ -484,13 +529,7 @@ impl ParamList {
     /// Lax variant — returns `0` for an undefined Int64. Use
     /// [`Self::get_int64_strict`] for C parity.
     pub fn get_int64(&self, index: usize, addr: i32) -> AsynResult<i64> {
-        match &self.get_entry(index, addr)?.value {
-            ParamValue::Int64(v) => Ok(*v),
-            other => Err(AsynError::TypeMismatch {
-                expected: "Int64",
-                actual: other.type_name(),
-            }),
-        }
+        self.get_entry(index, addr)?.value.as_int64()
     }
 
     /// Strict variant — returns [`AsynError::ParamUndefined`] when the
@@ -499,18 +538,11 @@ impl ParamList {
     /// (`asynPortDriver.cpp:328-349`).
     pub fn get_int64_strict(&self, index: usize, addr: i32) -> AsynResult<i64> {
         let entry = self.get_entry(index, addr)?;
-        match &entry.value {
-            ParamValue::Int64(v) => {
-                if !entry.defined {
-                    return Err(AsynError::ParamUndefined(index));
-                }
-                Ok(*v)
-            }
-            other => Err(AsynError::TypeMismatch {
-                expected: "Int64",
-                actual: other.type_name(),
-            }),
+        let value = entry.value.as_int64()?;
+        if !entry.defined {
+            return Err(AsynError::ParamUndefined(index));
         }
+        Ok(value)
     }
 
     pub fn set_int64(&mut self, index: usize, addr: i32, value: i64) -> AsynResult<()> {
@@ -534,13 +566,7 @@ impl ParamList {
     /// Lax variant — returns the empty string for an undefined Octet.
     /// Use [`Self::get_string_strict`] for C parity.
     pub fn get_string(&self, index: usize, addr: i32) -> AsynResult<&str> {
-        match &self.get_entry(index, addr)?.value {
-            ParamValue::Octet(s) => Ok(s),
-            other => Err(AsynError::TypeMismatch {
-                expected: "Octet",
-                actual: other.type_name(),
-            }),
-        }
+        self.get_entry(index, addr)?.value.as_octet()
     }
 
     /// Strict variant — returns [`AsynError::ParamUndefined`] when the
@@ -549,18 +575,11 @@ impl ParamList {
     /// (`asynPortDriver.cpp:543-566`).
     pub fn get_string_strict(&self, index: usize, addr: i32) -> AsynResult<&str> {
         let entry = self.get_entry(index, addr)?;
-        match &entry.value {
-            ParamValue::Octet(s) => {
-                if !entry.defined {
-                    return Err(AsynError::ParamUndefined(index));
-                }
-                Ok(s)
-            }
-            other => Err(AsynError::TypeMismatch {
-                expected: "Octet",
-                actual: other.type_name(),
-            }),
+        let value = entry.value.as_octet()?;
+        if !entry.defined {
+            return Err(AsynError::ParamUndefined(index));
         }
+        Ok(value)
     }
 
     pub fn set_string(&mut self, index: usize, addr: i32, value: String) -> AsynResult<()> {
@@ -585,13 +604,7 @@ impl ParamList {
     /// Lax variant — returns `0` for an undefined UInt32Digital. Use
     /// [`Self::get_uint32_strict`] for C parity.
     pub fn get_uint32(&self, index: usize, addr: i32) -> AsynResult<u32> {
-        match &self.get_entry(index, addr)?.value {
-            ParamValue::UInt32Digital(v) => Ok(*v),
-            other => Err(AsynError::TypeMismatch {
-                expected: "UInt32Digital",
-                actual: other.type_name(),
-            }),
-        }
+        self.get_entry(index, addr)?.value.as_uint32()
     }
 
     /// Strict variant — returns [`AsynError::ParamUndefined`] when the
@@ -600,18 +613,11 @@ impl ParamList {
     /// (`asynPortDriver.cpp:355-376`).
     pub fn get_uint32_strict(&self, index: usize, addr: i32) -> AsynResult<u32> {
         let entry = self.get_entry(index, addr)?;
-        match &entry.value {
-            ParamValue::UInt32Digital(v) => {
-                if !entry.defined {
-                    return Err(AsynError::ParamUndefined(index));
-                }
-                Ok(*v)
-            }
-            other => Err(AsynError::TypeMismatch {
-                expected: "UInt32Digital",
-                actual: other.type_name(),
-            }),
+        let value = entry.value.as_uint32()?;
+        if !entry.defined {
+            return Err(AsynError::ParamUndefined(index));
         }
+        Ok(value)
     }
 
     pub fn set_uint32(
@@ -920,16 +926,7 @@ impl ParamList {
     // --- Enum getters/setters ---
 
     pub fn get_enum(&self, index: usize, addr: i32) -> AsynResult<(usize, Arc<[EnumEntry]>)> {
-        match &self.get_entry(index, addr)?.value {
-            ParamValue::Enum {
-                index: idx,
-                choices,
-            } => Ok((*idx, choices.clone())),
-            other => Err(AsynError::TypeMismatch {
-                expected: "Enum",
-                actual: other.type_name(),
-            }),
-        }
+        self.get_entry(index, addr)?.value.as_enum()
     }
 
     pub fn set_enum_index(&mut self, index: usize, addr: i32, value: usize) -> AsynResult<()> {


### PR DESCRIPTION
## Defect

There are two derivations of "record value from driver data", and they disagree:

| path | derives from | code |
| --- | --- | --- |
| polled read | the **record's interface** (`asynFloat64` → `float_val`, `asynInt32` → `int_val`, …) | `AsynDeviceSupport::result_to_value` (`adapter.rs:1229`) |
| I/O-Intr read | the **variant of the cached `ParamValue`** | `param_value_to_epics_value` (`adapter.rs:923`), called at `:2195` |

Only the first is right. The consequence of the second is silent: a `ParamValue::Int32` delivered to an `asynFloat64` ai becomes `EpicsValue::Long`, misses every `asynFloat64` arm of `store_read_value` (`:1427`), and falls out the bottom onto the raw `Record::set_val` coercion (`record_trait.rs:490`) — which **bypasses the record's conversions**: ai `ASLO`/`AOFF`/`SMOO` (devAsynFloat64.c:595-602), asynInt32 ai `ESLO`/`EOFF` linear convert, bi/mbbi `RVAL` + state-table mapping.

The same mismatch on **any other path fails loudly**: `ParamList::get_float64`/`get_int32` (polled read) and `set_float64`/`set_int32` (write) return `AsynError::TypeMismatch`, which the polled read maps to a READ/INVALID alarm. The I/O-Intr read is the only path that degrades quietly, and quietly wrong record conversions are much worse than a loud alarm.

How a driver comes to fire a mismatched type at all: any driver that creates parameters on demand (C Autoparam lazy creation) has to decide the parameter's type at bind. Until #26 the bind did not carry the record's interface, so it could only guess — and this is the defect that made a wrong guess invisible. The two are independent (this fix stands alone; a driver can mistype a parameter with or without #26) and are in separate PRs.

## Fix

Make the record's interface the single derivation rule on both paths.

`param_value_for_iface(iface_type, pv)` reads the interrupt sample **through the interface the record is bound on** — the I/O-Intr twin of `result_to_value` — and the scalar rules it uses are the interface read rules themselves, hoisted into single-owner accessors on `ParamValue`:

```rust
ParamValue::as_int32()   // Int32 | Enum{index} → i32   (asynInt32 reads an enum's index, as C does)
ParamValue::as_int64()   // Int64
ParamValue::as_float64() // Float64
ParamValue::as_octet()   // Octet
ParamValue::as_uint32()  // UInt32Digital
ParamValue::as_enum()    // Enum
```

`ParamList::get_int32`/`get_int64`/`get_float64`/`get_string`/`get_uint32`/`get_enum` and their `_strict` variants now delegate to these (the strict ones keep C's WrongType-before-NotDefined order), so the parameter store and device support cannot drift apart: the value a record is handed on I/O Intr is derived by exactly the rule that governs the polled read of the same parameter. Arrays keep the per-interface `convert_param_array_to_iface` (C fires all six array interfaces, each with its own converted copy).

`param_value_to_epics_value` — the variant-directed mapping, and the whole source of the dual meaning — is deleted; it had one caller.

## ⚠️ Semantic change

An I/O-Intr sample whose type the record's interface cannot read now **alarms the record READ/INVALID** (WRITE/INVALID for an `asyn:READBACK` output — the existing direction-aware default) and **keeps the record's prior value**, where it used to be coerced in.

This is deliberate, and it is the uniform rule rather than a new special case:

- It is what the **polled read of that same parameter already does** (`TypeMismatch` → `asyn_error_to_alarm` → READ/INVALID, prior value kept). Before this PR, a mistyped parameter alarmed on a `SCAN=1 second` record and silently corrupted the identical `SCAN="I/O Intr"` record.
- **C cannot even reach this state**: asyn keeps one interrupt list per interface (`int32InterruptList` / `float64InterruptList` / …), so a record is only ever handed a value of its own type. The coercion had no C counterpart to be parity with.
- A driver whose parameter type disagrees with a bound record's DTYP is a configuration/driver defect. It should be visible.

No in-tree driver relied on the coercion (full workspace suite passes unchanged).

## Regression test

`crates/asyn-rs/src/adapter.rs::io_intr_sample_of_the_wrong_type_alarms_instead_of_coercing` — an `asynFloat64` I/O-Intr ai with `ASLO=2`, `AOFF=1`. A well-typed `Float64(5.0)` sample converts to `VAL = 5*2 + 1 = 11` and raises no alarm; an `Int32(5)` sample on the same reason must alarm READ/INVALID and leave VAL at 11.

Verified to fail on unfixed `main` (8d38c5e0), on both halves. The alarm assertion fires first:

```
thread 'adapter::tests::io_intr_sample_of_the_wrong_type_alarms_instead_of_coercing' panicked at crates/asyn-rs/src/adapter.rs:6520:9:
assertion `left == right` failed: an Int32 sample on an asynFloat64 record is a TypeMismatch: READ/INVALID, the same alarm the polled read raises
  left: None
 right: Some((1, 3))
```

and with that assertion removed, main shows the substantive damage — the raw 5 coerced straight into VAL, ASLO/AOFF never applied:

```
assertion `left == right` failed: the prior value is kept; the raw 5 must NOT be coerced into VAL (which would bypass ASLO/AOFF and read 5 instead of 11)
  left: Some(Double(5.0))
 right: Some(Double(11.0))
```

With the fix: `PASS asyn-rs adapter::tests::io_intr_sample_of_the_wrong_type_alarms_instead_of_coercing`.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7445 passed, 2 skipped
- `cargo test --doc --workspace` — clean