### PR TITLE
Fix CA put hang after IOC reboot (autosave restore corruption) and close the uncovered test-harness defect families

### DIFF
--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -2809,6 +2809,16 @@ impl DeviceSupport for AsynDeviceSupport {
         }
     }
 
+    fn output_callback_readback(&self) -> bool {
+        // The C `newOutputCallbackValue` contract applies exactly where
+        // `arm_readback_callback` arms: asyn:READBACK outputs (PRs #60/#208),
+        // whose callback cycle reads the driver value back and must not
+        // re-write the setpoint. Records without the readback subscription
+        // keep the full output stage on callback cycles, like any C
+        // `dbProcess`.
+        self.asyn_readback
+    }
+
     fn property_post_receiver(
         &mut self,
     ) -> Option<tokio::sync::mpsc::Receiver<Vec<(String, EpicsValue)>>> {

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -4122,33 +4122,44 @@ mod tests {
     /// `pasynManager->report` (asynShellCommands.c:589) — it is an answer to an
     /// iocsh question, so `asynReport 1 port > file` captures it. The Rust actor
     /// printed it to stderr, where a shell redirect misses it.
+    ///
+    /// A `dup2` on fd 1 around the call cannot observe this: libtest's default
+    /// capture rewrites `print!`/`println!` to an in-process buffer *before* the
+    /// bytes ever reach a file descriptor, and it does so regardless of which
+    /// thread makes the call — spawning a helper thread does not escape it
+    /// either. The intercept is only off for a process actually started with
+    /// `--nocapture`, so this re-execs the test binary as a child, selects just
+    /// this test by exact name, forces `--nocapture` on that child, and reads
+    /// the child's real stdout back through the pipe `Command::output` sets up.
+    /// That holds under plain `cargo test`, `cargo nextest run`, and
+    /// `--nocapture`, since the child's capture state is forced explicitly
+    /// rather than inherited from however the outer run was invoked.
     #[cfg(unix)]
     #[test]
     fn asyn_report_writes_to_stdout() {
-        use std::os::fd::AsRawFd as _;
-
-        let base = PortDriverBase::new("stdout_rep", 1, PortFlags::default());
-        let (_tx, rx) = mpsc::channel(1);
-        let actor = PortActor::new(Box::new(TestDriverBase(base)), rx);
-
-        // nextest runs each test in its own process, so redirecting fd 1 for the
-        // duration of the call cannot disturb another test.
-        let path = std::env::temp_dir().join(format!("asyn_report_stdout_{}", std::process::id()));
-        let file = std::fs::File::create(&path).unwrap();
-        unsafe {
-            let saved = libc::dup(1);
-            assert!(saved >= 0);
-            assert!(libc::dup2(file.as_raw_fd(), 1) >= 0);
+        const CHILD_ENV: &str = "ASYN_REPORT_WRITES_TO_STDOUT_CHILD";
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let base = PortDriverBase::new("stdout_rep", 1, PortFlags::default());
+            let (_tx, rx) = mpsc::channel(1);
+            let actor = PortActor::new(Box::new(TestDriverBase(base)), rx);
             actor.report_port(0);
-            assert!(libc::dup2(saved, 1) >= 0);
-            libc::close(saved);
+            return;
         }
-        drop(file);
-        let captured = std::fs::read_to_string(&path).unwrap();
-        let _ = std::fs::remove_file(&path);
+
+        let exe = std::env::current_exe().unwrap();
+        let output = std::process::Command::new(exe)
+            .args([
+                "port_actor::tests::asyn_report_writes_to_stdout",
+                "--exact",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .unwrap();
+        let captured = String::from_utf8_lossy(&output.stdout);
         assert!(
             captured.contains("stdout_rep multiDevice:No") && captured.contains("Port: stdout_rep"),
-            "the manager block and the driver block both belong on stdout: {captured:?}"
+            "the manager block and the driver block both belong on stdout: {captured}"
         );
     }
 

--- a/crates/epics-base-rs/src/error.rs
+++ b/crates/epics-base-rs/src/error.rs
@@ -115,7 +115,7 @@ const ECA_NOWTACCESS: u32 = 376; // defmsg(CA_K_WARNING, 47)
 const ECA_PUTFAIL: u32 = 160; // defmsg(CA_K_WARNING, 20)
 const ECA_BADTYPE: u32 = 114; // defmsg(CA_K_ERROR, 14)
 const ECA_DISCONN: u32 = 192; // defmsg(CA_K_WARNING, 24)
-const ECA_PUTCBINPROG: u32 = 366; // defmsg(CA_K_ERROR, 45)
+const ECA_PUTCBINPROG: u32 = 362; // defmsg(CA_K_ERROR, 45) = (45 << 3) | 2
 const ECA_TOLARGE: u32 = 72; // defmsg(CA_K_WARNING, 9)
 const ECA_BADCOUNT: u32 = 176; // defmsg(CA_K_WARNING, 22)
 

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -2083,8 +2083,29 @@ fn read_paren_string_list(
 mod tests {
     use super::*;
 
+    /// [`AS_CHECK_CLIENT_IP`] is a process-global flag, mirroring C's
+    /// global IOC variable — every `parse_acf` call whose ACF has a
+    /// `HAG(...)` block reads it via [`hag_members`]. Rust's default test
+    /// runner runs every `#[test]` fn in this module concurrently on its
+    /// own thread, so without serialization a test that never touches the
+    /// flag can still observe a value flipped mid-flight by a sibling
+    /// test's `set_as_check_client_ip(true)` / `(false)` window — that
+    /// race is what turned `"host1"` into `"unresolved:host1"` under plain
+    /// `cargo test`. Every test that reads or writes the flag (directly,
+    /// or by parsing an ACF containing a `HAG` block) takes this lock for
+    /// its whole body so at most one such test runs at a time; poisoning
+    /// is ignored so one test's panic doesn't cascade-fail its siblings.
+    static AS_CHECK_CLIENT_IP_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_as_check_client_ip() -> std::sync::MutexGuard<'static, ()> {
+        AS_CHECK_CLIENT_IP_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn test_parse_acf_basic() {
+        let _guard = lock_as_check_client_ip();
         let acf = r#"
 UAG(admins) { user1, user2 }
 HAG(operators) { host1, host2 }
@@ -2102,6 +2123,7 @@ ASG(DEFAULT) {
 
     #[test]
     fn test_parse_acf_hag_uag() {
+        let _guard = lock_as_check_client_ip();
         // Use `.invalid` so DNS resolution is guaranteed to fail
         // (RFC 6761 — every resolver returns NXDOMAIN). This isolates
         // the test from `expand_hag_members`' soft-DNS path: the
@@ -2130,6 +2152,7 @@ ASG(SECURE) {
     /// server keyed ACF on the peer IP. Both halves are C's now.
     #[test]
     fn hag_stores_names_by_default() {
+        let _guard = lock_as_check_client_ip();
         set_as_check_client_ip(false);
         let acf = r#"
 HAG(local) { LocalHost }
@@ -2160,6 +2183,7 @@ ASG(DEFAULT) {
     /// on the peer IP.
     #[test]
     fn hag_stores_resolved_ips_under_as_check_client_ip() {
+        let _guard = lock_as_check_client_ip();
         set_as_check_client_ip(true);
         let acf = r#"
 HAG(local) { localhost }
@@ -2186,6 +2210,7 @@ ASG(DEFAULT) {
     /// sentinel that simply never matches.
     #[test]
     fn hag_unresolvable_under_as_check_client_ip_becomes_sentinel() {
+        let _guard = lock_as_check_client_ip();
         set_as_check_client_ip(true);
         let config = parse_acf("HAG(lab) { lab-pc1.invalid }\n").unwrap();
         set_as_check_client_ip(false);
@@ -2194,6 +2219,7 @@ ASG(DEFAULT) {
 
     #[test]
     fn hag_unresolvable_name_does_not_abort_parser() {
+        let _guard = lock_as_check_client_ip();
         // `.invalid` TLD guarantees NXDOMAIN (RFC 6761). Pre-fix
         // upstream would `abort()` here; we keep the literal entries
         // verbatim — no resolved IPs are appended and the parser
@@ -2250,6 +2276,7 @@ ASG(READONLY) {
 
     #[test]
     fn test_check_access_hag_uag_match() {
+        let _guard = lock_as_check_client_ip();
         let acf = r#"
 UAG(ops) { alice }
 HAG(lab) { lab-pc1 }
@@ -2478,6 +2505,7 @@ ASG(MIXED_CASE) {
     /// denies, matching a C IOC whose only ASG is the empty DEFAULT.
     #[test]
     fn empty_acf_denies_all_access() {
+        let _guard = lock_as_check_client_ip();
         for acf in ["", "# just a comment\n", "UAG(ops){alice}\nHAG(h){pc1}\n"] {
             let config = parse_acf(acf).unwrap();
             assert_eq!(
@@ -2670,6 +2698,7 @@ ASG(DEFAULT) { RULE(1, READ) }
 
     #[test]
     fn hag_host_match_is_case_insensitive() {
+        let _guard = lock_as_check_client_ip();
         let acf = r#"
 HAG(lab) { LabPC1.invalid }
 ASG(C) {

--- a/crates/epics-base-rs/src/server/database/processing.rs
+++ b/crates/epics-base-rs/src/server/database/processing.rs
@@ -3215,14 +3215,24 @@ impl PvDatabase {
                 } else {
                     None
                 }
-            } else if device_callback {
-                // Driver-callback (`asyn:READBACK`) cycle on a hardware output:
-                // the new value was read back into VAL by the read stage above;
+            } else if device_callback
+                && instance
+                    .device
+                    .as_ref()
+                    .is_some_and(|d| d.output_callback_readback())
+            {
+                // Driver-callback (`asyn:READBACK`) cycle on a hardware output
+                // whose device support takes the callback-readback branch: the
+                // new value was read back into VAL by the read stage above;
                 // writing it here would re-assert the setpoint to the driver and
                 // re-trigger it (the AD `Acquire` loop). C
                 // `devAsynInt32.c::processBo` takes the `newOutputCallbackValue`
                 // readback branch and never calls `processCallbackOutput`'s
-                // `write()` on a callback cycle.
+                // `write()` on a callback cycle. Devices without that contract
+                // (`output_callback_readback` false — devMotorAsyn) run their
+                // output stage on callback cycles like any other C `dbProcess`:
+                // the motor record's retry / backlash / NTM-stop commands are
+                // emitted on exactly these passes.
                 None
             } else if !record_should_output {
                 // OOPT gating for hardware outputs (longout DTYP=...).

--- a/crates/epics-base-rs/src/server/device_support.rs
+++ b/crates/epics-base-rs/src/server/device_support.rs
@@ -237,6 +237,26 @@ pub trait DeviceSupport: Send + Sync + 'static {
     /// entry. Default no-op; see [`Self::arm_readback_callback`].
     fn reconcile_readback_callback(&mut self) {}
 
+    /// Whether a driver-callback (`asyn:READBACK`) processing cycle replaces
+    /// this device's output stage with a value readback.
+    ///
+    /// C devEpics (`devAsynInt32.c::processAo`/`processBo`/…) takes the
+    /// `newOutputCallbackValue` readback branch on a callback cycle and never
+    /// calls the output `write()` — re-writing would re-assert the setpoint
+    /// and re-trigger the driver (the AD `Acquire` loop). Only device support
+    /// implementing that contract (the [`Self::arm_readback_callback`] /
+    /// [`Self::reconcile_readback_callback`] pair) returns `true`.
+    ///
+    /// Default `false`: a C `dbProcess` driven by a driver callback is a full
+    /// record process, output stage included. `devMotorAsyn` has no readback
+    /// suppression — the motor record dispatches its retry, backlash-leg,
+    /// NTM-stop, and queued-motion-resume commands from exactly these
+    /// CALLBACK_DATA passes, and suppressing the write strands them in the
+    /// command mailbox (DMOV stuck 0, MIP=RETRY|MOVE, later puts time out).
+    fn output_callback_readback(&self) -> bool {
+        false
+    }
+
     /// Begin an asynchronous write (submit only, no blocking).
     /// Returns `Some(handle)` if the write was submitted to a worker queue —
     /// the caller should wait on the handle outside any record lock.

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -1840,6 +1840,13 @@ mod tests {
             fn io_intr_scan_independent(&self) -> bool {
                 true
             }
+            // ...and take the C `newOutputCallbackValue` readback branch on
+            // callback cycles (never re-write the setpoint). Devices that do
+            // not declare this — e.g. devMotorAsyn — still write on callback
+            // passes; that default-false path has its own regression tests.
+            fn output_callback_readback(&self) -> bool {
+                true
+            }
             fn read(
                 &mut self,
                 record: &mut dyn crate::server::record::Record,

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -856,11 +856,22 @@ impl IocApplication {
         announce!(InitHookState::AfterInitDrvSup);
         announce!(InitHookState::AfterInitRecSup);
 
-        // Phase 2b: iocInit — wire device support to all records with DTYP.
-        // C: initDevSup() then initHookAfterInitDevSup (autosave pass 0).
+        // Phase 2b: iocInit. C order is initDevSup() → initHookAfterInitDevSup
+        // (autosave pass 0) → initDatabase() (per-record init_record, where
+        // devMotorAsyn's init_controller runs). Rust's per-record device init
+        // lives in `wire_device_support` — the initDatabase-era half of C's
+        // init, not initDevSup (whose analogue, device-factory registration,
+        // already happened) — so the pass-0 hook fires BEFORE it. A pass0-
+        // restored field must land as a plain pre-init field write (C dbPut
+        // before init_record); `DeviceSupport::init` then anchors/clears any
+        // command state the write armed (motor `clear_last_write`). Firing the
+        // hook after wiring let a restored motor VAL survive as a pending move
+        // command, dispatched as a real move on the first driver-status pass —
+        // and on a fast axis (VELO high) the Startup readback then caught the
+        // move mid-flight and synced the instantaneous position into VAL/DVAL.
+        announce!(InitHookState::AfterInitDevSup);
         let record_count =
             wire_device_support(&db, &device_factories, &dynamic_device_factory).await?;
-        announce!(InitHookState::AfterInitDevSup);
         // Retain the registry in the database for runtime re-resolution
         // (aSub LFLG=READ / SUBL); `wire_subroutines` then performs the
         // static init-time SNAM resolution (C `init_record`).

--- a/crates/epics-base-rs/src/server/iocsh/access_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/access_commands.rs
@@ -36,6 +36,33 @@ fn as_state() -> &'static Mutex<AsState> {
     STATE.get_or_init(|| Mutex::new(AsState::default()))
 }
 
+/// `as_state()` is process-global, shared by every test in the crate that
+/// exercises the `as*` iocsh family — this module's own tests, and
+/// `iocsh::tests::test_as_commands_registered`. Locking [`as_state`] only
+/// protects one field access at a time, not a whole `asSetFilename` +
+/// `asInit` scenario, so under Rust's default concurrent test runner one
+/// test's `asSetFilename` (to a tempfile that is later deleted, or to a
+/// deliberately malformed ACF) can land in `as_state` while a sibling test
+/// that never touches `as*` itself runs `asInit` and reads that stale
+/// filename — turning its expected `Ok(Continue)` into a file-read or
+/// parse `Err`. Every test that touches `as_state`, directly or through
+/// an `as*` iocsh command, takes this lock for its whole body.
+#[cfg(test)]
+pub(crate) fn as_state_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Reset `as_state` to its startup default. A test that assumes "no
+/// filename set" (or any other default-state precondition) must call this
+/// itself rather than rely on process start order — the lock above only
+/// stops *concurrent* corruption, not a stale value left behind by
+/// whichever test happened to run earlier in the same process.
+#[cfg(test)]
+pub(crate) fn reset_as_state_for_test() {
+    *as_state().lock().unwrap() = AsState::default();
+}
+
 /// Register the `as*` command family on `registry`.
 pub(crate) fn register(registry: &mut CommandRegistry) {
     registry.register(cmd_as_check_client_ip());
@@ -516,11 +543,6 @@ mod tests {
         (db, ctx)
     }
 
-    fn reset_state() {
-        let mut st = as_state().lock().unwrap();
-        *st = AsState::default();
-    }
-
     /// asInit before asSetFilename is a success no-op: C `asInitCommon`
     /// (asDbLib.c:127-128) returns 0 with no filename, leaving access
     /// security disabled rather than failing. It must return Continue so
@@ -528,7 +550,8 @@ mod tests {
     /// not install any config.
     #[test]
     fn as_init_without_filename_is_noop_success() {
-        reset_state();
+        let _guard = as_state_test_guard();
+        reset_as_state_for_test();
         let (_db, ctx) = make_ctx();
         let mut reg = CommandRegistry::new();
         register(&mut reg);
@@ -548,7 +571,8 @@ mod tests {
     /// asSetFilename + asInit loads an ACF; asprules then dumps it.
     #[test]
     fn as_set_filename_then_init_loads_acf() {
-        reset_state();
+        let _guard = as_state_test_guard();
+        reset_as_state_for_test();
         let (_db, ctx) = make_ctx();
         let mut reg = CommandRegistry::new();
         register(&mut reg);
@@ -575,7 +599,8 @@ mod tests {
     /// asInit on a malformed ACF surfaces the parse error.
     #[test]
     fn as_init_bad_acf_errors() {
-        reset_state();
+        let _guard = as_state_test_guard();
+        reset_as_state_for_test();
         let (_db, ctx) = make_ctx();
         let mut reg = CommandRegistry::new();
         register(&mut reg);

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -1262,8 +1262,21 @@ mod tests {
     /// filename is a success no-op (C `asInitCommon`, asDbLib.c:127-128:
     /// returns 0 with no ACF file, leaving access security disabled), so
     /// a startup script under `on error break` is not aborted.
+    ///
+    /// `asInit` reads the process-global `as_state()` in
+    /// `access_commands.rs`, which `access_commands::tests` also mutates
+    /// (tempfile paths that get deleted, deliberately malformed ACFs). Take
+    /// the same test lock those tests use, and reset the state itself
+    /// rather than assume it starts fresh — the lock alone only stops a
+    /// *concurrent* sibling from racing in; it does nothing about a
+    /// filename a sibling left behind from running earlier in the same
+    /// process, which is what turned this test's expected `Ok(Continue)`
+    /// into a stale file-read `Err` under `cargo test`'s default
+    /// concurrency.
     #[test]
     fn test_as_commands_registered() {
+        let _guard = super::access_commands::as_state_test_guard();
+        super::access_commands::reset_as_state_for_test();
         let shell = make_shell();
         // asInit without asSetFilename leaves AS disabled and continues.
         assert!(matches!(

--- a/crates/epics-base-rs/tests/database_tests.rs
+++ b/crates/epics-base-rs/tests/database_tests.rs
@@ -2516,6 +2516,7 @@ struct MockDeviceSupport {
     read_count: Arc<AtomicU32>,
     write_count: Arc<AtomicU32>,
     dtyp_name: String,
+    callback_readback: bool,
 }
 
 impl MockDeviceSupport {
@@ -2524,7 +2525,16 @@ impl MockDeviceSupport {
             read_count,
             write_count,
             dtyp_name: dtyp.to_string(),
+            callback_readback: false,
         }
+    }
+
+    /// Declare the asyn devEpics `newOutputCallbackValue` contract
+    /// (`output_callback_readback` = true): a driver-callback cycle reads
+    /// the value back and suppresses the output write.
+    fn with_callback_readback(mut self) -> Self {
+        self.callback_readback = true;
+        self
     }
 }
 
@@ -2543,6 +2553,9 @@ impl epics_base_rs::server::device_support::DeviceSupport for MockDeviceSupport 
     }
     fn dtyp(&self) -> &str {
         &self.dtyp_name
+    }
+    fn output_callback_readback(&self) -> bool {
+        self.callback_readback
     }
 }
 
@@ -2564,6 +2577,73 @@ async fn test_ca_put_no_double_device_write() {
         .await
         .unwrap();
     assert_eq!(write_count.load(Ordering::SeqCst), 1);
+}
+
+/// A driver-callback cycle (`process_record_readback`) on a hardware output
+/// whose device support does NOT declare the `newOutputCallbackValue`
+/// contract is a full C `dbProcess`: the output stage runs. devMotorAsyn is
+/// the live case — the motor record emits its retry / backlash-leg /
+/// NTM-stop commands on exactly these passes, and suppressing the write
+/// strands them in the command mailbox (DMOV stuck 0, MIP=RETRY|MOVE).
+#[tokio::test]
+async fn test_readback_cycle_runs_device_write_without_callback_contract() {
+    let db = PvDatabase::new();
+    db.add_record("AO_CB1", Box::new(AoRecord::new(0.0)))
+        .await
+        .unwrap();
+    let read_count = Arc::new(AtomicU32::new(0));
+    let write_count = Arc::new(AtomicU32::new(0));
+    let mock = MockDeviceSupport::new("MockDev", read_count.clone(), write_count.clone());
+    if let Some(rec) = db.get_record("AO_CB1").await {
+        let mut inst = rec.write().await;
+        inst.common.dtyp = "MockDev".to_string();
+        inst.device = Some(Box::new(mock));
+    }
+    let mut visited = HashSet::new();
+    db.process_record_readback("AO_CB1", &mut visited, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        write_count.load(Ordering::SeqCst),
+        1,
+        "a callback cycle without the readback contract runs the output stage"
+    );
+}
+
+/// The asyn devEpics contract (`output_callback_readback` = true,
+/// `devAsynInt32.c::processBo` taking the `newOutputCallbackValue` branch):
+/// the callback cycle reads the driver value back and must NOT re-write the
+/// setpoint — re-asserting it would re-trigger the driver (AD `Acquire`
+/// loop).
+#[tokio::test]
+async fn test_readback_cycle_suppresses_device_write_with_callback_contract() {
+    let db = PvDatabase::new();
+    db.add_record("AO_CB2", Box::new(AoRecord::new(0.0)))
+        .await
+        .unwrap();
+    let read_count = Arc::new(AtomicU32::new(0));
+    let write_count = Arc::new(AtomicU32::new(0));
+    let mock = MockDeviceSupport::new("MockDev", read_count.clone(), write_count.clone())
+        .with_callback_readback();
+    if let Some(rec) = db.get_record("AO_CB2").await {
+        let mut inst = rec.write().await;
+        inst.common.dtyp = "MockDev".to_string();
+        inst.device = Some(Box::new(mock));
+    }
+    let mut visited = HashSet::new();
+    db.process_record_readback("AO_CB2", &mut visited, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        read_count.load(Ordering::SeqCst),
+        1,
+        "the callback cycle reads the driver value back into VAL"
+    );
+    assert_eq!(
+        write_count.load(Ordering::SeqCst),
+        0,
+        "the readback contract suppresses the output write on a callback cycle"
+    );
 }
 
 // epics-base f2fe9d12 (devBiSoftRaw): a `bi` record with

--- a/crates/epics-bridge-rs/src/ca_gateway/server.rs
+++ b/crates/epics-bridge-rs/src/ca_gateway/server.rs
@@ -1451,6 +1451,13 @@ mod tests {
     async fn build_with_minimal_config() {
         let config = GatewayConfig {
             pvlist_content: Some("".to_string()),
+            // Ephemeral bind: decouple from the ambient
+            // EPICS_CA_SERVER_PORT/EPICS_CAS_SERVER_PORT env vars, which
+            // other tests in this binary (e.g. upstream.rs's
+            // `#[serial(epics_env)]` group) mutate process-wide and can
+            // point at a port a concurrently-running test already owns
+            // exclusively.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await;
@@ -1468,6 +1475,8 @@ mod tests {
                 "#
                 .to_string(),
             ),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await.unwrap();
@@ -1489,6 +1498,8 @@ mod tests {
             pvlist_content: Some("".to_string()),
             upstream_tls: Some(TlsConfig::client_from_roots(Roots::empty())),
             upstream_tls_server_name: Some("ioc.example.com".to_string()),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await;
@@ -1506,7 +1517,11 @@ mod tests {
         // deny-all. Assumes no `gateway.pvlist` exists in the crate's
         // working directory (it does not) — the default-file probe is the
         // thin `is_file()` branch above, exercised by `parse_pvlist_file`.
-        let config = GatewayConfig::default();
+        let config = GatewayConfig {
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
+            ..Default::default()
+        };
         let server = GatewayServer::build(config).await.unwrap();
         let pvlist = server.pvlist().load_full();
         assert!(
@@ -1523,6 +1538,8 @@ mod tests {
         // the no-config path installs. This pins the two intents apart.
         let config = GatewayConfig {
             pvlist_content: Some(String::new()),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await.unwrap();
@@ -1544,6 +1561,8 @@ mod tests {
 
         let config = GatewayConfig {
             pvlist_content: Some("PV.* ALLOW\nPV.* DENY FROM 127.0.0.1\n".to_string()),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await.unwrap();
@@ -1598,6 +1617,8 @@ mod tests {
 
         let config = GatewayConfig {
             pvlist_content: Some("PV.* ALLOW\n".to_string()),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await.unwrap();
@@ -1674,6 +1695,8 @@ mod tests {
         let config = GatewayConfig {
             pvlist_content: Some("PV.* ALLOW\n".to_string()),
             stats_prefix: "gateway".to_string(),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await.unwrap();
@@ -1700,6 +1723,8 @@ mod tests {
         let config = GatewayConfig {
             pvlist_content: Some("PV.* ALLOW\ngateway.* ALLOW\n".to_string()),
             stats_prefix: "gateway".to_string(),
+            // Ephemeral bind — see `build_with_minimal_config`.
+            server_port: Some(0),
             ..Default::default()
         };
         let server = GatewayServer::build(config).await.unwrap();

--- a/crates/epics-pva-rs/src/client_native/channel.rs
+++ b/crates/epics-pva-rs/src/client_native/channel.rs
@@ -1252,14 +1252,18 @@ mod tests {
     /// engine layer; this guards the `Initial` reason at the
     /// `ensure_active` layer where the cap actually lived.
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(epics_env)]
     async fn initial_search_failure_is_owned_by_op_timeout_not_200ms() {
         use std::time::Duration;
 
         // Suppress real broadcast so no stray SEARCH on the LAN can be
         // answered and resolve the channel out from under the test.
-        // SAFETY: env vars are process-global; `current_thread` keeps
-        // other tokio tests from observing partial state, and these
-        // vars aren't read by any production path in this process.
+        // SAFETY: std::env mutation is unsafe in edition 2024; the
+        // `epics_env` serial guard makes it race-free. `current_thread`
+        // only constrains this test's own async executor, not the test
+        // harness's cross-test thread parallelism — these vars ARE read
+        // by production config code (config::env) and by other
+        // epics_env-group tests.
         unsafe {
             std::env::set_var("EPICS_PVA_AUTO_ADDR_LIST", "NO");
             std::env::set_var("EPICS_PVA_ADDR_LIST", "");

--- a/crates/epics-pva-rs/src/client_native/context.rs
+++ b/crates/epics-pva-rs/src/client_native/context.rs
@@ -617,21 +617,27 @@ impl PvaClient {
         Self::builder().server_addr(server_addr).build()
     }
 
-    async fn search_engine(&self) -> PvaResult<&SearchEngine> {
-        // The process-wide shared engine is a single `OnceCell` and cannot
-        // carry per-client name_servers (different clients may have
-        // different lists) NOR a per-client UDP-search config (address list /
-        // ports / auto-addr-list). pvxs keeps `nameServers` per-Context
-        // regardless of `overrideShareUDP` — shareUDP only shares the UDP
-        // socket. To match that and avoid silently dropping configured TCP
-        // name servers or a programmatic addr_list, a client that has name
-        // servers OR an overridden search config always uses its own
-        // per-client engine, even when `share_udp(true)` was requested.
-        // share_udp still saves the UDP socket for clients that have neither.
-        if self.inner.share_udp
+    /// True when [`Self::search_engine`] resolves to the process-wide
+    /// `SHARED_SEARCH_ENGINE` instead of spawning a per-client engine.
+    ///
+    /// The shared engine is a single `OnceCell` and cannot carry per-client
+    /// name_servers (different clients may have different lists) NOR a
+    /// per-client UDP-search config (address list / ports / auto-addr-list).
+    /// pvxs keeps `nameServers` per-Context regardless of `overrideShareUDP`
+    /// — shareUDP only shares the UDP socket. To match that and avoid
+    /// silently dropping configured TCP name servers or a programmatic
+    /// addr_list, a client that has name servers OR an overridden search
+    /// config always uses its own per-client engine, even when
+    /// `share_udp(true)` was requested. share_udp still saves the UDP
+    /// socket for clients that have neither.
+    fn uses_shared_search_engine(&self) -> bool {
+        self.inner.share_udp
             && self.inner.name_servers.is_empty()
             && !self.inner.search_config_overridden
-        {
+    }
+
+    async fn search_engine(&self) -> PvaResult<&SearchEngine> {
+        if self.uses_shared_search_engine() {
             let engine = SHARED_SEARCH_ENGINE
                 .get_or_try_init(|| async { SearchEngine::spawn(Vec::new(), Vec::new()).await })
                 .await?;
@@ -3334,6 +3340,13 @@ mod tests {
     // spawned with an empty name-server list and would silently drop the
     // configured TCP name servers. Such a client must fall back to its
     // own per-client engine, which carries the name-server list.
+    //
+    // The assertions are the client-local observables only: the singleton
+    // itself is process-wide and populated by whichever concurrently
+    // running test resolves the shared path first, so its emptiness is not
+    // observable soundly here. `search_engine()`'s early return makes the
+    // two paths mutually exclusive by construction, so the routing decision
+    // plus this client's engine cell fully pin the behavior.
     #[tokio::test]
     async fn mr_r9_share_udp_with_name_servers_uses_per_client_engine() {
         let ns: SocketAddr = "127.0.0.1:5099".parse().unwrap();
@@ -3342,15 +3355,14 @@ mod tests {
             .name_servers(vec![ns])
             .build();
 
-        // Resolving the engine must spawn a per-client engine, not the
-        // shared singleton.
-        let _engine = client.search_engine().await.expect("engine spawn");
-
         assert!(
-            SHARED_SEARCH_ENGINE.get().is_none(),
-            "share_udp(true) + name_servers must use the per-client engine, \
-             not the shared singleton that drops name servers"
+            !client.uses_shared_search_engine(),
+            "share_udp(true) + name_servers must route to the per-client \
+             engine, not the shared singleton that drops name servers"
         );
+
+        // Resolving the engine must spawn a per-client engine.
+        let _engine = client.search_engine().await.expect("engine spawn");
         assert!(
             client.inner.search.get().is_some(),
             "per-client engine must be populated"
@@ -3362,11 +3374,11 @@ mod tests {
     #[tokio::test]
     async fn mr_r9_share_udp_without_name_servers_uses_shared_engine() {
         let client = PvaClient::builder().share_udp(true).build();
-        let _engine = client.search_engine().await.expect("engine spawn");
         assert!(
-            SHARED_SEARCH_ENGINE.get().is_some(),
+            client.uses_shared_search_engine(),
             "share_udp(true) with no name servers must use the shared engine"
         );
+        let _engine = client.search_engine().await.expect("engine spawn");
         assert!(
             client.inner.search.get().is_none(),
             "shared-engine path must not spawn a per-client engine"

--- a/crates/epics-pva-rs/src/config/env.rs
+++ b/crates/epics-pva-rs/src/config/env.rs
@@ -1750,6 +1750,7 @@ mod tests {
     /// scoped config — that ambient fallback was the contamination this
     /// primitive exists to prevent.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn pva_config_defs_get_does_not_fall_back_to_ambient_env() {
         const KEY: &str = "EPICS_PVA_NAME_SERVERS";
         unsafe {
@@ -1778,6 +1779,7 @@ mod tests {
     /// A key absent from one config's defs must not bleed in from another
     /// config's map nor from the process environment.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn pva_config_defs_absent_key_does_not_bleed_between_maps_or_env() {
         const KEY: &str = "EPICS_PVA_ADDR_LIST";
         unsafe {
@@ -1843,9 +1845,12 @@ mod tests {
     /// ON, matching pvxs leaving `autoAddrList` untouched on an invalid
     /// value — `N`, `FALSE`, and `" NO "` no longer disable discovery.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn auto_addr_list_non_pvxs_bool_preserves_default_enabled() {
-        // SAFETY: nextest runs each test in its own process, so mutating
-        // the process environment here cannot race other tests.
+        // SAFETY: std::env mutation is unsafe in edition 2024; the
+        // `epics_env` serial guard makes it race-free under `cargo test`,
+        // which runs all lib tests as threads in one process (unlike
+        // nextest, which isolates each test in its own process).
         for invalid in ["N", "FALSE", " NO ", "false"] {
             unsafe { std::env::set_var("EPICS_PVA_AUTO_ADDR_LIST", invalid) };
             assert!(
@@ -1860,11 +1865,13 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(epics_env)]
     fn auto_addr_list_invalid_value_preserves_default_enabled() {
         // pvxs: a misspelled EPICS_PVA_AUTO_ADDR_LIST keeps auto-addr ON;
         // the old truthy-collapse turned it OFF on any non-true string.
-        // SAFETY: nextest runs each test in its own process, so mutating
-        // the process environment here cannot race other tests.
+        // SAFETY: std::env mutation is unsafe in edition 2024; the
+        // `epics_env` serial guard makes it race-free under `cargo test`,
+        // which runs all lib tests as threads in one process.
         unsafe { std::env::set_var("EPICS_PVA_AUTO_ADDR_LIST", "maybe") };
         assert!(
             auto_addr_list_enabled(),
@@ -1877,10 +1884,13 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(epics_env)]
     fn broadcast_port_zero_falls_back_to_5076_client_only() {
         // pvxs ignores EPICS_PVA_BROADCAST_PORT=0 and restores 5076 for the
         // client (a SEARCH to UDP port 0 can never reach a server).
-        // SAFETY: nextest runs each test in its own process.
+        // SAFETY: std::env mutation is unsafe in edition 2024; the
+        // `epics_env` serial guard makes it race-free under `cargo test`,
+        // which runs all lib tests as threads in one process.
         unsafe { std::env::set_var("EPICS_PVA_BROADCAST_PORT", "0") };
         assert_eq!(
             broadcast_port(),
@@ -1928,10 +1938,12 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(epics_env)]
     fn port_getters_truncate_out_of_range_like_pvxs() {
         // The finding's named cases, exercised through the getters.
-        // SAFETY: nextest runs each test in its own process, so mutating
-        // the process environment here cannot race other tests.
+        // SAFETY: std::env mutation is unsafe in edition 2024; the
+        // `epics_env` serial guard makes it race-free under `cargo test`,
+        // which runs all lib tests as threads in one process.
         // EPICS_PVAS_SERVER_PORT=70000 -> pvxs TCP port 4464, not the
         // default 5075 a strict u16 parse fell back to.
         unsafe { std::env::set_var("EPICS_PVAS_SERVER_PORT", "70000") };
@@ -2165,6 +2177,7 @@ mod tests {
     /// the wiring, ops who templated their st.cmd-style addr lists
     /// see literal `$(IFACE_IP)` tokens silently dropped as invalid.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn intf_and_ignore_addr_lists_expand_dollar_vars() {
         unsafe {
             std::env::set_var("EPICS_RS_AUDIT_IFACE", "127.0.0.1");
@@ -2208,6 +2221,7 @@ mod tests {
     /// literal IP, so `localhost` produced `[]` — the all-NIC / wildcard
     /// default — broadening the bind/search surface beyond pvxs.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn intf_addr_list_resolves_hostname_to_loopback() {
         unsafe {
             std::env::set_var("EPICS_PVA_INTF_ADDR_LIST", "localhost");
@@ -2238,6 +2252,7 @@ mod tests {
     /// error so the server refuses to start, NOT silently fall back to
     /// listening on every interface (`0.0.0.0`).
     #[test]
+    #[serial_test::serial(epics_env)]
     fn server_intf_checked_errors_when_all_tokens_unresolvable() {
         // Unset → Ok(None): caller keeps its own interfaces.
         unsafe {
@@ -2281,6 +2296,7 @@ mod tests {
     /// non-blank tokens unresolvable ⟹ `Err` (refuse a silently-empty
     /// blocklist) rather than dropping every entry.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn server_ignore_checked_errors_when_all_tokens_unresolvable() {
         // Unset → Ok(None): caller keeps its own ignore_addrs.
         unsafe {
@@ -2323,6 +2339,7 @@ mod tests {
     /// hostname that resolves to an IP already listed collapses into the
     /// existing entry.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn intf_addr_list_dedups_after_resolution() {
         unsafe {
             std::env::set_var("EPICS_PVA_INTF_ADDR_LIST", "127.0.0.1 localhost 127.0.0.1");
@@ -2390,9 +2407,11 @@ mod tests {
     /// that host (was an empty drop). Mixed numeric + hostname + invalid
     /// tokens: the invalid one is dropped, the rest resolve.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn server_ignore_addr_list_resolves_hostname_tokens() {
-        // SAFETY: nextest runs each test in its own process; the env
-        // mutation here cannot leak into a sibling test.
+        // SAFETY: std::env mutation is unsafe in edition 2024; the
+        // `epics_env` serial guard makes it race-free under `cargo test`,
+        // which runs all lib tests as threads in one process.
         unsafe {
             std::env::set_var(
                 "EPICS_PVAS_IGNORE_ADDR_LIST",

--- a/crates/epics-pva-rs/src/server_native/runtime.rs
+++ b/crates/epics-pva-rs/src/server_native/runtime.rs
@@ -1958,6 +1958,7 @@ mod with_env_preserve_tests {
     ];
 
     #[test]
+    #[serial_test::serial(epics_env)]
     fn with_env_preserves_caller_fields_when_vars_absent() {
         with_cleared_env(PORT_VARS, || {
             let cfg = PvaServerConfig {
@@ -1978,6 +1979,7 @@ mod with_env_preserve_tests {
     }
 
     #[test]
+    #[serial_test::serial(epics_env)]
     fn with_env_overrides_only_the_present_var() {
         with_cleared_env(PORT_VARS, || {
             unsafe { std::env::set_var("EPICS_PVAS_SERVER_PORT", "6789") };
@@ -2051,6 +2053,7 @@ mod with_env_preserve_tests {
     /// `PickOne{EPICS_PVAS_TLS_PORT, EPICS_PVA_TLS_PORT}`); an absent var
     /// preserves the caller value.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn with_env_tls_port_pvas_first_then_shared_then_preserve() {
         with_cleared_env(TLS_PORT_VARS, || {
             // Absent → caller value preserved.
@@ -2077,6 +2080,7 @@ mod with_env_preserve_tests {
     }
 
     #[test]
+    #[serial_test::serial(epics_env)]
     fn isolated_with_env_stays_isolated_in_empty_env() {
         let vars = [
             "EPICS_PVAS_SERVER_PORT",

--- a/crates/epics-pva-rs/src/server_native/udp.rs
+++ b/crates/epics-pva-rs/src/server_native/udp.rs
@@ -3281,11 +3281,12 @@ mod tests {
     /// beacon list never produced a join. Drive the real config path
     /// (`server_beacon_addr_list_opt`) and assert the group is selected.
     #[test]
+    #[serial_test::serial(epics_env)]
     fn pvas_beacon_addr_list_without_pva_addr_list_joins_multicast() {
-        // nextest isolates each test in its own process, so mutating the
-        // process environment here cannot leak into a sibling test.
         // SAFETY: std::env::{set,remove}_var are unsafe in the 2024
-        // edition; the per-process isolation makes the mutation sound.
+        // edition; the `epics_env` serial guard makes the mutation
+        // race-free under `cargo test`, which runs all lib tests as
+        // threads in one process.
         unsafe {
             std::env::remove_var("EPICS_PVA_ADDR_LIST");
             std::env::set_var("EPICS_PVAS_BEACON_ADDR_LIST", "224.0.7.7");

--- a/crates/epics-tools-rs/src/bin/procserv_rs.rs
+++ b/crates/epics-tools-rs/src/bin/procserv_rs.rs
@@ -549,7 +549,7 @@ mod app {
                     return ExitCode::FAILURE;
                 }
             };
-            let result = bind_rt.block_on(async { bind_endpoints(&cfg) });
+            let result = bind_rt.block_on(async { bind_endpoints(&cfg.listen) });
             // `bind_rt` drops here, before `fork_and_go`.
             match result {
                 Ok(listeners) => listeners,

--- a/crates/epics-tools-rs/src/procserv/daemon.rs
+++ b/crates/epics-tools-rs/src/procserv/daemon.rs
@@ -345,25 +345,84 @@ mod tests {
         }
     }
 
+    /// Env var marking "this process is the isolated child `run_isolated`
+    /// spawned; run the real test body instead of spawning another one."
+    const ISOLATION_CHILD_MARKER: &str = "EPICS_TOOLS_RS_DAEMON_SIGNAL_TEST_CHILD";
+
+    /// The tests below all mutate or inspect process-wide signal
+    /// dispositions through [`install_signal_handlers`]'s raw `sigaction`
+    /// calls, and each assumes it starts from that state fresh (e.g.
+    /// `sigxfsz_is_ignored_in_daemon_mode`'s `SIG_DFL` precondition). That
+    /// assumption is only true with one process per test — `cargo
+    /// nextest` gives that, but plain `cargo test` runs every test in
+    /// this binary as OS threads inside one shared process.
+    ///
+    /// Worse than an ordinary data race: `tokio::signal::unix::signal`
+    /// (used for SIGINT in daemon mode) installs its OS-level handler via
+    /// `signal-hook-registry`, which sets up its `sigaction` trampoline
+    /// exactly ONCE per signal number for the life of the process and
+    /// never re-installs or reverts it afterward (see its own
+    /// `unregister` docs). Once a *different* test's raw
+    /// `nix::sys::signal::signal(SIGINT, SigIgn)` (foreground mode) has
+    /// stomped that trampoline in a shared process, no later
+    /// `tokio::signal::unix::signal` call — nor a mutex, nor resetting
+    /// the disposition by hand — brings it back: the registry believes
+    /// its handler is already installed and won't touch `sigaction`
+    /// again. Only a fresh process per test avoids this, so `run_isolated`
+    /// re-execs this test binary for exactly one named test (`--exact`)
+    /// in a child process and asserts it exited cleanly, reproducing
+    /// nextest's process-per-test guarantee without depending on it being
+    /// installed. `Command::spawn` (fork+exec) is used rather than a bare
+    /// `fork()`, which would be unsafe here — this binary's other tests
+    /// run concurrently on other OS threads, and forking a multithreaded
+    /// process risks the child inheriting a lock (e.g. the allocator's)
+    /// held by a thread that no longer exists to release it.
+    fn run_isolated(test_name: &str, body: impl FnOnce()) {
+        if std::env::var_os(ISOLATION_CHILD_MARKER).is_some() {
+            body();
+            return;
+        }
+        let exe = std::env::current_exe().expect("current test exe");
+        let output = std::process::Command::new(exe)
+            .args(["--exact", test_name])
+            .env(ISOLATION_CHILD_MARKER, "1")
+            .output()
+            .expect("spawn isolated signal-disposition test process");
+        assert!(
+            output.status.success(),
+            "{test_name} failed in its isolated child process ({}):\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+        );
+    }
+
     /// R6-25 / C `procServ.cc:503-509`: foreground mode sets SIGINT and
     /// SIGQUIT to `SIG_IGN`. `Ctrl-C` and `Ctrl-\` at a `procserv-rs -f`
     /// prompt are the console client's keystrokes; they must not shut
     /// the supervisor down (SIGINT) or core-dump it (SIGQUIT's default).
-    ///
-    /// nextest runs each test in its own process, so mutating this
-    /// process's dispositions is contained.
-    #[tokio::test]
-    async fn foreground_mode_ignores_sigint_and_sigquit() {
-        let _shutdown = install_signal_handlers(true).await;
-        assert_eq!(
-            disposition(libc::SIGINT),
-            libc::SIG_IGN,
-            "foreground mode must ignore SIGINT (C procServ.cc:504-505)"
-        );
-        assert_eq!(
-            disposition(libc::SIGQUIT),
-            libc::SIG_IGN,
-            "foreground mode must ignore SIGQUIT (C procServ.cc:506-507)"
+    #[test]
+    fn foreground_mode_ignores_sigint_and_sigquit() {
+        run_isolated(
+            "procserv::daemon::tests::foreground_mode_ignores_sigint_and_sigquit",
+            || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build isolated test runtime")
+                    .block_on(async {
+                        let _shutdown = install_signal_handlers(true).await;
+                        assert_eq!(
+                            disposition(libc::SIGINT),
+                            libc::SIG_IGN,
+                            "foreground mode must ignore SIGINT (C procServ.cc:504-505)"
+                        );
+                        assert_eq!(
+                            disposition(libc::SIGQUIT),
+                            libc::SIG_IGN,
+                            "foreground mode must ignore SIGQUIT (C procServ.cc:506-507)"
+                        );
+                    });
+            },
         );
     }
 
@@ -372,30 +431,52 @@ mod tests {
     /// `RLIMIT_FSIZE` (a `ulimit -f`-capped log) must fail with `EFBIG`,
     /// not kill the supervisor, and the child must inherit the ignored
     /// disposition through `execvp`.
-    #[tokio::test]
-    async fn sigxfsz_is_ignored_in_daemon_mode() {
-        assert_eq!(
-            disposition(libc::SIGXFSZ),
-            libc::SIG_DFL,
-            "precondition: SIGXFSZ starts at its default disposition"
-        );
-        let _shutdown = install_signal_handlers(false).await;
-        assert_eq!(
-            disposition(libc::SIGXFSZ),
-            libc::SIG_IGN,
-            "SIGXFSZ must be ignored in the parent (C procServ.cc:502-503)"
+    #[test]
+    fn sigxfsz_is_ignored_in_daemon_mode() {
+        run_isolated(
+            "procserv::daemon::tests::sigxfsz_is_ignored_in_daemon_mode",
+            || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build isolated test runtime")
+                    .block_on(async {
+                        assert_eq!(
+                            disposition(libc::SIGXFSZ),
+                            libc::SIG_DFL,
+                            "precondition: SIGXFSZ starts at its default disposition"
+                        );
+                        let _shutdown = install_signal_handlers(false).await;
+                        assert_eq!(
+                            disposition(libc::SIGXFSZ),
+                            libc::SIG_IGN,
+                            "SIGXFSZ must be ignored in the parent (C procServ.cc:502-503)"
+                        );
+                    });
+            },
         );
     }
 
     /// Same set in foreground mode — the C call sits above the `inFgMode`
     /// block, so both modes must land on `SIG_IGN`.
-    #[tokio::test]
-    async fn sigxfsz_is_ignored_in_foreground_mode() {
-        let _shutdown = install_signal_handlers(true).await;
-        assert_eq!(
-            disposition(libc::SIGXFSZ),
-            libc::SIG_IGN,
-            "SIGXFSZ must be ignored in foreground mode too"
+    #[test]
+    fn sigxfsz_is_ignored_in_foreground_mode() {
+        run_isolated(
+            "procserv::daemon::tests::sigxfsz_is_ignored_in_foreground_mode",
+            || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build isolated test runtime")
+                    .block_on(async {
+                        let _shutdown = install_signal_handlers(true).await;
+                        assert_eq!(
+                            disposition(libc::SIGXFSZ),
+                            libc::SIG_IGN,
+                            "SIGXFSZ must be ignored in foreground mode too"
+                        );
+                    });
+            },
         );
     }
 
@@ -403,24 +484,35 @@ mod tests {
     /// installs neither `SIG_IGN`, so SIGINT stays a shutdown trigger
     /// (tokio installs its own handler — the disposition is neither
     /// `SIG_IGN` nor `SIG_DFL`) and SIGQUIT keeps its default.
-    #[tokio::test]
-    async fn daemon_mode_keeps_sigint_as_shutdown_and_sigquit_default() {
-        let _shutdown = install_signal_handlers(false).await;
-        let sigint = disposition(libc::SIGINT);
-        assert_ne!(
-            sigint,
-            libc::SIG_IGN,
-            "daemon mode must not ignore SIGINT — it is a shutdown trigger"
-        );
-        assert_ne!(
-            sigint,
-            libc::SIG_DFL,
-            "daemon mode installs a SIGINT handler for graceful shutdown"
-        );
-        assert_eq!(
-            disposition(libc::SIGQUIT),
-            libc::SIG_DFL,
-            "C leaves SIGQUIT alone outside foreground mode"
+    #[test]
+    fn daemon_mode_keeps_sigint_as_shutdown_and_sigquit_default() {
+        run_isolated(
+            "procserv::daemon::tests::daemon_mode_keeps_sigint_as_shutdown_and_sigquit_default",
+            || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build isolated test runtime")
+                    .block_on(async {
+                        let _shutdown = install_signal_handlers(false).await;
+                        let sigint = disposition(libc::SIGINT);
+                        assert_ne!(
+                            sigint,
+                            libc::SIG_IGN,
+                            "daemon mode must not ignore SIGINT — it is a shutdown trigger"
+                        );
+                        assert_ne!(
+                            sigint,
+                            libc::SIG_DFL,
+                            "daemon mode installs a SIGINT handler for graceful shutdown"
+                        );
+                        assert_eq!(
+                            disposition(libc::SIGQUIT),
+                            libc::SIG_DFL,
+                            "C leaves SIGQUIT alone outside foreground mode"
+                        );
+                    });
+            },
         );
     }
 }

--- a/crates/epics-tools-rs/src/procserv/listener.rs
+++ b/crates/epics-tools-rs/src/procserv/listener.rs
@@ -13,7 +13,7 @@ use tokio::net::{TcpListener, TcpSocket, UnixListener};
 use tokio::sync::mpsc;
 
 use crate::procserv::client::{ClientPeer, ClientStream, IncomingClient};
-use crate::procserv::config::ProcServConfig;
+use crate::procserv::config::ListenConfig;
 use crate::procserv::endpoint::{Endpoint, UnixEndpoint};
 use crate::procserv::error::{ProcServError, ProcServResult};
 
@@ -54,8 +54,19 @@ impl Drop for UnlinkOnDrop {
 /// `acceptItem` before `forkAndGo` and `exit(error)`s on failure
 /// (`procServ.cc:513-543,551`).
 enum BoundEndpoint {
-    Tcp(StdTcpListener),
+    /// The `SocketAddr` is read back from the kernel right after the bind
+    /// (C `getsockname`, `acceptFactory.cc:184`), so a `:0` config carries
+    /// the real assigned port from the moment the listener exists.
+    Tcp(StdTcpListener, SocketAddr),
     Unix(StdUnixListener, UnixEndpoint),
+}
+
+/// A bound listener's address, for publishing (info file / `PROCSERV_INFO`).
+/// TCP carries the kernel-reported address; UNIX carries the endpoint spec
+/// (C `writeAddress` prints `addr.sun_path`, which is the bound path).
+pub enum BoundAddr<'a> {
+    Tcp(SocketAddr),
+    Unix(&'a UnixEndpoint),
 }
 
 /// One bound-but-not-accepting listener plus the metadata its accept loop
@@ -77,9 +88,28 @@ impl PreboundListener {
     /// races anyone else binding an ephemeral port in that gap.
     pub fn local_addr(&self) -> Option<SocketAddr> {
         match &self.listener {
-            BoundEndpoint::Tcp(l) => l.local_addr().ok(),
+            BoundEndpoint::Tcp(_, addr) => Some(*addr),
             BoundEndpoint::Unix(..) => None,
         }
+    }
+
+    /// The bound address for publishing (info file / `PROCSERV_INFO`).
+    /// For TCP this is the kernel-reported address captured at bind time
+    /// (C refreshes its `addr` member via `getsockname` right after
+    /// `bind`+`listen`, `acceptFactory.cc:184`, and `writeInfoFile` prints
+    /// that member), so a config that said port `0` publishes the real
+    /// assigned port, never the `:0` placeholder.
+    pub fn bound_addr(&self) -> BoundAddr<'_> {
+        match &self.listener {
+            BoundEndpoint::Tcp(_, addr) => BoundAddr::Tcp(*addr),
+            BoundEndpoint::Unix(_, ep) => BoundAddr::Unix(ep),
+        }
+    }
+
+    /// `true` ⇒ read-only log/viewer endpoint (bound from `listen.log`);
+    /// `false` ⇒ control endpoint.
+    pub fn readonly(&self) -> bool {
+        self.readonly
     }
 
     /// Run this listener's accept loop until the supervisor's `out` channel
@@ -88,7 +118,7 @@ impl PreboundListener {
     /// per-listener in C too).
     pub async fn accept(self, out: mpsc::Sender<IncomingClient>) {
         let res = match self.listener {
-            BoundEndpoint::Tcp(l) => run_tcp_accept(l, self.readonly, out).await,
+            BoundEndpoint::Tcp(l, _) => run_tcp_accept(l, self.readonly, out).await,
             BoundEndpoint::Unix(l, ep) => run_unix_accept(l, ep, self.readonly, out).await,
         };
         if let Err(e) = res {
@@ -112,12 +142,12 @@ impl PreboundListener {
 /// UNIX/abstract binds go through tokio listeners (reused verbatim for
 /// their tested option/permission handling) which are then detached to
 /// their `std` form via `into_std`.
-pub fn bind_endpoints(config: &ProcServConfig) -> ProcServResult<Vec<PreboundListener>> {
+pub fn bind_endpoints(listen: &ListenConfig) -> ProcServResult<Vec<PreboundListener>> {
     let mut bound = Vec::new();
-    for ep in &config.listen.control {
+    for ep in &listen.control {
         bound.push(bind_one(ep.clone(), false, "control")?);
     }
-    if let Some(ep) = &config.listen.log {
+    if let Some(ep) = &listen.log {
         bound.push(bind_one(ep.clone(), true, "log")?);
     }
     Ok(bound)
@@ -128,7 +158,13 @@ pub fn bind_endpoints(config: &ProcServConfig) -> ProcServResult<Vec<PreboundLis
 fn bind_one(ep: Endpoint, readonly: bool, role: &'static str) -> ProcServResult<PreboundListener> {
     let listener = match ep {
         Endpoint::Tcp(addr) => {
-            BoundEndpoint::Tcp(tcp_listen(addr)?.into_std().map_err(ProcServError::Io)?)
+            let std_listener = tcp_listen(addr)?.into_std().map_err(ProcServError::Io)?;
+            // Read the real address back from the kernel while still in the
+            // fail-fast bind path (C `getsockname` right after `bind`+`listen`,
+            // `acceptFactory.cc:184`) — with port `0` this is the assigned
+            // port, and it is what gets published, not the config placeholder.
+            let bound = std_listener.local_addr().map_err(ProcServError::Io)?;
+            BoundEndpoint::Tcp(std_listener, bound)
         }
         Endpoint::Unix(u) => {
             let std_listener = bind_unix(&u)?.into_std().map_err(ProcServError::Io)?;

--- a/crates/epics-tools-rs/src/procserv/listener.rs
+++ b/crates/epics-tools-rs/src/procserv/listener.rs
@@ -366,16 +366,19 @@ mod tests {
 
     #[tokio::test]
     async fn tcp_listener_forwards_accepted_socket() {
-        // Pick an OS-assigned port.
+        // Bind once, to an OS-assigned port, and read the real address
+        // back from that same listener before handing it to
+        // `run_tcp_accept` — no separate bind-query-drop-then-reuse-the-
+        // number step, so nothing else on the box can steal the port in
+        // between (that was this test's own flake: another test's ephemeral
+        // bind could land on the number in the gap between `drop(listener)`
+        // and `tcp_listen(actual)` re-binding it).
         let bind = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
-        // Bind first to learn the port, then re-bind via run_tcp on
-        // that exact port. Simpler: just bind once and use the port.
-        let listener = tokio::net::TcpListener::bind(bind).await.unwrap();
+        let listener = tcp_listen(bind).unwrap();
         let actual = listener.local_addr().unwrap();
-        drop(listener);
+        let std_l = listener.into_std().unwrap();
 
         let (tx, mut rx) = mpsc::channel(4);
-        let std_l = tcp_listen(actual).unwrap().into_std().unwrap();
         let server = tokio::spawn(async move { run_tcp_accept(std_l, false, tx).await });
 
         // Give the listener a moment to bind.

--- a/crates/epics-tools-rs/src/procserv/listener.rs
+++ b/crates/epics-tools-rs/src/procserv/listener.rs
@@ -69,6 +69,19 @@ pub struct PreboundListener {
 }
 
 impl PreboundListener {
+    /// The address this listener is actually bound to, for a TCP endpoint
+    /// bound with port `0` (OS-assigned) — `None` for a UNIX endpoint,
+    /// which has no numeric port. Lets a caller that bound with port `0`
+    /// via [`bind_endpoints`] learn the real port with zero gap between
+    /// bind and use, unlike bind-query-drop-then-reuse-the-number, which
+    /// races anyone else binding an ephemeral port in that gap.
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        match &self.listener {
+            BoundEndpoint::Tcp(l) => l.local_addr().ok(),
+            BoundEndpoint::Unix(..) => None,
+        }
+    }
+
     /// Run this listener's accept loop until the supervisor's `out` channel
     /// closes. A loop that exits with an error is logged; the supervisor
     /// keeps running its other endpoints (steady-state accept failures are
@@ -506,12 +519,7 @@ mod tests {
     async fn bind_one_binds_a_free_port_and_accepts() {
         let bind = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
         let pl = bind_one(Endpoint::Tcp(bind), false, "control").expect("free port binds");
-        // Recover the actual port to connect to: re-read it from the bound
-        // std listener before the accept loop consumes `pl`.
-        let actual = match &pl.listener {
-            BoundEndpoint::Tcp(l) => l.local_addr().unwrap(),
-            _ => unreachable!(),
-        };
+        let actual = pl.local_addr().expect("tcp listener reports a local addr");
         let (tx, mut rx) = mpsc::channel(4);
         let server = tokio::spawn(pl.accept(tx));
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -522,5 +530,23 @@ mod tests {
         assert!(!inc.readonly);
 
         server.abort();
+    }
+
+    /// `local_addr` is how a caller that bound with port `0` learns the
+    /// real port with no gap between bind and use (unlike bind-query-drop-
+    /// then-reuse-the-number). A TCP listener bound to `:0` must report a
+    /// concrete, non-zero port; a UNIX listener has no numeric port at all.
+    #[tokio::test]
+    async fn local_addr_reports_bound_tcp_port_and_none_for_unix() {
+        let bind = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
+        let tcp = bind_one(Endpoint::Tcp(bind), false, "control").expect("free port binds");
+        let addr = tcp.local_addr().expect("tcp listener reports a local addr");
+        assert_eq!(addr.ip(), bind.ip());
+        assert_ne!(addr.port(), 0);
+
+        let dir = tempfile::tempdir().unwrap();
+        let ep = UnixEndpoint::filesystem(dir.path().join("ioc.sock"));
+        let unix = bind_one(Endpoint::Unix(ep), false, "control").expect("unix path binds");
+        assert_eq!(unix.local_addr(), None);
     }
 }

--- a/crates/epics-tools-rs/src/procserv/sidecar.rs
+++ b/crates/epics-tools-rs/src/procserv/sidecar.rs
@@ -27,9 +27,8 @@ use tokio::fs::{File, OpenOptions};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::procserv::config::ListenConfig;
-use crate::procserv::endpoint::Endpoint;
 use crate::procserv::error::{ProcServError, ProcServResult};
+use crate::procserv::listener::{BoundAddr, PreboundListener};
 
 /// Prefix every new line in `chunk` with `stamp`, tracking mid-line
 /// state across calls via `in_line`. This is the one stamp-at-newline
@@ -319,17 +318,22 @@ pub struct ListenAddress {
 }
 
 impl ListenAddress {
-    /// Format one parsed [`Endpoint`] as C's `writeAddress` / `writeAddressEnv`
+    /// Format one *bound* listener as C's `writeAddress` / `writeAddressEnv`
     /// token (`acceptFactory.cc:45-99`): `tcp:<ip>:<port>` (bare, no `[]`),
     /// `unix:<path>` for a filesystem socket, or `unix:@<name>` for an
-    /// abstract socket.
-    pub fn from_endpoint(ep: &Endpoint, readonly: bool) -> Self {
-        let addr = match ep {
-            Endpoint::Tcp(a) => format!("tcp:{}:{}", a.ip(), a.port()),
-            Endpoint::Unix(u) if u.abstract_socket => format!("unix:@{}", u.name.display()),
-            Endpoint::Unix(u) => format!("unix:{}", u.name.display()),
+    /// abstract socket. The TCP address is the one the kernel reported at
+    /// bind time (C `getsockname`, `acceptFactory.cc:184`), so a config
+    /// that asked for port `0` publishes the real assigned port here.
+    pub fn from_bound(pl: &PreboundListener) -> Self {
+        let addr = match pl.bound_addr() {
+            BoundAddr::Tcp(a) => format!("tcp:{}:{}", a.ip(), a.port()),
+            BoundAddr::Unix(u) if u.abstract_socket => format!("unix:@{}", u.name.display()),
+            BoundAddr::Unix(u) => format!("unix:{}", u.name.display()),
         };
-        Self { readonly, addr }
+        Self {
+            readonly: pl.readonly(),
+            addr,
+        }
     }
 }
 
@@ -374,23 +378,29 @@ pub fn render_procserv_info_env(info: &InfoSnapshot) -> String {
     out
 }
 
-/// Build the listener address list in C `connectionItem::head` iteration
-/// order. C prepends each acceptItem on creation (`procServ.cc:824-832`) and
-/// creates the control listeners before the log listener
-/// (`procServ.cc:515-534`), so head order is the reverse: the log endpoint
-/// first, then the control endpoints in reverse of their `ctlSpecs` order.
-/// `manage-procs` is order-independent (`manage.py:68` joins all ports), so
-/// this ordering is functional parity for any combination and byte-exact for
-/// the common control-only / control+log cases.
-pub fn listen_addresses(listen: &ListenConfig) -> Vec<ListenAddress> {
-    let mut out = Vec::new();
-    if let Some(ep) = &listen.log {
-        out.push(ListenAddress::from_endpoint(ep, true));
-    }
-    for ep in listen.control.iter().rev() {
-        out.push(ListenAddress::from_endpoint(ep, false));
-    }
-    out
+/// Build the published address list from the *bound* listeners, in C
+/// `connectionItem::head` iteration order. C prepends each acceptItem on
+/// creation (`procServ.cc:824-832`) and creates the control listeners
+/// before the log listener (`procServ.cc:515-534`), so head order is the
+/// reverse of creation order: the log endpoint first, then the control
+/// endpoints in reverse of their `ctlSpecs` order. [`bind_endpoints`]
+/// binds in creation order (controls, then log), so reverse iteration
+/// reproduces head order exactly. `manage-procs` is order-independent
+/// (`manage.py:68` joins all ports), so this ordering is functional parity
+/// for any combination and byte-exact for the common control-only /
+/// control+log cases.
+///
+/// Deriving from the bound listeners rather than the config is itself the
+/// C behavior: every acceptItem refreshes its address from the kernel
+/// after binding (`getsockname`, `acceptFactory.cc:184`), so with port `0`
+/// C's info file carries the real assigned port — a config-derived render
+/// would publish the unusable `:0` placeholder instead.
+pub fn bound_addresses(listeners: &[PreboundListener]) -> Vec<ListenAddress> {
+    listeners
+        .iter()
+        .rev()
+        .map(ListenAddress::from_bound)
+        .collect()
 }
 
 #[cfg(test)]
@@ -426,11 +436,14 @@ mod tests {
         let info = InfoSnapshot {
             procserv_pid: 1234,
             addresses: vec![
-                ListenAddress::from_endpoint(&Endpoint::Tcp("0.0.0.0:7001".parse().unwrap()), true),
-                ListenAddress::from_endpoint(
-                    &Endpoint::Tcp("127.0.0.1:7000".parse().unwrap()),
-                    false,
-                ),
+                ListenAddress {
+                    readonly: true,
+                    addr: "tcp:0.0.0.0:7001".into(),
+                },
+                ListenAddress {
+                    readonly: false,
+                    addr: "tcp:127.0.0.1:7000".into(),
+                },
             ],
         };
         assert_eq!(
@@ -446,11 +459,14 @@ mod tests {
         let info = InfoSnapshot {
             procserv_pid: 1234,
             addresses: vec![
-                ListenAddress::from_endpoint(&Endpoint::Tcp("0.0.0.0:7001".parse().unwrap()), true),
-                ListenAddress::from_endpoint(
-                    &Endpoint::Tcp("127.0.0.1:7000".parse().unwrap()),
-                    false,
-                ),
+                ListenAddress {
+                    readonly: true,
+                    addr: "tcp:0.0.0.0:7001".into(),
+                },
+                ListenAddress {
+                    readonly: false,
+                    addr: "tcp:127.0.0.1:7000".into(),
+                },
             ],
         };
         assert_eq!(
@@ -469,46 +485,66 @@ mod tests {
         assert_eq!(render_info_file(&info), "pid:42\n");
     }
 
-    #[test]
-    fn listen_addresses_orders_log_first_then_control_reversed() {
-        use crate::procserv::endpoint::UnixEndpoint;
-        // Control specs in CLI order: TCP 7000 then a UNIX socket; the log
-        // endpoint is 7001. C head order is log first, then control reversed.
+    #[tokio::test]
+    async fn bound_addresses_order_log_first_then_control_reversed_with_real_ports() {
+        use crate::procserv::config::ListenConfig;
+        use crate::procserv::endpoint::{Endpoint, UnixEndpoint};
+        use crate::procserv::listener::bind_endpoints;
+        // Control specs in CLI order: a TCP `:0` then a UNIX socket; the
+        // log endpoint is another TCP `:0`. C head order is log first,
+        // then control reversed — and every TCP token must carry the
+        // kernel-assigned port (C getsockname, acceptFactory.cc:184),
+        // never the `:0` placeholder from the config.
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ioc.sock");
         let listen = ListenConfig {
             control: vec![
-                Endpoint::Tcp("127.0.0.1:7000".parse().unwrap()),
-                Endpoint::Unix(UnixEndpoint::filesystem(PathBuf::from("/run/ioc.sock"))),
+                Endpoint::Tcp("127.0.0.1:0".parse().unwrap()),
+                Endpoint::Unix(UnixEndpoint::filesystem(sock.clone())),
             ],
-            log: Some(Endpoint::Tcp("0.0.0.0:7001".parse().unwrap())),
+            log: Some(Endpoint::Tcp("127.0.0.1:0".parse().unwrap())),
         };
-        let addrs = listen_addresses(&listen);
-        let tokens: Vec<(&str, bool)> = addrs
-            .iter()
-            .map(|a| (a.addr.as_str(), a.readonly))
-            .collect();
+        let listeners = bind_endpoints(&listen).expect("all three endpoints bind");
+        let ctl_port = listeners[0].local_addr().unwrap().port();
+        let log_port = listeners[2].local_addr().unwrap().port();
+        assert_ne!(ctl_port, 0, "kernel must have assigned a control port");
+        assert_ne!(log_port, 0, "kernel must have assigned a log port");
+
+        let addrs = bound_addresses(&listeners);
+        let tokens: Vec<(String, bool)> =
+            addrs.iter().map(|a| (a.addr.clone(), a.readonly)).collect();
         assert_eq!(
             tokens,
             vec![
-                ("tcp:0.0.0.0:7001", true),
-                ("unix:/run/ioc.sock", false),
-                ("tcp:127.0.0.1:7000", false),
+                (format!("tcp:127.0.0.1:{log_port}"), true),
+                (format!("unix:{}", sock.display()), false),
+                (format!("tcp:127.0.0.1:{ctl_port}"), false),
             ]
         );
     }
 
-    #[test]
-    fn abstract_unix_address_uses_the_at_prefix() {
-        use crate::procserv::endpoint::UnixEndpoint;
-        let ep = Endpoint::Unix(UnixEndpoint {
-            name: PathBuf::from("ioc-console"),
-            abstract_socket: true,
-            uid: None,
-            gid: None,
-            perms: 0o666,
-        });
+    #[tokio::test]
+    async fn abstract_unix_address_uses_the_at_prefix() {
+        use crate::procserv::config::ListenConfig;
+        use crate::procserv::endpoint::{Endpoint, UnixEndpoint};
+        use crate::procserv::listener::bind_endpoints;
+        // Abstract names live in a process-independent global namespace, so
+        // key it on the pid to keep parallel test runs from colliding.
+        let name = format!("procserv-rs-test-{}", std::process::id());
+        let listen = ListenConfig {
+            control: vec![Endpoint::Unix(UnixEndpoint {
+                name: PathBuf::from(&name),
+                abstract_socket: true,
+                uid: None,
+                gid: None,
+                perms: 0o666,
+            })],
+            log: None,
+        };
+        let listeners = bind_endpoints(&listen).expect("abstract socket binds");
         assert_eq!(
-            ListenAddress::from_endpoint(&ep, false).addr,
-            "unix:@ioc-console"
+            ListenAddress::from_bound(&listeners[0]).addr,
+            format!("unix:@{name}")
         );
     }
 

--- a/crates/epics-tools-rs/src/procserv/supervisor.rs
+++ b/crates/epics-tools-rs/src/procserv/supervisor.rs
@@ -250,43 +250,6 @@ impl SupervisorState {
             );
         }
 
-        // Publish the supervisor's identity + control endpoints ONCE, here at
-        // startup, before the main loop and before any child exists — C calls
-        // `setEnvVar()` then `writeInfoFile(infofile)` at `procServ.cc:559-563`,
-        // between `writePidFile` and the poll loop, with no dependency on the
-        // child ever being spawned. Both values (supervisor pid, listening
-        // addresses) are fixed for the supervisor's lifetime, so startup is the
-        // only moment they need to be published.
-        //
-        // Publishing this on the child-spawn path instead left the info file
-        // absent for the whole `--wait` window: under manual start there is no
-        // initial spawn, so a manager had no file to read the control endpoint
-        // from — and reading that endpoint is how it would issue the manual
-        // start. Chicken-and-egg.
-        let info = InfoSnapshot {
-            // C `writeInfoFile` / `setEnvVar` emit `getpid()` — the supervisor
-            // pid, which manage-procs probes for liveness (procServ.cc:938,946),
-            // NOT the child's.
-            procserv_pid: std::process::id() as i32,
-            addresses: super::sidecar::listen_addresses(&config.listen),
-        };
-        // SAFETY: PROCSERV_INFO is process-wide. Setting env in a running
-        // multi-threaded program is racy on POSIX; we accept that risk because
-        // (a) this is the single writer, and it runs once at startup before any
-        // child is spawned, (b) the child gets a fresh copy via execvp at fork
-        // time, so a torn read in another supervisor thread is harmless.
-        unsafe { std::env::set_var("PROCSERV_INFO", render_procserv_info_env(&info)) };
-        if let Some(p) = &config.logging.info_path
-            && let Err(e) = write_info_file(p, &info)
-        {
-            // Same "warn and run anyway" contract as the pid file above.
-            tracing::error!(
-                path = %p.display(),
-                error = %e,
-                "procserv-rs: unable to write info file; continuing without it"
-            );
-        }
-
         let log = if let Some(p) = &config.logging.log_path {
             // The LOG uses `stamp_log` + `stamp_format` (raw line prefix),
             // not the banner-facing `time_format`. With `stamp_log` off
@@ -327,8 +290,53 @@ impl SupervisorState {
         // (`procServ.cc:513-543`); control specs first, then the log spec.
         let listeners = match prebound {
             Some(listeners) => listeners,
-            None => bind_endpoints(&config)?,
+            None => bind_endpoints(&config.listen)?,
         };
+
+        // Publish the supervisor's identity + control endpoints ONCE, here at
+        // startup, before the main loop and before any child exists — C calls
+        // `setEnvVar()` then `writeInfoFile(infofile)` at `procServ.cc:557-563`,
+        // after every acceptItem is created (513-543) and before the poll
+        // loop, with no dependency on the child ever being spawned. Both
+        // values (supervisor pid, listening addresses) are fixed for the
+        // supervisor's lifetime, so startup is the only moment they need to
+        // be published.
+        //
+        // The addresses come from the *bound* listeners, not `config.listen`:
+        // C's acceptItems refresh their address from the kernel right after
+        // binding (`getsockname`, acceptFactory.cc:184), so a `--port 0`
+        // deployment publishes the real assigned port. A config-derived
+        // render published the unusable `tcp:...:0` placeholder here.
+        //
+        // Publishing this on the child-spawn path instead left the info file
+        // absent for the whole `--wait` window: under manual start there is no
+        // initial spawn, so a manager had no file to read the control endpoint
+        // from — and reading that endpoint is how it would issue the manual
+        // start. Chicken-and-egg.
+        let info = InfoSnapshot {
+            // C `writeInfoFile` / `setEnvVar` emit `getpid()` — the supervisor
+            // pid, which manage-procs probes for liveness (procServ.cc:938,946),
+            // NOT the child's.
+            procserv_pid: std::process::id() as i32,
+            addresses: super::sidecar::bound_addresses(&listeners),
+        };
+        // SAFETY: PROCSERV_INFO is process-wide. Setting env in a running
+        // multi-threaded program is racy on POSIX; we accept that risk because
+        // (a) this is the single writer, and it runs once at startup before any
+        // child is spawned, (b) the child gets a fresh copy via execvp at fork
+        // time, so a torn read in another supervisor thread is harmless.
+        unsafe { std::env::set_var("PROCSERV_INFO", render_procserv_info_env(&info)) };
+        if let Some(p) = &config.logging.info_path
+            && let Err(e) = write_info_file(p, &info)
+        {
+            // Same "warn and run anyway" contract as the pid file above.
+            tracing::error!(
+                path = %p.display(),
+                error = %e,
+                "procserv-rs: unable to write info file; continuing without it"
+            );
+        }
+
         // One accept loop task per listener. The readonly flag (set for the
         // log endpoint in `bind_endpoints`, C `acceptFactory(..., true)`
         // procServ.cc:533) flows to each accepted client and gates its input

--- a/crates/epics-tools-rs/tests/procserv_e2e.rs
+++ b/crates/epics-tools-rs/tests/procserv_e2e.rs
@@ -65,32 +65,45 @@ fn cat_config(port: u16) -> ProcServConfig {
     }
 }
 
-/// Allocate an OS-assigned localhost port: bind to :0, query, drop.
-async fn pick_port() -> u16 {
-    let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let p = l.local_addr().unwrap().port();
-    drop(l);
-    p
-}
-
 /// Bind `cfg`'s configured endpoints immediately and return a `ProcServ`
 /// ready to `.run()` (its listeners pre-bound via `with_prebound`)
 /// together with the real port(s) it is now listening on — control
 /// port(s) first (`cfg.listen.control` order), then the log port if one
 /// is configured. Build `cfg` with port `0` placeholders (`cat_config(0)`)
-/// and use this instead of `pick_port()` when a test's own load-bearing
-/// assertions depend on the server actually being reachable: unlike
-/// bind-query-drop-then-reuse-the-number, which races anyone else on the
-/// box binding an ephemeral port in that gap, the listener here is
-/// already bound before this function returns — nothing can steal the
-/// port in between.
-async fn spawn_bound(cfg: ProcServConfig) -> (ProcServ, Vec<u16>) {
+/// and use this for every test: unlike bind-query-drop-then-reuse-the-
+/// number (this used to be a `pick_port()` helper, removed — its own
+/// gap raced anyone else on the box binding an ephemeral port in that
+/// window), the listener here is already bound before this function
+/// returns — nothing can steal the port in between.
+///
+/// Also rewrites `cfg`'s `:0` placeholders to the addresses actually
+/// bound before constructing the `ProcServ`: `bootstrap` publishes the
+/// info file / `PROCSERV_INFO` env from `config.listen` verbatim, not
+/// from the prebound listeners, so a config left at `:0` would report an
+/// unusable port there even though the listener itself is bound and
+/// reachable.
+async fn spawn_bound(mut cfg: ProcServConfig) -> (ProcServ, Vec<u16>) {
     let listeners = bind_endpoints(&cfg).expect("bind configured endpoints");
-    let ports = listeners
+    let ports: Vec<u16> = listeners
         .iter()
         .filter_map(|l| l.local_addr())
         .map(|a| a.port())
         .collect();
+
+    let mut bound_tcp_addrs = listeners.iter().filter_map(|l| l.local_addr());
+    for ep in cfg
+        .listen
+        .control
+        .iter_mut()
+        .chain(cfg.listen.log.iter_mut())
+    {
+        if let Endpoint::Tcp(addr) = ep {
+            *addr = bound_tcp_addrs
+                .next()
+                .expect("a bound TCP address for each TCP control/log endpoint");
+        }
+    }
+
     let server = ProcServ::new(cfg).expect("build").with_prebound(listeners);
     (server, ports)
 }
@@ -182,9 +195,9 @@ fn strip_iac(input: &[u8]) -> Vec<u8> {
 
 #[tokio::test]
 async fn cat_round_trip_via_tcp_console() {
-    let port = pick_port().await;
-    let cfg = cat_config(port);
-    let server = ProcServ::new(cfg).expect("build");
+    let cfg = cat_config(0);
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
 
     // Run server in a background task; we'll abort it at the end.
     let server_task = tokio::spawn(async move {
@@ -281,15 +294,15 @@ async fn occupied_control_port_fails_fast_not_headless() {
 /// to open without preventing the child from starting.
 #[tokio::test]
 async fn unwritable_pid_and_log_paths_do_not_abort_startup() {
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     // A missing intermediate directory makes both opens fail with ENOENT,
     // exercising the pid-file and log-file sites of the same defect family.
     let dir = tempfile::tempdir().unwrap();
     let bad = dir.path().join("does-not-exist");
     cfg.logging.log_path = Some(bad.join("ioc.log"));
     cfg.logging.pid_path = Some(bad.join("ioc.pid"));
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
 
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
@@ -325,9 +338,9 @@ async fn unwritable_pid_and_log_paths_do_not_abort_startup() {
 
 #[tokio::test]
 async fn kill_keystroke_signals_child() {
-    let port = pick_port().await;
-    let cfg = cat_config(port);
-    let server = ProcServ::new(cfg).expect("build");
+    let cfg = cat_config(0);
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
 
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
@@ -389,9 +402,9 @@ async fn kill_keystroke_signals_child() {
 /// the next poll-loop iteration.
 #[tokio::test]
 async fn kill_key_on_a_dead_child_restarts_it_and_still_broadcasts() {
-    let port = pick_port().await;
-    let cfg = cat_config(port); // RestartMode::Disabled — no auto-respawn
-    let server = ProcServ::new(cfg).expect("build");
+    let cfg = cat_config(0); // RestartMode::Disabled — no auto-respawn
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -454,10 +467,9 @@ async fn server_messages_are_written_to_the_log() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("procserv.log");
 
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.logging.log_path = Some(log_path.clone());
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, _ports) = spawn_bound(cfg).await;
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -488,12 +500,16 @@ async fn log_port_client_is_readonly_but_receives_output() {
     // acceptFactory.cc:395). Verify a client on the log port (a) sees
     // child/party-line output and (b) cannot inject input — bytes it
     // sends never reach the child or the control client.
-    let ctl_port = pick_port().await;
-    let log_port = pick_port().await;
-    let mut cfg = cat_config(ctl_port);
-    cfg.listen.log = Some(Endpoint::Tcp(SocketAddr::from(([127, 0, 0, 1], log_port))));
+    let mut cfg = cat_config(0);
+    cfg.listen.log = Some(Endpoint::Tcp(SocketAddr::from(([127, 0, 0, 1], 0))));
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    assert_eq!(
+        ports.len(),
+        2,
+        "expected a control and a log port, got: {ports:?}"
+    );
+    let (ctl_port, log_port) = (ports[0], ports[1]);
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -670,12 +686,12 @@ async fn manual_restart_preempts_active_holdoff() {
     // (the child would already have auto-restarted and be alive), so the
     // manual "@@@ Restarting child" announcement would not appear before
     // the holdoff elapses.
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.restart_mode = RestartMode::OnExit;
     cfg.holdoff = Duration::from_secs(3); // long enough to observe the wait
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -813,11 +829,11 @@ async fn client_keystrokes_are_not_forwarded_to_other_clients() {
     // there is no PTY to echo through, so a second client must see NOTHING
     // when the first types. Under the old `fanout_excluding(Some(sender))`
     // the bytes were forwarded straight to the other client and this fails.
-    let port = pick_port().await;
-    let mut cfg = cat_config(port); // RestartMode::Disabled
+    let mut cfg = cat_config(0); // RestartMode::Disabled
     cfg.child.program = PathBuf::from("/bin/sh");
     cfg.child.args = vec!["-c".into(), "exit 0".into()];
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
 
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
@@ -866,10 +882,10 @@ async fn ignored_chars_are_stripped_from_child_stdin() {
     // input through the ignore filter. A plain letter keeps the assertion
     // free of control-byte / PTY-special-char confounds; the always-active
     // command keys join this same set via the supervisor auto-append.
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.child.ignore_chars = vec![b'Z'];
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -908,15 +924,14 @@ async fn child_exit_sigkills_orphaned_process_group() {
     // (same process group — no job control in a non-interactive shell),
     // records its PID to a file, then exits; the group SIGKILL must reap
     // the sleep.
-    let port = pick_port().await;
     let dir = tempfile::tempdir().unwrap();
     let pidfile = dir.path().join("gpid");
     let pf = pidfile.to_str().unwrap().to_string();
 
-    let mut cfg = cat_config(port); // Disabled: child exits, server stays up
+    let mut cfg = cat_config(0); // Disabled: child exits, server stays up
     cfg.child.program = PathBuf::from("/bin/sh");
     cfg.child.args = vec!["-c".into(), format!("sleep 30 & echo $! > '{pf}'; exit 0")];
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, _ports) = spawn_bound(cfg).await;
     let server_task = tokio::spawn(async move { server.run().await });
 
     // Wait for the grandchild PID to be recorded.
@@ -1080,12 +1095,11 @@ async fn child_exit_code_becomes_server_exit_code() {
     // exit status (childExitCode → main return, procServ.cc:798,701).
     // Under one-shot the supervisor runs the child once then exits, so
     // `run()` resolves to the child's code. `sh -c 'exit 7'` → 7.
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.child.program = PathBuf::from("/bin/sh");
     cfg.child.args = vec!["-c".into(), "exit 7".into()];
     cfg.restart_mode = RestartMode::OneShot;
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, _ports) = spawn_bound(cfg).await;
 
     let code = timeout(Duration::from_secs(5), server.run())
         .await
@@ -1184,9 +1198,9 @@ async fn banner_precedes_telnet_negotiation() {
     // telnet_negotiate (clientFactory.cc:153-174), so the first bytes on
     // the wire are the ASCII banner and the IAC (0xFF) negotiation follows.
     // The Rust port used to send the IAC handshake ahead of the greeting.
-    let port = pick_port().await;
-    let cfg = cat_config(port);
-    let server = ProcServ::new(cfg).expect("build");
+    let cfg = cat_config(0);
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -1233,8 +1247,7 @@ async fn banner_precedes_telnet_negotiation() {
 /// listening on. Pre-fix Rust removed only the pid file.
 #[tokio::test]
 async fn clean_shutdown_removes_both_the_info_and_pid_files() {
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     let dir = tempfile::tempdir().unwrap();
     let info = dir.path().join("ioc.info");
     let pid = dir.path().join("ioc.pid");
@@ -1246,7 +1259,7 @@ async fn clean_shutdown_removes_both_the_info_and_pid_files() {
     cfg.child.args = vec!["-c".into(), "exit 0".into()];
     cfg.restart_mode = RestartMode::OneShot;
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, _ports) = spawn_bound(cfg).await;
     timeout(Duration::from_secs(5), server.run())
         .await
         .expect("one-shot supervisor should exit promptly")
@@ -1271,14 +1284,14 @@ async fn clean_shutdown_removes_both_the_info_and_pid_files() {
 /// endpoint is how it would issue the manual start.
 #[tokio::test]
 async fn info_file_is_published_at_startup_even_under_wait_for_manual_start() {
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     let dir = tempfile::tempdir().unwrap();
     let info = dir.path().join("ioc.info");
     cfg.logging.info_path = Some(info.clone());
     cfg.wait_for_manual_start = true; // --wait: no initial child spawn
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });

--- a/crates/epics-tools-rs/tests/procserv_e2e.rs
+++ b/crates/epics-tools-rs/tests/procserv_e2e.rs
@@ -76,34 +76,17 @@ fn cat_config(port: u16) -> ProcServConfig {
 /// window), the listener here is already bound before this function
 /// returns — nothing can steal the port in between.
 ///
-/// Also rewrites `cfg`'s `:0` placeholders to the addresses actually
-/// bound before constructing the `ProcServ`: `bootstrap` publishes the
-/// info file / `PROCSERV_INFO` env from `config.listen` verbatim, not
-/// from the prebound listeners, so a config left at `:0` would report an
-/// unusable port there even though the listener itself is bound and
-/// reachable.
-async fn spawn_bound(mut cfg: ProcServConfig) -> (ProcServ, Vec<u16>) {
-    let listeners = bind_endpoints(&cfg).expect("bind configured endpoints");
+/// The config keeps its `:0` placeholders: everything the supervisor
+/// publishes (info file, `PROCSERV_INFO`) is derived from the bound
+/// listeners, not from `config.listen` (C getsockname parity,
+/// acceptFactory.cc:184), so no rewrite is needed here.
+async fn spawn_bound(cfg: ProcServConfig) -> (ProcServ, Vec<u16>) {
+    let listeners = bind_endpoints(&cfg.listen).expect("bind configured endpoints");
     let ports: Vec<u16> = listeners
         .iter()
         .filter_map(|l| l.local_addr())
         .map(|a| a.port())
         .collect();
-
-    let mut bound_tcp_addrs = listeners.iter().filter_map(|l| l.local_addr());
-    for ep in cfg
-        .listen
-        .control
-        .iter_mut()
-        .chain(cfg.listen.log.iter_mut())
-    {
-        if let Endpoint::Tcp(addr) = ep {
-            *addr = bound_tcp_addrs
-                .next()
-                .expect("a bound TCP address for each TCP control/log endpoint");
-        }
-    }
-
     let server = ProcServ::new(cfg).expect("build").with_prebound(listeners);
     (server, ports)
 }
@@ -1330,6 +1313,65 @@ async fn info_file_is_published_at_startup_even_under_wait_for_manual_start() {
         body.contains(&format!("tcp:127.0.0.1:{port}")),
         "info file must carry the control endpoint the manager connects to; got: {body:?}"
     );
+
+    server_task.abort();
+}
+
+/// The published addresses must come from the *bound* listeners, not the
+/// config. C refreshes each acceptItem's address from the kernel right
+/// after binding (`getsockname`, acceptFactory.cc:184) and `writeInfoFile`
+/// prints that refreshed address, so a `--port 0` deployment publishes the
+/// real assigned port. This drives the `prebound: None` path — bootstrap
+/// binds the endpoints itself (foreground/library mode), the config still
+/// says `:0` all the way through, and the info file is the only place the
+/// real port can be learned from; the sibling `--wait` test above covers
+/// the `with_prebound` path.
+#[tokio::test]
+async fn info_file_reports_the_kernel_assigned_port_for_a_port_zero_config() {
+    let mut cfg = cat_config(0);
+    let dir = tempfile::tempdir().unwrap();
+    let info = dir.path().join("ioc.info");
+    cfg.logging.info_path = Some(info.clone());
+
+    // No spawn_bound / with_prebound: bootstrap must bind and publish.
+    let server = ProcServ::new(cfg).expect("build");
+    let server_task = tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+
+    let body = {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match std::fs::read_to_string(&info) {
+                Ok(s) if !s.is_empty() => break s,
+                _ if Instant::now() < deadline => sleep(Duration::from_millis(25)).await,
+                _ => panic!("info file must be written at startup"),
+            }
+        }
+    };
+
+    let port: u16 = body
+        .lines()
+        .find_map(|l| l.strip_prefix("tcp:127.0.0.1:"))
+        .expect("info file must carry a tcp control endpoint")
+        .trim()
+        .parse()
+        .expect("the published port must be numeric");
+    assert_ne!(
+        port, 0,
+        "a :0 config must publish the kernel-assigned port, not the placeholder; got: {body:?}"
+    );
+
+    // The published port must be the live listener, not a guess: a client
+    // that reads the info file (manage-procs) can connect to it.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match TcpStream::connect(("127.0.0.1", port)).await {
+            Ok(_) => break,
+            Err(_) if Instant::now() < deadline => sleep(Duration::from_millis(50)).await,
+            Err(e) => panic!("published port {port} must be connectable: {e}"),
+        }
+    }
 
     server_task.abort();
 }

--- a/crates/epics-tools-rs/tests/procserv_e2e.rs
+++ b/crates/epics-tools-rs/tests/procserv_e2e.rs
@@ -18,6 +18,7 @@ use epics_tools_rs::procserv::{
     ProcServ, ProcServConfig,
     config::{ChildConfig, KeyBindings, ListenConfig, LoggingConfig},
     endpoint::Endpoint,
+    listener::bind_endpoints,
     restart::{RestartMode, RestartPolicy},
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -70,6 +71,28 @@ async fn pick_port() -> u16 {
     let p = l.local_addr().unwrap().port();
     drop(l);
     p
+}
+
+/// Bind `cfg`'s configured endpoints immediately and return a `ProcServ`
+/// ready to `.run()` (its listeners pre-bound via `with_prebound`)
+/// together with the real port(s) it is now listening on — control
+/// port(s) first (`cfg.listen.control` order), then the log port if one
+/// is configured. Build `cfg` with port `0` placeholders (`cat_config(0)`)
+/// and use this instead of `pick_port()` when a test's own load-bearing
+/// assertions depend on the server actually being reachable: unlike
+/// bind-query-drop-then-reuse-the-number, which races anyone else on the
+/// box binding an ephemeral port in that gap, the listener here is
+/// already bound before this function returns — nothing can steal the
+/// port in between.
+async fn spawn_bound(cfg: ProcServConfig) -> (ProcServ, Vec<u16>) {
+    let listeners = bind_endpoints(&cfg).expect("bind configured endpoints");
+    let ports = listeners
+        .iter()
+        .filter_map(|l| l.local_addr())
+        .map(|a| a.port())
+        .collect();
+    let server = ProcServ::new(cfg).expect("build").with_prebound(listeners);
+    (server, ports)
 }
 
 /// Read up to `deadline` and return everything that arrived.
@@ -529,14 +552,18 @@ async fn logstamp_prefixes_logger_client_stream_not_control() {
     // (read/write) client receives the bytes verbatim. A literal
     // `stamp_format` (no `%` specifiers) lets the prefix be asserted
     // exactly.
-    let ctl_port = pick_port().await;
-    let log_port = pick_port().await;
-    let mut cfg = cat_config(ctl_port);
-    cfg.listen.log = Some(Endpoint::Tcp(SocketAddr::from(([127, 0, 0, 1], log_port))));
+    let mut cfg = cat_config(0);
+    cfg.listen.log = Some(Endpoint::Tcp(SocketAddr::from(([127, 0, 0, 1], 0))));
     cfg.logging.stamp_log = true;
     cfg.logging.stamp_format = "STAMP> ".into();
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    assert_eq!(
+        ports.len(),
+        2,
+        "expected a control and a log port, got: {ports:?}"
+    );
+    let (ctl_port, log_port) = (ports[0], ports[1]);
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -553,8 +580,24 @@ async fn logstamp_prefixes_logger_client_stream_not_control() {
     };
     let mut ctl = connect(ctl_port).await;
     let mut log = connect(log_port).await;
-    let _ = read_for(&mut ctl, Duration::from_millis(400)).await;
-    let _ = read_for(&mut log, Duration::from_millis(400)).await;
+    // "procServ server started at:" is unconditional (every client, even
+    // a readonly logger — messages.rs `welcome`), unlike the readonly-gated
+    // "Welcome to procServ" greeting. Waiting for it, rather than a fixed
+    // window, proves both clients are registered in the roster (see the
+    // ordering note in `two_clients_share_same_party_line`) before ctl's
+    // line is typed below.
+    let _ = read_until(
+        &mut ctl,
+        "procServ server started at:",
+        Duration::from_secs(2),
+    )
+    .await;
+    let _ = read_until(
+        &mut log,
+        "procServ server started at:",
+        Duration::from_secs(2),
+    )
+    .await;
 
     // Control types; `cat` echoes the line back as child output, which the
     // supervisor broadcasts. The logger sees it stamped; control raw.
@@ -581,11 +624,11 @@ async fn timefmt_controls_banner_timestamp_format() {
     // format with no `%` specifiers is emitted as a literal, so a custom
     // timefmt shows up verbatim in the banner; the default ("%c") would
     // render a real calendar time instead.
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.logging.time_format = "TIMEFMT_MARKER".into();
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });
@@ -601,8 +644,12 @@ async fn timefmt_controls_banner_timestamp_format() {
         }
     };
 
-    let initial = read_for(&mut conn, Duration::from_millis(500)).await;
-    let cleaned = String::from_utf8_lossy(&strip_iac(&initial)).to_string();
+    let cleaned = read_until(
+        &mut conn,
+        "server started at: TIMEFMT_MARKER",
+        Duration::from_secs(2),
+    )
+    .await;
     assert!(
         cleaned.contains("server started at: TIMEFMT_MARKER"),
         "banner must render the start time with the configured timefmt; got: {cleaned:?}"
@@ -680,9 +727,9 @@ async fn manual_restart_preempts_active_holdoff() {
 
 #[tokio::test]
 async fn two_clients_share_same_party_line() {
-    let port = pick_port().await;
-    let cfg = cat_config(port);
-    let server = ProcServ::new(cfg).expect("build");
+    let cfg = cat_config(0);
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
 
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
@@ -701,11 +748,27 @@ async fn two_clients_share_same_party_line() {
             }
         }
     };
-    let _ = read_for(&mut a, Duration::from_millis(300)).await;
+    // The banner text is only enqueued to a client's outbound channel
+    // after `handle_new_client` has already inserted it into the client
+    // roster (supervisor.rs `handle_new_client`), so seeing it here is
+    // proof A is registered and will receive the party-line broadcast
+    // below — a fixed sleep isn't: under load the banner write can
+    // simply not have reached the socket yet within an arbitrary window.
+    let _ = read_until(
+        &mut a,
+        "procServ server started at:",
+        Duration::from_secs(2),
+    )
+    .await;
 
     // Connect client B.
     let mut b = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-    let _ = read_for(&mut b, Duration::from_millis(300)).await;
+    let _ = read_until(
+        &mut b,
+        "procServ server started at:",
+        Duration::from_secs(2),
+    )
+    .await;
 
     // A types — `cat` echoes the line back through the PTY, and the
     // supervisor broadcasts that child output to every client, so both A
@@ -897,19 +960,18 @@ async fn teardown_sigkills_a_child_that_traps_the_configurable_kill_signal() {
     // follow-up SIGKILL guarantees death. The child traps SIGTERM and
     // loops forever; supervisor teardown (Drop, fired by aborting the
     // run task) must still kill it.
-    let port = pick_port().await;
     let dir = tempfile::tempdir().unwrap();
     let pidfile = dir.path().join("childpid");
     let pf = pidfile.to_str().unwrap().to_string();
 
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.child.kill_signal = 15; // SIGTERM — catchable, the child ignores it
     cfg.child.program = PathBuf::from("/bin/sh");
     cfg.child.args = vec![
         "-c".into(),
         format!("trap '' TERM; echo $$ > '{pf}'; while true; do sleep 1; done"),
     ];
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, _ports) = spawn_bound(cfg).await;
     let server_task = tokio::spawn(async move { server.run().await });
 
     // Wait for the child to record its PID (proves it installed the trap).
@@ -931,19 +993,29 @@ async fn teardown_sigkills_a_child_that_traps_the_configurable_kill_signal() {
     server_task.abort();
     let _ = server_task.await;
 
-    // Give the OS time to reap the SIGKILLed child.
-    sleep(Duration::from_millis(700)).await;
-
-    let still_alive = std::process::Command::new("/bin/sh")
-        .arg("-c")
-        .arg(format!("kill -0 {child_pid} 2>/dev/null"))
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    assert!(
-        !still_alive,
-        "child {child_pid} traps SIGTERM, so teardown's follow-up SIGKILL must kill it"
-    );
+    // Drop's kill(2) calls are synchronous, but the actual reap runs on an
+    // independent `spawn_blocking` waitpid thread (`spawn_reaper`); until
+    // that thread's waitpid returns, the SIGKILLed child is a zombie and
+    // `kill -0` still reports it alive. Poll for the real condition
+    // instead of guessing how long the reaper thread takes to get
+    // scheduled under load.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let still_alive = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(format!("kill -0 {child_pid} 2>/dev/null"))
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !still_alive {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "child {child_pid} traps SIGTERM, so teardown's follow-up SIGKILL must kill it"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
 }
 
 #[tokio::test]
@@ -952,16 +1024,28 @@ async fn norestart_keeps_server_alive_after_child_exit() {
     // the SERVER stays up — only `oneshot` sets shutdownServer. The
     // operator reconnects and ^R relaunches (processFactory.cc:51,
     // procServ.cc:654-669).
-    let port = pick_port().await;
-    let mut cfg = cat_config(port); // Disabled == norestart
+    let dir = tempfile::tempdir().unwrap();
+    let marker = dir.path().join("child_done");
+    let mf = marker.to_str().unwrap().to_string();
+    let mut cfg = cat_config(0); // Disabled == norestart
     cfg.child.program = PathBuf::from("/bin/sh");
-    cfg.child.args = vec!["-c".into(), "exit 0".into()];
-    let server = ProcServ::new(cfg).expect("build");
+    cfg.child.args = vec!["-c".into(), format!("touch '{mf}'; exit 0")];
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move { server.run().await });
 
     // Connect AFTER the child has already exited; the server must still
-    // be accepting connections and serving a banner.
-    sleep(Duration::from_millis(400)).await;
+    // be accepting connections and serving a banner. Poll for the marker
+    // the child touches right before exiting rather than guessing a fixed
+    // delay — under load a blind sleep can both fire too early (flaking
+    // the invariant this test targets) and needlessly slow the fast path.
+    {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !marker.exists() {
+            assert!(Instant::now() < deadline, "child never exited");
+            sleep(Duration::from_millis(20)).await;
+        }
+    }
     let mut conn = {
         let deadline = Instant::now() + Duration::from_secs(2);
         loop {
@@ -972,10 +1056,15 @@ async fn norestart_keeps_server_alive_after_child_exit() {
             }
         }
     };
-    let banner = read_for(&mut conn, Duration::from_millis(300)).await;
+    let banner = read_until(
+        &mut conn,
+        "procServ server started at:",
+        Duration::from_secs(2),
+    )
+    .await;
     assert!(
-        !banner.is_empty(),
-        "server should still serve a banner after the child exited under norestart"
+        banner.contains("procServ server started at:"),
+        "server should still serve a banner after the child exited under norestart; got: {banner:?}"
     );
     assert!(
         !server_task.is_finished(),
@@ -1012,12 +1101,12 @@ async fn toggle_into_oneshot_grants_one_more_run() {
     // current exit; only the *next* exit shuts the server down
     // (procServ.cc:656-667). Start in OnExit so the toggle cycle reaches
     // oneshot via OnExit→Disabled→OneShot.
-    let port = pick_port().await;
-    let mut cfg = cat_config(port);
+    let mut cfg = cat_config(0);
     cfg.restart_mode = RestartMode::OnExit;
     cfg.holdoff = Duration::from_millis(50);
 
-    let server = ProcServ::new(cfg).expect("build");
+    let (server, ports) = spawn_bound(cfg).await;
+    let port = ports[0];
     let server_task = tokio::spawn(async move {
         let _ = server.run().await;
     });

--- a/crates/motor-rs/src/record/command_planner.rs
+++ b/crates/motor-rs/src/record/command_planner.rs
@@ -2027,6 +2027,46 @@ impl MotorRecord {
         // already applied; C would have run two passes).
         let idle_status_pass = std::mem::take(&mut self.internal.idle_status_pass);
 
+        // C iocInit parity: init_record runs before any dbProcess pass can
+        // exist, so the anchor outranks every command source. The Startup
+        // pass is handled before the put/res-reanchor/latent gates below —
+        // determine_event anchors on the first status pulse even when a
+        // write is parked (the pass-1-restore / init→first-poll put
+        // window), so Startup and a parked last_write CAN co-occur on this
+        // pass. The anchor runs; the parked write stays armed and replays
+        // on the pass the anchor's forced refresh queues (initial_readback
+        // sets request_poll whenever a write is parked).
+        if matches!(self.pending_event, Some(MotorEvent::Startup)) {
+            self.pending_event = None;
+            self.initialized = true;
+            // C init_record (motorRecord.cc:687-733): the first device
+            // readback runs process_motor_info(initcall), the RSTM
+            // restore decision (devMotorAsyn.c init_controller), and
+            // the OMSL-gated drive-triplet sync. determine_event()
+            // consumed the seq but left the status in the shared slot.
+            let status = self.device_state.as_ref().and_then(|state| {
+                state
+                    .lock()
+                    .ok()
+                    .and_then(|ds| ds.latest_status.as_ref().map(|s| s.status.clone()))
+            });
+            return match status {
+                Some(status) => self.initial_readback(&status),
+                None => ProcessEffects::default(),
+            };
+        }
+        // A mailbox-wired record that has not anchored yet may not consume
+        // or dispatch any command: a parked put, a res-reanchor mark, or a
+        // latched button waits for the anchor and replays afterwards. In C
+        // this pass cannot exist (no dbProcess before init_record); running
+        // it here dispatched real moves against an unanchored baseline, and
+        // the following Startup then synced the mid-flight readback into
+        // VAL/DVAL. Records without a device-state mailbox never see a
+        // Startup, so the anchor concept does not apply to them.
+        if !self.initialized && self.device_state.is_some() {
+            return ProcessEffects::default();
+        }
+
         // C do_work resolution block (1936-1991) on the pass a
         // pp(TRUE) MRES/SREV/UREV/ERES/UEIP put triggers — in this
         // dispatcher that pass carries no command source. The mark
@@ -2076,21 +2116,9 @@ impl MotorRecord {
 
         match self.pending_event.take() {
             Some(MotorEvent::Startup) => {
-                // C init_record (motorRecord.cc:687-733): the first device
-                // readback runs process_motor_info(initcall), the RSTM
-                // restore decision (devMotorAsyn.c init_controller), and
-                // the OMSL-gated drive-triplet sync. determine_event()
-                // consumed the seq but left the status in the shared slot.
-                let status = self.device_state.as_ref().and_then(|state| {
-                    state
-                        .lock()
-                        .ok()
-                        .and_then(|ds| ds.latest_status.as_ref().map(|s| s.status.clone()))
-                });
-                match status {
-                    Some(status) => self.initial_readback(&status),
-                    None => ProcessEffects::default(),
-                }
+                // Consumed by the anchor-first block at the top of this
+                // pass — a Startup can no longer reach the event match.
+                ProcessEffects::default()
             }
             Some(MotorEvent::UserWrite(cmd_src)) => self.plan_motion(cmd_src),
             Some(MotorEvent::DeviceUpdate(status)) => {

--- a/crates/motor-rs/src/record/status_update.rs
+++ b/crates/motor-rs/src/record/status_update.rs
@@ -12,7 +12,15 @@ impl MotorRecord {
         // mailbox untouched — no status consume, no STUP ack, no delay
         // take. The io_intr pulse that announced a pending status or
         // delay expiry is already queued and triggers its own pass.
-        if self.last_write.is_some() || self.internal.res_reanchor {
+        //
+        // The deferral applies only once the record is anchored: in C,
+        // init_record precedes any dbPutField pass (iocInit), so no put
+        // can exist before the anchor. A write parked before the first
+        // status pulse (an autosave pass-1 restore, or a CA put landing
+        // in the init→first-poll window) must NOT turn that pulse into a
+        // put pass — the pulse anchors (Startup) and the parked write
+        // replays on the pass the anchor's forced refresh queues.
+        if (self.last_write.is_some() || self.internal.res_reanchor) && self.initialized {
             return None;
         }
         // Extract data from shared state, then drop the lock before mutating self
@@ -434,6 +442,47 @@ impl MotorRecord {
         // skips URIP RDBL scaling and seeds the readback from motor position.
         self.process_motor_info_initcall(status, true);
 
+        // DMOV from driver
+        self.stat.dmov = status.done && !status.moving;
+
+        if status.moving {
+            // At startup, the poll loop may not be active yet — request it.
+            effects.request_poll = true;
+        }
+
+        // C init_record (motorRecord.cc:677-681): a CONSTANT .dol clears UDF
+        // at init (`pmr->udf = FALSE`) and seeds VAL from the constant. The
+        // motor never derives UDF from VAL otherwise — clears_udf() returns
+        // false so the framework's value_is_undefined() path is off — so this
+        // is the only init UDF clear for the common (no-DOL / literal-DOL)
+        // axis. A DB_LINK / CA DOL is left undefined until the closed-loop
+        // collection's first successful read clears it (1994-2005), exactly
+        // like C leaving udf TRUE for a non-CONSTANT .dol. An unset DOL has
+        // C link type CONSTANT (recGblInitConstantLink is a no-op leaving VAL
+        // at 0), so ParsedLink::None counts alongside a literal Constant.
+        if matches!(
+            parse_link_v2(&self.links.dol),
+            ParsedLink::None | ParsedLink::Constant(_)
+        ) {
+            self.internal.dol_udf = Some(false);
+        }
+
+        // A write parked before this anchor (an autosave pass-1 restore or
+        // a CA put in the init→first-poll window — a window C cannot have,
+        // since init_record precedes any dbPutField pass) means the drive
+        // triplet already carries that write's target, not saved state.
+        // Anchor the readback only: no RSTM decision (its DVAL input is
+        // gone, and a SetPosition to the parked target would redefine the
+        // axis to where the put asks it to MOVE), no drive-field sync (it
+        // would destroy the target), and no lasts anchoring (C anchors
+        // them to the pre-put values, which is what they still hold — an
+        // anchored-to-target lval would swallow the replay's val != lval
+        // change detection). The forced refresh queues the replay pass.
+        if self.last_write.is_some() {
+            effects.request_poll = true;
+            return effects;
+        }
+
         // C: devMotorAsyn.c init_controller — RSTM restore decision.
         // rdbd = max(|RDBD|, |MRES|); dval_non_zero_pos_near_zero is true when
         // the autosaved DVAL is meaningful but the driver currently sits near
@@ -501,31 +550,6 @@ impl MotorRecord {
             self.internal.lrvl = self.pos.rval;
         } else {
             self.sync_positions();
-        }
-
-        // DMOV from driver
-        self.stat.dmov = status.done && !status.moving;
-
-        if status.moving {
-            // At startup, the poll loop may not be active yet — request it.
-            effects.request_poll = true;
-        }
-
-        // C init_record (motorRecord.cc:677-681): a CONSTANT .dol clears UDF
-        // at init (`pmr->udf = FALSE`) and seeds VAL from the constant. The
-        // motor never derives UDF from VAL otherwise — clears_udf() returns
-        // false so the framework's value_is_undefined() path is off — so this
-        // is the only init UDF clear for the common (no-DOL / literal-DOL)
-        // axis. A DB_LINK / CA DOL is left undefined until the closed-loop
-        // collection's first successful read clears it (1994-2005), exactly
-        // like C leaving udf TRUE for a non-CONSTANT .dol. An unset DOL has
-        // C link type CONSTANT (recGblInitConstantLink is a no-op leaving VAL
-        // at 0), so ParsedLink::None counts alongside a literal Constant.
-        if matches!(
-            parse_link_v2(&self.links.dol),
-            ParsedLink::None | ParsedLink::Constant(_)
-        ) {
-            self.internal.dol_udf = Some(false);
         }
 
         effects

--- a/crates/motor-rs/tests/database_gate.rs
+++ b/crates/motor-rs/tests/database_gate.rs
@@ -18,6 +18,29 @@ fn make_record(state: motor_rs::device_state::SharedDeviceState) -> MotorRecord 
     rec
 }
 
+/// Anchor the record with a first idle status pulse (Startup pass). C's
+/// init_record precedes any dbPutField pass, so every put test below runs
+/// against an anchored record — an unanchored mailbox-wired record parks
+/// its signals until the anchor (see do_process_inner's anchor-first gate).
+async fn anchor(db: &PvDatabase, state: &motor_rs::device_state::SharedDeviceState) {
+    use asyn_rs::interfaces::motor::MotorStatus;
+    use motor_rs::device_state::StampedStatus;
+    state.lock().unwrap().latest_status = Some(StampedStatus {
+        seq: 1,
+        status: MotorStatus {
+            done: true,
+            ..MotorStatus::default()
+        },
+    });
+    let mut visited = std::collections::HashSet::new();
+    db.process_record_readback("M1", &mut visited, 0)
+        .await
+        .unwrap();
+    // Drop the anchor pass's mailbox batch so each test asserts only on
+    // the actions its own put produces.
+    state.lock().unwrap().pending_actions.take();
+}
+
 #[tokio::test]
 async fn non_pp_put_stores_without_processing() {
     // VELO has no pp(TRUE) in motorRecord.dbd: C stores it via special()
@@ -60,6 +83,7 @@ async fn sync_zero_release_processes_with_implicit_get_info() {
     db.add_record("M1", Box::new(make_record(state.clone())))
         .await
         .unwrap();
+    anchor(&db, &state).await;
 
     db.put_record_field_from_ca_no_notify("M1", "SYNC", EpicsValue::Short(0))
         .await
@@ -87,6 +111,7 @@ async fn user_limit_put_processes_with_implicit_get_info() {
     db.add_record("M1", Box::new(make_record(state.clone())))
         .await
         .unwrap();
+    anchor(&db, &state).await;
 
     db.put_record_field_from_ca_no_notify("M1", "HLM", EpicsValue::Double(50.0))
         .await
@@ -285,5 +310,177 @@ async fn retry_dispatched_on_callback_pass_reaches_the_driver() {
         db.get_pv("M1.MIP").await.unwrap(),
         EpicsValue::Short(0),
         "MIP collapses to DONE after the retry converges"
+    );
+}
+
+/// A write parked before the first status pulse (autosave pass-1 restore,
+/// or a CA put in the init→first-poll window) must not turn that pulse
+/// into a command pass: the pulse anchors (Startup), the anchor leaves the
+/// parked target untouched, and the write replays as a real move on the
+/// pass the anchor's forced refresh queues. Pre-fix, the pulse was consumed
+/// as a put pass against an unanchored baseline and the following Startup
+/// synced the mid-flight readback into VAL/DVAL.
+#[tokio::test]
+async fn parked_pre_pulse_put_anchors_first_then_replays_as_a_move() {
+    use asyn_rs::error::AsynError;
+    use asyn_rs::interfaces::motor::{AsynMotor, MotorStatus};
+    use asyn_rs::user::AsynUser;
+    use motor_rs::device_state::StampedStatus;
+    use motor_rs::device_support::MotorDeviceSupport;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    /// Lands exactly on target; counts moves and position redefines.
+    struct SpyMotor {
+        position: f64,
+        moves: Arc<AtomicU32>,
+        loads: Arc<AtomicU32>,
+    }
+    impl AsynMotor for SpyMotor {
+        fn poll(&mut self, _user: &AsynUser) -> Result<MotorStatus, AsynError> {
+            Ok(MotorStatus {
+                position: self.position,
+                done: true,
+                ..MotorStatus::default()
+            })
+        }
+        fn move_absolute(
+            &mut self,
+            _user: &AsynUser,
+            position: f64,
+            _min_vel: f64,
+            _max_vel: f64,
+            _accel: f64,
+        ) -> Result<(), AsynError> {
+            self.moves.fetch_add(1, Ordering::SeqCst);
+            self.position = position;
+            Ok(())
+        }
+        fn stop(&mut self, _user: &AsynUser, _accel: f64) -> Result<(), AsynError> {
+            Ok(())
+        }
+        fn home(
+            &mut self,
+            _user: &AsynUser,
+            _min_vel: f64,
+            _max_vel: f64,
+            _accel: f64,
+            _forwards: bool,
+        ) -> Result<(), AsynError> {
+            Ok(())
+        }
+        fn set_position(&mut self, _user: &AsynUser, position: f64) -> Result<(), AsynError> {
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            self.position = position;
+            Ok(())
+        }
+    }
+
+    let moves = Arc::new(AtomicU32::new(0));
+    let loads = Arc::new(AtomicU32::new(0));
+    let motor: Arc<Mutex<dyn AsynMotor>> = Arc::new(Mutex::new(SpyMotor {
+        position: 0.0,
+        moves: moves.clone(),
+        loads: loads.clone(),
+    }));
+    let user = AsynUser::new(0);
+
+    let state = motor_rs::device_state::new_shared_state();
+    let mut rec = MotorRecord::new();
+    rec.set_device_state(state.clone());
+    rec.conv.mres = 0.001;
+    rec.limits.dhlm = 100.0;
+    rec.limits.dllm = -100.0;
+    rec.limits.hlm = 100.0;
+    rec.limits.llm = -100.0;
+    rec.limits.lvio = false;
+    rec.vel.velo = 100000.0;
+    rec.vel.accl = 0.5;
+    rec.stat.msta = MstaFlags::DONE;
+
+    let (poll_cmd_tx, _poll_cmd_rx) = tokio::sync::mpsc::channel(16);
+    let mut dev = MotorDeviceSupport::new(
+        motor.clone(),
+        0,
+        Duration::from_secs(1),
+        poll_cmd_tx,
+        state.clone(),
+    );
+    {
+        use epics_base_rs::server::device_support::DeviceSupport;
+        use epics_base_rs::server::record::Record;
+        dev.init(&mut rec as &mut dyn Record).unwrap();
+    }
+
+    let db = PvDatabase::new();
+    db.add_record("M1", Box::new(rec)).await.unwrap();
+    if let Some(arc) = db.get_record("M1").await {
+        let mut inst = arc.write().await;
+        inst.common.dtyp = "simMotor".to_string();
+        inst.device = Some(Box::new(dev));
+    }
+
+    // Put BEFORE any status pulse processed: init() cleared the pass0
+    // latch, so this parks a fresh last_write — the pass-1/early-CA-put
+    // window. The put's own process pass consumes the init-seeded status
+    // (seq 1) as the ANCHOR, not as a put pass.
+    db.put_record_field_from_ca_no_notify("M1", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        moves.load(Ordering::SeqCst),
+        0,
+        "the anchor pass must not dispatch the parked put"
+    );
+    assert_eq!(
+        loads.load(Ordering::SeqCst),
+        0,
+        "the anchor must not redefine the controller position"
+    );
+    assert_eq!(
+        db.get_pv("M1.VAL").await.unwrap(),
+        EpicsValue::Double(1.0),
+        "the anchor must not sync the parked target away"
+    );
+    assert_eq!(
+        db.get_pv("M1.DVAL").await.unwrap(),
+        EpicsValue::Double(1.0),
+        "the anchor must not sync the parked dial target away"
+    );
+
+    let stamp = |seq: u64| {
+        let status = motor.lock().unwrap().poll(&user).unwrap();
+        state.lock().unwrap().latest_status = Some(StampedStatus { seq, status });
+    };
+
+    // The anchor's forced refresh queues the replay pass: the parked put
+    // now dispatches as an ordinary post-init move.
+    stamp(2);
+    let mut visited = HashSet::new();
+    db.process_record_readback("M1", &mut visited, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        moves.load(Ordering::SeqCst),
+        1,
+        "the parked put replays as a real move after the anchor"
+    );
+
+    // Completion pass: the axis landed on target.
+    stamp(3);
+    let mut visited = HashSet::new();
+    db.process_record_readback("M1", &mut visited, 0)
+        .await
+        .unwrap();
+    assert_eq!(db.get_pv("M1.DMOV").await.unwrap(), EpicsValue::Short(1));
+    assert_eq!(db.get_pv("M1.MIP").await.unwrap(), EpicsValue::Short(0));
+    assert_eq!(db.get_pv("M1.RBV").await.unwrap(), EpicsValue::Double(1.0));
+    assert_eq!(
+        loads.load(Ordering::SeqCst),
+        0,
+        "no position redefine anywhere on the parked-put path"
     );
 }

--- a/crates/motor-rs/tests/database_gate.rs
+++ b/crates/motor-rs/tests/database_gate.rs
@@ -131,3 +131,159 @@ async fn pid_gain_put_rides_its_pass_to_the_driver() {
         "SetPidGain forwarded through the put's process pass"
     );
 }
+
+/// A retry dispatch is emitted on a driver-callback (CALLBACK_DATA) pass —
+/// C `maybeRetry` arms MIP_RETRY and the same `dbProcess` re-enters
+/// `do_work`, whose move block re-fires through devMotorAsyn's write. The
+/// framework's driver-callback entry (`process_record_readback`) must
+/// therefore run the motor's output stage: the regression suppressed it
+/// (asyn `newOutputCallbackValue` semantics applied to every output
+/// record), so the retry command rotted in the mailbox and the record
+/// stuck at DMOV=0, MIP=RETRY|MOVE, with every later put timing out.
+#[tokio::test]
+async fn retry_dispatched_on_callback_pass_reaches_the_driver() {
+    use asyn_rs::error::AsynError;
+    use asyn_rs::interfaces::motor::{AsynMotor, MotorStatus};
+    use asyn_rs::user::AsynUser;
+    use motor_rs::device_state::StampedStatus;
+    use motor_rs::device_support::MotorDeviceSupport;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    /// Lands 0.05 EGU short of the first commanded target, exactly on
+    /// target afterwards — so the first completion needs one retry.
+    struct UndershootMotor {
+        position: f64,
+        moves: Arc<AtomicU32>,
+    }
+    impl AsynMotor for UndershootMotor {
+        fn poll(&mut self, _user: &AsynUser) -> Result<MotorStatus, AsynError> {
+            Ok(MotorStatus {
+                position: self.position,
+                done: true,
+                ..MotorStatus::default()
+            })
+        }
+        fn move_absolute(
+            &mut self,
+            _user: &AsynUser,
+            position: f64,
+            _min_vel: f64,
+            _max_vel: f64,
+            _accel: f64,
+        ) -> Result<(), AsynError> {
+            let n = self.moves.fetch_add(1, Ordering::SeqCst);
+            self.position = if n == 0 { position - 0.05 } else { position };
+            Ok(())
+        }
+        fn stop(&mut self, _user: &AsynUser, _accel: f64) -> Result<(), AsynError> {
+            Ok(())
+        }
+        fn home(
+            &mut self,
+            _user: &AsynUser,
+            _min_vel: f64,
+            _max_vel: f64,
+            _accel: f64,
+            _forwards: bool,
+        ) -> Result<(), AsynError> {
+            Ok(())
+        }
+        fn set_position(&mut self, _user: &AsynUser, position: f64) -> Result<(), AsynError> {
+            self.position = position;
+            Ok(())
+        }
+    }
+
+    let moves = Arc::new(AtomicU32::new(0));
+    let motor: Arc<Mutex<dyn AsynMotor>> = Arc::new(Mutex::new(UndershootMotor {
+        position: 0.0,
+        moves: moves.clone(),
+    }));
+    let user = AsynUser::new(0);
+
+    let state = motor_rs::device_state::new_shared_state();
+    let mut rec = MotorRecord::new();
+    rec.set_device_state(state.clone());
+    rec.conv.mres = 0.001;
+    rec.limits.dhlm = 100.0;
+    rec.limits.dllm = -100.0;
+    rec.limits.hlm = 100.0;
+    rec.limits.llm = -100.0;
+    rec.limits.lvio = false;
+    rec.vel.velo = 100000.0;
+    rec.vel.accl = 0.5;
+    rec.stat.msta = MstaFlags::DONE;
+
+    // poll_cmd_rx is held alive so PollDirective sends succeed; the test
+    // drives statuses by hand instead of running the poll loop.
+    let (poll_cmd_tx, _poll_cmd_rx) = tokio::sync::mpsc::channel(16);
+    let mut dev = MotorDeviceSupport::new(
+        motor.clone(),
+        0,
+        Duration::from_secs(1),
+        poll_cmd_tx,
+        state.clone(),
+    );
+    {
+        use epics_base_rs::server::device_support::DeviceSupport;
+        use epics_base_rs::server::record::Record;
+        dev.init(&mut rec as &mut dyn Record).unwrap();
+    }
+
+    let db = PvDatabase::new();
+    db.add_record("M1", Box::new(rec)).await.unwrap();
+    if let Some(arc) = db.get_record("M1").await {
+        let mut inst = arc.write().await;
+        inst.common.dtyp = "simMotor".to_string();
+        inst.device = Some(Box::new(dev));
+    }
+
+    // Startup pass consumes the init-seeded status (seq 1).
+    let mut visited = HashSet::new();
+    db.process_record_readback("M1", &mut visited, 0)
+        .await
+        .unwrap();
+
+    // Move to 1.0 — the put pass dispatches, the driver undershoots.
+    db.put_record_field_from_ca_no_notify("M1", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert_eq!(moves.load(Ordering::SeqCst), 1, "put pass dispatched");
+
+    // Completion callback pass: diff = 0.05 >= RDBD -> maybeRetry arms and
+    // re-dispatches ON THIS PASS. The write must reach the driver.
+    let stamp = |seq: u64| {
+        let status = motor.lock().unwrap().poll(&user).unwrap();
+        state.lock().unwrap().latest_status = Some(StampedStatus { seq, status });
+    };
+    stamp(2);
+    let mut visited = HashSet::new();
+    db.process_record_readback("M1", &mut visited, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        moves.load(Ordering::SeqCst),
+        2,
+        "the retry emitted on the callback pass must reach the driver"
+    );
+
+    // Retry landed on target: the next callback pass finalizes.
+    stamp(3);
+    let mut visited = HashSet::new();
+    db.process_record_readback("M1", &mut visited, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        db.get_pv("M1.DMOV").await.unwrap(),
+        EpicsValue::Short(1),
+        "retry completion finalizes the motion"
+    );
+    assert_eq!(
+        db.get_pv("M1.MIP").await.unwrap(),
+        EpicsValue::Short(0),
+        "MIP collapses to DONE after the retry converges"
+    );
+}

--- a/crates/motor-rs/tests/integration.rs
+++ b/crates/motor-rs/tests/integration.rs
@@ -884,3 +884,105 @@ async fn failed_poll_posts_comms_error_status() {
     let _ = poll_cmd_tx.send(PollCommand::Shutdown).await;
     let _ = poll_handle.await;
 }
+
+/// autosave pass0 restore contract. C `reboot_restore` pass0 writes fields
+/// with `dbPut` BEFORE `init_record` runs (`initHookAfterInitDevSup`
+/// precedes `initDatabase` in iocInit), so a restored VAL is a plain field
+/// write: per-record device init clears the parked put (`clear_last_write`)
+/// and the Startup readback's RSTM decision adopts the restored DVAL via
+/// `SetPosition` (redefine). A restore must never dispatch a move — the
+/// regression dispatched the restored VAL as a real move on the first
+/// status pass, and on a fast axis the Startup readback then caught the
+/// move mid-flight and synced the instantaneous position into VAL/DVAL.
+#[tokio::test]
+async fn pass0_restored_val_is_not_a_move_command() {
+    use asyn_rs::error::AsynError;
+    use asyn_rs::interfaces::motor::MotorStatus;
+    use asyn_rs::user::AsynUser;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct SpyMotor {
+        position: f64,
+        moves: Arc<AtomicU32>,
+        loads: Arc<AtomicU32>,
+    }
+    impl AsynMotor for SpyMotor {
+        fn poll(&mut self, _user: &AsynUser) -> Result<MotorStatus, AsynError> {
+            Ok(MotorStatus {
+                position: self.position,
+                done: true,
+                ..MotorStatus::default()
+            })
+        }
+        fn move_absolute(
+            &mut self,
+            _user: &AsynUser,
+            position: f64,
+            _min_vel: f64,
+            _max_vel: f64,
+            _accel: f64,
+        ) -> Result<(), AsynError> {
+            self.moves.fetch_add(1, Ordering::SeqCst);
+            self.position = position;
+            Ok(())
+        }
+        fn stop(&mut self, _user: &AsynUser, _accel: f64) -> Result<(), AsynError> {
+            Ok(())
+        }
+        fn home(
+            &mut self,
+            _user: &AsynUser,
+            _min_vel: f64,
+            _max_vel: f64,
+            _accel: f64,
+            _forwards: bool,
+        ) -> Result<(), AsynError> {
+            Ok(())
+        }
+        fn set_position(&mut self, _user: &AsynUser, position: f64) -> Result<(), AsynError> {
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            self.position = position;
+            Ok(())
+        }
+    }
+
+    let moves = Arc::new(AtomicU32::new(0));
+    let loads = Arc::new(AtomicU32::new(0));
+    let motor: Arc<Mutex<dyn AsynMotor>> = Arc::new(Mutex::new(SpyMotor {
+        position: 0.0,
+        moves: moves.clone(),
+        loads: loads.clone(),
+    }));
+    let mut setup = make_builder(motor.clone()).build();
+
+    // pass0 restore: a silent field write, before device init.
+    setup
+        .record
+        .put_field("VAL", EpicsValue::Double(1.5))
+        .unwrap();
+    // C init_record era: initial readback seed + parked-put clear.
+    setup.device_support.init(&mut setup.record).unwrap();
+    // First status pass = Startup -> initial_readback -> RSTM restore.
+    setup.record.process().unwrap();
+    setup.device_support.write(&mut setup.record).unwrap();
+
+    assert_eq!(
+        setup.record.pos.val, 1.5,
+        "restored VAL survives init and the Startup pass"
+    );
+    assert_eq!(setup.record.pos.dval, 1.5);
+    assert!(setup.record.stat.dmov, "restored axis comes up done");
+    assert_eq!(
+        moves.load(Ordering::SeqCst),
+        0,
+        "a pass0-restored VAL must never dispatch a move"
+    );
+    assert_eq!(
+        loads.load(Ordering::SeqCst),
+        1,
+        "RSTM NearZero adopts the autosaved DVAL via SetPosition"
+    );
+    let user = AsynUser::new(0);
+    let st = motor.lock().unwrap().poll(&user).unwrap();
+    assert_eq!(st.position, 1.5, "the controller was redefined, not moved");
+}

--- a/crates/motor-rs/tests/record_tests.rs
+++ b/crates/motor-rs/tests/record_tests.rs
@@ -4,6 +4,24 @@ use epics_base_rs::types::EpicsValue;
 use motor_rs::MotorRecord;
 use motor_rs::flags::*;
 
+/// Anchor a mailbox-wired record with a first idle status pulse (Startup
+/// pass). C's init_record precedes any dbProcess pass, so tests that drive
+/// put/scan passes must run them against an anchored record — an unanchored
+/// mailbox-wired record parks its signals until the anchor
+/// (do_process_inner's anchor-first gate).
+fn anchor(rec: &mut MotorRecord, state: &motor_rs::device_state::SharedDeviceState) {
+    use asyn_rs::interfaces::motor::MotorStatus;
+    use motor_rs::device_state::StampedStatus;
+    state.lock().unwrap().latest_status = Some(StampedStatus {
+        seq: 1,
+        status: MotorStatus {
+            done: true,
+            ..MotorStatus::default()
+        },
+    });
+    rec.process().unwrap();
+}
+
 #[test]
 fn test_default_values() {
     let rec = MotorRecord::new();
@@ -1691,7 +1709,9 @@ fn test_stup_does_not_drop_concurrent_user_write() {
     // write (last_write) arriving in the same cycle must still be planned —
     // the STUP must not early-return and discard it.
     let mut rec = MotorRecord::new();
-    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    let state = motor_rs::device_state::new_shared_state();
+    rec.set_device_state(state.clone());
+    anchor(&mut rec, &state);
     rec.put_field("HLM", EpicsValue::Double(1000.0)).unwrap();
     rec.put_field("LLM", EpicsValue::Double(-1000.0)).unwrap();
     rec.stat.stup = 1;
@@ -1718,7 +1738,9 @@ fn test_stup_put_rejects_non_on_and_busy_retrigger() {
     // back to OFF and does not trigger the protocol; (2615-2617): a put
     // while the previous request is in flight is refused.
     let mut rec = MotorRecord::new();
-    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    let state = motor_rs::device_state::new_shared_state();
+    rec.set_device_state(state.clone());
+    anchor(&mut rec, &state);
 
     rec.put_field("STUP", EpicsValue::Short(2)).unwrap();
     assert_eq!(rec.stat.stup, 0, "BUSY write forced to OFF");
@@ -1753,7 +1775,9 @@ fn test_idle_status_pass_blocks_implicit_get_info() {
     // one-pass mark from determine_event's Idle consume carries that
     // discriminator.
     let mut rec = MotorRecord::new();
-    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    let state = motor_rs::device_state::new_shared_state();
+    rec.set_device_state(state.clone());
+    anchor(&mut rec, &state);
 
     rec.internal.idle_status_pass = true;
     let effects = rec.do_process();


### PR DESCRIPTION
## Summary

Root-causes and fixes the "stuck PACT after IOC reboot" defect chain found while
testing bsrs against an epics-rs IOC (first CA put after reboot hung 30 s, every
later put failed `ECA_PUTCBINPROG`), plus the test-harness and parity defects
uncovered by the follow-up full-workspace sweep. All C/C++ parity claims below
were verified against the upstream sources (EPICS base C, procServ v2.8.0).

### Production fixes

- **ecc4562e — autosave pass-0 restore ran after per-record device init.**
  C `iocInit` runs pass-0 before `initDatabase`/`init_record`; the inverted
  order made a restored `VAL` look like a fresh user write, so booting fired a
  real motor move. Fast axes then sampled mid-move positions and `sync_positions()`
  clobbered VAL/DVAL with instantaneous garbage.
- **142e66fe — driver-callback passes suppressed the device write for all
  output records.** Motor retry/backlash re-fires are emitted exactly on those
  CALLBACK_DATA passes (C `maybeRetry` → `do_work`), so the boot-corruption
  retry rotted in `pending_actions`: DMOV=0, MIP=RETRY|MOVE, and every CA put
  against the record hung. New `DeviceSupport::output_callback_readback()`
  (default `false` = C `dbProcess` norm); only the asyn adapter's
  `asyn:READBACK` outputs return `true`.
- **2538a0eb — `ECA_PUTCBINPROG` constant was 366; correct is 362** (`(45<<3)|2`).
- **da7eef36 — anchor-first invariant for motor records:** a mailbox-wired
  motor record consumes no command before the Startup anchor; a parked
  pre-pulse write replays via the anchor's forced refresh.
- **44edb833 — procserv-rs published listener addresses from the config, not
  the bound sockets.** A port-0 config wrote the unusable `tcp:...:0` into the
  info file / `PROCSERV_INFO`. C procServ refreshes every acceptItem's address
  via `getsockname` right after bind (`acceptFactory.cc:184`) and writes the
  info file only after all listeners exist (`procServ.cc:513-563`). The bound
  listener is now the single source of published addresses by construction:
  `BoundEndpoint::Tcp` carries the `SocketAddr` captured at bind, and the
  config-derived render path no longer exists.

### Test-harness fixes (21 pre-existing failures + 2 flakes, all root-caused)

- **508229b2** — asyn stdout-capture test re-execs itself instead of dup2-ing fd 1.
- **1caed484** — serialize tests sharing the `AS_CHECK_CLIENT_IP` process global.
- **a71c3ca7** — guard and reset the global `as_state` across tests.
- **3aa8ed57** — pin gateway `build()` tests to ephemeral ports.
- **c7710b9a** — isolate signal-disposition tests in child processes.
- **a37e4a25 / 957513fa** — deflake procserv_e2e; delete the `pick_port`
  bind-drop-rebind primitive crate-wide (TOCTOU family closed structurally).
- **1b297247** — mr_r9 engine-routing test asserted emptiness of a process-wide
  `OnceCell` that sibling tests populate; assert the extracted
  `uses_shared_search_engine()` decision plus the client-local engine cell instead.
- **4532619e** — serialize all 18 env-mutating test fns missing the crate's
  `serial(epics_env)` group; correct SAFETY comments that assumed nextest
  per-process isolation under plain `cargo test`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — green (two consecutive full runs at the final tree).
- `cargo test --doc --workspace` — green.
- `cargo test -p epics-pva-rs --lib` — 8 consecutive green runs after the
  flake fixes (previously ~1-in-3 failure rate).
- procserv_e2e — 3 consecutive green runs including the new port-zero
  info-file boundary test.
- Motor regression tests proven to fail on the pre-fix gate
  (`retry_dispatched_on_callback_pass_reaches_the_driver`,
  `pass0_restored_val_is_not_a_move_command`,
  `parked_pre_pulse_put_anchors_first_then_replays_as_a_move`).
- Oracle cross-checks against C softIoc (EPICS base + asyn/calc/busy) pass 5/5.

https://claude.ai/code/session_016oXdK513ufXKtrm3m8qa2V
