### PR TITLE
fix(database): walk records in database load order, not hash order

### DIFF
--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -1383,9 +1383,42 @@ impl PvDatabase {
         self.inner.records.read().await.get(name).cloned()
     }
 
-    /// Get all record names.
+    /// Every record name, in **database load order** — the single owner of
+    /// whole-database iteration order.
+    ///
+    /// C parity: `dbFirstRecord`/`dbNextRecord` walk the record list of each
+    /// record type in the order `dbReadDatabase` appended them, so every
+    /// whole-database pass a C IOC makes — `initDevSup`, `initDatabase`,
+    /// `initialProcess` (PINI), `dbl`/`dbgrep` dumps — visits records in load
+    /// order. Device support is written against that contract: a dynamic device
+    /// support whose record references another record (epics-modules/opcua's
+    /// element records require their `opcuaItem` record to have bound first,
+    /// linkParser.cpp:226-234) only boots if the referenced record was wired
+    /// first, which the `.db` guarantees by declaring it first.
+    ///
+    /// The names live in a `HashMap`, so returning `keys()` made that order the
+    /// hash order: neither load order nor even stable across runs of the same
+    /// binary (`RandomState` reseeds per process). Booting the same database
+    /// twice could wire records in two different orders — one boot succeeding
+    /// and the next failing. Ordering here, at the one accessor every
+    /// whole-database walk already goes through, makes every such pass
+    /// deterministic and load-ordered at once.
+    ///
+    /// The order key is the existing per-record `load_order` sequence (the
+    /// scan-index's secondary sort key), so this ordering and the scan lists'
+    /// ordering are the same fact, not two. A record with no sequence — none
+    /// exists; `add_record` is the only insertion path — would sort last by
+    /// name rather than nondeterministically.
     pub async fn all_record_names(&self) -> Vec<String> {
-        self.inner.records.read().await.keys().cloned().collect()
+        // Lock order records → load_order, matching `add_record`/`remove_record`.
+        let records = self.inner.records.read().await;
+        let load_order = self.inner.load_order.read().await;
+        let mut names: Vec<String> = records.keys().cloned().collect();
+        names.sort_by(|a, b| {
+            let seq = |n: &String| load_order.get(n).copied().unwrap_or(u64::MAX);
+            seq(a).cmp(&seq(b)).then_with(|| a.cmp(b))
+        });
+        names
     }
 
     /// Get all alias names registered against existing records.

--- a/crates/epics-base-rs/src/server/database/scan_index.rs
+++ b/crates/epics-base-rs/src/server/database/scan_index.rs
@@ -94,7 +94,12 @@ impl PvDatabase {
             .unwrap_or_default()
     }
 
-    /// Get all record names that have PINI=true.
+    /// Get all record names that have PINI=true, in database load order.
+    ///
+    /// C `initialProcess` (`dbAccess.c`) walks the record lists with
+    /// `dbFirstRecord`/`dbNextRecord`, so PINI processing follows load
+    /// order; the order comes from [`PvDatabase::all_record_names`], the
+    /// single owner of whole-database iteration order.
     ///
     /// Snapshot the records map under the outer
     /// read lock, then drop it before fanning out per-record reads.
@@ -104,11 +109,12 @@ impl PvDatabase {
     /// records.write()), startup could stall while every PINI
     /// record was inspected serially.
     pub async fn pini_records(&self) -> Vec<String> {
+        let ordered = self.all_record_names().await;
         let snapshot: Vec<_> = {
             let records = self.inner.records.read().await;
-            records
-                .iter()
-                .map(|(n, r)| (n.clone(), r.clone()))
+            ordered
+                .into_iter()
+                .filter_map(|n| records.get(&n).map(|r| (n, r.clone())))
                 .collect()
         };
         let mut result = Vec::new();

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -1526,6 +1526,82 @@ mod tests {
         assert_eq!(observed.get("Q:group").map(String::as_str), Some("demo"));
     }
 
+    /// Regression: `wire_device_support` must bind records in **database load
+    /// order**, the order C's `initDevSup` walks
+    /// (`dbFirstRecord`/`dbNextRecord`). Real device support depends on it:
+    /// epics-modules/opcua's element records refuse to init unless their
+    /// `opcuaItem` record bound first (`linkParser.cpp:226-234`), and the
+    /// shipped databases guarantee that only by declaring the item record
+    /// first. This walked `all_record_names()` when that returned `HashMap`
+    /// keys, so binding ran in hash order — not load order, and not even
+    /// stable across runs of the same binary.
+    #[tokio::test]
+    async fn wire_device_support_binds_in_database_load_order() {
+        use crate::server::device_support::{DeviceReadOutcome, DeviceSupport};
+        use crate::server::records::ai::AiRecord;
+        use std::sync::{Arc as StdArc, Mutex as StdMutex};
+
+        struct NoopDev;
+        impl DeviceSupport for NoopDev {
+            fn write(&mut self, _record: &mut dyn crate::server::record::Record) -> CaResult<()> {
+                Ok(())
+            }
+            fn dtyp(&self) -> &str {
+                "SeqDev"
+            }
+            fn read(
+                &mut self,
+                _record: &mut dyn crate::server::record::Record,
+            ) -> CaResult<DeviceReadOutcome> {
+                Ok(DeviceReadOutcome::ok())
+            }
+        }
+
+        // A fixed permutation of 0..24 — load order is deliberately neither
+        // lexical nor hash order, so a pass cannot be a coincidence.
+        let names: Vec<String> = (0..24)
+            .map(|i: usize| format!("LOAD:{:02}", (i * 7 + 3) % 24))
+            .collect();
+
+        let db = Arc::new(PvDatabase::new());
+        for name in &names {
+            db.add_record(name, Box::new(AiRecord::new(0.0)))
+                .await
+                .unwrap();
+            let rec = db.get_record(name).await.unwrap();
+            let mut inst = rec.write().await;
+            inst.common.dtyp = "SeqDev".to_string();
+            // `DeviceSupportContext` carries the links, not the record name;
+            // echoing the name through INP is how the test observes which
+            // record is being wired.
+            inst.common.inp = format!("@{name}");
+        }
+
+        let wired: StdArc<StdMutex<Vec<String>>> = StdArc::new(StdMutex::new(Vec::new()));
+        let captured = wired.clone();
+        let dynamic: Option<DynamicDeviceSupportFactory> =
+            Some(Box::new(move |ctx: &DeviceSupportContext| {
+                captured
+                    .lock()
+                    .unwrap()
+                    .push(ctx.inp.trim_start_matches('@').to_string());
+                Some(Box::new(NoopDev) as Box<dyn DeviceSupport>)
+            }));
+
+        let factories: HashMap<String, DeviceSupportFactory> = HashMap::new();
+        let count = wire_device_support(&db, &factories, &dynamic)
+            .await
+            .unwrap();
+        assert_eq!(count, names.len());
+
+        let wired = std::mem::take(&mut *wired.lock().unwrap());
+        assert_eq!(
+            wired, names,
+            "device support must bind in database load order (C initDevSup), \
+             not HashMap hash order"
+        );
+    }
+
     /// Regression: an `asyn:READBACK` OUTPUT record processed because of a
     /// driver interrupt callback must READ the callback value back into VAL
     /// and MUST NOT write it to the driver. Writing it re-asserts the

--- a/crates/epics-base-rs/tests/record_load_order.rs
+++ b/crates/epics-base-rs/tests/record_load_order.rs
@@ -1,0 +1,143 @@
+//! Whole-database passes must visit records in **database load order**.
+//!
+//! C parity: `dbFirstRecord`/`dbNextRecord` walk each record type's list in the
+//! order `dbReadDatabase` appended them, so `initDevSup`, `initDatabase` and
+//! `initialProcess` (PINI) all follow the `.db` file order. Device support is
+//! written against that contract — epics-modules/opcua's element records refuse
+//! to init unless their `opcuaItem` record has already bound
+//! (`linkParser.cpp:226-234`), which the shipped databases guarantee only by
+//! declaring the item record first.
+//!
+//! The Rust database kept its records in a `HashMap` and `all_record_names()`
+//! returned `keys()`, so every whole-database pass ran in hash order: not load
+//! order, and not even stable across runs of the same binary (`RandomState`
+//! reseeds per process). Booting the same database twice could wire records in
+//! two different orders — one boot succeeding, the next failing with "opcuaItem
+//! record ... is not loaded yet".
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::error::CaResult;
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::device_support::{DeviceReadOutcome, DeviceSupport};
+use epics_base_rs::server::ioc_app::DeviceSupportContext;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::record::Record;
+use epics_base_rs::server::records::ai::AiRecord;
+
+/// Enough records that hash order cannot coincide with load order.
+const N: usize = 24;
+
+struct NoopDevice;
+
+impl DeviceSupport for NoopDevice {
+    fn read(&mut self, _record: &mut dyn Record) -> CaResult<DeviceReadOutcome> {
+        Ok(DeviceReadOutcome::ok())
+    }
+
+    fn write(&mut self, _record: &mut dyn Record) -> CaResult<()> {
+        Ok(())
+    }
+
+    fn dtyp(&self) -> &str {
+        "seqDev"
+    }
+}
+
+/// Names chosen so lexical order, hash order and load order are three different
+/// sequences: the load order below is deliberately *not* sorted.
+fn load_ordered_names() -> Vec<String> {
+    // A fixed permutation of 0..N, so a passing run cannot be an accident of
+    // the names happening to be sorted.
+    (0..N)
+        .map(|i| format!("LOAD:{:02}", (i * 7 + 3) % N))
+        .collect()
+}
+
+/// The `IocBuilder` path binds device support while iterating the parsed record
+/// defs, so it was already load-ordered; the nondeterministic path was
+/// `IocApplication`'s `wire_device_support` (pinned by the unit test
+/// `wire_device_support_binds_in_database_load_order`). Pinned here so the two
+/// paths cannot silently diverge — an IOC must wire the same way whether its
+/// database came from the builder or from iocsh `dbLoadRecords`.
+#[tokio::test]
+async fn builder_wires_device_support_in_database_load_order() {
+    let names = load_ordered_names();
+
+    let mut db = String::new();
+    for name in &names {
+        // The record's own name is echoed through INP because
+        // `DeviceSupportContext` carries the links, not the record name — this
+        // is how the test observes *which* record is being wired.
+        db.push_str(&format!(
+            "record(ai, \"{name}\") {{\n    field(DTYP, \"seqDev\")\n    field(INP, \"@{name}\")\n}}\n"
+        ));
+    }
+
+    let wired: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&wired);
+
+    let (_database, _) = IocBuilder::new()
+        .register_dynamic_device_support(move |ctx: &DeviceSupportContext| {
+            captured
+                .lock()
+                .unwrap()
+                .push(ctx.inp.trim_start_matches('@').to_string());
+            Some(Box::new(NoopDevice) as Box<dyn DeviceSupport>)
+        })
+        .db_string(&db, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    let wired = std::mem::take(&mut *wired.lock().unwrap());
+    assert_eq!(
+        wired, names,
+        "device support must be wired in database load order (C initDevSup \
+         walks dbFirstRecord/dbNextRecord); got hash order"
+    );
+}
+
+/// The ordering owner itself: every whole-database walk goes through
+/// `all_record_names`, so pinning it pins `wire_device_support`,
+/// `setup_io_intr`, `setup_cp_links`, `dbl`, and the rest.
+#[tokio::test]
+async fn all_record_names_returns_load_order() {
+    let db = Arc::new(PvDatabase::new());
+    let names = load_ordered_names();
+    for name in &names {
+        db.add_record(name, Box::new(AiRecord::new(0.0)))
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(
+        db.all_record_names().await,
+        names,
+        "all_record_names must return database load order, not hash order"
+    );
+}
+
+/// PINI processing is a whole-database walk too: C `initialProcess` iterates
+/// with `dbFirstRecord`/`dbNextRecord`, so a PINI record that depends on an
+/// earlier PINI record's output processes after it.
+#[tokio::test]
+async fn pini_records_returns_load_order() {
+    let db = Arc::new(PvDatabase::new());
+    let names = load_ordered_names();
+    for name in &names {
+        db.add_record(name, Box::new(AiRecord::new(0.0)))
+            .await
+            .unwrap();
+        let rec = db.get_record(name).await.unwrap();
+        rec.write().await.common.pini = true;
+    }
+
+    assert_eq!(
+        db.pini_records().await,
+        names,
+        "PINI records must process in database load order, not hash order"
+    );
+}


### PR DESCRIPTION
## Defect

`wire_device_support` (`ioc_app.rs`) iterates `PvDatabase::all_record_names()`, and that accessor returned `HashMap` keys:

```rust
pub async fn all_record_names(&self) -> Vec<String> {
    self.inner.records.read().await.keys().cloned().collect()
}
```

So every whole-database pass ran in **hash order** — neither database load order nor stable across runs of the same binary (`RandomState` reseeds per process).

C EPICS walks records with `dbFirstRecord`/`dbNextRecord`, i.e. in the order `dbReadDatabase` appended them; `initDevSup`, `initDatabase` and `initialProcess` (PINI) all follow the `.db` file order. Device support is written against that contract: epics-modules/opcua's element records refuse to init unless their `opcuaItem` record has already bound (`linkParser.cpp:226-234`), and the module's shipped databases guarantee that only by declaring the item record first.

Observed by the opcua porter: booting the ported example database failed with `opcuaItem record 'OPC:item' is not loaded yet` on one run and passed on the next — same binary, same db, hash-order dependent. That is observable nondeterminism plus a C-parity break, not missing feature work.

## Fix — structural, no new state

The database **already tracks load order**: `PvDatabaseInner.load_order` (name → monotonic sequence, assigned in `add_record`), used as the scan index's secondary sort key precisely for C `dbScan.c` same-PHAS FIFO parity. The nondeterminism was that the *record-name accessor* did not use it.

- `PvDatabase::all_record_names()` now returns names ordered by that sequence, and is documented as the **single owner of whole-database iteration order** (C `dbFirstRecord`/`dbNextRecord`). Every whole-database walk already goes through it — `wire_device_support`, `wire_subroutines`, `setup_io_intr`, `setup_property_posts`, `setup_cp_links`, `IocBuilder`, pvalink, qsrv, iocsh `dbl` — so all of them become load-ordered and deterministic at once. Lock order is `records` → `load_order`, matching `add_record`/`remove_record`.
- `pini_records()` (`scan_index.rs`) iterated the records map directly; it now takes its order from `all_record_names()`. C `initialProcess` walks with `dbFirstRecord`/`dbNextRecord`, so PINI processing follows load order too.

No `IndexMap` and no parallel `Vec<String>`: both would be a second copy of a fact the database already holds (and `IndexMap::swap_remove` reorders on `remove_record` anyway). Ordering by the existing sequence makes the wiring order and the scan lists' order the same fact, not two that can drift.

**No semantic change beyond the intended one.** Callers that were order-insensitive are unaffected; callers that were silently depending on nondeterminism now get C's order.

## Family audit

**Anchor:** `rg 'inner\.records\.read\(\)|all_record_names' crates/`

Same defect, fixed at source:
- `database/mod.rs` `all_record_names` — hash order; feeds ~20 whole-DB walks (listed above).
- `database/scan_index.rs` `pini_records` — iterated the map directly; C `initialProcess` is load-ordered.

Distinct, skipped (one line each):
- `database/mod.rs:515` breaktable registry install over `.values()` — installs the same `Arc` into every record, idempotent, no cross-record dependency.
- `scan_index.rs` `buildScanLists` / `records_for_scan` — already ordered on `(PHAS, load_order, name)`.
- `processing.rs`, `field_io.rs` — by-name `get()` lookups, not whole-database iterations.
- `all_alias_names()` is still hash-ordered: aliases carry no `load_order` (C keeps them in a separate `dbEntry` list) and their consumers sort or use them by name. Widening it would need new state; noting it rather than forcing it.

## Regression tests (fail on unfixed main)

`wire_device_support_binds_in_database_load_order` (unit test, the cited site) — 24 records added in a fixed non-lexical permutation, each with a dynamic device-support factory recording which record it is binding. On `main` (5ec24db9):

```
thread 'server::ioc_app::tests::wire_device_support_binds_in_database_load_order' panicked at
crates/epics-base-rs/src/server/ioc_app.rs:1596:9:
assertion `left == right` failed: device support must bind in database load order (C initDevSup), not HashMap hash order
  left: ["LOAD:06", "LOAD:16", "LOAD:15", "LOAD:21", "LOAD:10", "LOAD:04", "LOAD:05", "LOAD:11", "LOAD:09", "LOAD:23", "LOAD:22", "LOAD:02", "LOAD:14", "LOAD:01", "LOAD:13", "LOAD:12", "LOAD:03", "LOAD:00", "LOAD:07", "LOAD:17", "LOAD:08", "LOAD:19", "LOAD:20", "LOAD:18"]
 right: ["LOAD:03", "LOAD:10", "LOAD:17", "LOAD:00", "LOAD:07", "LOAD:14", "LOAD:21", "LOAD:04", "LOAD:11", "LOAD:18", "LOAD:01", "LOAD:08", "LOAD:15", "LOAD:22", "LOAD:05", "LOAD:12", "LOAD:19", "LOAD:02", "LOAD:09", "LOAD:16", "LOAD:23", "LOAD:06", "LOAD:13", "LOAD:20"]
```

`tests/record_load_order.rs`:
- `all_record_names_returns_load_order` — fails on main (`left` is a hash permutation, `right` is load order).
- `pini_records_returns_load_order` — fails on main, and with a *different* permutation than the test above in the same run, which is the nondeterminism itself.
- `builder_wires_device_support_in_database_load_order` — passes on main and after: the `IocBuilder` path binds while iterating the parsed record defs, so it was already load-ordered. Pinned so the builder path and the `IocApplication`/`dbLoadRecords` path cannot silently diverge.

## Gates

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 7453 passed, 2 skipped
- `cargo test --doc --workspace` — clean