### PR TITLE
Post-merge CI repairs: motor anchor gate, platform gate, fd-count isolation, fixed-port family

### DIFF
--- a/crates/epics-bridge-rs/src/ca_gateway/stats.rs
+++ b/crates/epics-bridge-rs/src/ca_gateway/stats.rs
@@ -898,38 +898,75 @@ mod tests {
         }
     }
 
+    /// Env var marking "this process is the isolated child `run_isolated`
+    /// spawned; run the real test body instead of spawning another one."
+    const ISOLATION_CHILD_MARKER: &str = "EPICS_BRIDGE_RS_FD_COUNT_TEST_CHILD";
+
+    /// [`open_fd_count`] samples the process-wide fd table, and this
+    /// binary's other tests churn descriptors (sockets, temp files) on
+    /// concurrent threads under plain `cargo test` — a batch-plus-margin
+    /// tolerance cannot bound that noise (observed: siblings closing more
+    /// fds between the two samples than the whole 32-fd probe batch
+    /// opened). Only a fresh process has a quiet fd table, so re-exec
+    /// this test binary for exactly one named test (`--exact`) in a child
+    /// process and assert it exits cleanly — nextest's process-per-test
+    /// guarantee, reproduced without depending on nextest being
+    /// installed. `Command::spawn` (fork+exec) rather than a bare
+    /// `fork()`: other tests run concurrently on other OS threads, and
+    /// forking a multithreaded process risks the child inheriting a lock
+    /// held by a thread that no longer exists to release it.
+    fn run_isolated(test_name: &str, body: impl FnOnce()) {
+        if std::env::var_os(ISOLATION_CHILD_MARKER).is_some() {
+            body();
+            return;
+        }
+        let exe = std::env::current_exe().expect("current test exe");
+        let output = std::process::Command::new(exe)
+            .args(["--exact", test_name])
+            .env(ISOLATION_CHILD_MARKER, "1")
+            .output()
+            .expect("spawn isolated fd-count test process");
+        assert!(
+            output.status.success(),
+            "{test_name} failed in its isolated child process ({}):\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+        );
+    }
+
     #[test]
     fn open_fd_count_tracks_new_descriptors() {
-        let before = match open_fd_count() {
-            Some(n) => n,
-            None => return, // unsupported platform — nothing to assert
-        };
-        // Open a batch of descriptors at once. A single fd would be
-        // lost in the noise of a parallel test runner (other threads
-        // open/close fds concurrently); a batch of 32 produces a
-        // delta that comfortably exceeds that noise floor. The files
-        // are held open in `_held` until the assertion runs.
-        const BATCH: usize = 32;
-        let dir = std::env::temp_dir();
-        let mut _held = Vec::with_capacity(BATCH);
-        let mut paths = Vec::with_capacity(BATCH);
-        for i in 0..BATCH {
-            let p = dir.join(format!("ca_gw_stats_fd_probe_{}_{i}", std::process::id()));
-            _held.push(std::fs::File::create(&p).expect("create temp file"));
-            paths.push(p);
-        }
-        let during = open_fd_count().expect("fd count available");
-        // The count must have risen by at least half the batch even
-        // if a few descriptors are transiently miscounted under
-        // parallel test execution.
-        assert!(
-            during >= before + (BATCH as u64) / 2,
-            "open fd count did not rise enough: before={before} during={during}"
+        run_isolated(
+            "ca_gateway::stats::tests::open_fd_count_tracks_new_descriptors",
+            || {
+                let before = match open_fd_count() {
+                    Some(n) => n,
+                    None => return, // unsupported platform — nothing to assert
+                };
+                // In the isolated child no other thread touches the fd
+                // table, so holding BATCH new files open must raise the
+                // count by the full batch (anything the harness itself
+                // opens only raises it further).
+                const BATCH: usize = 32;
+                let dir = std::env::temp_dir();
+                let mut _held = Vec::with_capacity(BATCH);
+                let mut paths = Vec::with_capacity(BATCH);
+                for i in 0..BATCH {
+                    let p = dir.join(format!("ca_gw_stats_fd_probe_{}_{i}", std::process::id()));
+                    _held.push(std::fs::File::create(&p).expect("create temp file"));
+                    paths.push(p);
+                }
+                let during = open_fd_count().expect("fd count available");
+                assert!(
+                    during >= before + BATCH as u64,
+                    "open fd count did not rise by the batch: before={before} during={during}"
+                );
+                drop(_held);
+                for p in paths {
+                    let _ = std::fs::remove_file(p);
+                }
+            },
         );
-        drop(_held);
-        for p in paths {
-            let _ = std::fs::remove_file(p);
-        }
     }
 
     #[tokio::test]

--- a/crates/epics-pva-rs/src/server_native/runtime.rs
+++ b/crates/epics-pva-rs/src/server_native/runtime.rs
@@ -585,9 +585,10 @@ pub struct PvaServer {
     /// vars (which may have changed since startup).
     effective_config: PvaServerConfig,
     /// Bound TCP socket address — useful when the configured port was
-    /// 0 and the OS picked one.  We capture the configured value here;
-    /// callers needing the post-bind port should query the listener
-    /// directly (future work).
+    /// 0, or the requested port was taken, and the OS picked one. This
+    /// is the actually-bound port (`start()` stamps it back from
+    /// `first_listener.local_addr()`), not the requested value —
+    /// query [`Self::report`] for it, never assume `config.tcp_port`.
     bound_tcp_port: u16,
     /// Bound dedicated-TLS port, advertised as the `"tls"` SEARCH endpoint.
     /// Equals [`Self::bound_tcp_port`] when TLS shares the plaintext port

--- a/crates/epics-pva-rs/tests/parity/interop.rs
+++ b/crates/epics-pva-rs/tests/parity/interop.rs
@@ -546,7 +546,7 @@ async fn rust_client_to_rust_server_ntndarray_full_roundtrip() {
         nt_nd_array_desc, nt_nd_array_value,
     };
     use epics_pva_rs::pvdata::{FieldDesc, PvField, ScalarValue, VariantValue};
-    use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServerConfig, run_pva_server};
+    use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServer, PvaServerConfig};
 
     #[derive(Clone)]
     struct ImageSource {}
@@ -612,16 +612,14 @@ async fn rust_client_to_rust_server_ntndarray_full_roundtrip() {
         }
     }
 
-    let (port, udp) = alloc_port_pair();
     let source = Arc::new(ImageSource {});
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
-    let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Native client retrieves the NTNDArray, decode union value back.
@@ -722,7 +720,8 @@ async fn rust_client_to_rust_server_ntndarray_full_roundtrip() {
         other => panic!("expected StructureArray for attribute, got {other:?}"),
     }
 
-    h.abort();
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }
 
 #[tokio::test]

--- a/crates/epics-pva-rs/tests/parity/test_client_server_lifecycle.rs
+++ b/crates/epics-pva-rs/tests/parity/test_client_server_lifecycle.rs
@@ -6,7 +6,6 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -63,12 +62,6 @@ impl ChannelSource for ConstSource {
     }
 }
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(48000);
-fn alloc_port() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
-
 fn client_to(port: u16) -> PvaClient {
     let server_addr =
         std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port);
@@ -83,13 +76,13 @@ fn client_to(port: u16) -> PvaClient {
 /// granularity.
 #[tokio::test]
 async fn pva_server_stop_ends_listener() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let server = PvaServer::start(Arc::new(ConstSource), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Healthy server: pvget succeeds.
@@ -129,13 +122,13 @@ async fn pva_server_stop_ends_listener() {
 /// opposite of pvxs.)
 #[tokio::test]
 async fn pva_client_close_is_terminal_no_reuse() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let server = PvaServer::start(Arc::new(ConstSource), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);

--- a/crates/epics-pva-rs/tests/parity/test_monitor_finish.rs
+++ b/crates/epics-pva-rs/tests/parity/test_monitor_finish.rs
@@ -12,14 +12,14 @@
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::sync::{Mutex, mpsc};
 
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
-use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServerConfig, run_pva_server};
+use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServer, PvaServerConfig};
 
 #[derive(Clone)]
 struct FiniteSource {
@@ -89,26 +89,18 @@ impl ChannelSource for FiniteSource {
     }
 }
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(47000);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
-
 #[tokio::test]
 async fn monitor_finish_returns_ok_when_source_closes() {
-    let (port, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
 
     let (source, _orig_tx) = FiniteSource::new();
     let source_for_drive = source.clone();
-    tokio::spawn(async move {
-        let _ = run_pva_server(Arc::new(source_for_drive), cfg).await;
-    });
+    let server = PvaServer::start(Arc::new(source_for_drive), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let server_addr =
@@ -163,6 +155,9 @@ async fn monitor_finish_returns_ok_when_source_closes() {
         received.load(Ordering::SeqCst) >= 1,
         "subscriber should have received at least one value before FINISH"
     );
+
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }
 
 /// Regression: a clean end-of-stream MONITOR FINISH must surface as
@@ -179,18 +174,16 @@ async fn monitor_finish_returns_ok_when_source_closes() {
 async fn monitor_finish_event_delivered_despite_mask_disconnected() {
     use epics_pva_rs::client_native::ops_v2::{MonitorEvent, MonitorEventMask};
 
-    let (port, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
 
     let (source, _orig_tx) = FiniteSource::new();
     let source_for_drive = source.clone();
-    tokio::spawn(async move {
-        let _ = run_pva_server(Arc::new(source_for_drive), cfg).await;
-    });
+    let server = PvaServer::start(Arc::new(source_for_drive), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let server_addr =

--- a/crates/epics-pva-rs/tests/parity/test_monitor_reload_deny_composite.rs
+++ b/crates/epics-pva-rs/tests/parity/test_monitor_reload_deny_composite.rs
@@ -21,7 +21,7 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::sync::{Mutex, mpsc};
@@ -32,7 +32,7 @@ use epics_base_rs::server::access_security::{
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
 use epics_pva_rs::server_native::{
-    ChannelSource, CompositeSource, DynSource, OpError, PvaServerConfig, run_pva_server,
+    ChannelSource, CompositeSource, DynSource, OpError, PvaServer, PvaServerConfig,
 };
 
 /// Child source backing the composite. Its `subscribe_checked`
@@ -130,18 +130,11 @@ impl VersionedChildSource {
     }
 }
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(47100);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
-
 #[tokio::test]
 async fn composite_monitor_finishes_after_inner_deny_bump() {
-    let (port, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
 
@@ -151,9 +144,8 @@ async fn composite_monitor_finishes_after_inner_deny_bump() {
         .unwrap();
 
     let server_comp = comp.clone();
-    tokio::spawn(async move {
-        let _ = run_pva_server(server_comp, cfg).await;
-    });
+    let server = PvaServer::start(server_comp, cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let server_addr =
@@ -245,4 +237,7 @@ ASG(DEFAULT) {
         !saw_post_deny.load(Ordering::SeqCst),
         "post-deny value (2.0) must NOT be forwarded after child ACL flips to deny"
     );
+
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }

--- a/crates/epics-pva-rs/tests/parity/test_put_get_process.rs
+++ b/crates/epics-pva-rs/tests/parity/test_put_get_process.rs
@@ -16,7 +16,7 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use parking_lot::Mutex;
@@ -122,12 +122,6 @@ impl ChannelSource for DoublingSource {
     }
 }
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(49200);
-fn alloc_port() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
-
 fn client_to(port: u16) -> PvaClient {
     let server_addr =
         std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port);
@@ -158,14 +152,14 @@ fn int_value(v: &PvField) -> i32 {
 /// returns 42 — proving the GET leg observed the post-put state.
 #[tokio::test]
 async fn put_get_round_trip() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -201,14 +195,14 @@ async fn put_get_round_trip() {
 /// server.
 #[tokio::test]
 async fn put_get_with_request_value_round_trips() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -253,14 +247,14 @@ async fn put_get_with_request_value_round_trips() {
 /// to a non-default 42 so the readback is unambiguous.
 #[tokio::test]
 async fn get_with_request_value_round_trips() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -298,14 +292,14 @@ async fn get_with_request_value_round_trips() {
 /// PUT_GET op leaves the channel in a consistent state.
 #[tokio::test]
 async fn put_get_then_get_consistent() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -337,14 +331,14 @@ async fn put_get_then_get_consistent() {
 /// payload-less frames failed to decode instead of returning data.
 #[tokio::test]
 async fn get_get_and_get_put_read_without_writing() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -411,15 +405,15 @@ async fn get_get_and_get_put_read_without_writing() {
 /// fires before any put leg, so the source is never mutated.
 #[tokio::test]
 async fn put_get_rejected_when_serve_put_get_disabled() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         serve_put_get: false,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -468,14 +462,14 @@ async fn put_get_rejected_when_serve_put_get_disabled() {
 /// increments and the stored value gains 100.
 #[tokio::test]
 async fn process_triggers_hook() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DoublingSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -615,14 +609,14 @@ impl ChannelSource for DenySource {
 /// error. The source's `put_value` hook never runs.
 #[tokio::test]
 async fn put_get_denied_for_read_only_peer() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DenySource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let server_addr =
@@ -662,14 +656,14 @@ async fn put_get_denied_for_read_only_peer() {
 /// The source's `process` hook never runs.
 #[tokio::test]
 async fn process_denied_for_read_only_peer() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = DenySource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let server_addr =
@@ -828,14 +822,14 @@ fn put_get_request(put_field: &str, get_field: &str) -> PvField {
 /// (9) only.
 #[tokio::test]
 async fn get_put_and_get_get_project_distinct_legs() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = TwoFieldSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -1003,14 +997,14 @@ impl ChannelSource for EnumSource {
 /// of index 1 proves the in-PUT snapshot round-tripped end-to-end.
 #[tokio::test]
 async fn enum_put_by_label_uses_in_put_getoput() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let src = EnumSource::new();
     let server = PvaServer::start(Arc::new(src.clone()), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);

--- a/crates/epics-pva-rs/tests/parity/test_pvrequest_filter.rs
+++ b/crates/epics-pva-rs/tests/parity/test_pvrequest_filter.rs
@@ -15,14 +15,13 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
 
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
-use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServerConfig, run_pva_server};
+use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServer, PvaServerConfig};
 
 #[derive(Clone)]
 struct NTScalarSource;
@@ -124,24 +123,19 @@ impl ChannelSource for NTScalarSource {
     }
 }
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(46000);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
-
-async fn start_server() -> u16 {
-    let (port, udp) = alloc_port_pair();
+/// Returns the running server alongside its actually-bound port; the
+/// caller must keep the `PvaServer` alive for the test's duration —
+/// dropping it aborts the listener.
+async fn start_server() -> (PvaServer, u16) {
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
-    tokio::spawn(async move {
-        let _ = run_pva_server(Arc::new(NTScalarSource), cfg).await;
-    });
+    let server = PvaServer::start(Arc::new(NTScalarSource), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
-    port
+    (server, port)
 }
 
 fn client_to(port: u16) -> PvaClient {
@@ -158,7 +152,7 @@ fn client_to(port: u16) -> PvaClient {
 /// and dropping every leaf, so `pvget` returned 0 for the value.
 #[tokio::test]
 async fn empty_pvrequest_returns_all_fields() {
-    let port = start_server().await;
+    let (server, port) = start_server().await;
     let client = client_to(port);
 
     let v = tokio::time::timeout(Duration::from_secs(5), client.pvget("dut"))
@@ -193,6 +187,9 @@ async fn empty_pvrequest_returns_all_fields() {
         Some(PvField::Scalar(ScalarValue::Long(1_700_000_000))) => {}
         other => panic!("expected seconds=1700000000, got {other:?}"),
     }
+
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }
 
 /// `pvget --field value` ⇒ only `value` carried on the wire. The other
@@ -200,7 +197,7 @@ async fn empty_pvrequest_returns_all_fields() {
 /// secondsPastEpoch=0) because they were not selected by the pvRequest.
 #[tokio::test]
 async fn field_value_only_omits_alarm_and_timestamp() {
-    let port = start_server().await;
+    let (server, port) = start_server().await;
     let client = client_to(port);
 
     let res = tokio::time::timeout(
@@ -233,4 +230,7 @@ async fn field_value_only_omits_alarm_and_timestamp() {
         Some(other) => panic!("alarm.severity should default to 0, got {other:?}"),
         None => {}
     }
+
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }

--- a/crates/epics-pva-rs/tests/parity/test_sharedpv_lazy_open.rs
+++ b/crates/epics-pva-rs/tests/parity/test_sharedpv_lazy_open.rs
@@ -19,18 +19,11 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
 use epics_pva_rs::server_native::{PvaServer, PvaServerConfig, SharedPV, SharedSource};
-
-static NEXT_PORT: AtomicU16 = AtomicU16::new(48600);
-fn alloc_port() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
 
 fn nt_int_desc() -> FieldDesc {
     FieldDesc::Structure {
@@ -75,13 +68,13 @@ fn client_to(port: u16) -> PvaClient {
 /// descriptor, not a frozen `None` prototype.
 #[tokio::test]
 async fn lazy_first_connect_pv_serves_get_on_creating_channel() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let server = PvaServer::start(lazy_source(), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);
@@ -106,13 +99,13 @@ async fn lazy_first_connect_pv_serves_get_on_creating_channel() {
 /// monitor INIT reads the channel prototype too.
 #[tokio::test]
 async fn lazy_first_connect_pv_serves_monitor_on_creating_channel() {
-    let (port, udp) = alloc_port();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
     let server = PvaServer::start(lazy_source(), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let client = client_to(port);

--- a/crates/epics-pva-rs/tests/parity/testendian_port.rs
+++ b/crates/epics-pva-rs/tests/parity/testendian_port.rs
@@ -9,7 +9,6 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -17,7 +16,7 @@ use tokio::sync::mpsc;
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::proto::ByteOrder;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
-use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServerConfig, run_pva_server};
+use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServer, PvaServerConfig};
 
 #[derive(Clone)]
 struct UInt32Source;
@@ -67,17 +66,10 @@ impl ChannelSource for UInt32Source {
     }
 }
 
-static NEXT_PORT: AtomicU16 = AtomicU16::new(45000);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
-
 async fn run_endian_case(server_be: bool) {
-    let (port, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         wire_byte_order: if server_be {
             ByteOrder::Big
         } else {
@@ -85,9 +77,8 @@ async fn run_endian_case(server_be: bool) {
         },
         ..Default::default()
     };
-    let h = tokio::spawn(async move {
-        let _ = run_pva_server(Arc::new(UInt32Source), cfg).await;
-    });
+    let server = PvaServer::start(Arc::new(UInt32Source), cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let server_addr =
@@ -110,7 +101,8 @@ async fn run_endian_case(server_be: bool) {
         panic!("expected NTScalar structure");
     }
 
-    h.abort();
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }
 
 #[tokio::test]

--- a/crates/epics-pva-rs/tests/parity/testget_port.rs
+++ b/crates/epics-pva-rs/tests/parity/testget_port.rs
@@ -8,26 +8,19 @@
 #![cfg(test)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::nt::NTScalar;
 use epics_pva_rs::pvdata::ScalarType;
-use epics_pva_rs::server_native::{PvaServerConfig, SharedPV, SharedSource, run_pva_server};
-
-static NEXT_PORT: AtomicU16 = AtomicU16::new(34000);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed);
-    (base, base + 1)
-}
+use epics_pva_rs::server_native::{PvaServer, PvaServerConfig, SharedPV, SharedSource};
 
 #[tokio::test]
 async fn pvxs_connect_onconnect_fires_after_server_start() {
-    let (port, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: port,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         ..Default::default()
     };
 
@@ -40,9 +33,8 @@ async fn pvxs_connect_onconnect_fires_after_server_start() {
     let src = Arc::new(SharedSource::new());
     src.add("mailbox", pv);
 
-    let h = tokio::spawn(async move {
-        let _ = run_pva_server(src, cfg).await;
-    });
+    let server = PvaServer::start(src, cfg).expect("test server must start");
+    let port = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(150)).await;
 
     let server_addr =
@@ -84,5 +76,6 @@ async fn pvxs_connect_onconnect_fires_after_server_start() {
     );
 
     drop(handle);
-    h.abort();
+    server.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server.wait()).await;
 }

--- a/crates/epics-pva-rs/tests/stability.rs
+++ b/crates/epics-pva-rs/tests/stability.rs
@@ -19,7 +19,6 @@
 #![allow(clippy::manual_async_fn)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use tokio::sync::{Mutex, mpsc};
@@ -27,7 +26,7 @@ use tokio::sync::{Mutex, mpsc};
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
 use epics_pva_rs::server_native::{
-    ChannelSource, OpError, PvaServer, PvaServerConfig, SharedPV, SharedSource, run_pva_server,
+    ChannelSource, OpError, PvaServer, PvaServerConfig, SharedPV, SharedSource,
 };
 
 // ── A tiny in-memory ChannelSource we can pump events into ───────────
@@ -285,25 +284,21 @@ impl ChannelSource for MemSource {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-static NEXT_PORT: AtomicU32 = AtomicU32::new(15075);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed) as u16;
-    (base, base + 1)
-}
-
 async fn spawn_server(source: Arc<MemSource>) -> (u16, u16, tokio::task::JoinHandle<()>) {
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
         monitor_queue_depth: 8,
         ..Default::default()
     };
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let report = server.report();
+    let (tcp, udp) = (report.tcp_port, report.udp_port);
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
+        let _ = server.wait().await;
     });
     // Give the server a moment to bind.
     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -344,10 +339,9 @@ async fn spawn_server_capped(
     source: Arc<MemSource>,
     cap: usize,
 ) -> (u16, u16, tokio::task::JoinHandle<()>) {
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -355,8 +349,11 @@ async fn spawn_server_capped(
         max_message_size: Some(cap),
         ..Default::default()
     };
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let report = server.report();
+    let (tcp, udp) = (report.tcp_port, report.udp_port);
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
+        let _ = server.wait().await;
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
     (tcp, udp, h)
@@ -369,7 +366,24 @@ async fn p2_auto_reconnect_after_server_restart() {
     let source = Arc::new(MemSource::new());
     source.add_pv("STAB:RECON", 1.0).await;
 
-    let (tcp, _udp, h1) = spawn_server(source.clone()).await;
+    // Started directly (not via `spawn_server`): this test needs the
+    // first server's port genuinely freed before the second bind, and
+    // `JoinHandle::abort()` on a task wrapping `wait()` does not give
+    // that — it cancels the supervisor task without running `wait()`'s
+    // own cross-abort logic, so the listener task is silently detached
+    // and keeps holding the port. `stop()` + awaiting `wait()` to
+    // completion is the API's actual shutdown contract.
+    let cfg1 = PvaServerConfig {
+        tcp_port: 0,
+        udp_port: 0,
+        idle_timeout: Duration::from_secs(60),
+        max_connections: 16,
+        max_channels_per_connection: 64,
+        monitor_queue_depth: 8,
+        ..Default::default()
+    };
+    let server1 = PvaServer::start(source.clone(), cfg1).expect("test server must start");
+    let tcp = server1.report().tcp_port;
     let client = client_for(tcp);
 
     // First GET succeeds.
@@ -380,11 +394,18 @@ async fn p2_auto_reconnect_after_server_restart() {
     assert!(matches!(v, PvField::Structure(_)));
 
     // Restart server on same port.
-    h1.abort();
-    let _ = h1.await;
+    server1.stop();
+    tokio::time::timeout(Duration::from_secs(2), server1.wait())
+        .await
+        .expect("server1.wait() timed out — stop did not complete")
+        .expect("server1.wait() returned Err");
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Reuse the same source — but we need to re-bind on the same port.
+    // `PvaServer::start` requests the exact port `client` is already wired
+    // to; if TIME_WAIT is still holding it, start() would silently fall
+    // back to an ephemeral port (the defect this test suite closes), so
+    // assert the readback instead of trusting the request.
     let source2 = source.clone();
     let cfg = PvaServerConfig {
         tcp_port: tcp,
@@ -395,9 +416,12 @@ async fn p2_auto_reconnect_after_server_restart() {
         monitor_queue_depth: 8,
         ..Default::default()
     };
-    let h2 = tokio::spawn(async move {
-        let _ = run_pva_server(source2, cfg).await;
-    });
+    let server2 = PvaServer::start(source2, cfg).expect("server must restart on the freed port");
+    assert_eq!(
+        server2.report().tcp_port,
+        tcp,
+        "second server must rebind the exact same port the first one used"
+    );
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // GET on the same client should succeed (channel state machine
@@ -408,8 +432,8 @@ async fn p2_auto_reconnect_after_server_restart() {
         .expect("post-restart pvget failed");
     assert!(matches!(v, PvField::Structure(_)));
 
-    h2.abort();
-    let _ = h2.await;
+    server2.stop();
+    let _ = tokio::time::timeout(Duration::from_secs(2), server2.wait()).await;
 }
 
 /// the default client is **unbounded** (pvxs parity — no
@@ -1756,8 +1780,7 @@ async fn ex_r7_unadvertised_auth_reverts_credential_to_anonymous() {
     use epics_pva_rs::proto::encode_string_into;
     use epics_pva_rs::proto::{ByteOrder, Command, PvaHeader, Status, WriteExt};
     use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
-    use epics_pva_rs::server_native::PvaServerConfig;
-    use epics_pva_rs::server_native::run_pva_server;
+    use epics_pva_rs::server_native::{PvaServer, PvaServerConfig};
 
     // Capture what the auth_complete hook observed.
     let captured: Arc<StdMutex<Option<(String, String)>>> = Arc::new(StdMutex::new(None));
@@ -1766,10 +1789,9 @@ async fn ex_r7_unadvertised_auth_reverts_credential_to_anonymous() {
     let source = Arc::new(MemSource::new());
     source.add_pv("AUTH:EXR7", 0.0).await;
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -1779,8 +1801,10 @@ async fn ex_r7_unadvertised_auth_reverts_credential_to_anonymous() {
         })),
         ..Default::default()
     };
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let tcp = server.report().tcp_port;
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
+        let _ = server.wait().await;
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -1863,17 +1887,15 @@ async fn r70_anonymous_method_yields_account_anonymous() {
     use epics_pva_rs::codec::CMD_CONNECTION_VALIDATED;
     use epics_pva_rs::proto::encode_string_into;
     use epics_pva_rs::proto::{ByteOrder, Command, PvaHeader, Status, WriteExt};
-    use epics_pva_rs::server_native::PvaServerConfig;
-    use epics_pva_rs::server_native::run_pva_server;
+    use epics_pva_rs::server_native::{PvaServer, PvaServerConfig};
 
     let captured: Arc<StdMutex<Option<(String, String)>>> = Arc::new(StdMutex::new(None));
     let captured_hook = captured.clone();
 
     let source = Arc::new(MemSource::new());
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -1883,8 +1905,10 @@ async fn r70_anonymous_method_yields_account_anonymous() {
         })),
         ..Default::default()
     };
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let tcp = server.report().tcp_port;
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
+        let _ = server.wait().await;
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -1947,17 +1971,15 @@ async fn r70_ca_without_user_falls_back_to_anonymous() {
     use epics_pva_rs::proto::encode_string_into;
     use epics_pva_rs::proto::{ByteOrder, Command, PvaHeader, Status, WriteExt};
     use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
-    use epics_pva_rs::server_native::PvaServerConfig;
-    use epics_pva_rs::server_native::run_pva_server;
+    use epics_pva_rs::server_native::{PvaServer, PvaServerConfig};
 
     let captured: Arc<StdMutex<Option<(String, String)>>> = Arc::new(StdMutex::new(None));
     let captured_hook = captured.clone();
 
     let source = Arc::new(MemSource::new());
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -1967,8 +1989,10 @@ async fn r70_ca_without_user_falls_back_to_anonymous() {
         })),
         ..Default::default()
     };
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let tcp = server.report().tcp_port;
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
+        let _ = server.wait().await;
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -2125,10 +2149,9 @@ async fn ignore_addr_list_does_not_block_direct_tcp_connect() {
     let source = Arc::new(MemSource::new());
     source.add_pv("IGN:PV", 1.0).await;
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -2137,8 +2160,10 @@ async fn ignore_addr_list_does_not_block_direct_tcp_connect() {
         ignore_addrs: vec![(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0)],
         ..Default::default()
     };
+    let server = PvaServer::start(source, cfg).expect("test server must start");
+    let tcp = server.report().tcp_port;
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
+        let _ = server.wait().await;
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -2436,15 +2461,16 @@ async fn array_concurrent_subop_replies_error_not_silent() {
 
     let gate = Arc::new(tokio::sync::Semaphore::new(0));
     let src = Arc::new(GatedArraySource { gate: gate.clone() });
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         ..Default::default()
     };
+    let server = PvaServer::start(src, cfg).expect("test server must start");
+    let tcp = server.report().tcp_port;
     let h = tokio::spawn(async move {
-        let _ = run_pva_server(src, cfg).await;
+        let _ = server.wait().await;
     });
     tokio::time::sleep(Duration::from_millis(50)).await;
     let server_addr =

--- a/crates/epics-pva-rs/tests/tls.rs
+++ b/crates/epics-pva-rs/tests/tls.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::manual_async_fn)]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
@@ -20,7 +19,7 @@ use tokio::sync::{Mutex, mpsc};
 use epics_pva_rs::auth::{TlsClientConfig, TlsServerConfig};
 use epics_pva_rs::client_native::context::PvaClient;
 use epics_pva_rs::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
-use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServerConfig, run_pva_server};
+use epics_pva_rs::server_native::{ChannelSource, OpError, PvaServer, PvaServerConfig};
 
 /// Server-side hook invoked once a peer's credentials are resolved.
 type AuthCompleteHook = Arc<
@@ -148,12 +147,6 @@ impl ChannelSource for StaticSource {
     }
 }
 
-static NEXT_PORT: AtomicU32 = AtomicU32::new(16075);
-fn alloc_port_pair() -> (u16, u16) {
-    let base = NEXT_PORT.fetch_add(2, Ordering::Relaxed) as u16;
-    (base, base + 1)
-}
-
 #[tokio::test]
 async fn tls_client_to_tls_server_full_handshake() {
     // Reseed the global rustls crypto provider with ring (otherwise
@@ -187,10 +180,10 @@ async fn tls_client_to_tls_server_full_handshake() {
     let source = Arc::new(StaticSource::new());
     source.put("TLS:PV", 12.5).await;
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
+        tls_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -198,14 +191,11 @@ async fn tls_client_to_tls_server_full_handshake() {
         tls: Some(server_tls),
         ..Default::default()
     };
-    let server_handle = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("server start");
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Client targeting the TLS server explicitly.
-    let server_addr =
-        std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), tcp);
+    let server_addr = server.tcp_addr();
     let client = PvaClient::builder()
         .timeout(Duration::from_secs(3))
         .server_addr(server_addr)
@@ -227,7 +217,7 @@ async fn tls_client_to_tls_server_full_handshake() {
         other => panic!("expected NTScalar structure, got {other:?}"),
     }
 
-    server_handle.abort();
+    server.stop();
 }
 
 /// A TLS-enabled server must bind a DEDICATED TLS listener on its own
@@ -445,10 +435,10 @@ async fn mtls_client_cert_populates_x509_credentials() {
         }
     });
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
+        tls_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -457,13 +447,10 @@ async fn mtls_client_cert_populates_x509_credentials() {
         auth_complete: Some(auth_complete),
         ..Default::default()
     };
-    let server_handle = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("server start");
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let server_addr =
-        std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), tcp);
+    let server_addr = server.tcp_addr();
     let client = PvaClient::builder()
         .timeout(Duration::from_secs(3))
         .server_addr(server_addr)
@@ -501,7 +488,7 @@ async fn mtls_client_cert_populates_x509_credentials() {
         "authority must be the root CA CommonName"
     );
 
-    server_handle.abort();
+    server.stop();
 }
 
 /// when the client sends only the leaf cert (no root CA in the chain),
@@ -561,10 +548,10 @@ async fn mtls_partial_chain_authority_resolved_from_trust_roots() {
         }
     });
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
+        tls_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -573,13 +560,10 @@ async fn mtls_partial_chain_authority_resolved_from_trust_roots() {
         auth_complete: Some(auth_complete),
         ..Default::default()
     };
-    let server_handle = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("server start");
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let server_addr =
-        std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), tcp);
+    let server_addr = server.tcp_addr();
     let client = PvaClient::builder()
         .timeout(Duration::from_secs(3))
         .server_addr(server_addr)
@@ -612,7 +596,7 @@ async fn mtls_partial_chain_authority_resolved_from_trust_roots() {
         "authority from trust store when peer sends partial chain"
     );
 
-    server_handle.abort();
+    server.stop();
 }
 
 /// PVA item #5: the client must extract the *server*'s X.509 identity
@@ -654,10 +638,10 @@ async fn client_extracts_server_x509_identity() {
     let source = Arc::new(StaticSource::new());
     source.put("SRVID:PV", 3.0).await;
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
+        tls_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -665,13 +649,11 @@ async fn client_extracts_server_x509_identity() {
         tls: Some(server_tls),
         ..Default::default()
     };
-    let server_handle = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("server start");
+    let tcp = server.report().tcp_port;
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let server_addr =
-        std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), tcp);
+    let server_addr = server.tcp_addr();
     let client = PvaClient::builder()
         .timeout(Duration::from_secs(3))
         .server_addr(server_addr)
@@ -697,7 +679,7 @@ async fn client_extracts_server_x509_identity() {
         "authority must be the root CA CommonName"
     );
 
-    server_handle.abort();
+    server.stop();
 }
 
 /// A plain `pva://` (non-TLS) connection has no peer certificate, so
@@ -710,10 +692,9 @@ async fn plain_connection_has_no_server_identity() {
     let source = Arc::new(StaticSource::new());
     source.put("PLAIN:PV", 1.0).await;
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -721,13 +702,10 @@ async fn plain_connection_has_no_server_identity() {
         tls: None,
         ..Default::default()
     };
-    let server_handle = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("server start");
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let server_addr =
-        std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), tcp);
+    let server_addr = server.tcp_addr();
     let client = PvaClient::builder()
         .timeout(Duration::from_secs(3))
         .server_addr(server_addr)
@@ -746,7 +724,7 @@ async fn plain_connection_has_no_server_identity() {
         "a plain pva:// connection must have no server X.509 identity"
     );
 
-    server_handle.abort();
+    server.stop();
 }
 
 /// TLS-NAMESERVER regression: a single TCP port configured with TLS must
@@ -773,10 +751,10 @@ async fn pva_tls_nameserver_mixed_mode_listener() {
     let source = Arc::new(StaticSource::new());
     source.put("MIXED:PV", 42.0).await;
 
-    let (tcp, udp) = alloc_port_pair();
     let cfg = PvaServerConfig {
-        tcp_port: tcp,
-        udp_port: udp,
+        tcp_port: 0,
+        udp_port: 0,
+        tls_port: 0,
         idle_timeout: Duration::from_secs(60),
         max_connections: 16,
         max_channels_per_connection: 64,
@@ -784,13 +762,10 @@ async fn pva_tls_nameserver_mixed_mode_listener() {
         tls: Some(server_tls),
         ..Default::default()
     };
-    let server_handle = tokio::spawn(async move {
-        let _ = run_pva_server(source, cfg).await;
-    });
+    let server = PvaServer::start(source, cfg).expect("server start");
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let server_addr =
-        std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), tcp);
+    let server_addr = server.tcp_addr();
 
     // ── TLS client ────────────────────────────────────────────────────────────
     let mut roots = RootCertStore::empty();
@@ -838,5 +813,5 @@ async fn pva_tls_nameserver_mixed_mode_listener() {
         other => panic!("plain client: expected NTScalar, got {other:?}"),
     }
 
-    server_handle.abort();
+    server.stop();
 }

--- a/crates/epics-tools-rs/src/procserv/sidecar.rs
+++ b/crates/epics-tools-rs/src/procserv/sidecar.rs
@@ -523,6 +523,10 @@ mod tests {
         );
     }
 
+    // Abstract-namespace sockets are a Linux-only feature (bind_one's
+    // platform fork errors on other targets), so the render test can
+    // only bind one there.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn abstract_unix_address_uses_the_at_prefix() {
         use crate::procserv::config::ListenConfig;

--- a/crates/motor-rs/tests/record_tests.rs
+++ b/crates/motor-rs/tests/record_tests.rs
@@ -9022,9 +9022,15 @@ fn test_same_value_dbput_after_miss_giveup_redispatches() {
     // processes, the entry gate (2240) passes via `!dmov`, the target
     // sits 500 steps out (not too_small), and the dispatch gate (2455,
     // `mip == MIP_DONE`) sends the move again — C retries a missed
-    // target on an operator re-put of the same value.
+    // target on an operator re-put of the same value. Anchored first:
+    // in C a dbPut pass can only exist after init_record, and an
+    // unanchored mailbox-wired record parks every pass
+    // (do_process_inner's anchor-first gate), which would swallow the
+    // re-dispatch this test asserts on.
     let mut rec = MotorRecord::new();
-    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    let state = motor_rs::device_state::new_shared_state();
+    rec.set_device_state(state.clone());
+    anchor(&mut rec, &state);
     rec.stat.msta = MstaFlags::DONE;
     rec.stat.phase = MotionPhase::MainMove;
     rec.stat.dmov = false;
@@ -9201,9 +9207,14 @@ fn test_blinked_zero_tweak_pulses_dmov() {
     // the request is too_small and the sub-step pulse runs — DMOV
     // 1→0→1, no controller command (C 2333-2342 restores DMOV=TRUE on
     // the same pass; the Rust pulse posts the low half and the
-    // recovery pass restores it).
+    // recovery pass restores it). Anchored first: in C a TWF put can
+    // only exist after init_record, and an unanchored mailbox-wired
+    // record parks every pass (do_process_inner's anchor-first gate),
+    // which would swallow the recovery pass this test asserts on.
     let mut rec = MotorRecord::new();
-    rec.set_device_state(motor_rs::device_state::new_shared_state());
+    let state = motor_rs::device_state::new_shared_state();
+    rec.set_device_state(state.clone());
+    anchor(&mut rec, &state);
     rec.stat.msta = MstaFlags::DONE;
     rec.conv.mres = 0.001;
     rec.pos.val = 10.0;


### PR DESCRIPTION
# Post-merge CI repairs: motor anchor gate, platform gate, fd-count isolation, fixed-port family

Follow-up to #33. The post-merge CI runs on `main` surfaced four findings; all four are test-harness defects — production code was verified correct in each case (one production doc comment is corrected, no production logic touched).

## 1. motor-rs: two PR-32 tests park under the PR-33 anchor-first gate (all platforms)

`test_blinked_zero_tweak_pulses_dmov` and `test_same_value_dbput_after_miss_giveup_redispatches` (merged in #32) modeled a TWF/dbPut pass on a mailbox-wired record **before** anchoring. #33's `do_process_inner` anchor-first gate (da7eef36) correctly parks every pass on an unanchored record — in C, such a put can only exist after `init_record`. Fixed by anchoring the record first via the existing `anchor()` helper, matching every other mailbox-wired test in the file.

## 2. epics-tools-rs: abstract-socket render test is Linux-only (macOS)

`abstract_unix_address_uses_the_at_prefix` binds an abstract-namespace unix socket, a Linux-only kernel feature (`bind_one`'s platform fork errors elsewhere). Gated with `#[cfg(target_os = "linux")]`.

## 3. epics-bridge-rs: fd-count test samples a process-global resource (~30% local flake)

`open_fd_count_tracks_new_descriptors` asserts on `/proc/self/fd` counts, but sibling tests in the same process open/close descriptors concurrently — no batch size or tolerance can bound that. Fixed structurally: the test re-execs itself as a `--exact` child process (marker env var), reproducing nextest's per-process isolation under plain `cargo test`; the assertion is *tightened* (full batch must be visible) because the child's fd table is quiet. 11 consecutive green runs locally.

## 4. epics-pva-rs: fixed-port test family (13 files audited, 11 changed)

`test_sharedpv_lazy_open` failed 6/6 on CI: tests allocated fixed ports from `static NEXT_PORT: AtomicU16` (48600 sits inside the Linux ephemeral range 32768–60999). A TIME-WAIT socket from a prior run blocks re-bind; `PvaServer::start`'s documented fallback then moves the server to an ephemeral port while the client still dials the fixed one → `ConnectionRefused`/timeout.

Family sweep (anchor: `rg -n 'AtomicU16|NEXT_PORT' crates/epics-pva-rs/tests/`), all same-defect sites converted to `tcp_port: 0` + dialing `server.report().tcp_port` (the readback of the actually-bound port):

- `testget_port.rs` (1 test), `testendian_port.rs` (2), `test_monitor_reload_deny_composite.rs` (1), `test_monitor_finish.rs` (2), `test_sharedpv_lazy_open.rs` (2), `test_client_server_lifecycle.rs` (2), `test_put_get_process.rs` (11), `test_pvrequest_filter.rs` (2, helper redesigned to return the server so it outlives the test body), `interop.rs` (1), `tls.rs` (6), `stability.rs` (24 via the shared `spawn_server`/`spawn_server_capped` helpers + 5 inline + the restart special case below)
- Where tests previously detached servers with `JoinHandle::abort()`, they now use the real shutdown contract (`server.stop()` + bounded `server.wait()`).
- **Bonus finding:** `stability.rs` `p2_auto_reconnect_after_server_restart` had been vacuously passing — aborting a task that wraps `wait()` silently detaches the listener, so its "restarted" server never actually replaced the first one. It now stops the first server through the shutdown contract and asserts the second bind lands on the exact same port.
- Distinct-skip (fixed ports retained, immune or out of scope): `stability_interop.rs`, `tls_interop.rs`, and 8 `interop.rs` tests — all `#[ignore]`d external-pvxs-tool tests whose clients discover via UDP SEARCH (no TCP TIME-WAIT; SEARCH responses advertise the actually-bound port).
- Production change: `runtime.rs` `bound_tcp_port` doc comment only — it claimed post-bind readback was "future work", contradicting the stamping code three screens below.

## Verification

- `cargo fmt --all` — no diff
- `cargo clippy -p epics-pva-rs --all-targets -- -D warnings` — clean (motor-rs, epics-tools-rs, epics-bridge-rs clippy ran on their respective commits)
- `parity_interop`, `tls`, `stability` binaries run 3× back-to-back (the TIME-WAIT trigger): green
- Full-workspace clippy + test sweep before push: green

## Known non-blocking observations

- `interop::rust_client_to_rust_server_ntndarray_full_roundtrip` (`#[ignore]`d) fails on an NTNDArray union-selector wire mismatch (`expected 5, got 3`) — pre-existing, confirmed identical with these changes stashed (git-stash A/B). Not touched here.
- `cli_monitor_separator` (epics-ca-rs) was FLAKY 2/3 on one CI run; 12/12 green locally, not reproducible. Documented, not changed.

https://claude.ai/code/session_016oXdK513ufXKtrm3m8qa2V
