### PR TITLE
release: v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v0.24.1 — 2026-07-18
+
+Patch release. Closes the Type3 differential-oracle parity gap: after this
+release the `epics-oracle-rs` differential harness is DEFECT 0 across all three
+phases (Channel Access, PVA read, PVA monitor). Eight fixes, one per finding,
+each grounded in the C reference (`epics-base`, `pvxs`). Additive record-trait
+API only; no breaking changes. Workspace version 0.24.0 -> 0.24.1.
+
+### epics-base-rs
+
+- **sseq TIME lags the VAL post by one cycle.** `sseqRecord.c::asyncFinish`
+  posts VAL and runs `recGblFwdLink` *before* `recGblGetTimeStamp`, so the VAL
+  monitor carries the pre-update timestamp and the restamp advances TIME for the
+  BUSY post and the next cycle. New hook `Record::restamps_time_after_completion()`.
+
+- **A sync UDF mbbo/mbboDirect leaves TIME at the EPICS epoch.** C
+  `mbboRecord.c` / `mbboDirectRecord.c` take `else if (prec->udf) goto CONTINUE`,
+  skipping the pre-output `recGblGetTimeStampSimm`; the only post-`CONTINUE`
+  stamp is `if (pact)`-guarded (async completion), so a soft (sync) UDF record
+  never stamps until VAL is defined. New hook
+  `Record::skips_timestamp_when_undefined()` (mbbo/mbboDirect only). The
+  async-completion path still stamps unconditionally, matching C's `if (pact)`.
+
+- **An empty-SNAM aSub resets VAL and stops over-posting on scan.** C
+  `aSubRecord.c` short-circuits an empty SNAM `do_sub` to `return 0` before the
+  `S_db_BadSub` check, so `process` sets VAL to 0 each cycle and `monitor()`
+  posts nothing when unchanged. The port had conflated empty-SNAM with bad-SNAM
+  and never wrote VAL, so a `.1 second`-scanned aSub re-posted the stale put
+  value on every scan.
+
+### epics-pva-rs, epics-bridge-rs
+
+- **`alarm.message` now serves the record's own `amsg`** (native PVA and
+  QSRV/bridge), preferring a non-empty carried amsg over a re-synthesized
+  condition string (pvxs `iocsource.cpp:230-236`). Closes the fabricated-amsg
+  family: generic UDF records fall back to `"UDF"`, only `mbboDirect` uses
+  `"UDFS"`, and the CALC-family literals are corrected to their real C strings.
+  New seam `Record::udf_alarm_message()`.
+
+### epics-oracle-rs
+
+- DTYP parity is exercised (asyn device menus registered; asyn device support
+  served in the DTYP choice list), the ASYN.BOUT live-length divergence is
+  recorded as an intentional design-divergence, and QSRV2 demo device support
+  is allowlisted as an instrument superset.
+
 ## v0.24.0 — 2026-07-18
 
 Minor release. A full C-parity hardening pass driven by the new differential

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "bitflags",
  "chrono",
@@ -992,7 +992,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2202,7 +2202,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3170,7 +3170,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3773,7 +3773,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4875,7 +4875,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ epics-rs reimplements the core components of C/C++ EPICS in Rust:
 
 ## Installation
 
-**Current release: v0.24.0** — the `v0.20.x` line completes a full C-parity
+**Current release: v0.24.1** — the `v0.20.x` line completes a full C-parity
 sweep of the motor record against `epics-modules/motor` and adds per-field
 DBE monitor event masks end to end, then layers ~60 commits of C-parity
 regression fixes (one commit per finding) across base/db, CA, the native PVA
@@ -60,7 +60,11 @@ behaviour — ~800 one-finding-per-commit fixes across asyn, the calc engines,
 the record/db metadata rsets, CA, and PVA/QSRV2 — plus two breaking asyn API
 changes (`ParamSetValue` folded into `ParamSetValue::Value`, and
 `drv_user_create` takes a `&DrvUserRequest`) and new oracle PVA-monitor and
-array differential phases. See [`CHANGELOG.md`](./CHANGELOG.md) for the full
+array differential phases. `v0.24.1` closes the Type3 differential-oracle
+parity gap — sseq/mbbo/aSub timestamp and monitor fixes, `alarm.message`
+serving the record's own `amsg`, and DTYP/BOUT/QSRV2 oracle coverage — leaving
+the differential harness DEFECT 0 across all three phases (additive API only,
+no breaking changes). See [`CHANGELOG.md`](./CHANGELOG.md) for the full
 audit trail.
 
 All crates are published on [crates.io](https://crates.io/crates/epics-rs). Add `epics-rs` with the feature flags you need:


### PR DESCRIPTION
Patch release v0.24.1. Bumps workspace version 0.24.0 -> 0.24.1, adds the CHANGELOG entry, and updates the README release pointer.

The code fixes themselves landed in #40 (Type3 differential-oracle parity gap, DEFECT 0 across all three oracle phases). This PR is release bookkeeping only — no source changes. Patch bump (additive record-trait API only, no BREAKING footer in the range).

After merge: tag `v0.24.1`, GitHub release from the CHANGELOG section, and `cargo publish --workspace` (16 library crates).