### PR TITLE
ci: run cargo fmt --check in Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,8 @@ jobs:
         toolchain: 1.94.0
         components: rustfmt, clippy
     - uses: taiki-e/install-action@nextest
+    - name: Format
+      run: cargo fmt --all -- --check
     - name: Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
     - name: Build


### PR DESCRIPTION
`rustfmt` was installed in CI but never run, so formatting drift could land unnoticed. This adds `cargo fmt --all -- --check` alongside the existing Clippy step.