### PR TITLE
fix(record): resolve DTYP put/read against the merged (declared + contributed) device menu

### DIFF
--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -1978,6 +1978,54 @@ record(bo, "$(P)_calc_ctrl") {{
         assert_eq!(dtyp, "Async Soft Channel");
     }
 
+    /// Regression for the put/read DTYP asymmetry: a device-support name that is
+    /// NOT in the record type's static `device()` menu but IS registered at
+    /// runtime (`register_device_menu`, the asyn / scaler-rs path) must be
+    /// put-able via `dbpf`, because the read path already advertises it. Before
+    /// the fix the CA-put validation (`coerce_put_value`) and the DTYP write-back
+    /// (`put_common_field`) both consulted the static-only device menu, so a
+    /// contributed name either failed `S_db_noRSET` (types with no static menu)
+    /// or resolved to `NoChange` (leaving DTYP unset) — exactly what blocked
+    /// scaler974-ioc's `dbpf scaler1.DTYP "Asyn Scaler"`.
+    #[test]
+    fn test_dbpf_dtyp_accepts_contributed_device_support_name() {
+        use crate::server::record::register_device_menu;
+        // A record-type name + DTYP name no other test touches (the registry is
+        // process-global and append-only).
+        register_device_menu("ai", &["Dbpf Contributed Probe"]);
+
+        let (db, ctx) = make_ctx();
+        ctx.block_on(async {
+            db.add_record("CONTRIB", Box::new(AiRecord::new(0.0)))
+                .await
+                .unwrap();
+        });
+
+        let mut registry = CommandRegistry::new();
+        register_builtins(&mut registry);
+
+        let cmd = registry.get("dbpf").unwrap();
+        let tokens = vec![
+            "CONTRIB.DTYP".to_string(),
+            "Dbpf Contributed Probe".to_string(),
+        ];
+        let args = parse_args(&tokens, &cmd.args).unwrap();
+        let result = cmd.handler.call(&args, &ctx);
+        if let Err(e) = &result {
+            panic!("dbpf CONTRIB.DTYP 'Dbpf Contributed Probe' should succeed, got Err({e})");
+        }
+        assert!(matches!(result, Ok(CommandOutcome::Continue)));
+
+        // The contributed NAME is what landed on DTYP — not NoChange, not a
+        // stale value.
+        let dtyp = ctx.block_on(async {
+            let rec = db.get_record("CONTRIB").await.expect("record present");
+            let inst = rec.read().await;
+            inst.common.dtyp.clone()
+        });
+        assert_eq!(dtyp, "Dbpf Contributed Probe");
+    }
+
     #[test]
     fn test_dbpr_levels() {
         let (db, ctx) = make_ctx();

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -263,7 +263,24 @@ fn cmd_dbpf() -> CommandDef {
                 None
             });
 
-            let value = if let Some(dbf) = dbf_type {
+            let value = if field == "DTYP" {
+                // DTYP is DBF_DEVICE: its choices are the record type's live
+                // device menu (dynamic, per record type — device support names
+                // registered at runtime), NOT the field-blind static table that
+                // `EpicsValue::parse(Enum, _)` consults via `resolve_menu_string`.
+                // `declared_field_type_of(DTYP)` reports `Enum`, so the generic
+                // path below parsed every device-support name as an enum/menu
+                // string and rejected it ("invalid enum or menu string"), which
+                // failed `dbpf <rec>.DTYP <device-support-name>` for every record
+                // type. Feed the value straight to the put path, which already
+                // resolves a numeric index against `device_menu` and stores a
+                // device-support NAME as-is (tier-3, `put_common_field`'s "DTYP"
+                // arm).
+                match value_str.trim().parse::<i64>() {
+                    Ok(i) => EpicsValue::Enum(i as u16),
+                    Err(_) => EpicsValue::String(value_str.trim().into()),
+                }
+            } else if let Some(dbf) = dbf_type {
                 EpicsValue::parse(dbf, value_str)
                     .map_err(|e| format!("cannot parse '{value_str}' as {dbf:?}: {e}"))?
             } else {
@@ -1917,6 +1934,48 @@ record(bo, "$(P)_calc_ctrl") {{
             EpicsValue::Double(v) => assert!((v - 42.0).abs() < 1e-10),
             other => panic!("expected Double(42.0), got {:?}", other),
         }
+    }
+
+    /// Regression: `dbpf <rec>.DTYP <device-support-name>` must succeed for a
+    /// device-support name valid for the record type. DTYP is `DBF_DEVICE`,
+    /// served as `DBR_ENUM`, but its choices are the record type's live device
+    /// menu, NOT the static common-menu table `EpicsValue::parse(Enum,_)`
+    /// consults via `resolve_menu_string`. `"Async Soft Channel"` is a declared
+    /// `ai` device support but is absent from that static table, so before the
+    /// fix `cmd_dbpf` parsed it as an Enum and the handler returned
+    /// `Err("invalid enum or menu string: ...")` — which, when the `dbpf` sat in
+    /// an st.cmd, made `iocInit` fail before the CA server bound. The fix routes
+    /// the value to the put path, which validates it against the record's live
+    /// device menu (`device_choices()` = declared + runtime-contributed + the
+    /// current DTYP).
+    #[test]
+    fn test_dbpf_dtyp_accepts_device_support_name() {
+        let (db, ctx) = make_ctx();
+        ctx.block_on(async {
+            db.add_record("DEV", Box::new(AiRecord::new(0.0)))
+                .await
+                .unwrap();
+        });
+
+        let mut registry = CommandRegistry::new();
+        register_builtins(&mut registry);
+
+        let cmd = registry.get("dbpf").unwrap();
+        let tokens = vec!["DEV.DTYP".to_string(), "Async Soft Channel".to_string()];
+        let args = parse_args(&tokens, &cmd.args).unwrap();
+        let result = cmd.handler.call(&args, &ctx);
+        if let Err(e) = &result {
+            panic!("dbpf DEV.DTYP 'Async Soft Channel' should succeed, got Err({e})");
+        }
+        assert!(matches!(result, Ok(CommandOutcome::Continue)));
+
+        // The device-support NAME landed on the record's DTYP.
+        let dtyp = ctx.block_on(async {
+            let rec = db.get_record("DEV").await.expect("record present");
+            let inst = rec.read().await;
+            inst.common.dtyp.clone()
+        });
+        assert_eq!(dtyp, "Async Soft Channel");
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/record/device_menu_registry.rs
+++ b/crates/epics-base-rs/src/server/record/device_menu_registry.rs
@@ -79,6 +79,27 @@ pub(crate) fn contributed_device_menu(record_type: &str) -> Vec<&'static str> {
     }
 }
 
+/// The full DTYP menu for `record_type` — the static `device()` declarations
+/// (base's build-time `dbd`) followed by every runtime-contributed device
+/// support, in C `dbDeviceMenu` load order — or an empty `Vec` when the type
+/// has no device menu at all.
+///
+/// The single source of "which DTYP names are valid for this record type",
+/// consulted by BOTH the read/announce side
+/// ([`RecordInstance::device_choices`](super::record_instance::RecordInstance::device_choices))
+/// and the CA-put validation ([`super::coerce_put_value`]'s DTYP branch), so a
+/// client can PUT exactly the DTYP names it can READ. `device_choices` layers
+/// the None-vs-empty distinction and the current-DTYP entry on top; the put
+/// path needs only the menu itself.
+pub(crate) fn merged_device_menu(record_type: &str) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = Vec::new();
+    if let Some(declared) = super::dbd_generated::device_menu(record_type) {
+        names.extend_from_slice(declared);
+    }
+    names.extend(contributed_device_menu(record_type));
+    names
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/epics-base-rs/src/server/record/mod.rs
+++ b/crates/epics-base-rs/src/server/record/mod.rs
@@ -17,8 +17,8 @@ pub use crate::server::recgbl::EventMask;
 pub use alarm::{AlarmSeverity, AnalogAlarmConfig};
 pub use common_fields::CommonFields;
 pub use constant_link::{rec_gbl_init_constant_link, reseed_constant_input_link};
-pub(crate) use device_menu_registry::contributed_device_menu;
 pub use device_menu_registry::register_device_menu;
+pub(crate) use device_menu_registry::{contributed_device_menu, merged_device_menu};
 pub use link::{
     CaLink, CalcLink, DbLink, DbLinkType, HwLink, HwLinkKind, JlinkValue, LinkAddress,
     LinkFieldType, LinkProcessPolicy, LinkType, LsLoad, MonitorSwitch, PVAJSON_IDENTITY_SEP,

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -1338,26 +1338,28 @@ impl RecordInstance {
         // `dbDeviceMenu` is the concatenation of every `device()` the loaded
         // `.dbd` set declares, in load order — base first, then asyn — so the
         // merge appends the contributed choices AFTER the declared ones.
-        let declared = super::dbd_generated::device_menu(record_type);
-        let contributed = super::contributed_device_menu(record_type);
         // The C None-vs-empty distinction (`dbAccess.c:176-179` vs `:205`): the
         // menu is present iff the loaded `.dbd` set declares ANY `device()` for
         // this type. A type base declares none for but asyn does (structurally
         // possible, though none of asyn's are such) is therefore present, not
         // None; a type neither declares for (calc) stays None.
-        if declared.is_none() && contributed.is_empty() {
+        if super::dbd_generated::device_menu(record_type).is_none()
+            && super::contributed_device_menu(record_type).is_empty()
+        {
             return None;
         }
-        let mut names: Vec<&str> = Vec::new();
-        if let Some(declared) = declared {
-            names.extend_from_slice(declared);
-        }
-        names.extend(contributed.iter().copied());
+        // `merged_device_menu` = declared + contributed, the SAME source the
+        // CA-put validation (`coerce_put_value`'s DTYP branch) resolves against,
+        // so a client can put exactly the DTYP names it can read here.
+        let mut names: Vec<PvString> = super::merged_device_menu(record_type)
+            .into_iter()
+            .map(PvString::from)
+            .collect();
         let dtyp = self.common.dtyp.as_str();
-        if !dtyp.is_empty() && !names.contains(&dtyp) {
-            names.push(dtyp);
+        if !dtyp.is_empty() && !names.iter().any(|n| n.as_str_lossy() == dtyp) {
+            names.push(PvString::from(dtyp));
         }
-        Some(names.iter().map(|c| PvString::from(*c)).collect())
+        Some(names)
     }
 
     /// C `dbPutFieldLink`'s link-type gate (`dbAccess.c:1125-1137`): a link
@@ -2704,14 +2706,17 @@ impl RecordInstance {
             //   incoming label through the device menu (C `putStringMenu`,
             //   which fails `S_db_badChoice` on a name the menu does not have).
             //
-            // The index is only meaningful against the DECLARED menu, which is
-            // what the converter bounded it by.
+            // The index is meaningful against the MERGED device menu (static
+            // `device()` declarations + runtime-contributed device support) —
+            // the exact list `coerce_put_value` bounded it by. Resolving it
+            // against the static-only menu here would drop every contributed
+            // name (asyn's "asynInt32", scaler-rs's "Asyn Scaler") back to
+            // NoChange, leaving DTYP unset after a valid put.
             "DTYP" => match value {
                 EpicsValue::String(s) => self.common.dtyp = s.as_str_lossy().into_owned(),
                 EpicsValue::Enum(i) => {
-                    let declared =
-                        super::dbd_generated::device_menu(self.record.record_type()).unwrap_or(&[]);
-                    match declared.get(i as usize) {
+                    let merged = super::merged_device_menu(self.record.record_type());
+                    match merged.get(i as usize) {
                         Some(name) => self.common.dtyp = (*name).to_string(),
                         None => return Ok(CommonFieldPutResult::NoChange),
                     }

--- a/crates/epics-base-rs/src/server/record/record_trait.rs
+++ b/crates/epics-base-rs/src/server/record/record_trait.rs
@@ -3571,7 +3571,27 @@ pub fn coerce_put_value<R: Record + ?Sized>(
     value: EpicsValue,
 ) -> CaResult<EpicsValue> {
     if let EpicsValue::String(s) = &value {
-        if let Some(choices) = super::record_instance::menu_choices_of(record, field) {
+        // DTYP (DBF_DEVICE) validates against the record type's FULL device
+        // menu — static `device()` lines PLUS runtime-contributed device
+        // support — the same set the read/announce path exposes via
+        // `RecordInstance::device_choices`. `menu_choices_of`'s DTYP branch
+        // returns only the static half, so a contributed device-support name
+        // (asyn's `asynInt32`, scaler-rs's `Asyn Scaler`, ...) would wrongly
+        // fail this put even though a client can read it in the DTYP choices.
+        // Resolve DTYP against the merged menu to keep put and read symmetric.
+        if field.eq_ignore_ascii_case("DTYP") {
+            let choices = super::merged_device_menu(record.record_type());
+            if !choices.is_empty() {
+                return super::resolve_menu_field_string(
+                    field,
+                    &choices,
+                    target,
+                    &s.as_str_lossy(),
+                );
+            }
+            // No device menu declared or contributed for this record type: fall
+            // through to the generic handling below (unchanged behavior).
+        } else if let Some(choices) = super::record_instance::menu_choices_of(record, field) {
             return super::resolve_menu_field_string(field, choices, target, &s.as_str_lossy());
         }
         if target == DbFieldType::Enum {


### PR DESCRIPTION
## Problem

Setting a record's `DTYP` field via `dbpf <record>.DTYP "<name>"` (and the
equivalent CA put) did **not** work for device-support names contributed at
runtime through `register_device_menu`. A `DBF_DEVICE` field's choices come from
two sources — static `dbd_generated::device_menu` (compile-time `device()`
declarations) and `contributed_device_menu` (runtime `register_device_menu`) —
but three DTYP paths consulted the **static menu only** and ignored the
contributed entries. A runtime-registered name was rejected or silently dropped
at each layer:

1. **Parse** (`cmd_dbpf`): the name→index lookup used the static menu → names
   not in it failed with "invalid enum or menu string".
2. **Put validation** (`coerce_put_value`): CA-put string coercion validated
   against the static-only `menu_choices_of` → same rejection.
3. **Put write-back** (`put_common_field` DTYP `Enum` arm): resolving the
   validated **index back to a name** used the static `device_menu`; a
   contributed index fell outside the static slice, yielded `NoChange`, and left
   `DTYP` unset (stale `DBF_ENUM`).

### Impact

Dynamic device support (bound by DTYP string at `iocInit` via
`register_dynamic_device_support`) is registered *after* the startup script's
`dbpf(...DTYP,"<name>")`. On 0.24.1 that put failed because the name was not yet
in the static menu, so an IOC using such a record (e.g. a `scalerRecord` with
DTYP `"Asyn Scaler"`) died at boot with `S_db_noRSET` / "no device support
registered".

## Fix

Introduce a single-source helper `device_menu_registry::merged_device_menu`
(declared + contributed) and route all three DTYP paths through it, restoring
symmetry between validation, write-back, and the read/announce path
(`device_choices`).

- `fix(iocsh)`: resolve `dbpf` DTYP against the record's live (merged) device
  menu.
- `fix(record)`: validate and store DTYP against the merged device menu, not the
  static-only one; `put_common_field`'s Enum arm and `coerce_put_value` now use
  the merged menu, and `device_choices` shares the same helper.

## Tests

- New: `test_dbpf_dtyp_accepts_device_support_name` (declared name) and
  `test_dbpf_dtyp_accepts_contributed_device_support_name`
  (`register_device_menu` then `dbpf ...DTYP <contributed name>`), asserting the
  put is `Ok` and `common.dtyp` holds the name.
- Full workspace gates on this branch: `cargo fmt --all --check` clean,
  `cargo clippy --workspace --all-targets -- -D warnings` 0 warnings,
  `cargo nextest run --workspace` 9733 passed / 2 skipped,
  `cargo test --doc -p epics-base-rs` ok.
- End-to-end: `scaler974-ioc` (downstream, separate repo) boots with this
  branch — `dbpf(scaler1.DTYP,"Asyn Scaler")` stores the value and `iocInit`
  reports 15 records / 1 with device support, zero "no device support" warnings.
