### PR TITLE
fix(asyn): carry every parameter type through CallParamCallbacks (ParamSetValue widened to ParamValue)

### DIFF
--- a/crates/ad-core-rs/src/plugin/runtime.rs
+++ b/crates/ad-core-rs/src/plugin/runtime.rs
@@ -29,6 +29,7 @@ use asyn_rs::port_handle::PortHandle;
 use crate::ndarray::NDArray;
 use crate::ndarray_pool::NDArrayPool;
 use crate::params::ndarray_driver::NDArrayDriverParams;
+use asyn_rs::param::ParamValue;
 
 use super::channel::{
     NDArrayOutput, NDArrayReceiver, NDArraySender, PublishOutcome, ndarray_channel,
@@ -691,21 +692,21 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
         let sort_free = self.sort_size - self.sort_buffer.len();
         ParamBatch {
             addr0: vec![
-                ParamSetValue::Int32 {
-                    reason: self.plugin_params.sort_free,
-                    addr: 0,
-                    value: sort_free,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.plugin_params.disordered_arrays,
-                    addr: 0,
-                    value: self.sort_buffer.disordered_arrays,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.plugin_params.dropped_output_arrays,
-                    addr: 0,
-                    value: self.sort_buffer.dropped_output_arrays,
-                },
+                ParamSetValue::new(
+                    self.plugin_params.sort_free,
+                    0,
+                    ParamValue::Int32(sort_free),
+                ),
+                ParamSetValue::new(
+                    self.plugin_params.disordered_arrays,
+                    0,
+                    ParamValue::Int32(self.sort_buffer.disordered_arrays),
+                ),
+                ParamSetValue::new(
+                    self.plugin_params.dropped_output_arrays,
+                    0,
+                    ParamValue::Int32(self.sort_buffer.dropped_output_arrays),
+                ),
             ],
             extra: std::collections::HashMap::new(),
         }
@@ -716,13 +717,14 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
     fn build_status_params_batch(&self) -> ParamBatch {
         use asyn_rs::request::ParamSetValue;
         let mut batch = self.build_sort_params_batch();
-        batch.addr0.push(ParamSetValue::Int32 {
-            reason: self.plugin_params.dropped_arrays,
-            addr: 0,
-            value: self
-                .dropped_arrays
-                .load(std::sync::atomic::Ordering::Acquire),
-        });
+        batch.addr0.push(ParamSetValue::new(
+            self.plugin_params.dropped_arrays,
+            0,
+            ParamValue::Int32(
+                self.dropped_arrays
+                    .load(std::sync::atomic::Ordering::Acquire),
+            ),
+        ));
         batch
     }
 
@@ -872,71 +874,71 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
             }
 
             addr0.extend([
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.array_counter,
-                    addr: 0,
-                    value: self.array_counter,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.unique_id,
-                    addr: 0,
-                    value: report_arr.unique_id,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.n_dimensions,
-                    addr: 0,
-                    value: report_arr.dims.len() as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.array_size_x,
-                    addr: 0,
-                    value: info.x_size as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.array_size_y,
-                    addr: 0,
-                    value: info.y_size as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.array_size_z,
-                    addr: 0,
-                    value: info.color_size as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.array_size,
-                    addr: 0,
-                    value: info.total_bytes as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.data_type,
-                    addr: 0,
-                    value: report_arr.data.data_type() as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.color_mode,
-                    addr: 0,
-                    value: color_mode,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.bayer_pattern,
-                    addr: 0,
-                    value: bayer_pattern,
-                },
-                ParamSetValue::Float64 {
-                    reason: self.ndarray_params.timestamp_rbv,
-                    addr: 0,
-                    value: report_arr.timestamp.as_f64(),
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.epics_ts_sec,
-                    addr: 0,
-                    value: report_arr.timestamp.sec as i32,
-                },
-                ParamSetValue::Int32 {
-                    reason: self.ndarray_params.epics_ts_nsec,
-                    addr: 0,
-                    value: report_arr.timestamp.nsec as i32,
-                },
+                ParamSetValue::new(
+                    self.ndarray_params.array_counter,
+                    0,
+                    ParamValue::Int32(self.array_counter),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.unique_id,
+                    0,
+                    ParamValue::Int32(report_arr.unique_id),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.n_dimensions,
+                    0,
+                    ParamValue::Int32(report_arr.dims.len() as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.array_size_x,
+                    0,
+                    ParamValue::Int32(info.x_size as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.array_size_y,
+                    0,
+                    ParamValue::Int32(info.y_size as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.array_size_z,
+                    0,
+                    ParamValue::Int32(info.color_size as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.array_size,
+                    0,
+                    ParamValue::Int32(info.total_bytes as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.data_type,
+                    0,
+                    ParamValue::Int32(report_arr.data.data_type() as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.color_mode,
+                    0,
+                    ParamValue::Int32(color_mode),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.bayer_pattern,
+                    0,
+                    ParamValue::Int32(bayer_pattern),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.timestamp_rbv,
+                    0,
+                    ParamValue::Float64(report_arr.timestamp.as_f64()),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.epics_ts_sec,
+                    0,
+                    ParamValue::Int32(report_arr.timestamp.sec as i32),
+                ),
+                ParamSetValue::new(
+                    self.ndarray_params.epics_ts_nsec,
+                    0,
+                    ParamValue::Int32(report_arr.timestamp.nsec as i32),
+                ),
             ]);
 
             // NDCodec / NDCompressedSize — C++ beginProcessCallbacks
@@ -946,37 +948,37 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
             // driver-base path in ndarray_driver::prepare_array).
             match &report_arr.codec {
                 Some(codec) => {
-                    addr0.push(ParamSetValue::Octet {
-                        reason: self.ndarray_params.codec,
-                        addr: 0,
-                        value: codec.name.as_str().to_string(),
-                    });
-                    addr0.push(ParamSetValue::Int32 {
-                        reason: self.ndarray_params.compressed_size,
-                        addr: 0,
-                        value: codec.compressed_size as i32,
-                    });
+                    addr0.push(ParamSetValue::new(
+                        self.ndarray_params.codec,
+                        0,
+                        ParamValue::Octet(codec.name.as_str().to_string()),
+                    ));
+                    addr0.push(ParamSetValue::new(
+                        self.ndarray_params.compressed_size,
+                        0,
+                        ParamValue::Int32(codec.compressed_size as i32),
+                    ));
                 }
                 None => {
-                    addr0.push(ParamSetValue::Octet {
-                        reason: self.ndarray_params.codec,
-                        addr: 0,
-                        value: String::new(),
-                    });
-                    addr0.push(ParamSetValue::Int32 {
-                        reason: self.ndarray_params.compressed_size,
-                        addr: 0,
-                        value: info.total_bytes as i32,
-                    });
+                    addr0.push(ParamSetValue::new(
+                        self.ndarray_params.codec,
+                        0,
+                        ParamValue::Octet(String::new()),
+                    ));
+                    addr0.push(ParamSetValue::new(
+                        self.ndarray_params.compressed_size,
+                        0,
+                        ParamValue::Int32(info.total_bytes as i32),
+                    ));
                 }
             }
         }
 
-        addr0.push(ParamSetValue::Float64 {
-            reason: self.plugin_params.execution_time,
-            addr: 0,
-            value: elapsed_ms,
-        });
+        addr0.push(ParamSetValue::new(
+            self.plugin_params.execution_time,
+            0,
+            ParamValue::Float64(elapsed_ms),
+        ));
 
         // ArrayRate_RBV is computed by a calc record in the DB template
         // (SCAN "1 second", reading ArrayCounter_RBV delta), not in Rust.
@@ -989,11 +991,7 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
                     addr,
                     value,
                 } => {
-                    let pv = ParamSetValue::Int32 {
-                        reason: *reason,
-                        addr: *addr,
-                        value: *value,
-                    };
+                    let pv = ParamSetValue::new(*reason, *addr, ParamValue::Int32(*value));
                     if *addr == 0 {
                         addr0.push(pv);
                     } else {
@@ -1005,11 +1003,7 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
                     addr,
                     value,
                 } => {
-                    let pv = ParamSetValue::Float64 {
-                        reason: *reason,
-                        addr: *addr,
-                        value: *value,
-                    };
+                    let pv = ParamSetValue::new(*reason, *addr, ParamValue::Float64(*value));
                     if *addr == 0 {
                         addr0.push(pv);
                     } else {
@@ -1021,11 +1015,7 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
                     addr,
                     value,
                 } => {
-                    let pv = ParamSetValue::Octet {
-                        reason: *reason,
-                        addr: *addr,
-                        value: value.clone(),
-                    };
+                    let pv = ParamSetValue::new(*reason, *addr, ParamValue::Octet(value.clone()));
                     if *addr == 0 {
                         addr0.push(pv);
                     } else {
@@ -1037,11 +1027,11 @@ impl<P: NDPluginProcess> SharedProcessorInner<P> {
                     addr,
                     value,
                 } => {
-                    let pv = ParamSetValue::Float64Array {
-                        reason: *reason,
-                        addr: *addr,
-                        value: value.clone(),
-                    };
+                    let pv = ParamSetValue::new(
+                        *reason,
+                        *addr,
+                        ParamValue::Float64Array(value.clone().into()),
+                    );
                     if *addr == 0 {
                         addr0.push(pv);
                     } else {
@@ -1798,16 +1788,12 @@ fn queue_status_batch(
     use asyn_rs::request::ParamSetValue;
     ParamBatch {
         addr0: vec![
-            ParamSetValue::Int32 {
-                reason: plugin_params.queue_size,
-                addr: 0,
-                value: max_capacity as i32,
-            },
-            ParamSetValue::Int32 {
-                reason: plugin_params.queue_use,
-                addr: 0,
-                value: free,
-            },
+            ParamSetValue::new(
+                plugin_params.queue_size,
+                0,
+                ParamValue::Int32(max_capacity as i32),
+            ),
+            ParamSetValue::new(plugin_params.queue_use, 0, ParamValue::Int32(free)),
         ],
         extra: std::collections::HashMap::new(),
     }
@@ -1820,11 +1806,11 @@ async fn clamp_writeback(port: &PortHandle, reason: usize, value: i32) {
     let _ = port
         .set_params_and_notify(
             0,
-            vec![ParamSetValue::Int32 {
+            vec![ParamSetValue::new(
                 reason,
-                addr: 0,
-                value,
-            }],
+                0,
+                asyn_rs::param::ParamValue::Int32(value),
+            )],
         )
         .await;
 }

--- a/crates/asyn-rs/src/param.rs
+++ b/crates/asyn-rs/src/param.rs
@@ -1023,6 +1023,62 @@ impl ParamList {
         }
     }
 
+    /// Store a value of **any** parameter type — the single owner of the
+    /// "set a parameter from a `ParamValue`" dispatch.
+    ///
+    /// Every caller that holds a value whose type is only known at runtime (the
+    /// port actor applying a [`crate::request::ParamSetValue`], above all) goes
+    /// through this instead of re-enumerating the type set at the call site. The
+    /// match is exhaustive, so a new [`ParamValue`] variant is a compile error
+    /// here rather than a value that silently never reaches the store.
+    ///
+    /// `UInt32Digital` is stored with a full write mask and no forced interrupt
+    /// bits; use [`Self::set_uint32`] directly for C `setUIntDigitalParam`'s
+    /// masked set.
+    pub fn set_value(&mut self, index: usize, addr: i32, value: ParamValue) -> AsynResult<()> {
+        let type_name = value.type_name();
+        match value {
+            ParamValue::Int32(v) => self.set_int32(index, addr, v),
+            ParamValue::Int64(v) => self.set_int64(index, addr, v),
+            ParamValue::Float64(v) => self.set_float64(index, addr, v),
+            ParamValue::Octet(s) => self.set_string(index, addr, s),
+            ParamValue::UInt32Digital(v) => self.set_uint32(index, addr, v, u32::MAX, 0),
+            ParamValue::Int8Array(a) => self.set_int8_array(index, addr, a.to_vec()),
+            ParamValue::Int16Array(a) => self.set_int16_array(index, addr, a.to_vec()),
+            ParamValue::Int32Array(a) => self.set_int32_array(index, addr, a.to_vec()),
+            ParamValue::Int64Array(a) => self.set_int64_array(index, addr, a.to_vec()),
+            ParamValue::Float32Array(a) => self.set_float32_array(index, addr, a.to_vec()),
+            ParamValue::Float64Array(a) => self.set_float64_array(index, addr, a.to_vec()),
+            ParamValue::Enum {
+                index: idx,
+                choices,
+            } => {
+                // Choices first — `set_enum_choices` clamps the index to the new
+                // table, so setting the index afterwards is what sticks. An empty
+                // table means "index only", leaving the parameter's own choices.
+                if !choices.is_empty() {
+                    self.set_enum_choices(index, addr, choices)?;
+                }
+                self.set_enum_index(index, addr, idx)
+            }
+            ParamValue::GenericPointer(p) => self.set_generic_pointer(index, addr, p),
+            // `UInt64`/`UInt64Array` are declared in `ParamValue`/`ParamType` but
+            // the store has no setter *or* getter for them (they are a Rust
+            // extension with no upstream asyn interface — see
+            // `interfaces::InterfaceType::UInt64`), so there is no store state a
+            // caller could reach through them. Refuse loudly rather than pretend
+            // the value landed.
+            ParamValue::UInt64(_) | ParamValue::UInt64Array(_) => Err(AsynError::Status {
+                status: AsynStatus::Error,
+                message: format!("{type_name} parameters have no store accessor; nothing to set"),
+            }),
+            ParamValue::Undefined => Err(AsynError::Status {
+                status: AsynStatus::Error,
+                message: "cannot set a parameter to Undefined".into(),
+            }),
+        }
+    }
+
     /// Check if a parameter has been explicitly set (C parity: valueDefined).
     pub fn is_param_defined(&self, index: usize, addr: i32) -> AsynResult<bool> {
         Ok(self.get_entry(index, addr)?.defined)

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -780,62 +780,47 @@ impl PortActor {
             }
             RequestOp::CallParamCallbacks { addr, updates } => {
                 let base = self.driver.base_mut();
+                // One dispatch for every parameter type (`ParamList::set_value`),
+                // so this carrier and the store cannot support different type sets.
+                let mut failed: Option<AsynError> = None;
                 for u in updates {
-                    match u {
-                        crate::request::ParamSetValue::Int32 {
+                    let outcome = match u {
+                        crate::request::ParamSetValue::Value {
                             reason,
                             addr,
                             value,
-                        } => {
-                            let _ = base.set_int32_param(*reason, *addr, *value);
-                        }
-                        crate::request::ParamSetValue::Float64 {
-                            reason,
-                            addr,
-                            value,
-                        } => {
-                            let _ = base.set_float64_param(*reason, *addr, *value);
-                        }
-                        crate::request::ParamSetValue::Octet {
-                            reason,
-                            addr,
-                            value,
-                        } => {
-                            let _ = base.params.set_string(*reason, *addr, value.clone());
-                        }
-                        crate::request::ParamSetValue::Float64Array {
-                            reason,
-                            addr,
-                            value,
-                        } => {
-                            let _ = base.params.set_float64_array(*reason, *addr, value.clone());
-                        }
-                        crate::request::ParamSetValue::Int32Array {
-                            reason,
-                            addr,
-                            value,
-                        } => {
-                            let _ = base.params.set_int32_array(*reason, *addr, value.clone());
-                        }
+                        } => base.params.set_value(*reason, *addr, value.clone()),
                         crate::request::ParamSetValue::UInt32Digital {
                             reason,
                             addr,
                             value,
                             mask,
                             interrupt_mask,
-                        } => {
-                            let _ = base.set_uint32_param(
-                                *reason,
-                                *addr,
-                                *value,
-                                *mask,
-                                *interrupt_mask,
+                        } => base.set_uint32_param(*reason, *addr, *value, *mask, *interrupt_mask),
+                    };
+                    // A set that fails (a value the parameter cannot hold) is
+                    // reported, not swallowed: C `asynPortDriver::setIntegerParam`
+                    // asynPrints the paramList error at ASYN_TRACE_ERROR and
+                    // returns the status. The remaining updates still land and the
+                    // callbacks still fire — one bad update must not strand the
+                    // good ones — and the first error is returned to whoever waits
+                    // on the reply.
+                    if let Err(e) = outcome {
+                        if let Some(trace) = base.trace.clone() {
+                            trace.output(
+                                &base.port_name,
+                                crate::trace::TraceMask::ERROR,
+                                &format!("callParamCallbacks: param set failed: {e}\n"),
                             );
                         }
+                        failed.get_or_insert(e);
                     }
                 }
                 base.call_param_callbacks(*addr)?;
-                Ok(RequestResult::write_ok())
+                match failed {
+                    Some(e) => Err(e),
+                    None => Ok(RequestResult::write_ok()),
+                }
             }
             RequestOp::GetOption { key } => {
                 let val = self.driver.get_option(key)?;

--- a/crates/asyn-rs/src/port_handle.rs
+++ b/crates/asyn-rs/src/port_handle.rs
@@ -3,6 +3,7 @@
 //! [`PortHandle`] is a lightweight, cloneable handle that sends requests to the
 //! actor via an mpsc channel and receives replies via oneshot channels.
 
+use crate::param::ParamValue;
 use std::future::Future;
 use std::pin::pin;
 use std::sync::Arc;
@@ -635,8 +636,8 @@ impl PortHandle {
     /// # Example
     /// ```ignore
     /// port_handle.set_params_and_notify(0, vec![
-    ///     ParamSetValue::Int32 { reason: acquire_busy, addr: 0, value: 0 },
-    ///     ParamSetValue::Int32 { reason: status, addr: 0, value: ADStatus::Idle as i32 },
+    ///     ParamSetValue::new(acquire_busy, 0, ParamValue::Int32(0)),
+    ///     ParamSetValue::new(status, 0, ParamValue::Int32(ADStatus::Idle as i32)),
     /// ]).await?;
     /// ```
     ///
@@ -1130,5 +1131,201 @@ mod tests {
         handle.set_auto_connect_blocking(false).unwrap();
         handle.set_auto_connect_blocking(false).unwrap();
         assert_eq!(hits.load(Ordering::Relaxed), 3);
+    }
+
+    /// Every parameter type the store supports must survive the actor path.
+    ///
+    /// `ParamSetValue` used to enumerate its own subset (Int32/Float64/Octet/
+    /// Int32Array/Float64Array/UInt32Digital), so a driver's background thread
+    /// pushing an `Int64`, `Int8Array`, `Int16Array`, `Int64Array`,
+    /// `Float32Array` or `Enum` — all of which `ParamList` stores and records
+    /// bind — had no variant to carry it, and the update was simply lost. The
+    /// carrier now holds a `ParamValue`, so the store's type set *is* the
+    /// request's type set.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn actor_path_carries_every_settable_param_type() {
+        use crate::param::{EnumEntry, ParamValue};
+        use crate::request::ParamSetValue;
+
+        struct TypedDriver {
+            base: PortDriverBase,
+        }
+        impl PortDriver for TypedDriver {
+            fn base(&self) -> &PortDriverBase {
+                &self.base
+            }
+            fn base_mut(&mut self) -> &mut PortDriverBase {
+                &mut self.base
+            }
+            // Serve the array reasons from the parameter cache, as a real driver
+            // does — this is what a bound waveform record reads.
+            fn read_int8_array(&mut self, user: &AsynUser, buf: &mut [i8]) -> AsynResult<usize> {
+                let a = self.base.params.get_int8_array(user.reason, user.addr)?;
+                let n = a.len().min(buf.len());
+                buf[..n].copy_from_slice(&a[..n]);
+                Ok(n)
+            }
+            fn read_int16_array(&mut self, user: &AsynUser, buf: &mut [i16]) -> AsynResult<usize> {
+                let a = self.base.params.get_int16_array(user.reason, user.addr)?;
+                let n = a.len().min(buf.len());
+                buf[..n].copy_from_slice(&a[..n]);
+                Ok(n)
+            }
+            fn read_int64_array(&mut self, user: &AsynUser, buf: &mut [i64]) -> AsynResult<usize> {
+                let a = self.base.params.get_int64_array(user.reason, user.addr)?;
+                let n = a.len().min(buf.len());
+                buf[..n].copy_from_slice(&a[..n]);
+                Ok(n)
+            }
+            fn read_float32_array(
+                &mut self,
+                user: &AsynUser,
+                buf: &mut [f32],
+            ) -> AsynResult<usize> {
+                let a = self.base.params.get_float32_array(user.reason, user.addr)?;
+                let n = a.len().min(buf.len());
+                buf[..n].copy_from_slice(&a[..n]);
+                Ok(n)
+            }
+        }
+        let mut base = PortDriverBase::new("handle_test", 1, PortFlags::default());
+        // reason 0..=5, in the order pushed below.
+        base.create_param("I64", ParamType::Int64).unwrap();
+        base.create_param("I8A", ParamType::Int8Array).unwrap();
+        base.create_param("I16A", ParamType::Int16Array).unwrap();
+        base.create_param("I64A", ParamType::Int64Array).unwrap();
+        base.create_param("F32A", ParamType::Float32Array).unwrap();
+        base.create_param("ENUM", ParamType::Enum).unwrap();
+        let handle = make_handle(TypedDriver { base });
+
+        handle
+            .set_params_and_notify(
+                0,
+                vec![
+                    ParamSetValue::new(0, 0, ParamValue::Int64(-9_000_000_000)),
+                    ParamSetValue::new(1, 0, ParamValue::Int8Array(vec![-1i8, 2].into())),
+                    ParamSetValue::new(2, 0, ParamValue::Int16Array(vec![7i16, -8].into())),
+                    ParamSetValue::new(3, 0, ParamValue::Int64Array(vec![1i64 << 40].into())),
+                    ParamSetValue::new(4, 0, ParamValue::Float32Array(vec![1.5f32].into())),
+                    ParamSetValue::new(
+                        5,
+                        0,
+                        ParamValue::Enum {
+                            index: 1,
+                            choices: vec![
+                                EnumEntry {
+                                    string: "Off".into(),
+                                    value: 0,
+                                    severity: 0,
+                                },
+                                EnumEntry {
+                                    string: "On".into(),
+                                    value: 1,
+                                    severity: 0,
+                                },
+                            ]
+                            .into(),
+                        },
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // Int64 lands in the store (read back through the actor, FIFO-ordered
+        // behind the update).
+        assert_eq!(
+            handle.read_int64(0, 0).await.unwrap(),
+            -9_000_000_000,
+            "an Int64 pushed through the actor path must reach the store"
+        );
+        // Enum lands too.
+        assert_eq!(handle.read_enum(5, 0).await.unwrap(), 1);
+
+        // The four array types land in the store — read each back through the
+        // actor, exactly as a bound waveform record would.
+        let rd = |op, reason| {
+            let h = handle.clone();
+            async move {
+                h.submit_async(op, AsynUser::new(reason).with_addr(0))
+                    .await
+                    .unwrap()
+            }
+        };
+        assert_eq!(
+            rd(RequestOp::Int8ArrayRead { max_elements: 8 }, 1)
+                .await
+                .int8_array
+                .unwrap(),
+            vec![-1i8, 2]
+        );
+        assert_eq!(
+            rd(RequestOp::Int16ArrayRead { max_elements: 8 }, 2)
+                .await
+                .int16_array
+                .unwrap(),
+            vec![7i16, -8]
+        );
+        assert_eq!(
+            rd(RequestOp::Int64ArrayRead { max_elements: 8 }, 3)
+                .await
+                .int64_array
+                .unwrap(),
+            vec![1i64 << 40]
+        );
+        assert_eq!(
+            rd(RequestOp::Float32ArrayRead { max_elements: 8 }, 4)
+                .await
+                .float32_array
+                .unwrap(),
+            vec![1.5f32]
+        );
+    }
+
+    /// A param set that FAILS must be reported, not swallowed. The actor used to
+    /// apply every update as `let _ = base.set_xxx_param(..)`, so pushing a value
+    /// the parameter cannot hold (here: an Int32 into a Float64 parameter)
+    /// returned success while the value went nowhere.
+    ///
+    /// The failing update is reported (C `setIntegerParam` asynPrints the
+    /// paramList error at ASYN_TRACE_ERROR and returns the status); the other
+    /// updates in the batch still land and the callbacks still fire.
+    #[test]
+    fn failed_param_set_is_reported_not_swallowed() {
+        use crate::param::ParamValue;
+        use crate::request::ParamSetValue;
+
+        let handle = make_handle(TestDriver::new());
+        // TestDriver: reason 0 = VAL (Int32), 1 = F64 (Float64), 2 = MSG (Octet).
+        let err = handle
+            .submit_blocking(
+                RequestOp::CallParamCallbacks {
+                    addr: 0,
+                    updates: vec![
+                        // Int32 into a Float64 param: the store cannot hold it.
+                        ParamSetValue::new(1, 0, ParamValue::Int32(7)),
+                        // A good update in the same batch must still land.
+                        ParamSetValue::new(0, 0, ParamValue::Int32(42)),
+                    ],
+                },
+                AsynUser::new(0),
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, AsynError::TypeMismatch { .. }),
+            "a set the parameter cannot hold must surface, got {err:?}"
+        );
+        assert_eq!(
+            handle.read_int32_blocking(0, 0).unwrap(),
+            42,
+            "the good update in the batch still lands"
+        );
+        assert!(
+            matches!(
+                handle.read_float64_blocking(1, 0),
+                Err(AsynError::ParamUndefined(1))
+            ),
+            "the failed update stored nothing: the Float64 param is still undefined"
+        );
     }
 }

--- a/crates/asyn-rs/src/request.rs
+++ b/crates/asyn-rs/src/request.rs
@@ -5,36 +5,32 @@ use std::sync::atomic::{AtomicU8, Ordering as AtomicOrdering};
 use std::time::SystemTime;
 
 use crate::error::AsynStatus;
+use crate::param::ParamValue;
 
 /// A param value to set directly in the store (no writeInt32/on_param_change).
 /// Mirrors C ADCore's setIntegerParam/setDoubleParam.
+///
+/// The value is a [`ParamValue`], not one variant per type: this carrier used to
+/// enumerate its own subset of the parameter types (Int32/Float64/Octet/
+/// Int32Array/Float64Array/UInt32Digital), so a driver thread pushing any other
+/// supported type — `Int64`, `Int8Array`, `Int16Array`, `Int64Array`,
+/// `Float32Array`, `Enum`, `GenericPointer` — simply had no variant to put it in.
+/// Carrying the store's own value type means the two type sets cannot drift
+/// apart again: the actor applies it through the single [`crate::param::ParamList::set_value`]
+/// dispatch, whose exhaustive match makes a new `ParamValue` variant a compile
+/// error rather than an update that never arrives.
 #[derive(Debug, Clone)]
 pub enum ParamSetValue {
-    Int32 {
+    /// Set a parameter of any type (C `setIntegerParam` / `setDoubleParam` /
+    /// `setStringParam` / `doCallbacksXxxArray` …).
+    Value {
         reason: usize,
         addr: i32,
-        value: i32,
+        value: ParamValue,
     },
-    Float64 {
-        reason: usize,
-        addr: i32,
-        value: f64,
-    },
-    Octet {
-        reason: usize,
-        addr: i32,
-        value: String,
-    },
-    Float64Array {
-        reason: usize,
-        addr: i32,
-        value: Vec<f64>,
-    },
-    Int32Array {
-        reason: usize,
-        addr: i32,
-        value: Vec<i32>,
-    },
+    /// asynUInt32Digital masked set — C `setUIntDigitalParam(reason, value,
+    /// mask, interruptMask)`, whose write mask and forced-callback mask a plain
+    /// [`Self::Value`] has no room for.
     UInt32Digital {
         reason: usize,
         addr: i32,
@@ -45,6 +41,35 @@ pub enum ParamSetValue {
         /// interruptMask)`); `0` for a plain value set.
         interrupt_mask: u32,
     },
+}
+
+impl ParamSetValue {
+    /// Set `reason` at `addr` to `value` — any parameter type.
+    pub fn new(reason: usize, addr: i32, value: ParamValue) -> Self {
+        Self::Value {
+            reason,
+            addr,
+            value,
+        }
+    }
+
+    /// C `setUIntDigitalParam`: store `value & mask`, and force `interrupt_mask`
+    /// bits into the callback mask even when the stored value is unchanged.
+    pub fn uint32_digital(
+        reason: usize,
+        addr: i32,
+        value: u32,
+        mask: u32,
+        interrupt_mask: u32,
+    ) -> Self {
+        Self::UInt32Digital {
+            reason,
+            addr,
+            value,
+            mask,
+            interrupt_mask,
+        }
+    }
 }
 
 /// Operation the worker thread will dispatch to the port driver.

--- a/crates/mqtt-rs/src/event_loop.rs
+++ b/crates/mqtt-rs/src/event_loop.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use asyn_rs::param::ParamValue;
 use asyn_rs::port_handle::PortHandle;
 use asyn_rs::request::ParamSetValue;
 use rumqttc::v5::{AsyncClient, Event, Incoming, MqttOptions};
@@ -142,11 +143,7 @@ pub async fn mqtt_event_loop(
                 let _ = port_handle
                     .set_params_and_notify(
                         0,
-                        vec![ParamSetValue::Int32 {
-                            reason: connected_param,
-                            addr: 0,
-                            value: 0,
-                        }],
+                        vec![ParamSetValue::new(connected_param, 0, ParamValue::Int32(0))],
                     )
                     .await;
                 is_connected = false;
@@ -166,11 +163,7 @@ async fn mark_connected(port_handle: &PortHandle, connected_param: usize, connec
     let _ = port_handle
         .set_params_and_notify(
             0,
-            vec![ParamSetValue::Int32 {
-                reason: connected_param,
-                addr: 0,
-                value: 1,
-            }],
+            vec![ParamSetValue::new(connected_param, 0, ParamValue::Int32(1))],
         )
         .await;
 }
@@ -290,52 +283,44 @@ async fn handle_incoming_message(
                 // UInt32Digital.
                 match decoded {
                     DecodedValue::Int32(v) => {
-                        batch_updates.push(ParamSetValue::Int32 {
-                            reason: *reason,
-                            addr: 0,
-                            value: v,
-                        });
+                        batch_updates.push(ParamSetValue::new(*reason, 0, ParamValue::Int32(v)));
                     }
                     DecodedValue::Float64(v) => {
-                        batch_updates.push(ParamSetValue::Float64 {
-                            reason: *reason,
-                            addr: 0,
-                            value: v,
-                        });
+                        batch_updates.push(ParamSetValue::new(*reason, 0, ParamValue::Float64(v)));
                     }
                     DecodedValue::String(v) => {
                         // asyn octet store truncates at the first NUL
                         // (setStringParam(index, val.c_str()), drvMqtt.cpp:299).
-                        batch_updates.push(ParamSetValue::Octet {
-                            reason: *reason,
-                            addr: 0,
-                            value: octet_cstr(&v).to_string(),
-                        });
+                        batch_updates.push(ParamSetValue::new(
+                            *reason,
+                            0,
+                            ParamValue::Octet(octet_cstr(&v).to_string()),
+                        ));
                     }
                     DecodedValue::Float64Array(v) => {
-                        batch_updates.push(ParamSetValue::Float64Array {
-                            reason: *reason,
-                            addr: 0,
-                            value: v,
-                        });
+                        batch_updates.push(ParamSetValue::new(
+                            *reason,
+                            0,
+                            ParamValue::Float64Array(v.into()),
+                        ));
                     }
                     DecodedValue::UInt32(v) => {
-                        batch_updates.push(ParamSetValue::UInt32Digital {
-                            reason: *reason,
-                            addr: 0,
-                            value: v,
-                            mask: 0xFFFF_FFFF,
-                            // Inbound MQTT value: changed bits derive from the
-                            // value merge; no forced interrupt mask.
-                            interrupt_mask: 0,
-                        });
+                        // Inbound MQTT value: changed bits derive from the value
+                        // merge; no forced interrupt mask.
+                        batch_updates.push(ParamSetValue::uint32_digital(
+                            *reason,
+                            0,
+                            v,
+                            0xFFFF_FFFF,
+                            0,
+                        ));
                     }
                     DecodedValue::Int32Array(v) => {
-                        batch_updates.push(ParamSetValue::Int32Array {
-                            reason: *reason,
-                            addr: 0,
-                            value: v,
-                        });
+                        batch_updates.push(ParamSetValue::new(
+                            *reason,
+                            0,
+                            ParamValue::Int32Array(v.into()),
+                        ));
                     }
                 }
             }

--- a/crates/mqtt-rs/src/payload.rs
+++ b/crates/mqtt-rs/src/payload.rs
@@ -955,7 +955,7 @@ mod tests {
 
     /// BUG 5 — the FLAT INTARRAY decode path (already producing
     /// `Int32Array`) stays intact; the event loop now delivers it via
-    /// `ParamSetValue::Int32Array`.
+    /// `ParamSetValue::Value` carrying a `ParamValue::Int32Array`.
     #[test]
     fn decode_flat_int_array_for_inbound_delivery() {
         let addr = TopicAddress::parse("FLAT:INTARRAY test/arr").unwrap();

--- a/examples/mini-beamline/src/moving_dot/task.rs
+++ b/examples/mini-beamline/src/moving_dot/task.rs
@@ -1,3 +1,4 @@
+use asyn_rs::param::ParamValue;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,21 +49,17 @@ impl AcquisitionContext {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire_busy,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.status,
-                        addr: 0,
-                        value: ADStatus::Idle as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire,
-                        addr: 0,
-                        value: 0,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Idle as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(self.ad.acquire, 0, ParamValue::Int32(0)),
                 ],
             )
             .await
@@ -121,21 +118,21 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.num_images_counter,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.status,
-                        addr: 0,
-                        value: ADStatus::Acquire as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.acquire_busy,
-                        addr: 0,
-                        value: 1,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.num_images_counter,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Acquire as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(1),
+                    ),
                 ],
             )
             .await
@@ -266,46 +263,46 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
                 .set_params_and_notify(
                     0,
                     vec![
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_counter,
-                            addr: 0,
-                            value: array_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.num_images_counter,
-                            addr: 0,
-                            value: num_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_size_x,
-                            addr: 0,
-                            value: info.x_size as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_size_y,
-                            addr: 0,
-                            value: info.y_size as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_size,
-                            addr: 0,
-                            value: info.total_bytes as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.ad.base.timestamp_rbv,
-                            addr: 0,
-                            value: frame.timestamp.as_f64(),
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.epics_ts_sec,
-                            addr: 0,
-                            value: frame.timestamp.sec as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.epics_ts_nsec,
-                            addr: 0,
-                            value: frame.timestamp.nsec as i32,
-                        },
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_counter,
+                            0,
+                            ParamValue::Int32(array_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.num_images_counter,
+                            0,
+                            ParamValue::Int32(num_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_size_x,
+                            0,
+                            ParamValue::Int32(info.x_size as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_size_y,
+                            0,
+                            ParamValue::Int32(info.y_size as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_size,
+                            0,
+                            ParamValue::Int32(info.total_bytes as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.timestamp_rbv,
+                            0,
+                            ParamValue::Float64(frame.timestamp.as_f64()),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.epics_ts_sec,
+                            0,
+                            ParamValue::Int32(frame.timestamp.sec as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.epics_ts_nsec,
+                            0,
+                            ParamValue::Int32(frame.timestamp.nsec as i32),
+                        ),
                     ],
                 )
                 .await

--- a/examples/ophyd-test-ioc/src/sim_detector/task.rs
+++ b/examples/ophyd-test-ioc/src/sim_detector/task.rs
@@ -1,3 +1,4 @@
+use asyn_rs::param::ParamValue;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,21 +49,17 @@ impl AcquisitionContext {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire_busy,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.status,
-                        addr: 0,
-                        value: ADStatus::Idle as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire,
-                        addr: 0,
-                        value: 0,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Idle as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(self.ad.acquire, 0, ParamValue::Int32(0)),
                 ],
             )
             .await
@@ -121,21 +118,21 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.num_images_counter,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.status,
-                        addr: 0,
-                        value: ADStatus::Acquire as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.acquire_busy,
-                        addr: 0,
-                        value: 1,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.num_images_counter,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Acquire as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(1),
+                    ),
                 ],
             )
             .await
@@ -222,31 +219,31 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
                 .set_params_and_notify(
                     0,
                     vec![
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_counter,
-                            addr: 0,
-                            value: array_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.num_images_counter,
-                            addr: 0,
-                            value: num_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.ad.base.timestamp_rbv,
-                            addr: 0,
-                            value: frame.timestamp.as_f64(),
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.epics_ts_sec,
-                            addr: 0,
-                            value: frame.timestamp.sec as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.epics_ts_nsec,
-                            addr: 0,
-                            value: frame.timestamp.nsec as i32,
-                        },
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_counter,
+                            0,
+                            ParamValue::Int32(array_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.num_images_counter,
+                            0,
+                            ParamValue::Int32(num_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.timestamp_rbv,
+                            0,
+                            ParamValue::Float64(frame.timestamp.as_f64()),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.epics_ts_sec,
+                            0,
+                            ParamValue::Int32(frame.timestamp.sec as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.epics_ts_nsec,
+                            0,
+                            ParamValue::Int32(frame.timestamp.nsec as i32),
+                        ),
                     ],
                 )
                 .await

--- a/examples/sim-detector/src/task.rs
+++ b/examples/sim-detector/src/task.rs
@@ -1,3 +1,4 @@
+use asyn_rs::param::ParamValue;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -49,21 +50,17 @@ impl AcquisitionContext {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire_busy,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.status,
-                        addr: 0,
-                        value: ADStatus::Idle as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire,
-                        addr: 0,
-                        value: 0,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Idle as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(self.ad.acquire, 0, ParamValue::Int32(0)),
                 ],
             )
             .await
@@ -204,21 +201,21 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.num_images_counter,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.status,
-                        addr: 0,
-                        value: ADStatus::Acquire as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.acquire_busy,
-                        addr: 0,
-                        value: 1,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.num_images_counter,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Acquire as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(1),
+                    ),
                 ],
             )
             .await
@@ -287,31 +284,31 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
                 .set_params_and_notify(
                     0,
                     vec![
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_counter,
-                            addr: 0,
-                            value: array_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.num_images_counter,
-                            addr: 0,
-                            value: num_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.ad.base.timestamp_rbv,
-                            addr: 0,
-                            value: frame.timestamp.as_f64(),
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.epics_ts_sec,
-                            addr: 0,
-                            value: frame.timestamp.sec as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.epics_ts_nsec,
-                            addr: 0,
-                            value: frame.timestamp.nsec as i32,
-                        },
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_counter,
+                            0,
+                            ParamValue::Int32(array_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.num_images_counter,
+                            0,
+                            ParamValue::Int32(num_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.timestamp_rbv,
+                            0,
+                            ParamValue::Float64(frame.timestamp.as_f64()),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.epics_ts_sec,
+                            0,
+                            ParamValue::Int32(frame.timestamp.sec as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.epics_ts_nsec,
+                            0,
+                            ParamValue::Int32(frame.timestamp.nsec as i32),
+                        ),
                     ],
                 )
                 .await

--- a/examples/xrt-beamline/src/detector/task.rs
+++ b/examples/xrt-beamline/src/detector/task.rs
@@ -1,3 +1,4 @@
+use asyn_rs::param::ParamValue;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,21 +43,17 @@ impl AcquisitionContext {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire_busy,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.status,
-                        addr: 0,
-                        value: ADStatus::Idle as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: self.ad.acquire,
-                        addr: 0,
-                        value: 0,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        self.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Idle as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(self.ad.acquire, 0, ParamValue::Int32(0)),
                 ],
             )
             .await
@@ -112,21 +109,21 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
             .set_params_and_notify(
                 0,
                 vec![
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.num_images_counter,
-                        addr: 0,
-                        value: 0,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.status,
-                        addr: 0,
-                        value: ADStatus::Acquire as i32,
-                    },
-                    asyn_rs::request::ParamSetValue::Int32 {
-                        reason: ctx.ad.acquire_busy,
-                        addr: 0,
-                        value: 1,
-                    },
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.num_images_counter,
+                        0,
+                        ParamValue::Int32(0),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.status,
+                        0,
+                        ParamValue::Int32(ADStatus::Acquire as i32),
+                    ),
+                    asyn_rs::request::ParamSetValue::new(
+                        ctx.ad.acquire_busy,
+                        0,
+                        ParamValue::Int32(1),
+                    ),
                 ],
             )
             .await
@@ -291,92 +288,92 @@ async fn acquisition_loop_async(mut ctx: AcquisitionContext) {
                 .set_params_and_notify(
                     0,
                     vec![
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_counter,
-                            addr: 0,
-                            value: array_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.num_images_counter,
-                            addr: 0,
-                            value: num_counter,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_size_x,
-                            addr: 0,
-                            value: nx as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_size_y,
-                            addr: 0,
-                            value: nz as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.ad.base.array_size,
-                            addr: 0,
-                            value: (nx * nz * 2) as i32,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.ad.base.timestamp_rbv,
-                            addr: 0,
-                            value: frame.timestamp.as_f64(),
-                        },
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_counter,
+                            0,
+                            ParamValue::Int32(array_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.num_images_counter,
+                            0,
+                            ParamValue::Int32(num_counter),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_size_x,
+                            0,
+                            ParamValue::Int32(nx as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_size_y,
+                            0,
+                            ParamValue::Int32(nz as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.array_size,
+                            0,
+                            ParamValue::Int32((nx * nz * 2) as i32),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.ad.base.timestamp_rbv,
+                            0,
+                            ParamValue::Float64(frame.timestamp.as_f64()),
+                        ),
                         // Simulation readbacks
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_source_energy,
-                            addr: 0,
-                            value: last_source_energy,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_dcm_energy,
-                            addr: 0,
-                            value: last_dcm_energy,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_efficiency,
-                            addr: 0,
-                            value: efficiency * 100.0,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_flux,
-                            addr: 0,
-                            value: flux,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_centroid_x,
-                            addr: 0,
-                            value: cx,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_centroid_z,
-                            addr: 0,
-                            value: cz,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_fwhm_x,
-                            addr: 0,
-                            value: fwhm_x,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_fwhm_z,
-                            addr: 0,
-                            value: fwhm_z,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_rms_x,
-                            addr: 0,
-                            value: rms_x,
-                        },
-                        asyn_rs::request::ParamSetValue::Float64 {
-                            reason: ctx.xrt.sim_rms_z,
-                            addr: 0,
-                            value: rms_z,
-                        },
-                        asyn_rs::request::ParamSetValue::Int32 {
-                            reason: ctx.xrt.sim_nrays,
-                            addr: 0,
-                            value: n_captured as i32,
-                        },
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_source_energy,
+                            0,
+                            ParamValue::Float64(last_source_energy),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_dcm_energy,
+                            0,
+                            ParamValue::Float64(last_dcm_energy),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_efficiency,
+                            0,
+                            ParamValue::Float64(efficiency * 100.0),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_flux,
+                            0,
+                            ParamValue::Float64(flux),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_centroid_x,
+                            0,
+                            ParamValue::Float64(cx),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_centroid_z,
+                            0,
+                            ParamValue::Float64(cz),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_fwhm_x,
+                            0,
+                            ParamValue::Float64(fwhm_x),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_fwhm_z,
+                            0,
+                            ParamValue::Float64(fwhm_z),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_rms_x,
+                            0,
+                            ParamValue::Float64(rms_x),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_rms_z,
+                            0,
+                            ParamValue::Float64(rms_z),
+                        ),
+                        asyn_rs::request::ParamSetValue::new(
+                            ctx.xrt.sim_nrays,
+                            0,
+                            ParamValue::Int32(n_captured as i32),
+                        ),
                     ],
                 )
                 .await


### PR DESCRIPTION
## Defect

`ParamSetValue` (`request.rs:12`) — the value carrier for the actor path a driver's background thread uses (`PortHandle::set_params_and_notify` → `RequestOp::CallParamCallbacks`) — enumerated **its own subset** of the parameter types:

| carried by `ParamSetValue` | stored by `ParamList`, bindable by records, **not carriable** |
| --- | --- |
| Int32, Float64, Octet, Int32Array, Float64Array, UInt32Digital | **Int64, Int8Array, Int16Array, Int64Array, Float32Array, Enum, GenericPointer** |

Every type in the right column has a `ParamValue` variant, a `ParamList` setter (`set_int64`, `set_int8_array`, `set_int16_array`, `set_int64_array`, `set_float32_array`, `set_enum_index`, `set_generic_pointer`) and an asyn interface records bind on. A driver thread holding one of them had no variant to put it in, so the update was **lost with no error** — `set_params_and_notify` returns `Ok`.

Reported by the twincat-ads porter, who worked around it by keeping the driver's own value cache and firing `InterruptValue`s through a cloned `InterruptManager` rather than using the framework's actor path at all.

### Second half: a *failed* set was swallowed too

The actor applied every update as `let _ = base.set_xxx_param(..)` (`port_actor.rs:781-836`). A set that fails — a value the parameter cannot hold — was discarded and the request still replied success. Same defect class: the update disappears silently.

## Fix

**`ParamSetValue` carries a `ParamValue`.** The store's type set *is* the request's type set, so the two cannot drift apart again:

```rust
pub enum ParamSetValue {
    Value { reason: usize, addr: i32, value: ParamValue },   // any type
    UInt32Digital { reason, addr, value, mask, interrupt_mask }, // C setUIntDigitalParam
}
```

`UInt32Digital` stays a distinct variant because C's `setUIntDigitalParam` carries a write mask and a forced-callback mask that a plain value has no room for.

**One dispatch applies it:** the new `ParamList::set_value(index, addr, ParamValue)` — the single owner of "set a parameter from a runtime-typed value". Its match is exhaustive, so a future `ParamValue` variant is a *compile error* here rather than a value that silently never reaches the store. The actor no longer re-enumerates the type set at the call site.

**A failed set is reported, not swallowed:** the paramList error is traced at `ASYN_TRACE_ERROR` (C `asynPortDriver::setIntegerParam` `asynPrint`s the failure and returns the status) and returned to whoever waits on the reply. The batch's other updates still land and `callParamCallbacks` still fires — one bad update must not strand the good ones.

## ⚠️ BREAKING API CHANGE

`ParamSetValue::{Int32, Float64, Octet, Int32Array, Float64Array}` are gone, replaced by `ParamSetValue::Value`. Migration is mechanical:

```rust
// before
ParamSetValue::Int32 { reason, addr: 0, value }
// after
ParamSetValue::new(reason, 0, ParamValue::Int32(value))
// and, for the masked digital set:
ParamSetValue::uint32_digital(reason, 0, value, mask, interrupt_mask)
```

All 105 in-tree call sites (ad-core-rs, mqtt-rs, four example IOCs) are migrated in this PR. `CallParamCallbacks` now returns the first failed set instead of always succeeding — callers that pushed type-mismatched updates and relied on the success reply will now see the error (that is the point).

## Audit of the rest of the family

- `RequestOp`'s read/write ops (`Int32`/`Int64`/`Float64`/`Octet`/`UInt32Digital`/`Enum` + all six array types): **no gap** — they cover every interface the store serves.
- `ParamValue::UInt64` / `UInt64Array`: **assessed, deliberately not widened.** `ParamList` has neither a setter *nor* a getter for them (no `set_uint64`/`get_uint64` exists anywhere), and `InterfaceType::UInt64` is documented in-tree as a Rust extension with no upstream asyn interface. There is no store state a caller could reach through them, so nothing is being silently dropped; wiring them up is feature work, not a gap in the request path. `set_value` refuses them with an explicit error rather than pretending the value landed.
- `protocol::PortCommand::CallParamCallbacks` (the serializable wire mirror) has **never** carried `updates` — a remote client can only trigger callbacks — and `From<&RequestOp>` drops them (`convert.rs:93`). That direction (local → wire) is exercised only by the round-trip test; the live in-process transport converts wire → local only. Carrying updates over a transport also runs into `GenericPointer`, a process-local `Arc` that cannot cross a process boundary by construction (`protocol::value::ParamValue` already maps it to `Undefined`). That is a transport-capability question — a remote param-set protocol — not this typed-drop defect, so it is **left alone and flagged**, not silently widened.

## Regression tests

`crates/asyn-rs/src/port_handle.rs`:

1. `actor_path_carries_every_settable_param_type` — pushes `Int64`, `Int8Array`, `Int16Array`, `Int64Array`, `Float32Array` and `Enum` through `set_params_and_notify`, then reads each back through the actor (as a bound record would).
2. `failed_param_set_is_reported_not_swallowed` — an `Int32` update aimed at a `Float64` parameter, batched with a good update: the request must return `TypeMismatch`, the good update must still land.

Verified to fail on unfixed `main` (5433b847). Main cannot even express the first one (no `Int64` variant to construct), so the equivalent test drops the update the way main forces a driver to — and the push still reports success:

```
thread 'port_handle::tests::actor_path_carries_every_settable_param_type' panicked at crates/asyn-rs/src/port_handle.rs:1166:9:
an Int64 pushed through the actor path must reach the store, got Err(ParamUndefined(0))
```

The second is verbatim-expressible on main and fails there:

```
thread 'port_handle::tests::failed_param_set_is_reported_not_swallowed' panicked at crates/asyn-rs/src/port_handle.rs:1200:14:
called `Result::unwrap_err()` on an `Ok` value: RequestResult { status: Success, ... }
```

Both pass with the fix.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7449 passed, 2 skipped
- `cargo test --doc --workspace` — clean