### PR TITLE
fix(base/array): aai/aao/subArray VAL served a 0-length channel + oracle array phase

### DIFF
--- a/crates/epics-base-rs/src/server/records/waveform.rs
+++ b/crates/epics-base-rs/src/server/records/waveform.rs
@@ -913,13 +913,17 @@ impl Record for WaveformRecord {
         Ok(())
     }
 
-    /// `waveform` VAL: `get_field("VAL")` serves NORD valid elements, but the
-    /// channel's native count is NELM (the buffer capacity) so a client sizes
-    /// its buffer right — C `cvt_dbaddr` `no_elements = nelm` vs
-    /// `get_array_info` `*no_elements = nord`. Only the waveform kind: `aai`/
-    /// `aao`/`subArray` serve their VAL at its own count.
+    /// `VAL`: `get_field("VAL")` serves NORD valid elements, but the channel's
+    /// native count is the buffer capacity so a client sizes its buffer right —
+    /// C `cvt_dbaddr` `no_elements` vs `get_array_info` `*no_elements = nord`.
+    /// The capacity is the same [`Self::val_capacity`] every array kind
+    /// advertises: waveform/aai/aao report `nelm` (`waveformRecord.c:183`,
+    /// `aaiRecord.c:215`, `aaoRecord.c:219`), subArray reports `malm`
+    /// (`subArrayRecord.c:168`). Reporting it only for the waveform kind left
+    /// aai/aao/subArray advertising a 0-length channel, so every array put/get
+    /// was refused "Invalid element count requested".
     fn field_native_count(&self, field: &str) -> Option<u32> {
-        (field == "VAL" && self.kind == ArrayKind::Waveform).then_some(self.nelm.max(0) as u32)
+        (field == "VAL").then(|| self.val_capacity() as u32)
     }
 
     /// `aao` is an output record; the rest of the array family read
@@ -1573,6 +1577,41 @@ mod array_kind_tests {
         let r = WaveformRecord::with_kind(ArrayKind::SubArray);
         assert_eq!(r.record_type(), "subArray");
         assert!(!r.can_device_write(), "subArray is input");
+    }
+
+    /// C's `cvt_dbaddr` fixes every array record's VAL channel `no_elements` at
+    /// the buffer capacity — `nelm` for waveform/aai/aao (`waveformRecord.c:183`,
+    /// `aaiRecord.c:215`, `aaoRecord.c:219`), `malm` for subArray
+    /// (`subArrayRecord.c:168`). A kind that reported `None` here advertised a
+    /// 0-length channel, so every array put/get was refused "Invalid element
+    /// count requested". Boundary: each kind's capacity source, plus a non-VAL
+    /// field that must stay `None`.
+    #[test]
+    fn every_array_kind_advertises_val_capacity_as_native_count() {
+        for kind in [ArrayKind::Waveform, ArrayKind::Aai, ArrayKind::Aao] {
+            let mut r = WaveformRecord::with_kind(kind);
+            r.nelm = 16;
+            assert_eq!(
+                r.field_native_count("VAL"),
+                Some(16),
+                "{} VAL native count must be NELM (its cvt_dbaddr no_elements)",
+                r.record_type()
+            );
+            assert_eq!(
+                r.field_native_count("NORD"),
+                None,
+                "{} native count only applies to VAL",
+                r.record_type()
+            );
+        }
+        let mut sa = WaveformRecord::with_kind(ArrayKind::SubArray);
+        sa.malm = 12;
+        assert_eq!(
+            sa.field_native_count("VAL"),
+            Some(12),
+            "subArray VAL native count must be MALM, not NELM"
+        );
+        assert_eq!(sa.field_native_count("VAL"), Some(sa.val_capacity() as u32));
     }
 
     #[test]

--- a/crates/epics-oracle-rs/src/bin/oracle.rs
+++ b/crates/epics-oracle-rs/src/bin/oracle.rs
@@ -26,6 +26,12 @@ enum Phase {
     Put,
     /// Monitor event sequence and count.
     Monitor,
+    /// Array put-and-readback across element-count boundaries (single, partial,
+    /// exactly NELM, one past NELM) for record types whose VAL is a bounded
+    /// array (waveform/aai/aao/subArray). Part of `All`: same C ground truth,
+    /// same CA tools, same allowlist — it just reaches the `DBF_NOACCESS` array
+    /// VAL the scalar phases exclude.
+    Array,
     /// **PVA** read: every channel of the `.dbd` surface on pvxs QSRV2
     /// (`softIocPVX`) and on `oracle-ioc --pva`, on two contracts — the
     /// declared type (`pvxinfo`) and the value+marking (`pvxget`).
@@ -157,6 +163,9 @@ async fn run() -> Result<ExitCode, String> {
         }
         if matches!(args.phase, Phase::Monitor | Phase::All) {
             cases.extend(runner.probe_monitor(rt, &surface, &mut allowlist));
+        }
+        if matches!(args.phase, Phase::Array | Phase::All) {
+            cases.extend(runner.probe_array(rt, &mut allowlist));
         }
     }
 

--- a/crates/epics-oracle-rs/src/lib.rs
+++ b/crates/epics-oracle-rs/src/lib.rs
@@ -94,8 +94,9 @@ pub fn record_stmt(record_type: &str, rec_name: &str) -> String {
 ///
 /// The single owner of the reproducer statement, so the `asyn` PORT rule above
 /// holds for every reproducer rather than for the one that happened to call the
-/// original. [`pvamonitor`] needs a `SCAN` field on its reproducer and must not
-/// grow a second, PORT-less spelling to get it.
+/// original. [`pvamonitor`] needs a `SCAN` field on its reproducer and the array
+/// phase needs `NELM`/`FTVL` on theirs — neither may grow a second, PORT-less
+/// spelling to get it.
 pub fn record_stmt_fields(record_type: &str, rec_name: &str, fields: &[(&str, &str)]) -> String {
     let mut body = String::new();
     if record_type == "asyn" {

--- a/crates/epics-oracle-rs/src/runner.rs
+++ b/crates/epics-oracle-rs/src/runner.rs
@@ -40,6 +40,16 @@ use crate::surface::{Surface, is_put_candidate};
 const MONITOR_SETTLE: Duration = Duration::from_millis(600);
 const MONITOR_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Array-phase capacity. Fixed so both sides declare the identical `NELM` and
+/// the over-capacity boundary is the same element count on each. Wide enough
+/// that "partial" (`NELM/2`) is a distinct case from "single".
+const ARRAY_NELM: u32 = 16;
+const ARRAY_NELM_STR: &str = "16";
+/// Element type for the array probe. `DOUBLE` because every array-capable
+/// record type in the fat dbd (`waveform`/`aai`/`aao`/`subArray`) accepts it as
+/// `FTVL`, so one type serves the whole phase.
+const ARRAY_FTVL: &str = "DOUBLE";
+
 pub struct Runner {
     tools: CTools,
     dbd: Dbd,
@@ -309,6 +319,89 @@ impl Runner {
             allowlist,
         ))
     }
+
+    /// Phase D — the **array** probe: put-and-readback of a bounded array VAL
+    /// across the element-count boundaries that break ports (single, partial,
+    /// exactly `NELM`, one past `NELM`). C truncates an over-capacity put to
+    /// `NELM`; a port that rejects it, or writes past the end, differs
+    /// observably in the readback count and `NORD`.
+    ///
+    /// Only record types whose VAL is a bounded array — both `NELM` and `FTVL`
+    /// declared — are driven; the rest have no array to probe and yield no
+    /// cases. That array VAL is `DBF_NOACCESS` in the `.dbd` (it is the record's
+    /// raw `BPTR` pointer), so it is excluded from the scalar field denominator
+    /// and never reached by the read/put/monitor phases. This phase is the only
+    /// one that exercises it, over CA, against the same C ground truth.
+    pub fn probe_array(&self, record_type: &str, allowlist: &mut Allowlist) -> Vec<CaseResult> {
+        // Array-capable iff the record declares both a capacity (NELM) and an
+        // element type (FTVL). Determined from the .dbd, not hard-listed.
+        let is_array = self
+            .dbd
+            .record_type(record_type)
+            .is_some_and(|r| r.field("NELM").is_some() && r.field("FTVL").is_some());
+        if !is_array {
+            return Vec::new();
+        }
+
+        let plan = crate::cases::array_cases(ARRAY_NELM);
+        let rec_of = |i: usize| format!("ORACLE:ARR:{}:{i}", record_type.to_uppercase());
+        let fields = &[("NELM", ARRAY_NELM_STR), ("FTVL", ARRAY_FTVL)];
+
+        // One record per case (isolation), each declaring the same NELM/FTVL so
+        // the capacity boundary is identical on both sides.
+        let mut db_text = String::new();
+        for i in 0..plan.len() {
+            db_text.push_str(&crate::record_stmt_fields(record_type, &rec_of(i), fields));
+        }
+
+        let db = match self.write_db(&format!("arr_{record_type}"), &db_text) {
+            Ok(p) => p,
+            Err(e) => return errored_array(record_type, &plan, &db_text, &e),
+        };
+        let pair = match Pair::boot(&self.tools, &db, &rec_of(0)) {
+            Ok(p) => p,
+            Err(e) => return errored_array(record_type, &plan, &db_text, &e.to_string()),
+        };
+
+        let c = CaTools::new(&self.tools, pair.c.port(), Side::C);
+        let r = CaTools::new(&self.tools, pair.rust.port(), Side::Rust);
+
+        // Drive the array puts on both sides concurrently, then read back.
+        // Separate IOCs, separate ports, no shared state — concurrency changes
+        // nothing either observes, it only stops each waiting on the other.
+        let (obs_c, obs_r) = std::thread::scope(|s| {
+            let hc = s.spawn(|| drive_array(&c, &plan, &rec_of));
+            let hr = s.spawn(|| drive_array(&r, &plan, &rec_of));
+            (
+                hc.join().expect("C array lane panicked"),
+                hr.join().expect("Rust array lane panicked"),
+            )
+        });
+
+        plan.iter()
+            .enumerate()
+            .map(|(i, (values, class))| {
+                let rec = rec_of(i);
+                let repro = Reproducer {
+                    db: crate::record_stmt_fields(record_type, &rec, fields),
+                    ops: vec![
+                        format!("caput -a {rec} {} {}", values.len(), values.join(" ")),
+                        format!("caget -t -# {ARRAY_NELM} {rec}    # returned count + payload"),
+                        format!("caget {rec}.NORD"),
+                    ],
+                };
+                adjudicate(
+                    record_type,
+                    "VAL",
+                    Some(class),
+                    repro,
+                    &obs_c[i],
+                    &obs_r[i],
+                    allowlist,
+                )
+            })
+            .collect()
+    }
 }
 
 /// Probe `pvs` with an all-or-nothing batch tool, isolating the PVs that fail.
@@ -469,6 +562,84 @@ fn drive_puts(
             .flat_map(|h| h.join().expect("put lane panicked"))
             .collect()
     })
+}
+
+/// Drive one array put per case and read back what each side stored: the array
+/// payload (with its leading returned count), `NORD`, native shape, and alarm.
+///
+/// The array payload is the primary observable, so a failure to read it back is
+/// an ERROR for that case (recorded in `errors`), never a silently skipped
+/// surface. `NORD`/`STAT`/`SEVR` are supplementary and best-effort, matching the
+/// scalar [`readback`].
+fn drive_array(
+    t: &CaTools,
+    plan: &[(Vec<String>, &'static str)],
+    rec_of: &(impl Fn(usize) -> String + Sync),
+) -> Vec<Observation> {
+    plan.iter()
+        .enumerate()
+        .map(|(i, (values, _))| {
+            let rec = rec_of(i);
+            let put = t.caput_array(&rec, values);
+
+            // Read back the whole declared capacity so a port that stored too
+            // many or too few elements shows a different leading count and
+            // payload than C's truncate-to-NELM.
+            let mut errors = Vec::new();
+            let value_string = match t.caget_array(&rec, ARRAY_NELM) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    errors.push(e);
+                    None
+                }
+            };
+            let info = match t.cainfo(&rec) {
+                Ok(ci) => Some(ci),
+                Err(e) => {
+                    errors.push(e);
+                    None
+                }
+            };
+            Observation {
+                info,
+                value_string,
+                value_numeric: t.caget_numeric(&format!("{rec}.NORD")).ok(),
+                stat: t.caget_string(&format!("{rec}.STAT")).ok(),
+                sevr: t.caget_string(&format!("{rec}.SEVR")).ok(),
+                put: Some(put),
+                monitor: None,
+                errors,
+            }
+        })
+        .collect()
+}
+
+/// A boot failure in the array phase — one ERROR case per element-count case it
+/// prevented, never one aggregate and never silence.
+fn errored_array(
+    record_type: &str,
+    plan: &[(Vec<String>, &'static str)],
+    db: &str,
+    msg: &str,
+) -> Vec<CaseResult> {
+    plan.iter()
+        .map(|(values, class)| {
+            errored_case(
+                record_type,
+                "VAL",
+                Some(class),
+                Reproducer {
+                    db: db.to_string(),
+                    ops: vec![format!(
+                        "caput -a <rec> {} {}",
+                        values.len(),
+                        values.join(" ")
+                    )],
+                },
+                msg,
+            )
+        })
+        .collect()
 }
 
 /// Batch the post-put readback: what each side stored, and what alarm it raised.


### PR DESCRIPTION
## What

Two commits, one finding + the measurement that surfaced it.

### `fix(base/array)` — aai/aao/subArray VAL advertised a 0-length channel
`WaveformRecord::field_native_count` returned the VAL buffer capacity **only for the waveform kind**, so aai/aao/subArray advertised `element_count=0` over CA and every array put/get was refused *"Invalid element count requested"*. waveform worked; the other three array records were unusable as arrays.

C's `cvt_dbaddr` fixes each array record's VAL `no_elements` at its buffer capacity for all four kinds:
- `nelm` — waveform (`waveformRecord.c:183`), aai (`aaiRecord.c:215`), aao (`aaoRecord.c:219`)
- `malm` — subArray (`subArrayRecord.c:168`)

**Structural fix:** remove the waveform-only special case; return `val_capacity()` for VAL on every array kind uniformly. `val_capacity()` already encodes the same `nelm`/`malm` mapping C's `cvt_dbaddr` uses, so the CA-advertised native count equals the buffer capacity by construction. Regression test covers every `ArrayKind`'s capacity source plus a non-VAL field.

### `feat(oracle)` — array phase measures the aai/aao/subArray/waveform VAL seam
The put/read/monitor phases only ever drove scalar fields; a record's VAL array — `DBF_NOACCESS` in the dbd, reachable only at runtime with NELM/FTVL — was never measured. New `Array` phase (part of `--phase all`) declares one record per boundary case (single, exactly NELM, partial NELM/2, over-NELM), drives `caput -a` / `caget -#` / `cainfo` on both sides, and adjudicates element count, stored value, and alarm.

This phase's first run surfaced the 0-length-channel defect above.

## Verification
- oracle `--phase array` (C ground truth vs Rust): **16/16 AGREED** (aai/aao/subArray/waveform × 4), 0 DEFECT, 0 ERROR
- standalone Rust IOC: all four types now `element_count=16`, `caput -a 16` stored, `caget -# 16` read back
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 9506 passed, 2 skipped

## Scope
Self-contained CA-side parity work; independent of the in-flight PVA oracle (PR #36). The `record_stmt_fields` reproducer helper is folded into the array-phase commit (its first consumer here).