### PR TITLE
ci(interop): always report the required interop check on PRs

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -2,32 +2,25 @@ name: Interop (gated)
 
 # Runs the wire-golden + interop nextest profile. Heavy: builds
 # epics-base (CA reference) and pvxs (PVA reference) on the runner.
-# Triggered manually + on a weekly cadence so the default PR loop
-# stays fast (`rust.yml` runs the default profile only).
+# Triggered manually + on a weekly cadence, and on pull requests.
+#
+# `interop` is a REQUIRED status check. If the trigger itself were
+# path-filtered, a PR that touches none of the wire/interop sources
+# would skip the whole workflow, the `interop` check would never
+# report, and branch protection would leave that PR permanently
+# BLOCKED. To avoid that, the workflow ALWAYS triggers on pull_request
+# and a cheap `changes` job decides whether the heavy `interop` job
+# runs. When the PR touches none of the interop paths, `interop` is
+# skipped via its `if:` — GitHub reports a skipped required job as
+# success, satisfying the check WITHOUT building pvxs/epics-base.
+# Manual and scheduled runs always run the heavy job.
 on:
   workflow_dispatch: {}
   schedule:
     # Sunday 03:00 UTC. Catches reference-implementation drift
     # without delaying weekday PRs.
     - cron: '0 3 * * 0'
-  pull_request:
-    # PRs touching wire-shape or interop test sources opt in.
-    paths:
-      - 'crates/epics-ca-rs/src/codec.rs'
-      - 'crates/epics-ca-rs/src/protocol.rs'
-      - 'crates/epics-ca-rs/src/server/**'
-      - 'crates/epics-ca-rs/tests/wire_golden*.rs'
-      - 'crates/epics-ca-rs/tests/interop_*.rs'
-      - 'crates/epics-ca-rs/tests/cases/**'
-      - 'crates/epics-pva-rs/src/codec.rs'
-      - 'crates/epics-pva-rs/src/proto/**'
-      - 'crates/epics-pva-rs/src/pvdata/**'
-      - 'crates/epics-pva-rs/src/server_native/**'
-      - 'crates/epics-pva-rs/tests/wire_golden*.rs'
-      - 'crates/epics-pva-rs/tests/interop_*.rs'
-      - 'crates/epics-pva-rs/tests/pva_cases/**'
-      - '.config/nextest.toml'
-      - '.github/workflows/interop.yml'
+  pull_request: {}
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,7 +28,44 @@ env:
   PVXS_VERSION: 1.3.3
 
 jobs:
+  # Cheap gate: decides whether the heavy interop job should run for a
+  # PR. Its own result is not a required check.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        # Same wire-shape / interop test sources the trigger used to
+        # gate on. Keep in sync with the paths that actually affect
+        # the interop profile.
+        filters: |
+          relevant:
+            - 'crates/epics-ca-rs/src/codec.rs'
+            - 'crates/epics-ca-rs/src/protocol.rs'
+            - 'crates/epics-ca-rs/src/server/**'
+            - 'crates/epics-ca-rs/tests/wire_golden*.rs'
+            - 'crates/epics-ca-rs/tests/interop_*.rs'
+            - 'crates/epics-ca-rs/tests/cases/**'
+            - 'crates/epics-pva-rs/src/codec.rs'
+            - 'crates/epics-pva-rs/src/proto/**'
+            - 'crates/epics-pva-rs/src/pvdata/**'
+            - 'crates/epics-pva-rs/src/server_native/**'
+            - 'crates/epics-pva-rs/tests/wire_golden*.rs'
+            - 'crates/epics-pva-rs/tests/interop_*.rs'
+            - 'crates/epics-pva-rs/tests/pva_cases/**'
+            - '.config/nextest.toml'
+            - '.github/workflows/interop.yml'
+
   interop:
+    needs: changes
+    # Run the heavy suite when the PR touches interop-relevant paths,
+    # or always for manual/scheduled runs. Otherwise this job is
+    # skipped and reported as success (see the header note).
+    if: ${{ needs.changes.outputs.relevant == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Problem

`interop` is a **required** status check, but `interop.yml` gated its
`pull_request` trigger on wire/interop source paths. A PR touching none
of those paths (e.g. #47, a pure iocsh change) never triggered the
workflow, so the `interop` check never reported — and branch protection
left the PR permanently **BLOCKED** (`mergeStateStatus: BLOCKED` with all
other checks green). Only an admin override could merge such PRs.

## Fix

Move the path gate off the trigger and use the GitHub-documented pattern
for required-but-conditional checks:

- `on.pull_request` now always triggers (no `paths:` filter).
- A cheap `changes` job (`dorny/paths-filter@v3`) detects whether the PR
  touches interop-relevant sources — the same path list that used to gate
  the trigger.
- The heavy `interop` job runs only when `changes` says so, or on any
  manual / scheduled run. Otherwise it is skipped via `if:`, and GitHub
  reports a skipped **required** job as success — so the check is
  satisfied **without** building pvxs/epics-base.

Net effect: unrelated PRs stop being blocked, while interop PRs (and the
weekly cadence) still run the full wire-golden + interop suite. This PR
touches `interop.yml`, so it is itself interop-relevant and runs the heavy
job end-to-end as validation.

## No behavior change to the heavy path

The build/cache/ldconfig/nextest steps are unchanged; only the trigger and
the job-gating wrapper changed.
