### PR TITLE
Fix nightly ophyd-epicsrs integration regressions: motor DMOV blink + pvRequest dotted selectors

### DIFF
--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -624,6 +624,14 @@ impl PvDatabase {
 
             let request = dbput_request(&*instance.record, &field, value)?;
 
+            // Pre-write special hook (C EPICS dbPutSpecial pass=0).
+            // C `dbPut` runs it on EVERY entry path — dbPutField and
+            // dbPutLink alike (dbAccess.c) — so the OUT-link route
+            // through this body must call it too (motor's drive-field
+            // DMOV blink, motorRecord.cc:2582-2608, fires on put-links
+            // in C). A non-zero status aborts the put like C.
+            instance.record.special(&field, false)?;
+
             // Capture the pre-put value so the metadata-cache
             // invalidation (and the downstream `DBE_PROPERTY`
             // emission) can be skipped when the put is a no-op —
@@ -885,6 +893,11 @@ impl PvDatabase {
             check_no_mod(&instance, &field)?;
 
             let request = dbput_request(&*instance.record, &field, value)?;
+
+            // Pre-write special hook (C EPICS dbPutSpecial pass=0) —
+            // C `dbPut` runs it on every entry path; this is the third
+            // `dbPut` body and must match the other two.
+            instance.record.special(&field, false)?;
 
             let old_value = instance.record.get_field(&field);
             let old_stat = instance.common.stat;

--- a/crates/epics-base-rs/tests/dbput_pass0_special_all_bodies.rs
+++ b/crates/epics-base-rs/tests/dbput_pass0_special_all_bodies.rs
@@ -1,0 +1,107 @@
+//! C `dbPut` runs `dbPutSpecial(paddr, 0)` on EVERY entry path —
+//! `dbPutField` (CA/PVA client) and `dbPutLink` (record OUT links)
+//! alike (dbAccess.c). The port has three `dbPut` bodies; only the
+//! external-put one called the record's pass-0 `special()` hook, so a
+//! put-link delivery skipped every pass-0 side effect. The first live
+//! consumer is motor's drive-field DMOV blink (motorRecord.cc:
+//! 2582-2608): without pass-0 on the internal bodies, a same-value
+//! put-link into `motor.VAL` refused at the move-block entry gate
+//! instead of pulsing DMOV like C.
+//!
+//! This pins pass-0 (and pass-1) `special()` on the two internal
+//! bodies: `put_pv` (`dbPutLink` route, via `put_pv_already_locked`)
+//! and `put_pv_and_post` (gateway/sequencer route).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use epics_base_rs::error::{CaError, CaResult};
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::record::{FieldDesc, Record};
+use epics_base_rs::types::{DbFieldType, EpicsValue};
+
+struct Pass0TrackingRecord {
+    val: f64,
+    pass0_count: Arc<AtomicU32>,
+    pass1_count: Arc<AtomicU32>,
+}
+
+impl Record for Pass0TrackingRecord {
+    fn record_type(&self) -> &'static str {
+        "test_pass0"
+    }
+    fn get_field(&self, name: &str) -> Option<EpicsValue> {
+        match name {
+            "VAL" => Some(EpicsValue::Double(self.val)),
+            _ => None,
+        }
+    }
+    fn put_field(&mut self, name: &str, value: EpicsValue) -> CaResult<()> {
+        match name {
+            "VAL" => {
+                if let EpicsValue::Double(v) = value {
+                    self.val = v;
+                    Ok(())
+                } else {
+                    Err(CaError::InvalidValue("bad type".into()))
+                }
+            }
+            _ => Err(CaError::FieldNotFound(name.into())),
+        }
+    }
+    fn declared_fields(&self) -> &'static [FieldDesc] {
+        static FIELDS: &[FieldDesc] = &[FieldDesc::new("VAL", DbFieldType::Double, false)];
+        FIELDS
+    }
+    fn special(&mut self, _field: &str, after: bool) -> CaResult<()> {
+        if after {
+            self.pass1_count.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.pass0_count.fetch_add(1, Ordering::SeqCst);
+        }
+        Ok(())
+    }
+}
+
+fn tracking_record() -> (Pass0TrackingRecord, Arc<AtomicU32>, Arc<AtomicU32>) {
+    let pass0 = Arc::new(AtomicU32::new(0));
+    let pass1 = Arc::new(AtomicU32::new(0));
+    let rec = Pass0TrackingRecord {
+        val: 0.0,
+        pass0_count: pass0.clone(),
+        pass1_count: pass1.clone(),
+    };
+    (rec, pass0, pass1)
+}
+
+/// `put_pv` is the C `dbPut` sitting under `dbPutLink`
+/// (`write_db_link_value` → `put_pv_already_locked` → `put_pv_inner`):
+/// pass-0 must run before the write, pass-1 after, exactly like the
+/// external-put body.
+#[tokio::test]
+async fn put_pv_runs_pass0_special() {
+    let db = PvDatabase::new();
+    let (rec, pass0, pass1) = tracking_record();
+    db.add_record("T0", Box::new(rec)).await.unwrap();
+
+    db.put_pv("T0.VAL", EpicsValue::Double(1.5)).await.unwrap();
+
+    assert_eq!(pass0.load(Ordering::SeqCst), 1, "dbPutSpecial pass 0");
+    assert_eq!(pass1.load(Ordering::SeqCst), 1, "dbPutSpecial pass 1");
+}
+
+/// `put_pv_and_post` is the third `dbPut` body (gateway / sequencer
+/// route) and must match the other two.
+#[tokio::test]
+async fn put_pv_and_post_runs_pass0_special() {
+    let db = PvDatabase::new();
+    let (rec, pass0, pass1) = tracking_record();
+    db.add_record("T1", Box::new(rec)).await.unwrap();
+
+    db.put_pv_and_post("T1.VAL", EpicsValue::Double(2.5))
+        .await
+        .unwrap();
+
+    assert_eq!(pass0.load(Ordering::SeqCst), 1, "dbPutSpecial pass 0");
+    assert_eq!(pass1.load(Ordering::SeqCst), 1, "dbPutSpecial pass 1");
+}

--- a/crates/epics-pva-rs/src/pv_request.rs
+++ b/crates/epics-pva-rs/src/pv_request.rs
@@ -186,8 +186,9 @@ fn build_with_pipeline(fields: &[&str], queue_size: u32, order: ByteOrder) -> Ve
 ///
 /// Rules:
 /// - The pvRequest has shape `structure { structure field { ... } }`.
-///   Each direct child of `field` selects the matching top-level field
-///   in `value_desc` and (recursively) its sub-fields named.
+///   Each entry of `field` — nested (`value { index {} }`) or a literal
+///   dotted name (`"value.index"`), both legal per pvxs's flattened
+///   `mlookup` matching — selects the named field of `value_desc`.
 /// - An empty `field {}` (no children) selects *every* bit (root + all
 ///   descendants).
 /// - Names in pvRequest that don't exist in `value_desc` are silently
@@ -305,10 +306,22 @@ fn mask_for_named_selector(
 /// (`field` / `putField` / `getField`) into a field `BitSet` over
 /// `value_desc`, using pvData spec §5.4 depth-first bit numbering.
 ///
-/// An empty selector (`{}`) selects every bit (root + all descendants);
-/// otherwise each named child selects the matching top-level field of
-/// `value_desc` and, recursively, the sub-fields it names. Returns
-/// `Err(EmptyMask)` when no named child matched any existing field.
+/// pvxs `request2mask` (pvrequest.cpp:13-52) iterates the request's
+/// *flattened* member map (`rdesc->mlookup`), whose keys include dotted
+/// paths propagated through nested sub-structures (type.cpp:270-279).
+/// Two request shapes are therefore equivalent on the wire and both must
+/// resolve: nested `field { value { index {} } }` AND a child literally
+/// named `"value.index"` (what a foreign client's low-level builder may
+/// emit — the Rust ≤0.17.x `build_pv_request_fields` did exactly this).
+/// Each entry resolves against the value descriptor's own flattened map
+/// (`desc->mlookup.find(pair.first)`), i.e. a dotted-path lookup.
+///
+/// An empty selector (`{}`) selects every bit (root + all descendants).
+/// A matched entry sets its own bit only — plus its whole sub-tree when
+/// the request child has no sub-selectors (pvrequest.cpp:41-46). Only
+/// structure-typed request children participate (pvrequest.cpp:31); a
+/// scalar child is skipped exactly as pvxs skips it. Returns
+/// `Err(EmptyMask)` when no entry matched any existing field.
 fn mask_from_selector_fields(
     value_desc: &crate::pvdata::FieldDesc,
     selector_fields: &[(String, crate::pvdata::FieldDesc)],
@@ -320,18 +333,50 @@ fn mask_from_selector_fields(
         return Ok(select_all_bits(value_desc));
     }
 
-    // Walk each requested top-level name and recursively select bits.
+    // Flatten the selector into dotted entries, mirroring the request
+    // side's `mlookup` (nested children contribute "parent.child" keys;
+    // propagation descends structures only, type.cpp:274).
+    fn flatten<'a>(
+        prefix: &str,
+        fields: &'a [(String, FieldDesc)],
+        out: &mut Vec<(String, &'a FieldDesc)>,
+    ) {
+        for (name, child) in fields {
+            if name.is_empty() {
+                continue;
+            }
+            if let FieldDesc::Structure { fields: sub, .. } = child {
+                let path = if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}.{name}")
+                };
+                flatten(&path, sub, out);
+                out.push((path, child));
+            }
+        }
+    }
+    let mut entries: Vec<(String, &FieldDesc)> = Vec::new();
+    flatten("", selector_fields, &mut entries);
+
     let mut mask = crate::proto::BitSet::new();
     let mut any_matched = false;
-    if let FieldDesc::Structure { fields, .. } = value_desc {
-        let mut child_bit = 1usize;
-        for (name, child_desc) in fields {
-            if let Some((_, sub_request)) = selector_fields.iter().find(|(n, _)| n == name) {
-                any_matched = true;
-                // Mark this field and recurse.
-                mark_path(&mut mask, child_bit, child_desc, sub_request);
+    for (path, req_child) in &entries {
+        let Some((start, end)) = value_desc.bit_span_for_path(path) else {
+            // Request of a non-existent field — silently skipped
+            // (pvrequest.cpp:48-50).
+            continue;
+        };
+        any_matched = true;
+        mask.set(start);
+        // No sub-selectors → implicit select of the entire sub-tree
+        // (pvrequest.cpp:41-46). For a leaf the span is the single bit.
+        let leaf_selector =
+            matches!(req_child, FieldDesc::Structure { fields, .. } if fields.is_empty());
+        if leaf_selector {
+            for bit in start..end {
+                mask.set(bit);
             }
-            child_bit += child_desc.total_bits();
         }
     }
 
@@ -340,42 +385,6 @@ fn mask_from_selector_fields(
     }
     mask.set(0); // root — pvxs `testpvreq.cpp` request/selection-mask parity
     Ok(mask)
-}
-
-/// Recursively mark `value_desc`'s bit (at `bit_offset`) plus any
-/// requested sub-fields as defined by `sub_request`.
-fn mark_path(
-    mask: &mut crate::proto::BitSet,
-    bit_offset: usize,
-    value_desc: &crate::pvdata::FieldDesc,
-    sub_request: &crate::pvdata::FieldDesc,
-) {
-    use crate::pvdata::FieldDesc;
-    mask.set(bit_offset);
-
-    // Pick out the named sub-fields requested.
-    let sub_fields = match sub_request {
-        FieldDesc::Structure { fields, .. } => fields,
-        _ => return,
-    };
-    if sub_fields.is_empty() {
-        // Empty {} selects this entire sub-tree.
-        let total = value_desc.total_bits();
-        for i in 0..total {
-            mask.set(bit_offset + i);
-        }
-        return;
-    }
-
-    if let FieldDesc::Structure { fields, .. } = value_desc {
-        let mut child_bit = bit_offset + 1;
-        for (name, child_desc) in fields {
-            if let Some((_, sub2)) = sub_fields.iter().find(|(n, _)| n == name) {
-                mark_path(mask, child_bit, child_desc, sub2);
-            }
-            child_bit += child_desc.total_bits();
-        }
-    }
 }
 
 /// Errors from [`request_to_mask`].
@@ -1763,6 +1772,151 @@ mod tests {
         assert!(
             request_to_mask(&ntenum, Some(&req)).is_ok(),
             "request_to_mask must resolve a nested value.index path"
+        );
+    }
+
+    /// NTEnum-shaped fixture. Bit numbering (pvData §5.4 DFS):
+    /// root=0, value=1, value.index=2, alarm=3.
+    fn ntenum_desc() -> FieldDesc {
+        use crate::pvdata::ScalarType;
+        FieldDesc::Structure {
+            struct_id: "epics:nt/NTEnum:1.0".to_string(),
+            fields: vec![
+                (
+                    "value".to_string(),
+                    FieldDesc::Structure {
+                        struct_id: String::new(),
+                        fields: vec![("index".to_string(), FieldDesc::Scalar(ScalarType::Int))],
+                    },
+                ),
+                (
+                    "alarm".to_string(),
+                    FieldDesc::Structure {
+                        struct_id: String::new(),
+                        fields: Vec::new(),
+                    },
+                ),
+            ],
+        }
+    }
+
+    /// pvRequest `structure { field { <children> } }` with the given
+    /// selector children.
+    fn req_with_field_children(children: Vec<(String, FieldDesc)>) -> FieldDesc {
+        FieldDesc::Structure {
+            struct_id: String::new(),
+            fields: vec![(
+                "field".to_string(),
+                FieldDesc::Structure {
+                    struct_id: String::new(),
+                    fields: children,
+                },
+            )],
+        }
+    }
+
+    fn empty_struct() -> FieldDesc {
+        FieldDesc::Structure {
+            struct_id: String::new(),
+            fields: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn dotted_literal_selector_matches_via_flattened_lookup() {
+        // pvxs `request2mask` iterates `rdesc->mlookup`, whose keys are
+        // flattened dotted paths (type.cpp:270-279), and resolves each
+        // against `desc->mlookup` — so a selector child literally named
+        // "value.index" (what the Rust ≤0.17.x `build_pv_request_fields`
+        // put on the wire for NTEnum puts) selects the nested field.
+        // Only the resolved offset is set (pvrequest.cpp:38): index's
+        // bit, NOT the intermediate `value` struct bit.
+        let req = req_with_field_children(vec![("value.index".to_string(), empty_struct())]);
+        let mask = request_to_mask(&ntenum_desc(), Some(&req))
+            .expect("dotted literal selector must resolve");
+        assert!(mask.get(0), "root bit");
+        assert!(!mask.get(1), "intermediate `value` struct bit stays clear");
+        assert!(mask.get(2), "value.index leaf bit");
+        assert!(!mask.get(3), "alarm not selected");
+    }
+
+    #[test]
+    fn dotted_literal_selector_unmatched_errors() {
+        let req = req_with_field_children(vec![("value.noSuch".to_string(), empty_struct())]);
+        assert_eq!(
+            request_to_mask(&ntenum_desc(), Some(&req)),
+            Err(RequestMaskError::EmptyMask),
+            "a dotted selector matching nothing must error like pvxs"
+        );
+    }
+
+    #[test]
+    fn nested_selector_sets_intermediate_and_leaf_bits() {
+        // The nested form `field { value { index {} } }` flattens to TWO
+        // request entries — "value" and "value.index" — so pvxs sets both
+        // offsets. `value`'s entry has a sub-selector, so it does NOT
+        // implicitly select its whole sub-tree.
+        let req = req_with_field_children(vec![(
+            "value".to_string(),
+            FieldDesc::Structure {
+                struct_id: String::new(),
+                fields: vec![("index".to_string(), empty_struct())],
+            },
+        )]);
+        let mask = request_to_mask(&ntenum_desc(), Some(&req)).expect("nested form resolves");
+        assert!(mask.get(0), "root bit");
+        assert!(mask.get(1), "`value` struct bit (own request entry)");
+        assert!(mask.get(2), "value.index leaf bit");
+        assert!(!mask.get(3), "alarm not selected");
+    }
+
+    #[test]
+    fn scalar_typed_selector_child_is_skipped() {
+        // pvxs processes only Struct request children
+        // (`crdesc->code==TypeCode::Struct`, pvrequest.cpp:31); a scalar
+        // child never marks `foundrequested`, so a request with only a
+        // scalar child errors.
+        use crate::pvdata::ScalarType;
+        let req = req_with_field_children(vec![(
+            "value".to_string(),
+            FieldDesc::Scalar(ScalarType::Int),
+        )]);
+        assert_eq!(
+            request_to_mask(&ntenum_desc(), Some(&req)),
+            Err(RequestMaskError::EmptyMask),
+            "scalar-typed selector children are skipped per pvxs"
+        );
+    }
+
+    #[test]
+    fn put_get_masks_resolve_dotted_literal_legs() {
+        // The PUT_GET putField/getField legs go through the same
+        // selector translation and must accept dotted literals too.
+        let req = FieldDesc::Structure {
+            struct_id: String::new(),
+            fields: vec![
+                (
+                    "putField".to_string(),
+                    FieldDesc::Structure {
+                        struct_id: String::new(),
+                        fields: vec![("value.index".to_string(), empty_struct())],
+                    },
+                ),
+                (
+                    "getField".to_string(),
+                    FieldDesc::Structure {
+                        struct_id: String::new(),
+                        fields: vec![("value".to_string(), empty_struct())],
+                    },
+                ),
+            ],
+        };
+        let (put_mask, get_mask) =
+            put_get_masks(&ntenum_desc(), Some(&req)).expect("both legs resolve");
+        assert!(put_mask.get(2) && !put_mask.get(1), "put leg: index only");
+        assert!(
+            get_mask.get(1) && get_mask.get(2),
+            "get leg: value sub-tree (empty selector → implicit all)"
         );
     }
 

--- a/crates/epics-pva-rs/src/pvdata/field.rs
+++ b/crates/epics-pva-rs/src/pvdata/field.rs
@@ -95,6 +95,19 @@ impl FieldDesc {
         find_bit_for_path(self, 0, &parts).map(|(idx, _)| idx)
     }
 
+    /// Resolve a dotted field path to its `(start, end)` bit span —
+    /// `start` is the field's own bit, `end` is one past its last
+    /// descendant (`start + total_bits`). Non-structure fields span one
+    /// bit. Returns `None` for a missing segment; the empty path is the
+    /// root's full span.
+    pub(crate) fn bit_span_for_path(&self, path: &str) -> Option<(usize, usize)> {
+        if path.is_empty() {
+            return Some((0, self.total_bits()));
+        }
+        let parts: Vec<&str> = path.split('.').collect();
+        find_bit_for_path(self, 0, &parts)
+    }
+
     /// True iff this descriptor names a string type (Scalar/String).
     pub fn is_string_like(&self) -> bool {
         matches!(self, FieldDesc::Scalar(ScalarType::String))

--- a/crates/motor-rs/ioc/motor.template
+++ b/crates/motor-rs/ioc/motor.template
@@ -2,6 +2,11 @@ record(motor, "$(P)$(M)") {
     field(DTYP, "simMotor_$(PORT)")
     field(SCAN, "Passive")
     field(VELO, "$(VELO=1.0)")
+    # HVEL must be configured for homing to be usable: C leaves HVEL at 0
+    # (no dbd initial) and check_speed_and_resolution derives it from VBAS
+    # (motorRecord.cc:4064-4065), which is also 0 here — the home dispatch
+    # would send SET_VELOCITY 0 (C 2047 has no zero guard).
+    field(HVEL, "$(HVEL=1.0)")
     field(ACCL, "$(ACCL=0.5)")
     field(DHLM, "$(HLM=100.0)")
     field(DLLM, "$(LLM=-100.0)")

--- a/crates/motor-rs/src/record/command_planner.rs
+++ b/crates/motor-rs/src/record/command_planner.rs
@@ -394,12 +394,17 @@ impl MotorRecord {
                         }
                     }
                 }
-                // C move-block entry (2240): `dval != ldvl || !dmov`. A
-                // same-value re-put does not re-enter the move block —
-                // notably after a retry give-up, where maybeRetry adopted
-                // the unreached target into the lasts (1067-1069) with
-                // MISS latched — the pass falls to the chain end instead
-                // (latched SYNC, implicit GET_INFO, 2540-2557).
+                // C move-block entry (2240): `dval != ldvl || !dmov`.
+                // A database put never fails this gate — the special()
+                // pass-0 blink (2582-2608) dropped DMOV before the pass
+                // — so a same-value dbPut re-put re-enters and the
+                // dispatch gate (2455, `mip == MIP_DONE || MIP_RETRY`)
+                // re-sends the move: C retries a missed target on an
+                // operator re-put. What the entry gate refuses is the
+                // UNBLINKED same-value pass — the closed-loop DOL
+                // collection (a bare dbGetLink, 1994, no special) and
+                // housekeeping passes — which falls to the chain end
+                // instead (latched SYNC, implicit GET_INFO, 2540-2557).
                 if !self.stat.dmov || self.pos.dval != self.internal.ldvl {
                     self.plan_absolute_move(&mut effects);
                 } else {
@@ -477,9 +482,11 @@ impl MotorRecord {
             CommandSource::Twf | CommandSource::Twr => {
                 // The fold already ran in the collection above (SET-mode
                 // redefinition included); dispatch the pending move (C
-                // move block firing on the folded val change). A zero
-                // fold (TWV = 0) leaves DVAL at the lasts and the entry
-                // gate (2240) refuses like C — chain end instead.
+                // move block firing on the folded val change). A dbPut
+                // to TWF/TWR is blinked (special pass-0, 2582-2608), so
+                // even a zero fold (TWV = 0) enters via `!dmov` and
+                // too_small pulses DMOV like C; only an unblinked zero
+                // fold refuses at the entry gate (2240) — chain end.
                 if tweak_pending {
                     if !self.stat.dmov || self.pos.dval != self.internal.ldvl {
                         self.plan_absolute_move(&mut effects);
@@ -501,10 +508,11 @@ impl MotorRecord {
                 // C: the SET-mode redefinition dispatches through the
                 // move block (2240-2263) — plan_absolute_move recomputes
                 // DIFF/RDIF and its set test routes to load_pos. The
-                // entry gate (2240) applies first: a same-value
-                // redefinition re-put (load_pos synced the lasts at
-                // dispatch) does not re-send LOAD_POS — like C it falls
-                // to the chain end.
+                // entry gate (2240) applies first, but a dbPut to a
+                // drive field is blinked (special pass-0, 2582-2608) and
+                // always re-enters — C re-sends LOAD_POS on a same-value
+                // redefinition re-put. Only an unblinked same-value pass
+                // (no fresh drive write) falls to the chain end.
                 if !self.stat.dmov || self.pos.dval != self.internal.ldvl {
                     self.plan_absolute_move(&mut effects);
                 } else {
@@ -738,6 +746,28 @@ impl MotorRecord {
         };
         if self.is_blocked_by_hw_limit(dir) {
             tracing::warn!("hardware limit active, blocking {dir:?} move");
+            // C has no hardware-limit gate in the move block: it
+            // dispatches (2455-2540, adopting the lasts at 2469-2471),
+            // the driver stops at the switch, and maybeRetry's
+            // limit-switch escape (1049, `hls && user_cdir`) completes
+            // the move as close-enough. This refusal skips the futile
+            // controller command but must land the same end state:
+            // lasts adopted (the written target stays in VAL/DVAL like
+            // C, and no dangling `dval != ldvl` re-dispatches on a
+            // later SPMG pass), an armed retry collapsed, and a
+            // pending pulse completed — a blinked put (special pass-0,
+            // 2582-2608) must not leave DMOV latched low with nothing
+            // in flight to restore it.
+            self.internal.ldvl = self.pos.dval;
+            self.internal.lval = self.pos.val;
+            self.internal.lrvl = self.pos.rval;
+            if self.stat.mip.contains(MipFlags::RETRY) {
+                self.stat.mip = MipFlags::empty();
+            }
+            if self.stat.mip.is_empty() && !self.stat.dmov {
+                self.stat.dmov = true;
+                self.set_phase(MotionPhase::Idle);
+            }
             return;
         }
 
@@ -2053,8 +2083,30 @@ impl MotorRecord {
         }
 
         // Sub-step pulse recovery: if DMOV is false but phase is Idle
-        // (no real motion started), finalize to restore DMOV=1.
-        if !self.stat.dmov && self.stat.phase == MotionPhase::Idle && self.stat.mip.is_empty() {
+        // (no real motion started), finalize to restore DMOV=1. This is
+        // the pulse's high half — C's too_small (2333-2347) restores
+        // DMOV on the same pass; the Rust pulse splits it so the low
+        // half posts, and too_small's lasts adoption (ldvl <- dval) is
+        // what marks the pulse as started. Two states share the DMOV-
+        // low/Idle/MIP-empty shape and must NOT be finalized:
+        //
+        // - A put-owned pass: the C special() pass-0 blink (2582-2608)
+        //   drops DMOV before the record processes, so a pending
+        //   last_write/UserWrite arrives here with DMOV already low —
+        //   the blink is the pass's move-block entry ticket (2240), not
+        //   a completed pulse, and the pass must reach its dispatch arm.
+        // - A parked blinked put (dval != ldvl): written under
+        //   SPMG=Pause/Stop, waiting for the Go pass to dispatch — C
+        //   keeps DMOV low across the pause ("not done": a move is
+        //   pending).
+        let put_owned = self.last_write.is_some()
+            || matches!(self.pending_event, Some(MotorEvent::UserWrite(_)));
+        if !put_owned
+            && !self.stat.dmov
+            && self.stat.phase == MotionPhase::Idle
+            && self.stat.mip.is_empty()
+            && self.pos.dval == self.internal.ldvl
+        {
             let mut effects = ProcessEffects::default();
             self.finalize_motion(&mut effects);
             return effects;

--- a/crates/motor-rs/src/record/mod.rs
+++ b/crates/motor-rs/src/record/mod.rs
@@ -395,6 +395,42 @@ impl Record for MotorRecord {
         dbd_generated::MOTOR_FIELDS
     }
 
+    /// C `special()` pass-0 blink (motorRecord.cc:2582-2608): "Someone
+    /// wrote to drive field. Blink .dmov unless record is disabled."
+    /// Every database put to a drive field drops DMOV before the record
+    /// processes — that blink is what carries the put pass through the
+    /// do_work move-block entry gate (2240, `dval != ldvl || !dmov`)
+    /// even when the target equals the last-dispatched one; the move
+    /// block then decides between the sub-step pulse restore
+    /// (too_small, 2333-2342), a re-dispatch (2455, `mip == MIP_DONE ||
+    /// MIP_RETRY`), and the SET-mode load_pos. The entry gate itself
+    /// only ever refuses passes that did NOT come through database put
+    /// access — C's closed-loop DOL collection is a bare `dbGetLink`
+    /// into VAL (1994) with no special, mirrored here by the framework
+    /// link reads landing via `put_field_internal`, which never runs
+    /// this hook.
+    ///
+    /// C's disabled-record gate (2600-2601): the DISP half is enforced
+    /// upstream — the framework rejects the put before this hook runs
+    /// (`check_put_disabled`, C dbPutField's put-disable test), so no
+    /// blink can land on a DISP'd record. The DISA==DISV half is not
+    /// reachable from the record trait (DISA/DISV are framework common
+    /// fields); a drive put to a processing-disabled motor blinks DMOV
+    /// low and it stays low until the record next processes, where C
+    /// keeps DMOV=1. Known divergence.
+    fn special(&mut self, field: &str, after: bool) -> CaResult<()> {
+        if after {
+            return Ok(());
+        }
+        if ["VAL", "DVAL", "RVAL", "RLV", "TWF", "TWR"]
+            .iter()
+            .any(|f| field.eq_ignore_ascii_case(f))
+        {
+            self.stat.dmov = false;
+        }
+        Ok(())
+    }
+
     /// C `init_record`: on pass 1, once all `field()` values have been
     /// applied, reconcile the rev↔EGU speed pairs (C
     /// `check_speed_and_resolution`) and establish the limit invariant from
@@ -419,6 +455,12 @@ impl Record for MotorRecord {
             if self.conv.eres == 0.0 {
                 self.conv.eres = self.conv.mres;
             }
+            // C 721-723: `dmov = TRUE; movn = FALSE` — DMOV starts done
+            // no matter what the load wrote. In particular this
+            // neutralizes any `special()` pass-0 blink a load-time /
+            // restore write to a drive field may have left behind.
+            self.stat.dmov = true;
+            self.stat.movn = false;
             // C 734-743: LVIO starts clear; with soft limits enabled
             // (the dial pair not both 0), an initial dial readback
             // outside the dial window by more than one MRES, or an

--- a/crates/motor-rs/tests/record_tests.rs
+++ b/crates/motor-rs/tests/record_tests.rs
@@ -8946,13 +8946,15 @@ fn test_alarm_cycle_fans_out_alarm_mask_to_monitored_fields() {
 }
 
 #[test]
-fn test_same_value_reput_after_miss_giveup_refuses_with_get_info() {
-    // C do_work entry gates (motorRecord.cc:2204, 2240): after a retry
-    // give-up (maybeRetry 1060-1075 adopts the unreached target into
-    // lval/ldvl/lrvl with MISS latched), a re-put of the SAME target
-    // fails `val != lval` and `dval != ldvl || !dmov` — no new move
-    // dispatches; the pass falls to the chain end and fires the
-    // implicit GET_INFO (2546-2557).
+fn test_same_value_unblinked_pass_after_miss_giveup_refuses_with_get_info() {
+    // C do_work entry gates (motorRecord.cc:2204, 2240) refuse a pass
+    // that arrives WITHOUT the special() pass-0 blink — the closed-loop
+    // DOL collection (a bare dbGetLink into VAL, 1994, no special) and
+    // housekeeping passes. After a retry give-up (maybeRetry 1060-1075
+    // adopts the unreached target into lval/ldvl/lrvl with MISS
+    // latched), a same-value unblinked delivery fails `val != lval` and
+    // `dval != ldvl || !dmov` — no new move dispatches; the pass falls
+    // to the chain end and fires the implicit GET_INFO (2546-2557).
     let mut rec = MotorRecord::new();
     rec.set_device_state(motor_rs::device_state::new_shared_state());
     rec.stat.msta = MstaFlags::DONE;
@@ -8971,11 +8973,11 @@ fn test_same_value_reput_after_miss_giveup_refuses_with_get_info() {
     assert!(rec.stat.dmov);
     assert_eq!(rec.internal.ldvl, 10.0, "lasts adopt the unreached target");
 
-    // Same-value re-put: the write cascade leaves VAL/DVAL unchanged.
+    // Same-value delivery with no blink (no dbPut ran).
     let effects = rec.plan_motion(CommandSource::Val);
     assert!(
         effects.commands.is_empty(),
-        "C 2240: same-value re-put does not re-dispatch the move"
+        "C 2240: same-value unblinked pass does not re-dispatch the move"
     );
     assert!(
         rec.retry.miss,
@@ -8987,6 +8989,52 @@ fn test_same_value_reput_after_miss_giveup_refuses_with_get_info() {
         "chain end fires the implicit GET_INFO"
     );
     assert_eq!(rec.stat.stup, 2, "STUP goes BUSY for the refresh");
+}
+
+#[test]
+fn test_same_value_dbput_after_miss_giveup_redispatches() {
+    // A database put is preceded by the special() pass-0 blink
+    // (motorRecord.cc:2582-2608): DMOV drops before the record
+    // processes, the entry gate (2240) passes via `!dmov`, the target
+    // sits 500 steps out (not too_small), and the dispatch gate (2455,
+    // `mip == MIP_DONE`) sends the move again — C retries a missed
+    // target on an operator re-put of the same value.
+    let mut rec = MotorRecord::new();
+    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    rec.stat.msta = MstaFlags::DONE;
+    rec.stat.phase = MotionPhase::MainMove;
+    rec.stat.dmov = false;
+    rec.conv.mres = 0.001;
+    rec.retry.rdbd = 0.1;
+    rec.retry.rtry = 3;
+    rec.retry.rcnt = 3; // exhausted
+    rec.pos.val = 10.0;
+    rec.pos.dval = 10.0;
+    rec.pos.drbv = 9.5; // error 0.5 > rdbd -> give-up
+
+    let _ = rec.check_completion();
+    assert!(rec.retry.miss, "give-up latches MISS");
+    assert!(rec.stat.dmov);
+
+    // dbPut of the same VAL: framework order is special(pass 0), then
+    // put_field, then the pp process pass.
+    rec.special("VAL", false).unwrap();
+    assert!(!rec.stat.dmov, "pass-0 blink drops DMOV");
+    rec.put_field("VAL", EpicsValue::Double(10.0)).unwrap();
+    let effects = rec.do_process();
+    assert!(
+        effects
+            .commands
+            .iter()
+            .any(|c| matches!(c, MotorCommand::MoveAbsolute { .. })),
+        "C 2455: blinked same-value re-put re-dispatches the missed move"
+    );
+    assert!(!rec.stat.dmov, "move in flight");
+    assert_eq!(rec.stat.phase, MotionPhase::MainMove);
+    assert!(
+        rec.retry.miss,
+        "MISS stays latched until maybeRetry lands close enough"
+    );
 }
 
 #[test]
@@ -9023,10 +9071,14 @@ fn test_new_target_after_miss_giveup_dispatches() {
 }
 
 #[test]
-fn test_same_value_set_redefinition_does_not_resend_load_pos() {
-    // C 2240 sits ahead of the set test (2257-2263): load_pos synced
-    // the lasts at dispatch (3771-3817), so re-putting the same DVAL in
-    // SET mode falls to the chain end instead of re-sending LOAD_POS.
+fn test_same_value_set_redefinition_resends_load_pos_when_blinked() {
+    // C: a dbPut to DVAL is preceded by the special() pass-0 blink
+    // (2582-2608) even in SET mode, so a same-value redefinition re-put
+    // re-enters the move block via `!dmov` (2240) and the set test
+    // (2257-2263) routes it to load_pos again — the redefinition is a
+    // command, not a value change, and C re-sends LOAD_POS for it.
+    // Without the blink (no fresh drive write) the entry gate refuses
+    // and the pass falls to the chain end instead.
     let mut rec = MotorRecord::new();
     rec.set_device_state(motor_rs::device_state::new_shared_state());
     rec.conv.mres = 1.0;
@@ -9038,6 +9090,7 @@ fn test_same_value_set_redefinition_does_not_resend_load_pos() {
     rec.internal.ldvl = 5.0;
     rec.put_field("SET", EpicsValue::Short(1)).unwrap();
 
+    rec.special("DVAL", false).unwrap();
     rec.put_field("DVAL", EpicsValue::Double(0.0)).unwrap();
     let effects = rec.plan_motion(CommandSource::Set);
     assert!(
@@ -9056,11 +9109,32 @@ fn test_same_value_set_redefinition_does_not_resend_load_pos() {
     let _ = rec.check_completion();
     assert!(rec.stat.dmov, "LOAD_P cycle completed");
 
+    // Same-value re-put, blinked like every dbPut.
+    rec.special("DVAL", false).unwrap();
     rec.put_field("DVAL", EpicsValue::Double(0.0)).unwrap();
     let effects = rec.plan_motion(CommandSource::Set);
     assert!(
+        effects
+            .commands
+            .iter()
+            .any(|c| matches!(c, MotorCommand::SetPosition { .. })),
+        "C re-sends LOAD_POS on a blinked same-value redefinition re-put"
+    );
+
+    // Unblinked same-value pass (no fresh drive write): entry gate
+    // (2240) refuses — chain end, implicit GET_INFO.
+    let status = asyn_rs::interfaces::motor::MotorStatus {
+        position: 0.0,
+        done: true,
+        ..Default::default()
+    };
+    rec.process_motor_info(&status);
+    let _ = rec.check_completion();
+    assert!(rec.stat.dmov, "second LOAD_P cycle completed");
+    let effects = rec.plan_motion(CommandSource::Set);
+    assert!(
         effects.commands.is_empty(),
-        "no second LOAD_POS for the same value"
+        "no LOAD_POS on an unblinked same-value pass"
     );
     assert!(
         effects.status_refresh,
@@ -9069,11 +9143,11 @@ fn test_same_value_set_redefinition_does_not_resend_load_pos() {
 }
 
 #[test]
-fn test_zero_tweak_refuses_and_falls_to_chain_end() {
-    // C: the tweak fold (2167-2181) with TWV = 0 leaves VAL unchanged;
-    // the collection gate (2204) and the move-block entry (2240) both
-    // refuse, and the pass ends at the chain end (implicit GET_INFO,
-    // 2546-2557) — no move, no DMOV pulse.
+fn test_unblinked_zero_tweak_refuses_and_falls_to_chain_end() {
+    // An UNBLINKED zero fold (TWV = 0, no dbPut ran): the fold leaves
+    // VAL unchanged, the collection gate (2204) and the move-block
+    // entry (2240) both refuse, and the pass ends at the chain end
+    // (implicit GET_INFO, 2546-2557) — no move, no DMOV pulse.
     let mut rec = MotorRecord::new();
     rec.set_device_state(motor_rs::device_state::new_shared_state());
     rec.stat.msta = MstaFlags::DONE;
@@ -9092,5 +9166,108 @@ fn test_zero_tweak_refuses_and_falls_to_chain_end() {
     assert!(
         effects.status_refresh,
         "chain end fires the implicit GET_INFO"
+    );
+}
+
+#[test]
+fn test_blinked_zero_tweak_pulses_dmov() {
+    // A dbPut to TWF is preceded by the special() pass-0 blink
+    // (2582-2608, TWF is in the blink list), so even a zero fold
+    // (TWV = 0) enters the move block via `!dmov` (2240); at position
+    // the request is too_small and the sub-step pulse runs — DMOV
+    // 1→0→1, no controller command (C 2333-2342 restores DMOV=TRUE on
+    // the same pass; the Rust pulse posts the low half and the
+    // recovery pass restores it).
+    let mut rec = MotorRecord::new();
+    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    rec.stat.msta = MstaFlags::DONE;
+    rec.conv.mres = 0.001;
+    rec.pos.val = 10.0;
+    rec.pos.dval = 10.0;
+    rec.pos.drbv = 10.0;
+    rec.internal.lval = 10.0;
+    rec.internal.ldvl = 10.0;
+    rec.ctrl.twv = 0.0;
+
+    rec.special("TWF", false).unwrap();
+    assert!(!rec.stat.dmov, "pass-0 blink drops DMOV");
+    rec.ctrl.twf = true;
+    let effects = rec.plan_motion(CommandSource::Twf);
+    assert!(effects.commands.is_empty(), "zero fold sends no command");
+    assert!(!rec.stat.dmov, "pulse low half");
+    assert!(rec.stat.movn, "pulse presents as a (zero-length) move");
+    assert!(effects.request_poll, "pulse schedules the recovery pass");
+
+    // The recovery pass (no pending put) restores DMOV=1.
+    let _ = rec.do_process();
+    assert!(rec.stat.dmov, "pulse high half restores DMOV");
+    assert!(!rec.stat.movn);
+}
+
+#[test]
+fn test_special_pass0_blinks_dmov_for_drive_fields_only() {
+    // C special() pass-0 (motorRecord.cc:2582-2608): exactly the six
+    // drive fields blink DMOV; nothing else does, and the after-put
+    // pass (pass 1) never blinks.
+    for f in ["VAL", "DVAL", "RVAL", "RLV", "TWF", "TWR"] {
+        let mut rec = MotorRecord::new();
+        assert!(rec.stat.dmov);
+        rec.special(f, false).unwrap();
+        assert!(!rec.stat.dmov, "pass-0 blink drops DMOV for {f}");
+    }
+    let mut rec = MotorRecord::new();
+    rec.special("VAL", true).unwrap();
+    assert!(rec.stat.dmov, "after-put special does not blink");
+    for f in ["TWV", "SET", "SPMG", "STOP", "HOMF", "JOGF", "VELO"] {
+        rec.special(f, false).unwrap();
+        assert!(rec.stat.dmov, "{f} is not a drive field — no blink");
+    }
+}
+
+#[test]
+fn test_init_record_pass1_restores_dmov_after_load_time_blink() {
+    // C init_record (721-723): dmov = TRUE, movn = FALSE no matter
+    // what the load wrote — a load-time write to a drive field may
+    // have run the pass-0 blink, and DMOV must still start done.
+    let mut rec = MotorRecord::new();
+    rec.special("VAL", false).unwrap();
+    rec.put_field("VAL", EpicsValue::Double(1.0)).unwrap();
+    assert!(!rec.stat.dmov, "load-time blink left DMOV low");
+    rec.init_record(1).unwrap();
+    assert!(rec.stat.dmov, "init pass 1 restores DMOV=1 (C 721)");
+    assert!(!rec.stat.movn, "init pass 1 clears MOVN (C 723)");
+}
+
+#[test]
+fn test_blinked_put_blocked_by_hw_limit_completes_with_lasts_adopted() {
+    // A blinked put whose first leg is blocked by an active hardware
+    // limit switch: C dispatches it (no hw-limit gate in the move
+    // block), the driver stops at the switch, and maybeRetry's
+    // limit-switch escape (1049) completes it with the lasts already
+    // adopted at dispatch (2469-2471). The Rust refusal skips the
+    // controller command but lands the same end state — the written
+    // target stays in VAL/DVAL, the lasts adopt it (no dangling
+    // re-dispatch on a later SPMG pass), and the pending pulse
+    // completes with DMOV=1 (the blink must not stay latched low).
+    let mut rec = MotorRecord::new();
+    rec.stat.msta = MstaFlags::DONE;
+    rec.conv.mres = 0.001;
+    rec.limits.hls = true; // parked on the high limit switch
+
+    rec.special("VAL", false).unwrap();
+    rec.put_field("VAL", EpicsValue::Double(10.0)).unwrap();
+    let effects = rec.do_process();
+    assert!(effects.commands.is_empty(), "blocked move sends nothing");
+    assert!(rec.stat.dmov, "refusal completes the pending pulse");
+    assert_eq!(rec.stat.phase, MotionPhase::Idle);
+    assert_eq!(rec.pos.val, 10.0, "the written target stays (C parity)");
+    assert_eq!(rec.internal.ldvl, rec.pos.dval, "lasts adopt the target");
+
+    // No dangling re-dispatch: an SPMG=Go pass finds nothing pending.
+    rec.ctrl.spmg = SpmgMode::Go;
+    let effects = rec.plan_motion(CommandSource::Spmg);
+    assert!(
+        effects.commands.is_empty(),
+        "no stale target dispatches after the refusal"
     );
 }

--- a/crates/motor-rs/tests/scenarios.rs
+++ b/crates/motor-rs/tests/scenarios.rs
@@ -1169,10 +1169,15 @@ fn sim_motor_end_to_end() {
     assert!((rec.pos.rbv - 10.0).abs() < 1e-6);
 }
 
-/// Setting VAL to the current position must still produce a DMOV 1→0→1
-/// transition. ophyd/bluesky rely on this to detect move completion.
+/// A database put of VAL to the current position produces a DMOV
+/// 1→0→1 pulse: the special() pass-0 blink (motorRecord.cc:2582-2608)
+/// drops DMOV, the move-block entry gate (2240) passes via `!dmov`,
+/// and too_small (2333-2342) completes the zero-length "move".
+/// ophyd/bluesky rely on this edge to detect move completion.
+/// Full framework order: special(pass 0) → put_field → process pass
+/// (consumes last_write) → recovery pass restores DMOV.
 #[test]
-fn move_to_same_position_refuses_without_dmov_pulse() {
+fn dbput_to_same_position_pulses_dmov() {
     let mut rec = make_record();
 
     rec.pos.val = 0.0;
@@ -1183,35 +1188,100 @@ fn move_to_same_position_refuses_without_dmov_pulse() {
     rec.stat.dmov = true;
     rec.stat.phase = MotionPhase::Idle;
 
-    // Write VAL=0 (same as the last-dispatched target): C do_work
-    // refuses the pass at the entry gates (motorRecord.cc:2204, 2240)
-    // — no command, no DMOV edge; the pass is pure housekeeping.
+    rec.special("VAL", false).unwrap();
+    assert!(!rec.stat.dmov, "pass-0 blink drops DMOV");
     rec.put_field("VAL", EpicsValue::Double(0.0)).unwrap();
-    let effects = rec.plan_motion(CommandSource::Val);
 
-    assert!(rec.stat.dmov, "DMOV stays 1 — C refuses the pass");
+    // The pp process pass: put-owned (last_write = Val), so the pulse
+    // recovery must NOT eat it — it dispatches, lands in too_small,
+    // and posts the pulse's low half.
+    let effects = rec.do_process();
+    assert!(!rec.stat.dmov, "pulse low half");
+    assert!(rec.stat.movn, "pulse presents as a (zero-length) move");
     assert!(effects.commands.is_empty(), "no motor command");
+    assert!(effects.request_poll, "pulse schedules the recovery pass");
     assert_eq!(rec.stat.phase, MotionPhase::Idle);
+
+    // The recovery pass restores DMOV=1 — the pulse's high half.
+    let _ = rec.do_process();
+    assert!(rec.stat.dmov, "DMOV returns to 1");
+    assert!(!rec.stat.movn);
 }
 
-/// Same-position re-put after a genuinely completed move: the lasts
-/// were synced at the dispatch, so the C entry gate (2240) refuses —
-/// no command, no DMOV edge — end-to-end through the completion flow.
+/// Same-position dbPut re-put after a genuinely completed move,
+/// end-to-end through the completion flow: the blink re-opens the
+/// entry gate, too_small pulses. An unblinked same-value pass (no
+/// fresh drive write — C's closed-loop DOL dbGetLink delivery) is the
+/// one the entry gate (2240) refuses with no DMOV edge.
 #[test]
-fn same_position_reput_after_completed_move_refuses() {
+fn same_position_reput_after_completed_move_pulses() {
     let mut rec = make_record();
 
+    rec.special("VAL", false).unwrap();
     rec.put_field("VAL", EpicsValue::Double(5.0)).unwrap();
-    let effects = rec.plan_motion(CommandSource::Val);
+    let effects = rec.do_process();
     assert!(!effects.commands.is_empty(), "real move dispatched");
     complete_move(&mut rec, 5.0);
     let _ = rec.check_completion();
     assert!(rec.stat.dmov);
 
+    // Blinked re-put of the same target: DMOV pulses, no command.
+    rec.special("VAL", false).unwrap();
     rec.put_field("VAL", EpicsValue::Double(5.0)).unwrap();
-    let effects = rec.plan_motion(CommandSource::Val);
-    assert!(rec.stat.dmov, "DMOV stays 1 — C refuses the pass");
+    let effects = rec.do_process();
+    assert!(!rec.stat.dmov, "pulse low half");
     assert!(effects.commands.is_empty(), "no motor command");
+    let _ = rec.do_process();
+    assert!(rec.stat.dmov, "pulse high half restores DMOV");
+
+    // Unblinked same-value pass: entry gate refuses, no DMOV edge.
+    let effects = rec.plan_motion(CommandSource::Val);
+    assert!(rec.stat.dmov, "DMOV stays 1 — C refuses the unblinked pass");
+    assert!(effects.commands.is_empty(), "no motor command");
+}
+
+/// A blinked drive put while SPMG=Pause parks like C: the special()
+/// blink drops DMOV, the top-block stop_or_pause return (C 2237)
+/// refuses the dispatch with mip=STOP, and DMOV reads 0 — "not done",
+/// a move is pending. Go falls through to the move block (1909-1925)
+/// and dispatches the parked target; the pulse recovery must not
+/// finalize the parked state early (mip=STOP keeps it out).
+#[test]
+fn blinked_put_while_paused_parks_and_resumes_on_go() {
+    let mut rec = make_record();
+
+    // Idle at 0, then Pause.
+    rec.ctrl.spmg = SpmgMode::Pause;
+    let effects = rec.plan_motion(CommandSource::Spmg);
+    assert!(matches!(effects.commands[0], MotorCommand::Stop { .. }));
+    assert_eq!(rec.stat.mip, MipFlags::STOP);
+    complete_move(&mut rec, 0.0);
+    let _ = rec.check_completion();
+
+    // dbPut VAL=7 while paused: blink + park, no dispatch.
+    rec.special("VAL", false).unwrap();
+    rec.put_field("VAL", EpicsValue::Double(7.0)).unwrap();
+    let effects = rec.do_process();
+    assert!(effects.commands.is_empty(), "paused put dispatches nothing");
+    assert!(!rec.stat.dmov, "DMOV stays low — a move is pending (C)");
+    assert_eq!(rec.pos.dval, 7.0, "parked target survives the pause");
+
+    // A stray non-put pass must not finalize the parked state.
+    let effects = rec.do_process();
+    assert!(effects.commands.is_empty());
+    assert!(!rec.stat.dmov, "recovery does not eat the parked move");
+
+    // Go dispatches the parked target.
+    rec.ctrl.spmg = SpmgMode::Go;
+    let effects = rec.plan_motion(CommandSource::Spmg);
+    assert!(
+        effects
+            .commands
+            .iter()
+            .any(|c| matches!(c, MotorCommand::MoveAbsolute { .. })),
+        "Go dispatches the move parked during the pause"
+    );
+    assert!(!rec.stat.dmov, "move in flight");
 }
 
 /// Sequential moves: move to multiple positions and verify each.


### PR DESCRIPTION
The ophyd-epicsrs nightly `integration` workflow (unpinned epics-rs main checkout) has failed every night since 2026-05-18 with two families: 25 motor `MoveStatus`-timeout failures and 3 NTEnum PUT INIT failures. Both root causes are server-side in this repo; with these four commits the full downstream suite passes 293/293 against the unmodified PyPI client (ophyd-epicsrs 0.12.1 / epics-rs 0.17.2).

## Family 1 — motor MoveStatus timeouts

**`fix(motor): port special() pass-0 DMOV blink; correct 070a2da2's entry-gate reading`**
C motorRecord special() pass-0 (motorRecord.cc:2582-2608) drops DMOV on any dbPut to VAL/DVAL/RVAL/RLV/TWF/TWR; the move-block entry gate (2240: `dval != ldvl || !dmov`) therefore always admits a blinked put — same-value re-puts included — and refuses only unblinked passes. 070a2da2 added the gates from a misreading ("C refuses same-value re-puts") because the port lacked the blink entirely, so ophyd/bluesky same-position moves hung waiting for the DMOV 1→0→1 pulse. Also: init_record pass-1 dmov=true/movn=false (C 721-723), recovery guarded against put-owned/parked passes, hw-limit blocked dispatch changed from rollback to C's adopt-and-complete.

**`fix(base): run pass-0 special() on the internal dbPut bodies`**
C dbPut runs dbPutSpecial(paddr, 0) on every entry path (dbPutField and dbPutLink). The port has three dbPut bodies and only the external-put one called pass-0; put-link deliveries skipped every pass-0 side effect. Added to `put_pv_inner` and `put_pv_and_post_with_origin`, with a test pinning pass-0/pass-1 on both.

**`fix(motor): configure HVEL in motor.template`**
4ddf5cc4's C-faithful init derivation (`hvel==0 → hvel=vbas`, motorRecord.cc:4064-4067) exposed that motor.template sets neither HVEL nor VBAS: home velocity became 0.0 (C would send SET_VELOCITY 0 too — 2047 has no zero guard) and SimMotor's 0.001 u/s clamp turned every home into a ~1000 s crawl. The record code is correct; the template now sets `HVEL=$(HVEL=1.0)` like any real site must.

## Family 2 — NTEnum PUT INIT "invalid pvRequest mask"

**`fix(pva): resolve dotted-literal pvRequest selectors via flattened lookup (pvxs parity)`**
pvxs `FieldDesc::mlookup` carries flattened dotted keys (type.cpp:270-279, dataencode.cpp:174-182), and `request2mask` resolves request entries against it — so `field { value { index {} } }` (nested) and a child literally named `"value.index"` are equivalent on the wire. The Rust ≤0.17.x client's `build_pv_request_fields` emits the dotted-literal form for `pvput_field("value.index", …)` (the NTEnum put path); the server's exact-top-level-name matching rejected it with EmptyMask at INIT. The client-side nesting fix already on main cannot reach released clients; this makes the server accept both forms exactly as pvxs does. `mask_from_selector_fields` now flattens both sides (new `FieldDesc::bit_span_for_path` gives the subtree span); nested/dotted/scalar-child/PUT_GET-leg semantics pinned by 5 new tests.

## Validation

- ophyd-epicsrs `tests/integration` (serialized, mini-beamline IOC from this branch): 293 passed / 0 failed
- upstream `test_epicsmotor.py`: 22/22 (was 0/23 on main), homing included
- `mini:KohzuModeBO` PVA put round-trip (PyPI 0.12.1 client): pass
- motor-rs 583/583, epics-pva-rs 1265/1265, workspace clippy + nextest (macOS: asyn-rs excluded — BSD-only cfg compile error pre-existing on main; epics-oracle-rs excluded — machine-local fixture paths)

Known divergences left documented in code: DISA==DISV blink branch (record trait cannot see framework common fields); no monitor events on inline refusal (pre-existing for LVIO).