### PR TITLE
release: v0.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v0.24.3 — 2026-07-20
+
+Patch release. Adds the `dbLoadTemplate` iocsh command to `epics-base-rs`,
+plus three parity fixes across `epics-base-rs`, `epics-ca-rs`, and `asyn-rs`.
+Additive API only; no breaking changes. Workspace version 0.24.2 -> 0.24.3.
+
+### epics-base-rs
+
+- **New `dbLoadTemplate(subFile [, globalMacros])` iocsh command** — the
+  counterpart to `dbLoadRecords` for `.substitutions` template files. It
+  expands each pattern row and installs the resulting records through the
+  *same* routine as `dbLoadRecords` (identical duplicate-name merge,
+  `apply_fields`, load-then-init ordering, alias registration, and
+  post-load passes), so a template-loaded record is byte-for-byte identical
+  to a directly-loaded one. Command-line global macros are the lowest
+  precedence and are overridden per row, matching C `dbLoadTemplate`. The
+  `dbLoadRecords` install loop and include-path resolution are extracted
+  into shared helpers both commands now use. (#47)
+
+- **`histogram` signals inverted limits consistently (CBUG-F12 refused).**
+  When `LLIM >= ULIM` the record now raises the alarm through `nsta`/`nsev`
+  on *both* the compute and array-read paths, instead of reproducing the C
+  bug on one of them.
+
+### epics-ca-rs
+
+- **CA server clamps a request's element count to the channel capacity.**
+  A read/subscribe asking for more elements than the channel holds is
+  clamped to the channel's max rather than honored as given.
+
+### asyn-rs
+
+- **Both asyn escapers render NUL as `\0` through one shared table
+  (CBUG-D4 refused).** The two escape paths previously diverged; a NUL byte
+  is now escaped identically on both.
+
+### epics-pva-rs
+
+- **Doc fix:** corrected a stale `ack_at_from` comment that still referenced
+  the removed CBUG-B12 sentinel. No behavior change.
+
 ## v0.24.2 — 2026-07-19
 
 Patch release. Two DTYP-resolution fixes in `epics-base-rs` (the `dbpf`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "bitflags",
  "chrono",
@@ -992,7 +992,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2202,7 +2202,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3170,7 +3170,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3773,7 +3773,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4875,7 +4875,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.24.2"
+version = "0.24.3"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"


### PR DESCRIPTION
Workspace version **0.24.2 -> 0.24.3**. Patch release, additive API only.

## Contents (since v0.24.2)

**epics-base-rs**
- New `dbLoadTemplate(subFile [, globalMacros])` iocsh command — counterpart to
  `dbLoadRecords` for `.substitutions` files, installing records through the
  same routine (byte-for-byte identical to a directly-loaded record). (#47)
- `histogram` raises the inverted-limits alarm through `nsta`/`nsev` on both
  paths (CBUG-F12 refused).

**epics-ca-rs**
- CA server clamps a request's element count to the channel capacity.

**asyn-rs**
- Both escapers render NUL as `\0` through one shared table (CBUG-D4 refused).

**epics-pva-rs**
- Doc-only: corrected a stale `ack_at_from` comment. No behavior change.

## Verification
- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo nextest run --workspace --retries 2` — 9743 passed, 2 skipped
  (one pre-existing parallel-load flake, `epics-bridge-rs
  br24_cached_get_serves_shadow_value`, absorbed by retry; passes 3/3 isolated)
- Cargo.lock changes are the 27 workspace-member version bumps only.

Tag `v0.24.3` + crates.io publish follow this merge.
