### PR TITLE
chore: remove unused module-level allow(unused_imports)

### DIFF
--- a/crates/asyn-rs/src/interpose/mod.rs
+++ b/crates/asyn-rs/src/interpose/mod.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![allow(unused_imports)]
 //! Interpose (middleware) framework for layered I/O processing.
 //!
 //! Currently implements octet-level interpose only. The pattern is designed

--- a/crates/asyn-rs/src/protocol/mod.rs
+++ b/crates/asyn-rs/src/protocol/mod.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![allow(unused_imports)]
 //! Pure-data protocol types for port communication.
 //!
 //! All types in this module are serializable and contain no trait objects,

--- a/crates/asyn-rs/src/protocol/types.rs
+++ b/crates/asyn-rs/src/protocol/types.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 pub use crate::interfaces::Capability;
 pub use crate::interfaces::InterfaceType;
 pub use crate::param::ParamType;

--- a/crates/asyn-rs/src/transport/mod.rs
+++ b/crates/asyn-rs/src/transport/mod.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![allow(unused_imports)]
 //! Transport layer for port communication.
 //!
 //! Defines the [`RuntimeClient`] trait and provides [`InProcessClient`]

--- a/crates/motor-rs/src/record/field_access.rs
+++ b/crates/motor-rs/src/record/field_access.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 use epics_base_rs::error::{CaError, CaResult};
 use epics_base_rs::server::recgbl::{rec_gbl_get_alarm_double, rec_gbl_get_graphic_double};
 use epics_base_rs::types::{DbFieldType, EpicsValue};


### PR DESCRIPTION
Module-level `#![allow(unused_imports)]` in asyn-rs and motor-rs were suppressing nothing, all imports are actually used.

Removing them so unused-import debt can't hide behind a blanket allow.