### PR TITLE
release: v0.24.2 (documentation-only patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.24.2 — 2026-07-19
+
+Documentation-only patch release. No functional code change since v0.24.1 — the
+sole source edit is a doc comment. Workspace version 0.24.1 -> 0.24.2.
+
+### ad-plugins-rs
+
+- **CBUG-B25 reclassified: the port already matches upstream.** The
+  `NDPluginTimeSeries` integer averaging has divided *before* narrowing (the
+  correct order) since `d8f27b88`; ADCore #596 (merged upstream 2026-07-16)
+  applies the same fix to C, so the port and current upstream C now agree. The
+  module header and `averaged_value` doc comment are reframed from a live
+  "deliberate deviation / reproduces C's bug" to "matches upstream since #596";
+  the worked example now shows the correct `200`, not C's pre-#596 `29`. No
+  behaviour change.
+
+### Docs
+
+- `doc/upstream-c-bugs.md`: reconciled the upstream-PR submission status against
+  live GitHub (20 PRs by author, was 4 in the stale catalogue), added a single
+  authoritative filed-PR table, and reclassified CBUG-B25
+  REPRODUCED -> NOT-REPRODUCED (fixed upstream #596).
+
 ## v0.24.1 — 2026-07-18
 
 Patch release. Closes the Type3 differential-oracle parity gap: after this

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "bitflags",
  "chrono",
@@ -992,7 +992,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2202,7 +2202,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3170,7 +3170,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3773,7 +3773,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4875,7 +4875,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.24.1"
+version = "0.24.2"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ epics-rs reimplements the core components of C/C++ EPICS in Rust:
 
 ## Installation
 
-**Current release: v0.24.1** — the `v0.20.x` line completes a full C-parity
+**Current release: v0.24.2** — the `v0.20.x` line completes a full C-parity
 sweep of the motor record against `epics-modules/motor` and adds per-field
 DBE monitor event masks end to end, then layers ~60 commits of C-parity
 regression fixes (one commit per finding) across base/db, CA, the native PVA
@@ -64,8 +64,10 @@ array differential phases. `v0.24.1` closes the Type3 differential-oracle
 parity gap — sseq/mbbo/aSub timestamp and monitor fixes, `alarm.message`
 serving the record's own `amsg`, and DTYP/BOUT/QSRV2 oracle coverage — leaving
 the differential harness DEFECT 0 across all three phases (additive API only,
-no breaking changes). See [`CHANGELOG.md`](./CHANGELOG.md) for the full
-audit trail.
+no breaking changes). `v0.24.2` is a documentation-only patch: CBUG-B25 is
+reclassified now that ADCore #596 landed upstream (the port already divided
+before narrowing), with no functional code change. See
+[`CHANGELOG.md`](./CHANGELOG.md) for the full audit trail.
 
 All crates are published on [crates.io](https://crates.io/crates/epics-rs). Add `epics-rs` with the feature flags you need:
 


### PR DESCRIPTION
## v0.24.2 — documentation-only patch

No functional code change since v0.24.1. The only source edit is a doc comment
in `ad-plugins-rs`.

### Contents
- **CBUG-B25 reclassified.** `NDPluginTimeSeries` integer averaging has divided
  before narrowing (correct order) since `d8f27b88`; ADCore #596 (merged
  upstream 2026-07-16) applies the same fix to C. Module header + `averaged_value`
  doc comment reframed from "deliberate deviation / reproduces" to "matches
  upstream since #596"; worked example now shows the correct `200`, not `29`.
- **`doc/upstream-c-bugs.md`** reconciled against live GitHub PR status (20 PRs,
  authoritative filed-PR table) and B25 bucket REPRODUCED -> NOT-REPRODUCED.

### Release mechanics
- `[workspace.package] version` 0.24.1 -> 0.24.2 (patch; dependency pins left,
  caret resolves). `Cargo.lock` diff is version lines only.
- Three commits: version bump / changelog / readme pointer.