### PR TITLE
Parity r6: retire the REPRODUCED bucket + CA server element-count clamp (PR #934 parity)

### DIFF
--- a/crates/asyn-rs/src/escape.rs
+++ b/crates/asyn-rs/src/escape.rs
@@ -10,18 +10,32 @@
 //! \xNN                            everything else, lower-case hex
 //! ```
 //!
-//! There are two C entry points and they differ on **one byte**:
+//! There are two C entry points, and in C they diverge on **the NUL byte**
+//! (CBUG-D4): `epicsStrnEscapedFromRaw` has a deliberate `case '\0'` printing
+//! `\0` (:145), while `epicsStrPrintEscaped` forgot it, so NUL falls through to
+//! the `\xNN` default and prints `\x00` (:259). Under the clean-is-the-goal
+//! strategy (`doc/strategy-2026-07-13.md §2`) the port **refuses** that
+//! divergence: both forms render NUL as `\0` — C's deliberate escape, the one
+//! its round-trippable decoder `epicsStrnRawFromEscaped` was written to accept
+//! (`case '0'`). The refusal is structural: [`escape`] holds the single table
+//! and there is no per-form NUL parameter to disagree over, so the two renderings
+//! are unrepresentable by construction. The C bug was a *missing* named case; the
+//! fix supplies it to both, rather than deleting the deliberate one.
 //!
-//! - [`escaped_from_raw`] — `epicsStrnEscapedFromRaw` (epicsString.c:120-160),
-//!   which prints NUL as `\0` (:145) and writes into a *sized* destination.
-//!   `epicsStrSnPrintEscaped` is a macro alias for it (epicsString.h:125). This
-//!   is what `asynShowEos` (asynShellCommands.c:305), the echo interpose
-//!   (asynInterposeEcho.c:73-74), the trace errlog branch (asynManager.c:3159)
-//!   and every `asynRecord` field (asynRecord.c:725,1629,2005) escape through —
-//!   each with its own buffer size, which the caller must state.
+//! The two entry points still differ where C genuinely differs — but not on the
+//! escape table:
+//!
+//! - [`escaped_from_raw`] — `epicsStrnEscapedFromRaw` (epicsString.c:120-160)
+//!   writes into a *sized* destination. `epicsStrSnPrintEscaped` is a macro alias
+//!   for it (epicsString.h:125). This is what `asynShowEos`
+//!   (asynShellCommands.c:305), the echo interpose (asynInterposeEcho.c:73-74),
+//!   the trace errlog branch (asynManager.c:3159) and every `asynRecord` field
+//!   (asynRecord.c:725,1629,2005) escape through — each with its own buffer size,
+//!   which the caller must state.
 //! - [`print_escaped`] — `epicsStrPrintEscaped` (epicsString.c:230-262), the
-//!   `FILE *` form, which has no NUL case and so falls to `\x00` (:259). This is
-//!   what `asynPortDriver::report` prints the EOS pair with
+//!   `FILE *` form, has no destination bound, and keeps C's `strlen(s) == 0`
+//!   first-byte-NUL early-return quirk (R17-49). This is what
+//!   `asynPortDriver::report` prints the EOS pair with
 //!   (asynPortDriver.cpp:3687,3690).
 //!
 //! Every escaping caller in this crate names one of the two, so the table exists
@@ -29,7 +43,8 @@
 //! `\n` and write a `\x03` terminator raw into stdout (R16-48).
 
 /// C `epicsStrnEscapedFromRaw(dst, dstlen, src, srclen)` (epicsString.c:120-160)
-/// — NUL escapes as `\0`, and **the destination bound is part of the call**.
+/// — NUL escapes as `\0` (C's deliberate `case '\0'`), and **the destination
+/// bound is part of the call**.
 ///
 /// C's `OUT` macro is `ndst++; if (--rem > 0) *dst++ = chr` with `rem = dstlen`:
 /// at most `dstlen - 1` escaped characters reach the buffer before the closing
@@ -40,33 +55,40 @@
 /// the size of the C buffer it is writing into; there is no unbounded form of
 /// this function in C.
 pub(crate) fn escaped_from_raw(src: &[u8], dstlen: usize) -> String {
-    escape(src, "\\0", dstlen.saturating_sub(1))
+    escape(src, dstlen.saturating_sub(1))
 }
 
-/// C `epicsStrPrintEscaped` (epicsString.c:230-262) — the `FILE *` form, whose
-/// `switch` has no NUL case, so a NUL takes the `\xNN` default: `\x00`. It
-/// writes to a stream, so it has no destination bound.
+/// C `epicsStrPrintEscaped` (epicsString.c:230-262) — the `FILE *` form. C's
+/// `switch` forgot the NUL case, so C prints `\x00`; the port **refuses that
+/// CBUG-D4 divergence** and renders NUL as `\0`, identically to
+/// [`escaped_from_raw`] (both reach the one [`escape`] table). It writes to a
+/// stream, so it has no destination bound.
 ///
 /// It takes an explicit `len`, yet guards on `strlen(s) == 0` (`:236-237`):
 /// a buffer whose **first byte** is NUL is "no work to do" and prints
 /// *nothing*, however many bytes follow it. A NUL anywhere later is escaped
 /// normally — `strlen` only looks at the first one. Compiled libCom:
 /// `epicsStrPrintEscaped(fp, "\0a", 2)` returns 0 and prints nothing, while
-/// `("a\0b", 3)` prints `a\x00b`. This is a C quirk, not a Rust convenience:
-/// the ESCAPE trace form on a `FILE *` sink prints an empty data line for a
-/// payload that starts with NUL.
+/// `("a\0b", 3)` prints an escaped interior NUL (C `a\x00b`; the port refuses
+/// CBUG-D4 and renders `a\0b`). This first-byte-NUL early-return is a C quirk,
+/// not a Rust convenience: the ESCAPE trace form on a `FILE *` sink prints an
+/// empty data line for a payload that starts with NUL. It is a *separate*
+/// behaviour from the NUL-rendering divergence, and is kept.
 pub(crate) fn print_escaped(src: &[u8]) -> String {
     if src.first().is_none_or(|&c| c == 0) {
         return String::new();
     }
-    escape(src, "\\x00", usize::MAX)
+    escape(src, usize::MAX)
 }
 
 /// The shared table. `max` is the number of escaped characters that fit in the
 /// destination — C's `dstlen - 1`, or `usize::MAX` for the stream form. The cut
 /// is per *character*, not per escape pair, which is what produces C's dangling
 /// backslash.
-fn escape(src: &[u8], nul: &str, max: usize) -> String {
+///
+/// NUL renders as `\0` for *both* entry points — the CBUG-D4 refusal is
+/// structural: there is no NUL parameter for the two forms to disagree over.
+fn escape(src: &[u8], max: usize) -> String {
     let mut out = String::with_capacity(src.len().min(max));
     let mut hex = String::new();
     for &c in src {
@@ -81,7 +103,7 @@ fn escape(src: &[u8], nul: &str, max: usize) -> String {
             b'\\' => "\\\\",
             b'\'' => "\\'",
             b'"' => "\\\"",
-            0 => nul,
+            0 => "\\0",
             // C `isprint` in the C locale: the printable ASCII range.
             0x20..=0x7e => {
                 hex.clear();
@@ -109,10 +131,11 @@ fn escape(src: &[u8], nul: &str, max: usize) -> String {
 mod tests {
     use super::*;
 
-    /// The two C entry points agree on every byte but NUL — one case per escape
-    /// class, plus the byte they disagree on.
+    /// The two C entry points share one escape table. In C they disagreed on
+    /// NUL (`\0` vs `\x00`, CBUG-D4); the port refuses that divergence, so both
+    /// forms now render every byte — NUL included — identically.
     #[test]
-    fn the_table_is_c_s_and_the_two_forms_differ_only_on_nul() {
+    fn the_table_is_c_s_and_both_forms_now_agree_on_nul() {
         let named = b"\x07\x08\x0c\n\r\t\x0b\\'\"";
         assert_eq!(escaped_from_raw(named, 80), r#"\a\b\f\n\r\t\v\\\'\""#);
         assert_eq!(print_escaped(named), r#"\a\b\f\n\r\t\v\\\'\""#);
@@ -125,10 +148,13 @@ mod tests {
         );
         assert_eq!(print_escaped(b"\x03\x1b\x7f\xff"), r"\x03\x1b\x7f\xff");
 
-        // The one divergence: epicsStrnEscapedFromRaw has a `case '\0'`
-        // (epicsString.c:145); epicsStrPrintEscaped does not (:255-260).
+        // CBUG-D4 refused: C's `epicsStrnEscapedFromRaw` has a `case '\0'`
+        // (epicsString.c:145) and `epicsStrPrintEscaped` does not (:255-260), so
+        // C prints `\0` vs `\x00`. The port supplies the missing case to both —
+        // NUL is `\0` from either form. Round-trips through the port decoder:
+        // `\0` decodes to a single NUL with no octal continuation (C `case '0'`).
         assert_eq!(escaped_from_raw(b"a\0b", 80), r"a\0b");
-        assert_eq!(print_escaped(b"a\0b"), r"a\x00b");
+        assert_eq!(print_escaped(b"a\0b"), r"a\0b");
     }
 
     /// C's destination bound, byte for byte against compiled libCom
@@ -174,7 +200,8 @@ mod tests {
     ///
     /// ```text
     /// epicsStrPrintEscaped(fp, "\0a", 2)  -> ret 0, prints nothing
-    /// epicsStrPrintEscaped(fp, "a\0b", 3) -> ret 6, prints a\x00b
+    /// epicsStrPrintEscaped(fp, "a\0b", 3) -> ret 6, prints a\x00b in C;
+    ///                                        port refuses CBUG-D4 -> a\0b
     /// epicsStrPrintEscaped(fp, "",   0)   -> ret 0, prints nothing
     /// ```
     ///
@@ -186,8 +213,9 @@ mod tests {
         assert_eq!(print_escaped(b"\0"), "");
         assert_eq!(print_escaped(b""), "");
 
-        // Only the FIRST byte: strlen stops there, and a later NUL still escapes.
-        assert_eq!(print_escaped(b"a\0b"), r"a\x00b");
+        // Only the FIRST byte: strlen stops there, and a later NUL still escapes
+        // — now as `\0` (CBUG-D4 refused), identically to escaped_from_raw.
+        assert_eq!(print_escaped(b"a\0b"), r"a\0b");
 
         // The bounded form keeps escaping — the guard is C's, and C put it in
         // one function only.

--- a/crates/asyn-rs/src/iocsh.rs
+++ b/crates/asyn-rs/src/iocsh.rs
@@ -2967,6 +2967,16 @@ mod tests {
                 "escape/unescape must round-trip"
             );
         }
+
+        // CBUG-D4: both escapers now render NUL as `\0`; prove that survives the
+        // port's own decoder. EPICS has no octal escape — `raw_from_escaped`
+        // decodes `\0` via C's `case '0'` (one NUL, following digits literal), so
+        // `\0` is unambiguous and a NUL-then-digit round-trips exactly.
+        assert_eq!(escaped_from_raw(b"\0", n), r"\0");
+        assert_eq!(raw_from_escaped(r"\0"), vec![0u8]); // `\0` in -> single NUL out
+        assert_eq!(raw_from_escaped(r"\x00"), vec![0u8]); // decoder also accepts `\x00`
+        assert_eq!(escaped_from_raw(b"\x001", n), r"\01"); // NUL then '1'
+        assert_eq!(raw_from_escaped(r"\01"), vec![0u8, b'1']); // no octal: NUL then '1'
         // C sizes `cbuf` at 4 * sizeof(eos) + 2 precisely so the widest
         // terminator — 10 bytes, every one of them `\xNN` — still escapes whole
         // (40 chars, one under the bound).

--- a/crates/asyn-rs/src/port.rs
+++ b/crates/asyn-rs/src/port.rs
@@ -3872,8 +3872,8 @@ mod tests {
         let mut out = String::new();
         drv.report(&mut out, 1);
         assert!(
-            out.contains("  Input EOS[2]: \\x1b\\x00\n"),
-            "C's epicsStrPrintEscaped prints NUL as \\x00 — it has no `case 0` (epicsString.c:255-260): {out}"
+            out.contains("  Input EOS[2]: \\x1b\\0\n"),
+            "CBUG-D4 refused: C's epicsStrPrintEscaped lacked a `case 0` (epicsString.c:255-260) and printed \\x00; the port supplies it so NUL renders \\0, matching epicsStrnEscapedFromRaw: {out}"
         );
         assert!(
             out.contains("  Output EOS[2]: \\t\\a\n"),

--- a/crates/asyn-rs/src/trace.rs
+++ b/crates/asyn-rs/src/trace.rs
@@ -1013,9 +1013,11 @@ fn append_io_data(out: &mut Vec<u8>, data: &[u8], cfg: &TraceConfig) {
 ///
 /// and `getTraceFile` (:2928-2941) returns `NULL` for `traceFileErrlog` alone —
 /// every other sink, including the `traceFileStderr` a port is born with
-/// (`tracePvtInit`, :458), takes the `FILE *` branch. The two differ: the stream
-/// form has no destination bound and no `case '\0'`, so a NUL prints as `\x00`
-/// (and a first-byte NUL prints nothing at all — R17-49). Hardwiring
+/// (`tracePvtInit`, :458), takes the `FILE *` branch. The two differ in their
+/// destination bound (the stream form has none) and in the stream form's
+/// first-byte-NUL early-return quirk (R17-49). They no longer differ on the NUL
+/// byte: C's stream form printed `\x00` where the errlog form printed `\0`
+/// (CBUG-D4), and the port refuses that — both render NUL as `\0`. Hardwiring
 /// `escaped_from_raw` gave every sink the errlog form.
 ///
 /// The table itself is one table: its own four-case copy left `\a`, `\b`, `\f`,
@@ -1462,7 +1464,10 @@ mod tests {
     /// errlog → `epicsStrSnPrintEscaped`. `getTraceFile` (:2928-2941) hands back
     /// `NULL` for errlog alone, and a port's default sink is stderr
     /// (`tracePvtInit`, :458) — so the *default* trace line takes the stream
-    /// form, which prints a NUL as `\x00` where the errlog form prints `\0`.
+    /// form. C's stream form printed a NUL as `\x00` where the errlog form
+    /// printed `\0` (CBUG-D4); the port refuses that divergence, so every sink
+    /// now renders NUL as `\0`. The destination still selects the entry point
+    /// (bound / first-byte-NUL quirk differ); the escape table does not.
     #[test]
     fn the_escape_entry_point_is_chosen_by_the_trace_destination() {
         let n = DEFAULT_TRACE_BUFFER_SIZE;
@@ -1471,14 +1476,15 @@ mod tests {
         // errlog: epicsStrSnPrintEscaped — has `case '\0'` (epicsString.c:145).
         assert_eq!(format_escape(data, &TraceFile::Errlog, n), r"a\0b");
 
-        // Every FILE* sink, the stderr default included: epicsStrPrintEscaped,
-        // whose switch has no NUL case (:255-260).
-        assert_eq!(format_escape(data, &TraceFile::Stderr, n), r"a\x00b");
-        assert_eq!(format_escape(data, &TraceFile::Stdout, n), r"a\x00b");
+        // Every FILE* sink, the stderr default included: epicsStrPrintEscaped.
+        // C left it without a NUL case (:255-260) and printed `\x00`; the port
+        // supplies the missing case (CBUG-D4 refused) so it matches errlog: `\0`.
+        assert_eq!(format_escape(data, &TraceFile::Stderr, n), r"a\0b");
+        assert_eq!(format_escape(data, &TraceFile::Stdout, n), r"a\0b");
         let f = TraceFile::File(Arc::new(Mutex::new(
             std::fs::File::create(std::env::temp_dir().join("asyn_r17_46.txt")).unwrap(),
         )));
-        assert_eq!(format_escape(data, &f, n), r"a\x00b");
+        assert_eq!(format_escape(data, &f, n), r"a\0b");
         let _ = std::fs::remove_file(std::env::temp_dir().join("asyn_r17_46.txt"));
 
         // And the default TraceConfig is one of the FILE* sinks, not errlog.

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -686,11 +686,15 @@ impl PvDatabase {
             if instance.record.special_commits_alarms(&field) {
                 let _ = crate::server::recgbl::rec_gbl_reset_alarms(&mut instance.common);
             }
-            // histogram SGNL SPC_MOD: `add_count` writes stat/sevr directly and
-            // no monitor follows, so it sticks (histogramRecord.c:329-334).
+            // histogram SGNL SPC_MOD: `add_count` raises the inverted-limits
+            // alarm (histogramRecord.c:329-334). The port routes it through
+            // `nsta`/`nsev` (CBUG-F12 refused), so this monitor-less special
+            // path must commit it — check then reset — for the SOFT/INVALID to
+            // be observable, matching the process path.
             if instance.record.special_checks_alarms(&field) {
                 let inst = &mut *instance;
                 inst.record.check_alarms(&mut inst.common);
+                let _ = crate::server::recgbl::rec_gbl_reset_alarms(&mut inst.common);
             }
 
             // Invalidate metadata cache only if the metadata-class
@@ -1721,18 +1725,18 @@ impl PvDatabase {
                 }
             };
 
-            // C `add_count` writes stat/sevr DIRECTLY during a SGNL SPC_MOD
-            // `special()` (histogramRecord.c:329-334); with no monitor on the
-            // special path that write STICKS and a later caget observes it
-            // (STAT=SOFT on inverted limits). `check_alarms` performs that
-            // direct write. Unlike the process path — where the cycle's
-            // `recGblResetAlarms` erases it — this special-only put runs no
-            // process, so it persists, matching C. Gated on
-            // `special_checks_alarms` (histogram SGNL only). No STAT post: C's
-            // `add_count` posts nothing, and the special path has no monitor.
+            // C `add_count` raises the inverted-limits alarm during a SGNL
+            // SPC_MOD `special()` (histogramRecord.c:329-334). The port raises
+            // it through `nsta`/`nsev` (CBUG-F12 refused, not C's direct write),
+            // so this monitor-less special path commits it — check then reset —
+            // to make STAT=SOFT/INVALID observable, matching the process path.
+            // Gated on `special_checks_alarms` (histogram SGNL only). No STAT
+            // post: C's `add_count` posts nothing, and the special path has no
+            // monitor — the alarm shows on the next caget's field read.
             if instance.record.special_checks_alarms(&field) {
                 let inst = &mut *instance;
                 inst.record.check_alarms(&mut inst.common);
+                let _ = crate::server::recgbl::rec_gbl_reset_alarms(&mut inst.common);
             }
 
             // Invalidate metadata cache only if the metadata-class
@@ -1885,14 +1889,16 @@ impl PvDatabase {
                     }
                 }
                 // The same `dbPutSpecial(paddr, 1)`-on-reject rule for a field
-                // whose special() writes stat/sevr DIRECTLY (histogram SGNL →
-                // add_count): C still runs add_count when the SGNL conversion
-                // fails, so its stuck STAT=SOFT on inverted limits appears even
-                // for a rejected `caput .SGNL notanumber`. `check_alarms` makes
-                // that direct write; no process follows, so it persists.
+                // whose special() raises the inverted-limits alarm (histogram
+                // SGNL → add_count): C still runs add_count when the SGNL
+                // conversion fails, so STAT=SOFT/INVALID appears even for a
+                // rejected `caput .SGNL notanumber`. The port raises it through
+                // `nsta`/`nsev` (CBUG-F12 refused) and commits it here — check
+                // then reset — since no process follows.
                 if instance.record.special_checks_alarms(&field) {
                     let inst = &mut *instance;
                     inst.record.check_alarms(&mut inst.common);
+                    let _ = crate::server::recgbl::rec_gbl_reset_alarms(&mut inst.common);
                 }
                 // The same `dbPutSpecial(paddr, 1)`-on-reject rule for a field
                 // whose special() clears UDF: C `mbboDirectRecord.c::special`

--- a/crates/epics-base-rs/src/server/records/histogram.rs
+++ b/crates/epics-base-rs/src/server/records/histogram.rs
@@ -145,9 +145,10 @@ impl HistogramRecord {
             return;
         }
         // Inverted limits: count nothing. C's `add_count` also writes
-        // stat/sevr=SOFT/INVALID directly here; that direct write is modelled
-        // by `check_alarms` (erased on the process path, sticks on the SGNL
-        // special path — CBUG-F12), which the counting-only path leaves out.
+        // stat/sevr=SOFT/INVALID directly here; the port raises that alarm
+        // through `check_alarms` via the `nsta`/`nsev` owner instead, so it is
+        // observable consistently on both paths (CBUG-F12 refused). The
+        // counting-only path leaves the alarm out.
         if self.llim >= self.ulim || self.nelm <= 0 {
             return;
         }
@@ -262,34 +263,40 @@ impl Record for HistogramRecord {
     ///         prec->sevr = INVALID_ALARM;
     /// ```
     ///
-    /// C writes `stat`/`sevr` DIRECTLY, not `nsta`/`nsev` via `recGblSetSevr`.
-    /// That single mechanism yields two OBSERVABLE behaviours depending on
-    /// whether `recGblResetAlarms` runs afterwards:
+    /// **DEVIATION from C, deliberate — CBUG-F12 refused.** An inverted-limits
+    /// histogram (`LLIM >= ULIM`) cannot bin anything: it is genuinely
+    /// misconfigured, and the record's *intent* — the C code literally tries to
+    /// set `SOFT_ALARM`/`INVALID_ALARM` — is to flag it. C's *mechanism* is
+    /// broken: it writes `stat`/`sevr` DIRECTLY instead of `nsta`/`nsev` via
+    /// `recGblSetSevr`, so the alarm's visibility depends on which trigger ran
+    /// `add_count` — a path-dependent dual meaning:
     ///
-    /// * process path (this record's `process()` → `monitor()`): the cycle's
-    ///   `recGblResetAlarms` copies `nsta/nsev`(0/0) over the direct write, so
-    ///   it is erased before any client sees it — NO_ALARM (CBUG-F12, the
-    ///   `LLIM=10 ULIM=5` softIoc proof still holds).
-    /// * SGNL SPC_MOD `special()` path: `add_count` runs with NO monitor after
-    ///   it, so the direct write STICKS — a `caget` reports STAT=SOFT
-    ///   (verified on compiled softIoc: fresh histogram, `caput .SGNL 1` →
-    ///   STAT=SOFT SEVR=INVALID).
+    /// * process path (`process()` → `monitor()`): the cycle's
+    ///   `recGblResetAlarms` copies `nsta/nsev`(0/0) over the direct write and
+    ///   erases it before any client sees it — C shows NO_ALARM (dead code:
+    ///   C's intent to alarm, C's behaviour NO_ALARM).
+    /// * SGNL SPC_MOD `special()` path: no monitor follows `add_count`, so the
+    ///   direct write STICKS and a `caget` reports STAT=SOFT SEVR=INVALID.
     ///
-    /// Writing through `rec_gbl_set_sevr` (`nsta`/`nsev`) instead — the prior
-    /// shape — made `recGblResetAlarms` COMMIT it on the process path (a stuck
-    /// SOFT, wrong) and left the special path unwritten (born UDF, wrong):
-    /// inverted on both. The direct write is the only shape that matches C on
-    /// both. C's `nsev < INVALID_ALARM` guard is preserved — it keeps a
-    /// higher pending severity from being overwritten. Gated on `csta` because
-    /// C's `add_count` returns before the limits test when counting is stopped.
+    /// Per `doc/strategy-2026-07-13.md` §2 — *C's bugs are not the contract;
+    /// clean is the goal* — the port raises the alarm through the single
+    /// `nsta`/`nsev` owner (`rec_gbl_set_sevr`), so a misconfigured histogram
+    /// reports SOFT/INVALID CONSISTENTLY: committed by `recGblResetAlarms` on
+    /// the process path, and committed by the SGNL special path's own
+    /// post-`check_alarms` `recGblResetAlarms` (see `field_io.rs`). This refuses
+    /// C's path-dependent dead-code/sticky behaviour and its direct-write
+    /// anti-pattern in one move. `rec_gbl_set_sevr`'s raise-only rule subsumes
+    /// C's `nsev < INVALID_ALARM` guard (it only raises when strictly higher).
+    /// Gated on `csta` because C's `add_count` returns before the limits test
+    /// when counting is stopped.
     fn check_alarms(&mut self, common: &mut crate::server::record::CommonFields) {
         use crate::server::record::AlarmSeverity;
-        if self.csta
-            && self.llim >= self.ulim
-            && (common.nsev as u16) < (AlarmSeverity::Invalid as u16)
-        {
-            common.stat = crate::server::recgbl::alarm_status::SOFT_ALARM;
-            common.sevr = AlarmSeverity::Invalid;
+        if self.csta && self.llim >= self.ulim {
+            crate::server::recgbl::rec_gbl_set_sevr(
+                common,
+                crate::server::recgbl::alarm_status::SOFT_ALARM,
+                AlarmSeverity::Invalid,
+            );
         }
     }
 
@@ -382,11 +389,13 @@ impl Record for HistogramRecord {
         Ok(())
     }
 
-    /// A `.SGNL` caput is C's SPC_MOD `special()` → `add_count`, which writes
-    /// `stat`/`sevr` directly (histogramRecord.c:329-334) with no monitor after
-    /// it. The put owner runs [`Record::check_alarms`] once the value is stored
-    /// so that direct write lands and — with no process cycle to follow —
-    /// persists, matching C's stuck STAT=SOFT on inverted limits.
+    /// A `.SGNL` caput is C's SPC_MOD `special()` → `add_count`, which raises
+    /// the inverted-limits alarm (histogramRecord.c:329-334) with no process
+    /// cycle to follow. The put owner runs [`Record::check_alarms`] once the
+    /// value is stored, then commits it via `recGblResetAlarms` (see
+    /// `field_io.rs`), so the SOFT/INVALID the record raises is observable on
+    /// this monitor-less path — CBUG-F12 refused (raised consistently, not
+    /// path-dependent).
     fn special_checks_alarms(&self, put_field: &str) -> bool {
         put_field.eq_ignore_ascii_case("SGNL")
     }

--- a/crates/epics-base-rs/tests/histogram_invalid_limits_alarm.rs
+++ b/crates/epics-base-rs/tests/histogram_invalid_limits_alarm.rs
@@ -1,24 +1,27 @@
-//! CBUG-F12 — a histogram with `LLIM >= ULIM` and its invalid-limits alarm.
+//! CBUG-F12 REFUSED — a histogram with `LLIM >= ULIM` and its invalid-limits
+//! alarm.
 //!
 //! C's `add_count` (histogramRecord.c:329-334) refuses to count when the limits
-//! are inverted and raises SOFT_ALARM / INVALID_ALARM for it — but it writes
-//! `prec->stat` and `prec->sevr` DIRECTLY, not `nsta`/`nsev` via `recGblSetSevr`.
-//! That single mechanism yields two OBSERVABLE behaviours, depending on whether
-//! a `recGblResetAlarms` runs after the write:
+//! are inverted and *tries* to raise SOFT_ALARM / INVALID_ALARM for it — but it
+//! writes `prec->stat`/`prec->sevr` DIRECTLY, not `nsta`/`nsev` via
+//! `recGblSetSevr`. That broken mechanism makes the alarm's visibility depend on
+//! which trigger ran `add_count`:
 //!
 //! * process path (`process()` → `monitor()`): the cycle's `recGblResetAlarms`
-//!   copies `nsta/nsev`(0/0) over the direct write and erases it before any
-//!   client can see it — STAT=NO_ALARM (CBUG-F12; compiled softIoc, this host:
-//!   `LLIM=10 ULIM=5`, process → STAT=NO_ALARM SEVR=NO_ALARM).
-//! * SGNL SPC_MOD `special()` path: `add_count` runs with no monitor after it,
-//!   so the direct write STICKS — a `caget` reports STAT=SOFT SEVR=INVALID
-//!   (compiled softIoc: fresh histogram, `caput .SGNL 1` → STAT=SOFT).
+//!   copies `nsta/nsev`(0/0) over the direct write and erases it — C shows
+//!   NO_ALARM (dead code: C's intent to alarm, C's behaviour NO_ALARM).
+//! * SGNL SPC_MOD `special()` path: no monitor follows, so the direct write
+//!   STICKS and a `caget` reports STAT=SOFT SEVR=INVALID.
 //!
-//! The port reproduces C's exact mechanism: `check_alarms` writes `stat`/`sevr`
-//! directly, so it is erased on the process path and persists on the SGNL
-//! special path — matching C on both. (An earlier port shape raised it through
-//! `recGblSetSevr`, which made `recGblResetAlarms` COMMIT it on the process path
-//! — a stuck SOFT that contradicted the compiled-C proof and the oracle.)
+//! Per `doc/strategy-2026-07-13.md` §2 — *clean is the goal* — the port REFUSES
+//! that path-dependent dead-code/sticky behaviour. An inverted-limits histogram
+//! is genuinely misconfigured (it can bin nothing), so the port raises the
+//! alarm through the single `nsta`/`nsev` owner and reports SOFT/INVALID
+//! CONSISTENTLY on BOTH paths: committed by `recGblResetAlarms` on the process
+//! path, and committed by the SGNL special path's own post-`check_alarms`
+//! `recGblResetAlarms`. (This is a Tier-2 deviation from a compiled C IOC on the
+//! process path, where C erases the alarm; recorded as a CBUG-F12 allowlist
+//! row.)
 
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::alarm_status;
@@ -37,8 +40,11 @@ async fn alarm(db: &PvDatabase, name: &str) -> (AlarmSeverity, u16) {
     (inst.common.sevr, inst.common.stat)
 }
 
+/// The process path raises the misconfiguration alarm through `nsta`/`nsev`, so
+/// `recGblResetAlarms` COMMITS it (rather than erasing a direct write) —
+/// SOFT/INVALID. C erases it here (NO_ALARM); the port refuses that dead code.
 #[tokio::test]
-async fn inverted_limits_alarm_is_erased_by_the_process_cycle() {
+async fn inverted_limits_alarm_is_raised_on_the_process_cycle() {
     let db = PvDatabase::new();
     // LLIM=10, ULIM=5 — the compiled-C proof case.
     db.add_record("H1", Box::new(HistogramRecord::new(16, 10.0, 5.0)))
@@ -49,16 +55,16 @@ async fn inverted_limits_alarm_is_erased_by_the_process_cycle() {
 
     assert_eq!(
         alarm(&db, "H1").await,
-        (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
-        "add_count writes SOFT directly, monitor()'s recGblResetAlarms erases it \
-         in the same cycle — NO_ALARM (CBUG-F12)"
+        (AlarmSeverity::Invalid, alarm_status::SOFT_ALARM),
+        "inverted limits raise SOFT/INVALID through nsta/nsev; recGblResetAlarms \
+         commits it — CBUG-F12 refused (C erases it to NO_ALARM)"
     );
 }
 
-/// The process path always reads NO_ALARM: the direct write is erased every
-/// cycle, inverted or not. Fixing the limits changes nothing observable here.
+/// Inverted limits alarm SOFT/INVALID every process cycle; fixing the limits to
+/// valid clears the alarm on the next cycle.
 #[tokio::test]
-async fn process_path_reads_no_alarm_inverted_or_valid() {
+async fn process_path_alarms_while_inverted_clears_when_valid() {
     let db = PvDatabase::new();
     db.add_record("H2", Box::new(HistogramRecord::new(16, 10.0, 5.0)))
         .await
@@ -68,8 +74,8 @@ async fn process_path_reads_no_alarm_inverted_or_valid() {
     process(&db, "H2").await;
     assert_eq!(
         alarm(&db, "H2").await,
-        (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
-        "inverted, but the direct SOFT write is erased by recGblResetAlarms"
+        (AlarmSeverity::Invalid, alarm_status::SOFT_ALARM),
+        "inverted: SOFT/INVALID raised and committed every cycle (CBUG-F12 refused)"
     );
 
     db.put_pv("H2.ULIM", EpicsValue::Double(20.0))
@@ -79,14 +85,14 @@ async fn process_path_reads_no_alarm_inverted_or_valid() {
     assert_eq!(
         alarm(&db, "H2").await,
         (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
-        "LLIM=10 < ULIM=20: valid limits raise nothing either"
+        "LLIM=10 < ULIM=20: valid limits raise nothing, and the prior alarm clears"
     );
 }
 
-/// Equal limits are inverted limits (C's test is `>=`); on the process path they
-/// too read NO_ALARM.
+/// Equal limits are inverted limits (C's test is `>=`); they too raise
+/// SOFT/INVALID on the process path.
 #[tokio::test]
-async fn equal_limits_erased_on_process_too() {
+async fn equal_limits_alarm_on_process_too() {
     let db = PvDatabase::new();
     db.add_record("H3", Box::new(HistogramRecord::new(16, 5.0, 5.0)))
         .await
@@ -96,34 +102,35 @@ async fn equal_limits_erased_on_process_too() {
 
     assert_eq!(
         alarm(&db, "H3").await,
-        (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
-        "LLIM == ULIM is the `>=` boundary — still erased on the process cycle"
+        (AlarmSeverity::Invalid, alarm_status::SOFT_ALARM),
+        "LLIM == ULIM is the `>=` boundary — still a misconfiguration, raised"
     );
 }
 
-/// The SGNL SPC_MOD special path has no monitor after `add_count`, so the direct
-/// SOFT/INVALID write persists — a client reads STAT=SOFT (compiled softIoc:
-/// `caput .SGNL 1` on inverted limits → STAT=SOFT).
+/// The SGNL SPC_MOD special path runs `check_alarms` then commits it via
+/// `recGblResetAlarms`, so the SOFT/INVALID is observable — same as the process
+/// path, and same value C's sticky direct write happens to leave here.
 #[tokio::test]
-async fn sgnl_special_path_sticks_the_soft_alarm() {
+async fn sgnl_special_path_raises_the_soft_alarm() {
     let db = PvDatabase::new();
     db.add_record("H5", Box::new(HistogramRecord::new(16, 10.0, 5.0)))
         .await
         .unwrap();
 
-    // A SGNL caput is C's SPC_MOD special() -> add_count; no process follows.
+    // A SGNL caput is C's SPC_MOD special() -> add_count; no process follows,
+    // but the port commits the alarm on the special path.
     db.put_pv("H5.SGNL", EpicsValue::Double(1.0)).await.unwrap();
 
     assert_eq!(
         alarm(&db, "H5").await,
         (AlarmSeverity::Invalid, alarm_status::SOFT_ALARM),
-        "no monitor after add_count on the special path — the direct write sticks"
+        "special path commits the nsta/nsev alarm — SOFT/INVALID observable (CBUG-F12)"
     );
 }
 
-/// The negative control: valid limits raise nothing. (A histogram never clears
-/// UDF and has no UDF alarm, so a well-formed one publishes NO_ALARM even though
-/// UDF stays 1 — `udf_clear_is_per_record_type` pins that half.)
+/// The negative control: valid limits raise nothing on either path. (A histogram
+/// never clears UDF and has no UDF alarm, so a well-formed one publishes
+/// NO_ALARM even though UDF stays 1 — `udf_clear_is_per_record_type` pins that.)
 #[tokio::test]
 async fn valid_limits_raise_no_alarm() {
     let db = PvDatabase::new();
@@ -132,10 +139,17 @@ async fn valid_limits_raise_no_alarm() {
         .unwrap();
 
     process(&db, "H4").await;
-
     assert_eq!(
         alarm(&db, "H4").await,
         (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
-        "LLIM < ULIM: nothing to alarm about"
+        "LLIM < ULIM: nothing to alarm about (process path)"
+    );
+
+    // And the SGNL special path with valid limits also stays quiet.
+    db.put_pv("H4.SGNL", EpicsValue::Double(1.0)).await.unwrap();
+    assert_eq!(
+        alarm(&db, "H4").await,
+        (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
+        "valid limits: the SGNL special path's commit leaves NO_ALARM"
     );
 }

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -489,6 +489,20 @@ struct ChannelEntry {
     /// which C `cvt_dbaddr` presents as a scalar `DBF_STRING`. `Plain`
     /// for every other channel.
     long_string_mode: LongStringMode,
+    /// Final (post-filter) element count announced to the client at
+    /// `CA_PROTO_CREATE_CHAN` — the port's `dbChannelFinalElements`
+    /// equivalent. Every request's wire element count is clamped to this
+    /// ceiling on READ / READ_NOTIFY / EVENT_ADD so an oversized
+    /// `m_count` cannot drive the reply zero-fill
+    /// ([`pad_dbr_to_requested_count`] / the steady-state monitor
+    /// producer) past the channel's real capacity. Mirrors epics-base
+    /// PR #934's `if (mp->m_count > dbChannelFinalElements(pciu->dbch))
+    /// mp->m_count = dbChannelFinalElements(pciu->dbch);` clamp. This is
+    /// the channel's true capacity (NELM), NOT the live value length
+    /// (`snapshot.value.count()`, which is NORD for a partially-filled
+    /// waveform) — clamping to the live length would truncate a
+    /// legitimate `caget -# NELM` on a dynamic waveform.
+    final_element_count: u32,
 }
 
 impl ChannelEntry {
@@ -2765,6 +2779,10 @@ async fn dispatch_message<W: AsyncWrite + Unpin + Send + 'static>(
                         filter_suffix: filter_suffix.clone(),
                         put_notify_slot: PutNotifySlot::default(),
                         long_string_mode,
+                        // The post-filter capacity computed above and
+                        // announced in the CREATE_CHAN reply — the ceiling
+                        // a later request's element count is clamped to.
+                        final_element_count: element_count,
                     },
                 );
                 state.channel_access.insert(sid, access_level);
@@ -2837,7 +2855,7 @@ async fn dispatch_message<W: AsyncWrite + Unpin + Send + 'static>(
             let sid = hdr.cid;
             let ioid = hdr.available;
             let requested_type = hdr.data_type;
-            let requested_count = hdr.actual_count();
+            let mut requested_count = hdr.actual_count();
 
             // the two read commands differ in WHERE the
             // `INVALID_DB_REQ(m_dataType)` type check sits relative to
@@ -2898,6 +2916,18 @@ async fn dispatch_message<W: AsyncWrite + Unpin + Send + 'static>(
                     )));
                 }
             };
+
+            // PR #934 (epics-base) parity: clamp the wire element count to
+            // the channel's final element count so an oversized `m_count`
+            // cannot drive the reply zero-fill (`pad_dbr_to_requested_count`)
+            // past the channel's real capacity. C `read_action`
+            // (`camessage.c`) / `read_notify_action`:
+            // `if (mp->m_count > dbChannelFinalElements(pciu->dbch))
+            //     mp->m_count = dbChannelFinalElements(pciu->dbch);`.
+            // `requested_count == 0` is autosize and is preserved untouched.
+            if requested_count != 0 && requested_count > entry.final_element_count {
+                requested_count = entry.final_element_count;
+            }
 
             // Deprecated READ: C `read_action` (`rsrv/camessage.c:616-619`)
             // checks `INVALID_DB_REQ` AFTER resolving the channel and
@@ -4077,7 +4107,7 @@ async fn dispatch_message<W: AsyncWrite + Unpin + Send + 'static>(
             // delivery and the EVENT_CANCEL ack can echo it (matches
             // C `event_add_action` capturing `pevext->msg` for later
             // `read_reply` / `event_cancel_reply` use).
-            let requested_count = hdr.actual_count();
+            let mut requested_count = hdr.actual_count();
 
             // DoS guard: cap subscriptions per channel. Default-unbounded
             // (`None`) — C `event_add_action` imposes no per-channel
@@ -4167,6 +4197,20 @@ async fn dispatch_message<W: AsyncWrite + Unpin + Send + 'static>(
                     )));
                 }
             };
+
+            // PR #934 (epics-base) parity: clamp the wire element count to
+            // the channel's final element count BEFORE it is stored on the
+            // subscription (`SubscriptionEntry::data_count`), so neither the
+            // initial snapshot (`pad_dbr_to_requested_count`) nor every
+            // steady-state monitor delivery (the producer in `monitor.rs`)
+            // can zero-fill past the channel's real capacity. C
+            // `event_add_action`:
+            // `if (mp->m_count > dbChannelFinalElements(pciu->dbch))
+            //     mp->m_count = dbChannelFinalElements(pciu->dbch);`.
+            // `requested_count == 0` is autosize and is preserved untouched.
+            if requested_count != 0 && requested_count > entry.final_element_count {
+                requested_count = entry.final_element_count;
+            }
 
             // C `db_add_event` (dbEvent.c:437-439) returns NULL when
             // `select == 0 || select > UCHAR_MAX`, which propagates as
@@ -8188,6 +8232,257 @@ mod deprecated_read_autosize_tests {
             24,
             "READ_NOTIFY count==0 ships all 3 DBR_DOUBLE elements (3*8=24 bytes); got {}",
             resp.actual_postsize()
+        );
+
+        drop(client);
+        handle.abort();
+    }
+
+    /// Build a CA_PROTO_EVENT_ADD subscribing `sub_id` on `sid` with an
+    /// explicit element `count` (the stock `event_add_frame` pins count=1).
+    fn event_add_request_count(sid: u32, sub_id: u32, count: u32) -> Vec<u8> {
+        let mut h = CaHeader::new(CA_PROTO_EVENT_ADD);
+        h.data_type = DBR_DOUBLE;
+        h.cid = sid;
+        h.available = sub_id;
+        h.set_payload_size(16, count, crate::protocol::CA_MINOR_VERSION)
+            .expect("modern peer accepts the extended header");
+        let mut frame = h.to_bytes_extended().to_vec();
+        frame.extend_from_slice(&0f32.to_be_bytes());
+        frame.extend_from_slice(&0f32.to_be_bytes());
+        frame.extend_from_slice(&0f32.to_be_bytes());
+        frame.extend_from_slice(&3u16.to_be_bytes()); // mask: value+alarm
+        frame.extend_from_slice(&0u16.to_be_bytes()); // pad
+        frame
+    }
+
+    /// Build a fire-and-forget CA_PROTO_WRITE of `values` so a test can
+    /// seed a waveform's NORD below its NELM before reading it back.
+    fn write_doubles_request(sid: u32, values: &[f64]) -> Vec<u8> {
+        let mut h = CaHeader::new(CA_PROTO_WRITE);
+        h.data_type = DBR_DOUBLE;
+        h.cid = sid;
+        h.available = 0;
+        let mut body = Vec::with_capacity(values.len() * 8);
+        for v in values {
+            body.extend_from_slice(&v.to_be_bytes());
+        }
+        h.set_payload_size(
+            body.len(),
+            values.len() as u32,
+            crate::protocol::CA_MINOR_VERSION,
+        )
+        .expect("modern peer accepts the extended header");
+        let mut frame = h.to_bytes_extended().to_vec();
+        frame.extend_from_slice(&body);
+        frame
+    }
+
+    /// Spawn `handle_client` over a duplex pair holding one waveform record
+    /// `wf:rec` of buffer capacity `nelm` (NELM). A partial write leaves
+    /// NORD < NELM, so this fixture separates the two — the clamp ceiling
+    /// must be NELM, never the live NORD.
+    async fn spawn_waveform_server(
+        peer_port: u16,
+        nelm: i32,
+    ) -> (
+        tokio::io::DuplexStream,
+        tokio::task::JoinHandle<CaResult<()>>,
+        broadcast::Sender<()>,
+    ) {
+        use epics_base_rs::server::records::waveform::WaveformRecord;
+        use epics_base_rs::types::DbFieldType;
+        let db = Arc::new(PvDatabase::new());
+        db.add_record(
+            "wf:rec",
+            Box::new(WaveformRecord::new(nelm, DbFieldType::Double)),
+        )
+        .await
+        .expect("add waveform record");
+        let acf = Arc::new(tokio::sync::RwLock::new(None));
+        let (acf_reload_tx, acf_reload_rx) = broadcast::channel::<()>(4);
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let peer: SocketAddr = format!("127.0.0.1:{peer_port}").parse().unwrap();
+        let handle = tokio::spawn(async move {
+            handle_client(
+                server_io,
+                peer,
+                db,
+                acf,
+                acf_reload_rx,
+                5064,
+                None,
+                None,
+                None,
+                None,
+                None,
+                #[cfg(feature = "cap-tokens")]
+                None,
+                #[cfg(feature = "cap-tokens")]
+                None,
+            )
+            .await
+        });
+        (client_io, handle, acf_reload_tx)
+    }
+
+    /// SECURITY — epics-base PR #934 (Item 2) parity. An oversized wire
+    /// element count on READ_NOTIFY must clamp to the channel's final
+    /// element count, never drive the reply zero-fill
+    /// (`pad_dbr_to_requested_count`) to a `count * element_size`
+    /// allocation. Pre-fix an extended-header count of 0xFFFFFFFF on a
+    /// DBR_DOUBLE channel sized the reply to ~34 GB and the `Vec` zero-fill
+    /// aborted the whole process — a remote, unauthenticated DoS.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_notify_oversized_count_clamps_to_channel_capacity() {
+        let (mut client, handle, _acf_reload_tx) =
+            spawn_array_server(55342, vec![1.0, 2.0, 3.0]).await;
+        let sid = handshake(&mut client).await;
+
+        client
+            .write_all(&read_request(
+                CA_PROTO_READ_NOTIFY,
+                sid,
+                0x21,
+                DBR_DOUBLE,
+                0xFFFF_FFFF,
+            ))
+            .await
+            .expect("read_notify");
+        client.flush().await.expect("flush read_notify");
+
+        let resp =
+            read_frame_of_cmmd(&mut client, CA_PROTO_READ_NOTIFY, Duration::from_secs(3)).await;
+        assert_eq!(
+            resp.actual_count(),
+            3,
+            "0xFFFFFFFF must clamp to the 3-element channel capacity, not the wire count; got {}",
+            resp.actual_count()
+        );
+        assert_eq!(
+            resp.actual_postsize(),
+            24,
+            "clamped reply ships exactly 3 DBR_DOUBLE elements (24 bytes), not a count-sized \
+             buffer; got {}",
+            resp.actual_postsize()
+        );
+
+        drop(client);
+        handle.abort();
+    }
+
+    /// SECURITY — same PR #934 clamp on the EVENT_ADD path. The count is
+    /// clamped BEFORE it is stored on the subscription, so both the initial
+    /// snapshot and every steady-state monitor delivery (the producer in
+    /// `monitor.rs`, a second copy of the unbounded zero-fill) are bounded.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn event_add_oversized_count_clamps_to_channel_capacity() {
+        let (mut client, handle, _acf_reload_tx) =
+            spawn_array_server(55343, vec![1.0, 2.0, 3.0]).await;
+        let sid = handshake(&mut client).await;
+
+        client
+            .write_all(&event_add_request_count(sid, 0x31, 0xFFFF_FFFF))
+            .await
+            .expect("event_add");
+        client.flush().await.expect("flush event_add");
+
+        let resp =
+            read_frame_of_cmmd(&mut client, CA_PROTO_EVENT_ADD, Duration::from_secs(3)).await;
+        assert_eq!(
+            resp.actual_count(),
+            3,
+            "EVENT_ADD 0xFFFFFFFF must clamp to the 3-element capacity; got {}",
+            resp.actual_count()
+        );
+        assert_eq!(
+            resp.actual_postsize(),
+            24,
+            "clamped monitor frame ships 3 DBR_DOUBLE elements (24 bytes); got {}",
+            resp.actual_postsize()
+        );
+
+        drop(client);
+        handle.abort();
+    }
+
+    /// SECURITY + parity boundary — the clamp ceiling is the channel's
+    /// final element count (NELM, buffer capacity), NOT the live value
+    /// length (NORD). A dynamic waveform (NELM=8) written to only 3
+    /// elements (NORD=3) must still frame a `caget -# 8` at 8 padded
+    /// elements — a NORD ceiling would wrongly truncate it to 3 — while an
+    /// oversized 0xFFFFFFFF request clamps to 8, not 3.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_notify_count_clamps_to_waveform_nelm_not_nord() {
+        let (mut client, handle, _acf_reload_tx) = spawn_waveform_server(55344, 8).await;
+        client.write_all(&version_frame()).await.expect("version");
+        client
+            .write_all(&create_chan_frame(0xE1, "wf:rec"))
+            .await
+            .expect("create_chan");
+        client.flush().await.expect("flush create_chan");
+        let sid = read_create_chan_sid(&mut client, Duration::from_secs(3)).await;
+
+        // Seed NORD=3 (< NELM=8) with a fire-and-forget WRITE.
+        client
+            .write_all(&write_doubles_request(sid, &[1.0, 2.0, 3.0]))
+            .await
+            .expect("write");
+        client.flush().await.expect("flush write");
+
+        // A request AT the NELM ceiling (8 > NORD 3) pads up to 8 — proving
+        // the ceiling is NELM, not NORD (which would truncate to 3).
+        client
+            .write_all(&read_request(
+                CA_PROTO_READ_NOTIFY,
+                sid,
+                0x41,
+                DBR_DOUBLE,
+                8,
+            ))
+            .await
+            .expect("read at nelm");
+        client.flush().await.expect("flush read at nelm");
+        let at_nelm =
+            read_frame_of_cmmd(&mut client, CA_PROTO_READ_NOTIFY, Duration::from_secs(3)).await;
+        assert_eq!(
+            at_nelm.actual_count(),
+            8,
+            "count=8 (NELM) must pad up from NORD=3, not clamp to 3; got {}",
+            at_nelm.actual_count()
+        );
+        assert_eq!(
+            at_nelm.actual_postsize(),
+            64,
+            "8 DBR_DOUBLE elements = 64 bytes; got {}",
+            at_nelm.actual_postsize()
+        );
+
+        // An oversized request clamps to NELM (8), never NORD (3).
+        client
+            .write_all(&read_request(
+                CA_PROTO_READ_NOTIFY,
+                sid,
+                0x42,
+                DBR_DOUBLE,
+                0xFFFF_FFFF,
+            ))
+            .await
+            .expect("read oversized");
+        client.flush().await.expect("flush read oversized");
+        let oversized =
+            read_frame_of_cmmd(&mut client, CA_PROTO_READ_NOTIFY, Duration::from_secs(3)).await;
+        assert_eq!(
+            oversized.actual_count(),
+            8,
+            "0xFFFFFFFF must clamp to NELM=8, not NORD=3; got {}",
+            oversized.actual_count()
+        );
+        assert_eq!(
+            oversized.actual_postsize(),
+            64,
+            "clamped to 8 DBR_DOUBLE elements = 64 bytes; got {}",
+            oversized.actual_postsize()
         );
 
         drop(client);

--- a/crates/epics-oracle-rs/allowlist/expected-deviations.toml
+++ b/crates/epics-oracle-rs/allowlist/expected-deviations.toml
@@ -300,16 +300,27 @@ port serves the same menu minus that one instrument-only choice.
 
 [[deviation]]
 id = "CBUG-F12"
-bucket = "REPRODUCED"
+bucket = "NOT-REPRODUCED"
 enabled = false
 upstream = "epics-base / histogram"
 record_types = ["histogram"]
 fields = ["STAT", "SEVR"]
 surface = ["value_string"]
 why = """
-C's histogram raises the LLIM >= ULIM alarm by writing stat/sevr directly instead
-of nsta/nsev, so recGblResetAlarms erases it in the same cycle -- the alarm is dead
-code and never reaches a client. The port reproduces this, so the oracle must see
-AGREEMENT (both report NO_ALARM). Strategy §4 schedules the fix (actually raise
-it); when it lands, flip enabled = true.
+An inverted-limits histogram (LLIM >= ULIM) cannot bin anything, so the record is
+genuinely misconfigured. C's add_count tries to raise SOFT/INVALID but writes
+stat/sevr DIRECTLY instead of nsta/nsev, so recGblResetAlarms erases it on the
+process path (dead code -> NO_ALARM) while it sticks on the .SGNL special path.
+Per strategy-2026-07-13 §2 (clean is the goal) the port now REFUSES this: it raises
+the alarm through the single nsta/nsev owner (recGblSetSevr), so a misconfigured
+histogram reports SOFT/INVALID CONSISTENTLY on both the process and the .SGNL
+special paths (port fix landed 2026-07-20, CBUG-F12 REPRODUCED -> NOT-REPRODUCED;
+covered by epics-base-rs `histogram_invalid_limits_alarm` unit tests).
+
+Kept `enabled = false`: the deviation is only observable on an inverted-limits
+histogram, and the put-phase harness never drives LLIM >= ULIM (no such case in
+cases.rs), so its scope agrees at NO_ALARM and enabling this row would report a
+FALSE STALE. Flip `enabled = true` once cases.rs grows an inverted-limits case
+that reads STAT/SEVR after a process — then the port's SOFT/INVALID vs C's
+NO_ALARM on the process path becomes the EXPECTED deviation this row allowlists.
 """

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -138,7 +138,9 @@ enum MonitorPipelineRequest {
 /// [`crate::pvdata::convert::as_u32`] converts — bool, every signed/unsigned
 /// integer, both reals, and a BASE-0 numeric string) or a percentage string
 /// (`"N%"`). An absent or unconvertible value keeps the pvxs default of
-/// `1`; an explicit `0` becomes `queueSize / 2`; the result clamps to
+/// `1`; an explicit `0` (below the representable minimum) clamps up to
+/// `1` — CBUG-B12, where pvxs instead reads `0` as "no ackAny given" and
+/// jumps it to `queueSize / 2`; the result clamps to
 /// `[1, queueSize]`. `queue_size` MUST be `>= 1` (the caller only
 /// invokes this for an enabled pipeline, where `queueSize >= 2`).
 ///

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -109,21 +109,22 @@ proven defect (see "Leads rejected").
 This is the authoritative submission-status table; it replaces the per-entry
 `Status:` prose, which is stale (the catalogue was extracted 2026-07-13, before
 most of these PRs were filed on 7/16–7/20). Author: `physwkim`. State is the live
-GitHub PR state, not a claim about the catalogue. Total filed: **32** — 26
-NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 5 REPRODUCED in
+GitHub PR state, not a claim about the catalogue. Total filed: **35** — 26
+NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 8 REPRODUCED in
 the separate table after it.
 
 **Catalogued CBUGs that are filed (27):**
 
-Some 2026-07-19 PRs bundle several CBUGs into one PR (calc **#41** = D2/F5/F2/F3;
+Some PRs bundle several CBUGs into one PR (calc **#41** = D2/F5/F2/F3;
 epics-base **#932** = D3/D5/F6; std **#28** = B15/B16; ADCore **#598** =
-B22/B23/B27) — each CBUG gets its own row pointing at the shared PR.
+B22/B23/B27; optics **#27** = B1/B2/B4, spanning both tables) — each CBUG gets
+its own row pointing at the shared PR.
 
 | CBUG | PR | state | note |
 |---|---|---|---|
 | CBUG-A1 | epics-modules/calc **#38** | open | `MODULO INT_MIN % -1` SIGFPE guard |
 | CBUG-A2 | epics-base/epics-base **#925** | open | `calcPerform` NINT/MODULO `d2i` narrowing |
-| CBUG-B2 | epics-modules/optics **#26** | open | pf4 Pb top-bin `keV[j+1]`/`mu[j+1]` OOB read |
+| CBUG-B2 | epics-modules/optics **#27** | open | pf4 Pb top-bin `keV[j+1]`/`mu[j+1]` OOB read — removed by the `[j-1,j]` interval fix (supersedes closed #26) |
 | CBUG-B3 | epics-modules/optics **#25** | open | pf4 glass-term guard |
 | CBUG-B5 | epics-modules/asyn **#234** | merged | `asynInterposeCom` ixon `return` |
 | CBUG-B9 | epics-modules/asyn **#233** | merged | `drvAsynIPServerPort` UDP read bound |
@@ -159,7 +160,7 @@ B22/B23/B27) — each CBUG gets its own row pointing at the shared PR.
 > the catalogue bucket and the `time_series_plugin.rs` comment framing were
 > corrected.
 
-**REPRODUCED bugs also reported upstream (5):**
+**REPRODUCED bugs also reported upstream (8):**
 
 These are genuine C defects the port carries **on purpose** for bug-for-bug
 parity — their `Bucket: REPRODUCED` classification is unchanged, and the port
@@ -168,8 +169,11 @@ then retires that REPRODUCE and tracks the corrected C. Until then, reproduce.
 
 | CBUG | PR | state | note |
 |---|---|---|---|
+| CBUG-B1 | epics-modules/optics **#27** | open | `pf4` `OtherAbsorptionLength` interpolate on `[j-1,j]` (frac was always negative) |
+| CBUG-B4 | epics-modules/optics **#27** | open | `pf4` unknown/out-of-range Other material: skip the blade + diagnose, not silently opaque |
 | CBUG-B6 | epics-modules/asyn **#236** | open | `asynInterposeCom` disable flow control now sends NOFLOW (crtscts + ixon) |
 | CBUG-B8 | epics-modules/asyn **#236** | open | `asynInterposeCom` IAC-stuff the COM-PORT-OPTION subnegotiation payload |
+| CBUG-B10 | epics-modules/asyn **#237** | open | `asyn*Base.c` `readDefault` errorMessage "read", not "write", is not supported (6 files) |
 | CBUG-B13 | epics-modules/motor **#254** | open | `motorRecord` key CDIR on the commanded stroke after a jog-stop backlash |
 | CBUG-B18 | epics-modules/scaler **#4** | open | `scalerRecord` `special(RATE)` posts `.RATE`, not `.TP` |
 | CBUG-B19 | epics-modules/scaler **#4** | open | `scalerRecord` `monitor()` posts `monitor_mask`, not literal `DBE_LOG` |

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -104,12 +104,14 @@ proven defect (see "Leads rejected").
 
 ---
 
-### Filed upstream PRs — live GitHub status (as of 2026-07-19)
+### Filed upstream PRs — live GitHub status (as of 2026-07-20)
 
 This is the authoritative submission-status table; it replaces the per-entry
 `Status:` prose, which is stale (the catalogue was extracted 2026-07-13, before
-most of these PRs were filed on 7/16–7/19). Author: `physwkim`. State is the live
-GitHub PR state, not a claim about the catalogue.
+most of these PRs were filed on 7/16–7/20). Author: `physwkim`. State is the live
+GitHub PR state, not a claim about the catalogue. Total filed: **32** — 26
+NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 5 REPRODUCED in
+the separate table after it.
 
 **Catalogued CBUGs that are filed (27):**
 
@@ -156,6 +158,21 @@ B22/B23/B27) — each CBUG gets its own row pointing at the shared PR.
 > #596 fix three days before it landed. No port behaviour change is owed; only
 > the catalogue bucket and the `time_series_plugin.rs` comment framing were
 > corrected.
+
+**REPRODUCED bugs also reported upstream (5):**
+
+These are genuine C defects the port carries **on purpose** for bug-for-bug
+parity — their `Bucket: REPRODUCED` classification is unchanged, and the port
+keeps reproducing them. Filing upstream is deliberate: if a fix merges, the port
+then retires that REPRODUCE and tracks the corrected C. Until then, reproduce.
+
+| CBUG | PR | state | note |
+|---|---|---|---|
+| CBUG-B6 | epics-modules/asyn **#236** | open | `asynInterposeCom` disable flow control now sends NOFLOW (crtscts + ixon) |
+| CBUG-B8 | epics-modules/asyn **#236** | open | `asynInterposeCom` IAC-stuff the COM-PORT-OPTION subnegotiation payload |
+| CBUG-B13 | epics-modules/motor **#254** | open | `motorRecord` key CDIR on the commanded stroke after a jog-stop backlash |
+| CBUG-B18 | epics-modules/scaler **#4** | open | `scalerRecord` `special(RATE)` posts `.RATE`, not `.TP` |
+| CBUG-B19 | epics-modules/scaler **#4** | open | `scalerRecord` `monitor()` posts `monitor_mask`, not literal `DBE_LOG` |
 
 **Filed upstream PRs with no catalogue CBUG entry yet (6):**
 

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -109,11 +109,11 @@ proven defect (see "Leads rejected").
 This is the authoritative submission-status table; it replaces the per-entry
 `Status:` prose, which is stale (the catalogue was extracted 2026-07-13, before
 most of these PRs were filed on 7/16–7/20). Author: `physwkim`. State is the live
-GitHub PR state, not a claim about the catalogue. Total filed: **35** — 26
-NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 8 REPRODUCED in
+GitHub PR state, not a claim about the catalogue. Total filed: **37** — 27
+NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 9 REPRODUCED in
 the separate table after it.
 
-**Catalogued CBUGs that are filed (27):**
+**Catalogued CBUGs that are filed (28):**
 
 Some PRs bundle several CBUGs into one PR (calc **#41** = D2/F5/F2/F3;
 epics-base **#932** = D3/D5/F6; std **#28** = B15/B16; ADCore **#598** =
@@ -142,6 +142,7 @@ its own row pointing at the shared PR.
 | CBUG-D2 | epics-modules/calc **#41** | open | `sCalc` `<<`/`>>` negative shift-count OOB read/write |
 | CBUG-D3 | epics-base/epics-base **#932** | open | `EPICS_CA_CONN_TMO` non-positive watchdog flood |
 | CBUG-D5 | epics-base/epics-base **#932** | open | `EPICS_CA_MAX_SEARCH_PERIOD` non-finite crash |
+| CBUG-E2 | epics-base/epics-base **#933** | open | `dbConvert`/`dbFastLinkConv` float→int cast UB → saturation; **port already saturates (refuses the bug)**, so the catalogue's `Bucket: REPRODUCED` header is stale — see note below |
 | CBUG-F1 | epics-modules/calc **#40** | open | `aCalc INC()` off-by-two |
 | CBUG-F2 | epics-modules/calc **#41** | open | `aCalc SUBRANGE` inclusive upper bound OOB read |
 | CBUG-F3 | epics-modules/calc **#41** | open | `aCalc DERIV`/`nderiv` fit-window > array OOB read |
@@ -160,7 +161,19 @@ its own row pointing at the shared PR.
 > the catalogue bucket and the `time_series_plugin.rs` comment framing were
 > corrected.
 
-**REPRODUCED bugs also reported upstream (8):**
+> **CBUG-E2 — stale bucket (like B25).** The catalogue entry still carries
+> `Bucket: REPRODUCED`, but its own adjudication records that the port
+> **saturates** float/double → integer conversions (`epics-base-rs`
+> `types/c_cast.rs`, Rust `as`), i.e. it **refuses** the C bug and is
+> byte-identical to the aarch64 hardware result. So E2 is effectively
+> **NOT-REPRODUCED** (port refuses) and belongs in this table, not the
+> REPRODUCED one. The upstream PR **#933** defines the C behaviour (saturate,
+> NaN → 0) on both the network (`dbConvert.c`) and DB-link (`dbFastLinkConv.c`)
+> paths, aligning x86-64 onto the aarch64/port semantics. No port behaviour
+> change is owed; if #933 merges, the C side simply stops diverging from the
+> port.
+
+**REPRODUCED bugs also reported upstream (9):**
 
 These are genuine C defects the port carries **on purpose** for bug-for-bug
 parity — their `Bucket: REPRODUCED` classification is unchanged, and the port
@@ -174,6 +187,7 @@ then retires that REPRODUCE and tracks the corrected C. Until then, reproduce.
 | CBUG-B6 | epics-modules/asyn **#236** | open | `asynInterposeCom` disable flow control now sends NOFLOW (crtscts + ixon) |
 | CBUG-B8 | epics-modules/asyn **#236** | open | `asynInterposeCom` IAC-stuff the COM-PORT-OPTION subnegotiation payload |
 | CBUG-B10 | epics-modules/asyn **#237** | open | `asyn*Base.c` `readDefault` errorMessage "read", not "write", is not supported (6 files) |
+| CBUG-B11 | areaDetector/ADCore **#599** | open | `NDPluginCircularBuff` writing `0` to `SoftTrigger` disarms, not fires (guard latch+flush behind `if (value)`) |
 | CBUG-B13 | epics-modules/motor **#254** | open | `motorRecord` key CDIR on the commanded stroke after a jog-stop backlash |
 | CBUG-B18 | epics-modules/scaler **#4** | open | `scalerRecord` `special(RATE)` posts `.RATE`, not `.TP` |
 | CBUG-B19 | epics-modules/scaler **#4** | open | `scalerRecord` `monitor()` posts `monitor_mask`, not literal `DBE_LOG` |

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -56,6 +56,35 @@ the rest the proof is the decisive code path, quoted.
 > catalogue was extracted, so the original REPRODUCED count was stale by that
 > evening; upstream then fixed it as ADCore #596 (merged 2026-07-16).
 
+> **Mass reconciliation 2026-07-20 — REPRODUCED fully retired.** Per
+> strategy-2026-07-13 §2 ("C's bugs are not the contract. Clean is the goal.") the
+> port refuses C's defects rather than mirroring them. On 2026-07-20 the REPRODUCED
+> bucket was reconciled against the actual port state, flipping **all 16** entries
+> REPRODUCED → NOT-REPRODUCED: **A3, B1, B4, B6, B8, B10, B11, B12, B13, B18, B19,
+> C2, D4, E2, F8, F12**. After this pass **no catalogue entry is REPRODUCED** — the
+> port refuses every catalogued C upstream bug.
+>
+> Fourteen the port had *already* refused before this catalogue was even extracted
+> (the fixes are ancestors of `main`, the B25/E2 precedent) — A3 `ed43b05f`,
+> B1 `ba79fd0f`, B4 `d906ad45`, B6 `edaa41b7`, B8 `93f7baee`, B10 `06c05dbe`,
+> B11 `aecc980a`, B12 code `972ac9b0`, B13 `7d2b48ac`, B18 `a0c723b9`,
+> B19 `46be9a08`, C2 `67097734` (deleted `MonitorRequestFatal` — circuit teardown
+> unrepresentable), F8 `25318fcd`; E2 already saturates (`651bf392`). Two needed a
+> fresh fix on 2026-07-20: **F12** a structural code fix (`9a51ba4c` — raises
+> SOFT/INVALID consistently on both the process and `.SGNL` paths via the single
+> `nsta`/`nsev` owner) and **D4** a structural code fix (`09af6a24` — both
+> `asyn-rs` escapers render NUL as `\0` through one parameter-free table,
+> superseding the 2026-07-14 "keep both" adjudication). One needed a doc-line fix:
+> **B12** (`b0704bff`). This historical wave-1 table is left as extracted; the
+> per-entry `Bucket:` headers carry the current classification.
+>
+> **Caveats, not exceptions.** B19's flip is correct but *inert* until `do_alarm()`
+> is ported (see the B19 body). D4's refusal carries a deliberate one-byte
+> deviation on the display/trace path (`print_escaped` now emits `\0`, not C's
+> `\x00`) — stated in the D4 body. CBUG-A2 is unchanged — **FIXED-UPSTREAM** (base
+> half tracks PR #925), not REPRODUCED, so it is neither in the flip set nor a
+> remaining REPRODUCED.
+
 | severity | n |
 |---|---|
 | High | 8 |
@@ -71,28 +100,28 @@ proven defect (see "Leads rejected").
 | id | upstream | one line | severity | bucket |
 |---|---|---|---|---|
 | CBUG-A1 | base calc | `MODULO` `INT_MIN % -1` — SIGFPE kills the IOC | High | NOT-REPRODUCED |
-| CBUG-A2 | base calc | `NINT`/`MODULO` skip C's own `d2i` guard — out-of-range → `INT_MIN` | Medium | REPRODUCED |
-| CBUG-A3 | base calc | `ISINF` leaks glibc's *signed* isinf (±1) into the value | Low | REPRODUCED |
+| CBUG-A2 | base calc | `NINT`/`MODULO` skip C's own `d2i` guard — out-of-range → `INT_MIN` | Medium | FIXED-UPSTREAM |
+| CBUG-A3 | base calc | `ISINF` leaks glibc's *signed* isinf (±1) into the value | Low | NOT-REPRODUCED |
 | CBUG-A4 | base calc | `RNDM` fixed seed + unsynchronised global RMW | Low | NOT-REPRODUCED |
-| CBUG-B1 | optics | `pf4.st` interpolates on the interval *above* the energy — `frac < 0` always | Medium | REPRODUCED |
+| CBUG-B1 | optics | `pf4.st` interpolates on the interval *above* the energy — `frac < 0` always | Medium | NOT-REPRODUCED |
 | CBUG-B2 | optics | `pf4.st` reads `keV[274]`/`mu[274]` out of bounds for Pb | Medium | NOT-REPRODUCED |
 | CBUG-B3 | optics | `pf4.st` unguarded glass divide — all 16 transmissions NaN below 2 keV | High | NOT-REPRODUCED |
-| CBUG-B4 | optics | `pf4.st` unknown material silently reports the blade fully opaque | Medium | REPRODUCED |
+| CBUG-B4 | optics | `pf4.st` unknown material silently reports the blade fully opaque | Medium | NOT-REPRODUCED |
 | CBUG-B5 | asyn | `asynInterposeCom setOption("ixon")` missing `return` — ships an uninitialized stack byte | High | NOT-REPRODUCED |
-| CBUG-B6 | asyn | `asynInterposeCom` can enable flow control but never disable it | Medium | REPRODUCED |
+| CBUG-B6 | asyn | `asynInterposeCom` can enable flow control but never disable it | Medium | NOT-REPRODUCED |
 | CBUG-B7 | asyn | `asynInterposeCom nextChar` ignores `nbytes` — uninitialized char on a 0-byte success | Low | NOT-REPRODUCED |
-| CBUG-B8 | asyn | telnet subnegotiation payload is not IAC-stuffed | Low | REPRODUCED |
+| CBUG-B8 | asyn | telnet subnegotiation payload is not IAC-stuffed | Low | NOT-REPRODUCED |
 | CBUG-B9 | asyn | `drvAsynIPServerPort` UDP read returns stale heap + drops a byte | High | NOT-REPRODUCED |
-| CBUG-B10 | asyn | every `asyn*Base.c` `readDefault` says "**write** is not supported" (6 files) | Low | REPRODUCED |
-| CBUG-B11 | ADCore | `NDPluginCircularBuff` — writing **0** to `SoftTrigger` triggers | Medium | REPRODUCED |
-| CBUG-B12 | pvxs | `ackAt == 0` sentinel makes the `ackAny` percentage mapping non-monotonic | Low | REPRODUCED |
-| CBUG-B13 | motor | `motorRecord` publishes CDIR=forward for a reverse jog-stop backlash leg | Medium | REPRODUCED |
+| CBUG-B10 | asyn | every `asyn*Base.c` `readDefault` says "**write** is not supported" (6 files) | Low | NOT-REPRODUCED |
+| CBUG-B11 | ADCore | `NDPluginCircularBuff` — writing **0** to `SoftTrigger` triggers | Medium | NOT-REPRODUCED |
+| CBUG-B12 | pvxs | `ackAt == 0` sentinel makes the `ackAny` percentage mapping non-monotonic | Low | NOT-REPRODUCED |
+| CBUG-B13 | motor | `motorRecord` publishes CDIR=forward for a reverse jog-stop backlash leg | Medium | NOT-REPRODUCED |
 | CBUG-B14 | std | `throttleRecord` callback mutates the record with no `dbScanLock` | High | NOT-REPRODUCED |
 | CBUG-B15 | std | `epidRecord` raises UDF then returns before committing it | Medium | NOT-REPRODUCED |
 | CBUG-B16 | std | `devEpidSoft` "nothing to control" abort falls through when already INVALID | Medium | NOT-REPRODUCED |
 | CBUG-B17 | std | `throttleRecord` writes CA-link status for the wrong link (2 sites) | Low | NOT-REPRODUCED |
-| CBUG-B18 | scaler | `special(RATE)` posts `.TP` and never posts the clamped `.RATE` | Low | REPRODUCED |
-| CBUG-B19 | scaler | `monitor()` builds the alarm mask, then posts a literal `DBE_LOG` and discards it | Low | REPRODUCED |
+| CBUG-B18 | scaler | `special(RATE)` posts `.TP` and never posts the clamped `.RATE` | Low | NOT-REPRODUCED |
+| CBUG-B19 | scaler | `monitor()` builds the alarm mask, then posts a literal `DBE_LOG` and discards it | Low | NOT-REPRODUCED |
 | CBUG-B20 | ADCore | `NDPluginROIStat` writes ROI geometry OOB for any RGB (3-D) array | High | NOT-REPRODUCED |
 | CBUG-B21 | ADCore | `NDPluginAttrPlot` `<=` off-by-one → heap OOB write on the first frame | High | NOT-REPRODUCED |
 | CBUG-B22 | ADCore | `NDPluginProcess` divides by `numFiltered` with `NumFilter == 0` | Medium | NOT-REPRODUCED |
@@ -109,9 +138,12 @@ proven defect (see "Leads rejected").
 This is the authoritative submission-status table; it replaces the per-entry
 `Status:` prose, which is stale (the catalogue was extracted 2026-07-13, before
 most of these PRs were filed on 7/16–7/20). Author: `physwkim`. State is the live
-GitHub PR state, not a claim about the catalogue. Total filed: **39** — 29
-NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 9 REPRODUCED in
-the separate table after it.
+GitHub PR state, not a claim about the catalogue. Total filed: **39** — 38
+NOT-REPRODUCED (port refuses) + 1 FIXED-UPSTREAM. Of these, the 9 grouped in the
+separate table after the main one were classified REPRODUCED when this catalogue
+was extracted (2026-07-13), but all nine were flipped REPRODUCED →
+NOT-REPRODUCED on 2026-07-20 (the port already refused them — see the 2026-07-20
+reconciliation note); the second table is kept only as a grouped PR-status view.
 
 **Catalogued CBUGs that are filed (30):**
 
@@ -144,7 +176,7 @@ its own row pointing at the shared PR.
 | CBUG-D2 | epics-modules/calc **#41** | open | `sCalc` `<<`/`>>` negative shift-count OOB read/write |
 | CBUG-D3 | epics-base/epics-base **#932** | open | `EPICS_CA_CONN_TMO` non-positive watchdog flood |
 | CBUG-D5 | epics-base/epics-base **#932** | open | `EPICS_CA_MAX_SEARCH_PERIOD` non-finite crash |
-| CBUG-E2 | epics-base/epics-base **#933** | open | `dbConvert`/`dbFastLinkConv` float→int cast UB → saturation; **port already saturates (refuses the bug)**, so the catalogue's `Bucket: REPRODUCED` header is stale — see note below |
+| CBUG-E2 | epics-base/epics-base **#933** | open | `dbConvert`/`dbFastLinkConv` float→int cast UB → saturation; **port already saturates (refuses the bug)**; the entry's `Bucket:` header was flipped REPRODUCED → NOT-REPRODUCED on 2026-07-20 to match its body — see note below |
 | CBUG-F1 | epics-modules/calc **#40** | open | `aCalc INC()` off-by-two |
 | CBUG-F2 | epics-modules/calc **#41** | open | `aCalc SUBRANGE` inclusive upper bound OOB read |
 | CBUG-F3 | epics-modules/calc **#41** | open | `aCalc DERIV`/`nderiv` fit-window > array OOB read |
@@ -163,24 +195,28 @@ its own row pointing at the shared PR.
 > the catalogue bucket and the `time_series_plugin.rs` comment framing were
 > corrected.
 
-> **CBUG-E2 — stale bucket (like B25).** The catalogue entry still carries
-> `Bucket: REPRODUCED`, but its own adjudication records that the port
-> **saturates** float/double → integer conversions (`epics-base-rs`
-> `types/c_cast.rs`, Rust `as`), i.e. it **refuses** the C bug and is
-> byte-identical to the aarch64 hardware result. So E2 is effectively
-> **NOT-REPRODUCED** (port refuses) and belongs in this table, not the
-> REPRODUCED one. The upstream PR **#933** defines the C behaviour (saturate,
+> **CBUG-E2 — stale bucket (like B25), reconciled 2026-07-20.** The entry's
+> `Bucket:` header read `REPRODUCED` until 2026-07-20, but its own adjudication
+> records that the port **saturates** float/double → integer conversions
+> (`epics-base-rs` `types/c_cast.rs`, Rust `as`), i.e. it **refuses** the C bug
+> and is byte-identical to the aarch64 hardware result. The header was flipped to
+> **NOT-REPRODUCED** (port refuses) on 2026-07-20 to match the body; E2 belongs in
+> this table, not the (now-retired) REPRODUCED one. The upstream PR **#933** defines the C behaviour (saturate,
 > NaN → 0) on both the network (`dbConvert.c`) and DB-link (`dbFastLinkConv.c`)
 > paths, aligning x86-64 onto the aarch64/port semantics. No port behaviour
 > change is owed; if #933 merges, the C side simply stops diverging from the
 > port.
 
-**REPRODUCED bugs also reported upstream (9):**
+**Was REPRODUCED, now NOT-REPRODUCED — also reported upstream (9):**
 
-These are genuine C defects the port carries **on purpose** for bug-for-bug
-parity — their `Bucket: REPRODUCED` classification is unchanged, and the port
-keeps reproducing them. Filing upstream is deliberate: if a fix merges, the port
-then retires that REPRODUCE and tracks the corrected C. Until then, reproduce.
+These nine were catalogued as REPRODUCED at extraction (2026-07-13), but the
+port had already been flipped to **refuse** each of them (the fixes predate the
+catalogue snapshot; see the per-entry `Bucket:` headers and the 2026-07-20
+reconciliation note), so on 2026-07-20 all nine were reclassified REPRODUCED →
+NOT-REPRODUCED. The port no longer reproduces any of them; the note column below
+already describes the corrected behaviour. Filing upstream still stands: the C
+side stays wrong until a fix merges, at which point C simply stops diverging
+from the already-correct port.
 
 | CBUG | PR | state | note |
 |---|---|---|---|
@@ -307,7 +343,7 @@ A%B      A=-nan B=7 -> -2
 ```
 
 ### CBUG-A3: `ISINF` leaks glibc's *signed* isinf result (±1) into the expression value
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Low
 C: `calcPerform.c:276-277`: `*ptop = isinf(*ptop);`. On glibc this resolves to the
 GNU/BSD *function*, which returns `+1` for `+Inf` and **`-1` for `-Inf`** — not the
 C99 *macro* (a plain boolean 1). Same in `sCalcPerform.c:703`/`:1407` and
@@ -364,7 +400,7 @@ run2: RNDM = 0.7500724804, 0.03596551461, 0.3266956588, 0.009201190204, 0.297611
 ---
 
 ### CBUG-B1: `pf4.st` `OtherAbsorptionLength` interpolates on the wrong interval — every "Other" filter transmission is wrong
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `optics/opticsApp/src/pf4.st:641-643`. The bracketing loop
 `for (j=0; j<numEntries; j++) if (keV < filtermat[i].keV[j]) break;` leaves `j` as
 the first node **strictly above** `keV`. C then interpolates on `[j, j+1]`:
@@ -463,7 +499,7 @@ Proof — `proof_nan.c`:
 ```
 
 ### CBUG-B4: `pf4.st` an unknown "Other" material name, or an energy above the table, silently reports the blade as fully opaque
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `pf4.st:629-631` and `:637-639` — `OtherAbsorptionLength` returns `0.` both when
 `strcmp` matches no species and when `j >= numEntries`. Both `printf` diagnostics that
 would have reported it are **commented out** in the shipped source:
@@ -525,7 +561,7 @@ Proof: `:593-596` has no `return`; `:597` unconditionally calls
 and `:430` writes `cbuf` to the device. `xBuf[1]` is never assigned on that path.
 
 ### CBUG-B6: `asynInterposeCom` can turn flow control **on** but never **off**
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `asynInterposeCom.c:575` and `:591` — both the `crtscts` and the `ixon` branch
 implement "n" as `if (epicsStrCaseCmp(val, "n") == 0) xBuf[1] = pinterposePvt->flow;`
 — the value transmitted for "turn this off" is the port's **current** flow-control mode.
@@ -581,7 +617,7 @@ Proof: `:103` writes `&nbytes`; no read of `nbytes` exists in the function; `:10
 returns `c` whenever `status == asynSuccess`.
 
 ### CBUG-B8: `asynInterposeCom` telnet negotiation bypasses its own IAC-stuffing, so a payload byte of 0xFF corrupts the subnegotiation
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Low
 C: `asynInterposeCom.c:430-431` — the negotiation frame is written straight to the
 driver **below** the interpose (`pinterposePvt->pasynOctetDrv->write`), not through this
 interpose's own `writeIt` (`:146-182`), which is the function that doubles `C_IAC`
@@ -640,7 +676,7 @@ Proof: `UDPbufferSize` is written only at `:311` and reset at `:202-203`/`:244-2
 reason. It never bounds the loop at `:196`.
 
 ### CBUG-B10: every `asyn*Base.c` `readDefault` reports "**write** is not supported" for a failed **read** (6 files)
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Low
 C: `asyn/asyn/interfaces/asynInt32Base.c:81-84` (`readDefault`):
 ```c
 :81     epicsSnprintf(pasynUser->errorMessage,pasynUser->errorMessageSize,
@@ -671,7 +707,7 @@ actively misdirects the person debugging.
 Proof: read both functions in any of the six files.
 
 ### CBUG-B11: `NDPluginCircularBuff` — writing **0** to `SoftTrigger` triggers the capture exactly like writing 1
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `ADCore/ADApp/pluginSrc/NDPluginCircularBuff.cpp:266-278` (`writeInt32`):
 ```c
 :266    }  else if (function == NDCircBuffSoftTrigger){
@@ -701,7 +737,7 @@ unconditional on it. (The `flushOn > 0` gate at `:276` is *correct* C — see th
 correction to R11-63 below.)
 
 ### CBUG-B12: pvxs `ackAt == 0` is overloaded as "caller said nothing", so a small `ackAny` percentage acks **later** than a larger one
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Low
 C: `pvxs/src/servermon.cpp:564` and `:577-578` (`ServerMonitorSetup::onSetup`, pipeline branch):
 ```c++
 :564            op->ackAt = std::max(0.0, std::min(percent, 100.0)) / 100.0 * op->limit;
@@ -739,7 +775,7 @@ NON-MONOTONIC: ackAny="25%" -> 1 ; ackAny="10%" -> 2
 ```
 
 ### CBUG-B13: `motorRecord` publishes CDIR=forward after a jog-stop backlash take-out that actually commands the reverse direction
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `motor/motorApp/MotorSrc/motorRecord.cc:827-829`, `:845`, `:973` (`postProcess`). The
 "sync drive to readback" block runs for every MIP except `{MOVE, MOVE_BL, JOG_BL1,
 JOG_BL2}` — the predicate does **not** exclude `MIP_JOG_STOP`. Inside it,
@@ -855,7 +891,7 @@ Proof: `:371` is inside the branch reached for `fieldIndex == throttleRecordSINP
 `:687-688` declarations are outside the loop opened at `:698`.
 
 ### CBUG-B18: `scalerRecord` `special(RATE)` posts `.TP` — a field the write never touched — and never posts the clamped RATE
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note) · Severity: Low
 C: `scaler/scalerApp/src/scalerRecord.c:690-693` (`special`) — `case scalerRecordRATE:
 pscal->rate = MIN(60.,MAX(0.,pscal->rate)); db_post_events(pscal,&(pscal->tp),DBE_VALUE);
 break;` The clamp writes `rate`; the post passes `&pscal->tp`. Second site of the same
@@ -871,7 +907,7 @@ before any monitor exists).
 Proof: `:691` writes `pscal->rate`; `:692` passes `&(pscal->tp)` to `db_post_events`.
 
 ### CBUG-B19: `scalerRecord` `monitor()` computes the alarm monitor mask, then posts with a hard-coded `DBE_LOG` and discards it
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; see the 2026-07-20 reconciliation note; the fix is inert until `do_alarm()` is ported — see body) · Severity: Low
 C: `scalerRecord.c:758-773` — `monitor_mask = recGblResetAlarms(pscal); monitor_mask |=
 (DBE_VALUE|DBE_LOG);` then the only post in the function is
 `for (i=0;i<pscal->nch;i++) db_post_events(pscal,&(pscaler[i]),DBE_LOG);` — a **literal**
@@ -1138,7 +1174,7 @@ and `LRC(AA)` with an empty `AA`.
 ---
 
 ### CBUG-C2: pvxs QSRV resets the whole TCP circuit when one channel's request options fail to parse
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — flipped 2026-07-20; already refused since commit `67097734` (2026-07-13, ancestor of main): `MonitorRequestFatal` was deleted, so a per-op request-option parse failure returns an ordinary per-op `OpError` and cannot tear down the circuit — teardown is unrepresentable by construction; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `pvxs/ioc/singlesource.cpp:147` / `pvxs/ioc/groupsource.cpp:399` — `onSubscribe` calls a
 bare `connect()`; the `NoConvert` its DBE/options parse can throw propagates uncaught into the
 connection layer, which tears the circuit down.
@@ -1233,7 +1269,7 @@ Proof: compiled upstream exits after ONE iteration for both `UNTIL(A:=A+1;"0")` 
 | CBUG-D1 | calc | out-of-count `FETCH` leaves the stack cell stale (sCalc scalar) / the array tail stale (aCalc) | Low | NOT-REPRODUCED |
 | CBUG-D2 | calc | sCalc string `<<`/`>>` with a negative count writes past the 40-byte `local_string` | Medium | NOT-REPRODUCED |
 | CBUG-D3 | base ca | non-positive `EPICS_CA_CONN_TMO` accepted — watchdog flood, 177k stderr lines / 3 s | Medium | NOT-REPRODUCED |
-| CBUG-D4 | base libCom | the two escape printers render NUL differently — `\0` vs `\x00` | Low | REPRODUCED |
+| CBUG-D4 | base libCom | the two escape printers render NUL differently — `\0` vs `\x00` | Low | NOT-REPRODUCED |
 | CBUG-D5 | base ca | `EPICS_CA_MAX_SEARCH_PERIOD=inf` aborts the client in malloc; `=nan` NaN-drives the timer wheel | Medium | NOT-REPRODUCED |
 
 ### CBUG-D1: sCalc's string engine leaves the stack cell stale on an out-of-count `FETCH`; aCalc's array `FETCH` zeroes only element 0
@@ -1300,38 +1336,50 @@ Proof: measured on the compiled camonitor on this host during the R16-19 fix wav
 ---
 
 ### CBUG-D4: libCom's two escape printers render NUL differently — `\0` vs `\x00`
-Bucket: REPRODUCED (adjudicated 2026-07-14 — **keep both; not a defect to fix**) · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — fixed 2026-07-20, `09af6a24`: both `asyn-rs` escapers now render NUL as `\0` through one parameter-free table, so the `\0`-vs-`\x00` divergence is unrepresentable by construction; this supersedes the 2026-07-14 "keep both" adjudication — see the D4 body and the 2026-07-20 reconciliation note) · Severity: Low
 
-**Adjudication.** The divergence is real (both switch bodies re-read in the local tree:
-`epicsStrnEscapedFromRaw` has `case '\0': OUT('\\'); OUT('0');` at `:145`;
-`epicsStrPrintEscaped` `:245-259` has no `'\0'` arm, so NUL falls to
-`fprintf(fp, "\\x%02x", ...)`). Every other arm of the two switches is identical.
+**Adjudication (revised 2026-07-20 — the earlier "keep both" is superseded).** The C
+divergence is real: `epicsStrnEscapedFromRaw` has an explicit `case '\0': OUT('\\');
+OUT('0');` at `:145`, while `epicsStrPrintEscaped` (`:230-262`) has **no `'\0'` arm**, so a
+NUL falls through to the `fprintf(fp, "\\x%02x", ...)` default and prints `\x00`. The C bug
+is therefore a **missing case in the display escaper**, not two deliberately-different
+renderings: C's round-trippable escaper renders NUL as the deliberate `\0`; the display
+escaper merely forgot the case.
 
-But the "Defect" line below overstates it: these are **not two implementations of one
-escape table**. They have different contracts, and only one of them has an inverse —
-`epicsStrnEscapedFromRaw` is the round-trippable escape (undone by
-`epicsStrnRawFromEscaped`, and it is what `.db`/`.dbd` quoting relies on), whereas
-`epicsStrPrintEscaped` is a display escape streamed to a `FILE*` with no inverse. So there
-is no shared table for them to disagree *about*.
-
-Unifying them in the port would therefore *break* byte-parity with C on whichever path we
-changed, for a purely cosmetic gain — and asyn trace files are diffed against C's. The port
-keeps both renderings (see Port, below), which is correct as written. **No port change; the
-entry stays catalogued so the inconsistency is not "rediscovered" as a port bug later.**
+The earlier adjudication kept both renderings on a byte-parity-with-C argument. That is
+rejected under strategy-2026-07-13 §2 (clean is the goal), and two of its premises are wrong:
+(1) `\0` is **round-trip-safe** — `epicsStrnRawFromEscaped` decodes `\0` via `case '0'`,
+consuming only the `0` with no octal continuation (the port decoder matches at
+`iocsh.rs`), so `\0` followed by a digit round-trips as NUL-then-digit; and (2) the port is
+**not** parameter-free of a shared table — `escape.rs` had ONE table whose only per-form
+knob was the NUL rendering, i.e. exactly the shared table the argument claimed did not
+exist. The port also already renders NUL as `\0` in its calc escaper
+(`epics-base-rs/src/calc/engine/string.rs`, `ESC$`), so `\x00` on the asyn path was an
+internal inconsistency too.
 C: `epics-base modules/libcom/src/misc/epicsString.c` — `epicsStrnEscapedFromRaw` has an
 explicit `case '\0': OUT('\\'); OUT('0');` (`:145`), while `epicsStrPrintEscaped`
 (`:230-262`) has no `'\0'` case, so a NUL falls to the `fprintf(fp, "\\x%02x", ...)` default arm and
 prints `\x00` (`:256-259`). Asyn traffic tracing escapes through both, chosen by output path, so
 the same traced byte renders differently in a trace file than in an errlog capture.
 Defect: two implementations of the same escape table diverge on one byte.
-Port: `crates/asyn-rs/src/escape.rs` — ONE table parameterised only on the NUL rendering:
-`escaped_from_raw` yields `\0` (`:31`) and `print_escaped` yields `\x00` (`:37`), so each C
-call path is reproduced byte-for-byte (R16-48, commit `e0a71007`); the inconsistency itself
-is carried deliberately and documented in the module header.
-Impact: cosmetic but real — diffing the same binary-protocol traffic captured via an
-asynTrace file against an errlog capture shows spurious differences on every NUL byte.
-Proof: both switch arms quoted; the port's table is pinned by tests at
-`crates/asyn-rs/src/escape.rs:73-83`.
+Port (**refuses** — fixed 2026-07-20, `09af6a24`): `crates/asyn-rs/src/escape.rs` — the
+`nul` parameter was removed from the shared `escape()`; the NUL arm is now the constant
+`0 => "\\0"`, so **both** `escaped_from_raw` and `print_escaped` render NUL as `\0` and the
+`\0`-vs-`\x00` divergence is unrepresentable by construction. Converging onto `\0` matches
+C's deliberate round-trippable case and the port's calc escaper.
+Deliberate deviation (stated, not hidden): the port's `print_escaped` now emits `\0` where
+compiled C's `epicsStrPrintEscaped` still emits `\x00`. On the display/trace path the port
+diverges from an unfixed C IOC by exactly this one byte — the port owns that deviation,
+choosing internal consistency (and agreement with C's own deliberate `\0` case) over
+mirroring C's omission. Filing upstream (supply the missing `'\0'` case to
+`epicsStrPrintEscaped`) would remove the deviation.
+Impact: on the asyn trace/display path a NUL now prints `\0` (was `\x00`); a NUL captured
+via asynTrace and via errlog now render identically, and consistently with the
+round-trippable escaper. Diffs of the same NUL byte against an *unfixed* C IOC's display
+escaper differ by this one deliberate byte.
+Proof: both C switch arms quoted; the port's convergence is pinned by tests
+(`escape::the_table_is_c_s_and_both_forms_now_agree_on_nul`, plus a NUL and
+NUL-then-digit round-trip through the port decoder). Fix `09af6a24`.
 
 ---
 
@@ -1362,7 +1410,7 @@ site during the R15 wave); the NaN-blind gate (`:77`) and the UB cast (`:99`) qu
 | id | upstream | one line | severity | bucket |
 |---|---|---|---|---|
 | CBUG-E1 | base db | a scalar `dbPut` into a FIFO compress VAL writes through `get_array_info`'s READ offset, rewriting one slot instead of appending | Medium | NOT-REPRODUCED |
-| CBUG-E2 | base db | `dbConvert`'s double→integer PUT/GET is a bare C cast — UB out of range, x86-64 gives `INT_MIN`/truncation garbage | Medium | REPRODUCED |
+| CBUG-E2 | base db | `dbConvert`'s double→integer PUT/GET is a bare C cast — UB out of range, x86-64 gives `INT_MIN`/truncation garbage | Medium | NOT-REPRODUCED |
 
 ### CBUG-E1: scalar `dbPut` into a FIFO compress VAL writes at the READ start — every put during initial fill rewrites the same slot
 Bucket: NOT-REPRODUCED · Severity: Medium
@@ -1387,7 +1435,7 @@ pinned by the compress ingest tests. Filed as the R17-85 documented deviation
 (`doc/c-parity-review-2026-07-10.md`), flagged for user sign-off.
 
 ### CBUG-E2: `dbConvert`'s double→integer conversion is a bare C cast — undefined behaviour out of range; compiled x86-64 yields `INT_MIN` / truncation garbage
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port saturates — refuses; the bucket label was flipped 2026-07-20 to match the body, which already recorded the saturating behaviour; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `epics-base modules/database/src/ioc/db/dbConvert.c:96-113` — the PUT macro body is
 `*pdst = (typeb) *psrc;`, instantiated for every integer destination at `:1631-1638`
 (`putDoubleShort`, `putDoubleLong`, `putDoubleUlong`, ...); the GET twin (`:63-70`) is the
@@ -1478,11 +1526,11 @@ decisive code path is quoted.
 | CBUG-F5 | calc (sCalc) | `LITERAL_STRING` copy guard never increments its counter — a >39-char literal overruns the 40-byte cell | Medium | NOT-REPRODUCED |
 | CBUG-F6 | base calc | `INPM`..`INPU` declare `special(SPC_MOD)` that `special()` rejects — nine documented fields unwritable via CA | Medium | NOT-REPRODUCED |
 | CBUG-F7 | calc (sCalc) | unconditional debug `printf` in the `SUBLAST` scan loop | Low | NOT-REPRODUCED |
-| CBUG-F8 | calc (sCalc) | `CRC16`/`MODBUS` sign-extends payload bytes ≥ 0x80 — wire-incompatible with the Modbus standard | Medium | REPRODUCED |
+| CBUG-F8 | calc (sCalc) | `CRC16`/`MODBUS` sign-extends payload bytes ≥ 0x80 — wire-incompatible with the Modbus standard | Medium | NOT-REPRODUCED |
 | CBUG-F9 | pvxs | process-only blocking PUT selects a `requestType` dbNotify never matches — silent no-op success | Medium | NOT-REPRODUCED |
 | CBUG-F10 | pvxs | UnionArray encode omits the selector its own decoder requires — a decoded UnionA cannot be re-serialized | Medium | NOT-REPRODUCED |
 | CBUG-F11 | asyn | `caput REC.TSIZ -1` suspends the put thread forever inside `callocMustSucceed`, holding the global trace mutex | High | NOT-REPRODUCED |
-| CBUG-F12 | base histogram | the `LLIM >= ULIM` alarm writes `stat`/`sevr` directly — erased on the process path (NO_ALARM) but STICKS on the `.SGNL` special path (SOFT); port reproduces both (`932291d9`) | Low | REPRODUCED |
+| CBUG-F12 | base histogram | the `LLIM >= ULIM` alarm writes `stat`/`sevr` directly — erased on the process path (NO_ALARM) but STICKS on the `.SGNL` special path (SOFT); port now refuses — raises SOFT/INVALID consistently on both paths via `nsta`/`nsev` (`9a51ba4c`) | Low | NOT-REPRODUCED |
 
 ### CBUG-F1: aCalc's `INC` bounds check admits writes two elements past the runtime stack — SIGSEGV at legal compile depth
 Bucket: NOT-REPRODUCED · Severity: High
@@ -1652,7 +1700,7 @@ Proof: the `printf` at `:999` is inside the loop with no `if
 (sCalcPerformDebug)` guard.
 
 ### CBUG-F8: sCalc `CRC16`/`MODBUS` sign-extends payload bytes ≥ 0x80 — wire-incompatible with the Modbus CRC standard
-Bucket: REPRODUCED · Severity: Medium
+Bucket: NOT-REPRODUCED (port refuses — emits the standard Modbus digest, XORs the unsigned byte; flipped 2026-07-20, code fix `25318fcd`; the "Adjudicated REPRODUCE" line below is superseded; see the 2026-07-20 reconciliation note) · Severity: Medium
 C: `sCalcPerform.c:193-212` (the `CRC16` case). Payload is
 `char tranInput[40]` (signed on x86-64) folded into `unsigned int crc` via
 `crc ^= (unsigned int)tranInput[i]`; a byte ≥ 0x80 sign-extends to
@@ -1661,18 +1709,25 @@ that back down. The commented-out predecessor at `:211` masks to the low
 byte, showing the low-byte XOR was intended.
 Defect: the standard Modbus CRC-16 XORs the *unsigned* byte; C's signed
 `char` makes every high byte wrong.
-Port: `crates/epics-base-rs/src/calc/engine/checksum.rs` (R18-6,
-`ee4f6bff`) — reproduces the 32-bit accumulator and the signed-`char`
-sign-extension deliberately, with the deviation-from-standard documented
-at the function. **Adjudicated REPRODUCE**: bug-for-bug parity with the
-compiled IOC is the contract on exactly the binary Modbus frames the
-operator uses; deviating to standard-correct would make the port
-wire-incompatible with every existing C IOC.
-Impact: `CRC16` of any payload containing a byte ≥ 0x80 differs from the
-Modbus standard — but agrees with the C IOC, which is the point. ASCII-only
-payloads are unaffected (`XOR8`/`LRC`/`AMODBUS` unaffected entirely).
-Proof (compiled C, this host): `CRC16("\x80")` → C `\x41\x1f`,
-standard-correct → `\xbe\xe0`; port matches C.
+Port: `crates/epics-base-rs/src/calc/engine/checksum.rs:34` (`crc16`) —
+**refuses** the C bug. It XORs the *unsigned* byte (`crc ^= byte as u16`),
+the standard Modbus CRC-16, so a byte ≥ 0x80 no longer sign-extends.
+History: R18-6/`ee4f6bff` first reproduced C's 32-bit-accumulator
+signed-`char` sign-extension deliberately; commit `25318fcd`
+("CBUG-F8 — sCalc CRC16 emits the STANDARD Modbus digest") flipped that to
+the standard digest, superseding the earlier "Adjudicated REPRODUCE".
+Refused per strategy-2026-07-13 §2 (clean is the goal): the port emits the
+correct Modbus digest rather than mirroring the compiled IOC's wrong one.
+Test `test_crc16_high_bytes_are_standard_not_c` pins the standard values
+(`0x80` → `0xE0BE`) and asserts C's `0x1F41` is refused.
+Impact: `CRC16` of a payload containing a byte ≥ 0x80 now matches the
+Modbus standard and diverges from an unfixed C IOC (which is wrong); this
+is a deliberate deviation the port owns. ASCII-only payloads were never
+affected (`XOR8`/`LRC`/`AMODBUS` unaffected entirely). Filing upstream is
+still open (the C IOC stays wire-wrong until a fix merges).
+Proof (compiled C, this host): `CRC16("\x80")` → C `\x41\x1f` (= 0x1F41,
+wrong), standard-correct → `\xbe\xe0` (= 0xE0BE); the port now emits the
+standard `\xbe\xe0`, refusing C.
 
 ### CBUG-F9: pvxs process-only blocking PUT selects a `requestType` `dbNotify` never matches — silent no-op success
 Bucket: NOT-REPRODUCED · Severity: Medium
@@ -1752,7 +1807,7 @@ Proof: `epicsInt32 tsiz` (`:196`) → `size_t` param (`asynManager.c:2943`) →
 unlocked on this path.
 
 ### CBUG-F12: base `histogram` `LLIM >= ULIM` alarm writes `stat`/`sevr` directly and `recGblResetAlarms` erases it in the same cycle — dead code
-Bucket: REPRODUCED · Severity: Low
+Bucket: NOT-REPRODUCED (port refuses — raises SOFT/INVALID consistently on BOTH the process and `.SGNL` paths via the single `nsta`/`nsev` owner; fixed 2026-07-20, code fix `9a51ba4c`; see the 2026-07-20 reconciliation note) · Severity: Low
 C: `epics-base modules/database/src/std/rec/histogramRecord.c:328-334`
 (`add_count`):
 ```c

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -104,29 +104,46 @@ proven defect (see "Leads rejected").
 
 ---
 
-### Filed upstream PRs — live GitHub status (as of 2026-07-18)
+### Filed upstream PRs — live GitHub status (as of 2026-07-19)
 
 This is the authoritative submission-status table; it replaces the per-entry
 `Status:` prose, which is stale (the catalogue was extracted 2026-07-13, before
-most of these PRs were filed on 7/16–7/17). Author: `physwkim`. State is the live
+most of these PRs were filed on 7/16–7/19). Author: `physwkim`. State is the live
 GitHub PR state, not a claim about the catalogue.
 
-**Catalogued CBUGs that are filed (14):**
+**Catalogued CBUGs that are filed (27):**
+
+Some 2026-07-19 PRs bundle several CBUGs into one PR (calc **#41** = D2/F5/F2/F3;
+epics-base **#932** = D3/D5/F6; std **#28** = B15/B16; ADCore **#598** =
+B22/B23/B27) — each CBUG gets its own row pointing at the shared PR.
 
 | CBUG | PR | state | note |
 |---|---|---|---|
 | CBUG-A1 | epics-modules/calc **#38** | open | `MODULO INT_MIN % -1` SIGFPE guard |
 | CBUG-A2 | epics-base/epics-base **#925** | open | `calcPerform` NINT/MODULO `d2i` narrowing |
+| CBUG-B2 | epics-modules/optics **#26** | open | pf4 Pb top-bin `keV[j+1]`/`mu[j+1]` OOB read |
 | CBUG-B3 | epics-modules/optics **#25** | open | pf4 glass-term guard |
 | CBUG-B5 | epics-modules/asyn **#234** | merged | `asynInterposeCom` ixon `return` |
 | CBUG-B9 | epics-modules/asyn **#233** | merged | `drvAsynIPServerPort` UDP read bound |
 | CBUG-B14 | epics-modules/std **#27** | open | `throttleRecord` `dbScanLock` |
+| CBUG-B15 | epics-modules/std **#28** | open | `epidRecord` commit UDF alarm before return |
+| CBUG-B16 | epics-modules/std **#28** | open | `devEpidSoft` abort unconditionally when INP constant |
 | CBUG-B20 | areaDetector/ADCore **#594** | merged | `NDPluginROIStat` RGB heap OOB |
 | CBUG-B21 | areaDetector/ADCore **#595** | merged | `NDPluginAttrPlot` `<=` off-by-one |
+| CBUG-B22 | areaDetector/ADCore **#598** | open | `NDPluginProcess` `numFilter < 1` divide-by-zero guard |
+| CBUG-B23 | areaDetector/ADCore **#598** | open | `NDPluginProcess` `autoOffsetScale` `maxValue > minValue` guard |
 | CBUG-B25 | areaDetector/ADCore **#596** | merged | `NDPluginTimeSeries` narrow-before-divide |
 | CBUG-B26 | areaDetector/ADCore **#597** | merged | `NDPluginStats` dark-frame value-init |
+| CBUG-B27 | areaDetector/ADCore **#598** | open | `NDPluginStats` histogram `histMax <= histMin` guard |
 | CBUG-C1 | epics-modules/calc **#39** | open | `sCalc lrc()` empty-operand OOB read |
+| CBUG-D2 | epics-modules/calc **#41** | open | `sCalc` `<<`/`>>` negative shift-count OOB read/write |
+| CBUG-D3 | epics-base/epics-base **#932** | open | `EPICS_CA_CONN_TMO` non-positive watchdog flood |
+| CBUG-D5 | epics-base/epics-base **#932** | open | `EPICS_CA_MAX_SEARCH_PERIOD` non-finite crash |
 | CBUG-F1 | epics-modules/calc **#40** | open | `aCalc INC()` off-by-two |
+| CBUG-F2 | epics-modules/calc **#41** | open | `aCalc SUBRANGE` inclusive upper bound OOB read |
+| CBUG-F3 | epics-modules/calc **#41** | open | `aCalc DERIV`/`nderiv` fit-window > array OOB read |
+| CBUG-F5 | epics-modules/calc **#41** | open | `sCalc LITERAL_STRING` copy bound never advances OOB write |
+| CBUG-F6 | epics-base/epics-base **#932** | open | `calcRecord` drop unhandled `special(SPC_MOD)` from INPM..INPU |
 | CBUG-F11 | epics-modules/asyn **#235** | merged | `asynManager` traceIO truncate hang |
 | CBUG-G1 | epics-base/pvxs **#196** | open | QSRV2 `display.precision` |
 
@@ -155,11 +172,16 @@ These want back-fill CBUG entries (or an explicit "no entry — direct find" not
 so the catalogue and the filed set stay reconcilable.
 
 **Catalogued NOT-REPRODUCED, still UNFILED (the remaining easy-to-accept set):**
-CBUG-B2 (pf4 Pb OOB read), CBUG-B7 (`nextChar` 0-byte uninit), CBUG-B17
-(throttle wrong-link CA status), CBUG-B22 / CBUG-B23 / CBUG-B27 (NDPluginProcess /
-NDPluginStats divide-by-zero, 3), CBUG-D2 (sCalc string shift OOB write), CBUG-D3
-(`EPICS_CA_CONN_TMO` watchdog flood), CBUG-D5 (`EPICS_CA_MAX_SEARCH_PERIOD`
-inf/nan crash). None filed as of 2026-07-18.
+CBUG-B7 (`nextChar` 0-byte uninit), CBUG-B17 (throttle wrong-link CA status).
+The 2026-07-19 batch cleared the rest of this list: B2, B22, B23, B27, D2, D3,
+D5 are now filed (see the table above).
+
+**Prepared but held (not filed):** the pvxs pair CBUG-F9 (process-only blocking
+PUT silent no-op) and CBUG-F10 (UnionArray round-trip) — fixes committed on
+`fix/blocking-put-and-unionarray` in a worktree, held pending re-verification of
+F10 (the prepared fix is decode-side, contradicting F10's encode-side framing).
+CBUG-B24 (modbus ASCII-serial LRC) is deferred on a `physwkim/modbus` fork
+question.
 
 ---
 

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -109,11 +109,11 @@ proven defect (see "Leads rejected").
 This is the authoritative submission-status table; it replaces the per-entry
 `Status:` prose, which is stale (the catalogue was extracted 2026-07-13, before
 most of these PRs were filed on 7/16–7/20). Author: `physwkim`. State is the live
-GitHub PR state, not a claim about the catalogue. Total filed: **37** — 27
+GitHub PR state, not a claim about the catalogue. Total filed: **39** — 29
 NOT-REPRODUCED + 1 FIXED-UPSTREAM in the main table below, plus 9 REPRODUCED in
 the separate table after it.
 
-**Catalogued CBUGs that are filed (28):**
+**Catalogued CBUGs that are filed (30):**
 
 Some PRs bundle several CBUGs into one PR (calc **#41** = D2/F5/F2/F3;
 epics-base **#932** = D3/D5/F6; std **#28** = B15/B16; ADCore **#598** =
@@ -127,10 +127,12 @@ its own row pointing at the shared PR.
 | CBUG-B2 | epics-modules/optics **#27** | open | pf4 Pb top-bin `keV[j+1]`/`mu[j+1]` OOB read — removed by the `[j-1,j]` interval fix (supersedes closed #26) |
 | CBUG-B3 | epics-modules/optics **#25** | open | pf4 glass-term guard |
 | CBUG-B5 | epics-modules/asyn **#234** | merged | `asynInterposeCom` ixon `return` |
+| CBUG-B7 | epics-modules/asyn **#238** | open | `asynInterposeCom` `nextChar` returns uninitialized `c` on a successful 0-byte read → guard `nbytes == 0` as EOF |
 | CBUG-B9 | epics-modules/asyn **#233** | merged | `drvAsynIPServerPort` UDP read bound |
 | CBUG-B14 | epics-modules/std **#27** | open | `throttleRecord` `dbScanLock` |
 | CBUG-B15 | epics-modules/std **#28** | open | `epidRecord` commit UDF alarm before return |
 | CBUG-B16 | epics-modules/std **#28** | open | `devEpidSoft` abort unconditionally when INP constant |
+| CBUG-B17 | epics-modules/std **#29** | open | `throttleRecord` writes link-status for the wrong link (special hardcodes `outLinkStat`; checkLink `caLink`/`caLinkNc` stale across loop) |
 | CBUG-B20 | areaDetector/ADCore **#594** | merged | `NDPluginROIStat` RGB heap OOB |
 | CBUG-B21 | areaDetector/ADCore **#595** | merged | `NDPluginAttrPlot` `<=` off-by-one |
 | CBUG-B22 | areaDetector/ADCore **#598** | open | `NDPluginProcess` `numFilter < 1` divide-by-zero guard |
@@ -207,9 +209,9 @@ These want back-fill CBUG entries (or an explicit "no entry — direct find" not
 so the catalogue and the filed set stay reconcilable.
 
 **Catalogued NOT-REPRODUCED, still UNFILED (the remaining easy-to-accept set):**
-CBUG-B7 (`nextChar` 0-byte uninit), CBUG-B17 (throttle wrong-link CA status).
-The 2026-07-19 batch cleared the rest of this list: B2, B22, B23, B27, D2, D3,
-D5 are now filed (see the table above).
+none — the list is now empty. CBUG-B7 (asyn **#238**) and CBUG-B17
+(std **#29**) were filed 2026-07-20; the 2026-07-19 batch had already cleared
+B2, B22, B23, B27, D2, D3, D5 (all in the table above).
 
 **Prepared but held (not filed):** the pvxs pair CBUG-F9 (process-only blocking
 PUT silent no-op) and CBUG-F10 (UnionArray round-trip) — fixes committed on


### PR DESCRIPTION
Batches the 11 review/parity-r6 commits accumulated since origin/main: the upstream-C-bug catalogue reconciliation, the upstream filings/recordings, three code refusals/fixes, and one CA-server security fix.

## Code fixes
- **fix(ca/server): clamp a request's element count to the channel capacity** — an oversized wire element count on READ / READ_NOTIFY / EVENT_ADD drove the reply zero-fill past the channel's real capacity (`requested_count * element_size`, up to ~34 GB → `Vec` alloc abort → remote unauthenticated DoS). The port's copy of the gap epics-base PR #934 (Item 2) closes in RSRV. Structural fix: store the channel's final (post-filter) element count on `ChannelEntry` and clamp the request count to it once, at the point it enters from the wire (after the READ / EVENT_ADD lookups). Ceiling is NELM (capacity), not the live NORD. WRITE/WRITE_NOTIFY are structurally immune (`from_bytes_array` bounds the decode by the received body length).
- **fix(escape): refuse CBUG-D4** — both asyn escapers render NUL as `\0` through one shared table.
- **fix(histogram): refuse CBUG-F12** — raise inverted-limits alarm through nsta/nsev, consistently on both paths.
- **fix(pva): correct stale ack_at_from doc** that still claimed the CBUG-B12 sentinel.

## Catalogue / oracle docs
- **docs(catalogue): retire the REPRODUCED bucket** — all C upstream bugs are now refused (NOT-REPRODUCED) in the port.
- **docs(oracle): register CBUG-F12 expected-deviation** (NOT-REPRODUCED, disabled — no inverted-limits put case in the harness).
- Recordings of the upstream filings: asyn #237/#238, ADCore #598/#599, optics #26/#27, std #28/#29, calc #41, epics-base #932/#933, motor #254, scaler #4, B12.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo nextest run --workspace`: 9691 passed; 1 pre-existing flaky timing test (`epics-pva-rs client_native::search_engine::tests::retry_escalation_pvxs_pattern`, unrelated crate, passes in isolation).
- `cargo test --doc --workspace`: pass.
- New security fix has three regression tests in `epics-ca-rs`; the clamp was verified load-bearing (disabling it fails the NELM-vs-NORD assertion).