### PR TITLE
build: update spin 0.9.8 -> 0.9.9 (0.9.8 yanked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
`spin` arrives transitively via `flume` <- `rumqttc` <- `mqtt-rs`. Version 0.9.8 was yanked from crates.io, surfacing a warning during the v0.24.0 publish.

**Change:** `cargo update -p spin` → 0.9.9 (Cargo.lock only, single block). 0.9.9 satisfies flume's `^0.9.8` and clears the yank warning.

**Why not bump flume instead:** flume's latest is 0.12.0 (there is no 0.12.2), but `rumqttc` 0.24 and 0.25 both require `flume ^0.11`, so flume 0.12 is unreachable in our tree — and flume 0.12.0 still depends on `spin ^0.9.8` anyway, so bumping flume would not remove spin. Updating spin directly is the effective fix.

**Verified:** `cargo build -p mqtt-rs` passes; flume 0.11.1 / rumqttc 0.24.0 unchanged.