### PR TITLE
fix: translate SNL pvPut as put-and-process, with writer-origin-tagged cascades

### DIFF
--- a/crates/epics-base-rs/src/server/database/db_access.rs
+++ b/crates/epics-base-rs/src/server/database/db_access.rs
@@ -158,10 +158,21 @@ impl DbChannel {
     /// Use for motor VAL, busy records, etc. where processing drives hardware.
     /// Fire-and-forget — C `dbPutField` semantics; no put-notify is
     /// parked, so concurrent `ca_put_callback`s on the record stay legal.
+    ///
+    /// Carries the channel's `origin` (when set): every event the put's
+    /// synchronous process cascade posts is tagged with it, so a
+    /// `DbSubscription`/`DbMultiMonitor` filtering on the same origin does
+    /// not hear the writer's own put — same self-write contract as the
+    /// `put_*_post` tier.
     pub async fn put_f64_process(&self, v: f64) -> CaResult<()> {
         let (record_name, field) = parse_pv_name(&self.name);
         self.db
-            .put_record_field_from_ca_no_notify(record_name, field, EpicsValue::Double(v))
+            .put_record_field_from_ca_no_notify_with_origin(
+                record_name,
+                field,
+                EpicsValue::Double(v),
+                self.origin,
+            )
             .await
     }
 
@@ -169,7 +180,12 @@ impl DbChannel {
     pub async fn put_i16_process(&self, v: i16) -> CaResult<()> {
         let (record_name, field) = parse_pv_name(&self.name);
         self.db
-            .put_record_field_from_ca_no_notify(record_name, field, EpicsValue::Short(v))
+            .put_record_field_from_ca_no_notify_with_origin(
+                record_name,
+                field,
+                EpicsValue::Short(v),
+                self.origin,
+            )
             .await
     }
 
@@ -177,7 +193,12 @@ impl DbChannel {
     pub async fn put_i32_process(&self, v: i32) -> CaResult<()> {
         let (record_name, field) = parse_pv_name(&self.name);
         self.db
-            .put_record_field_from_ca_no_notify(record_name, field, EpicsValue::Long(v))
+            .put_record_field_from_ca_no_notify_with_origin(
+                record_name,
+                field,
+                EpicsValue::Long(v),
+                self.origin,
+            )
             .await
     }
 
@@ -185,10 +206,11 @@ impl DbChannel {
     pub async fn put_string_process(&self, v: &str) -> CaResult<()> {
         let (record_name, field) = parse_pv_name(&self.name);
         self.db
-            .put_record_field_from_ca_no_notify(
+            .put_record_field_from_ca_no_notify_with_origin(
                 record_name,
                 field,
                 EpicsValue::String(v.to_string().into()),
+                self.origin,
             )
             .await
     }

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -970,14 +970,13 @@ impl PvDatabase {
         // shadow PVs, IOCsh stats PVs) are stored in `simple_pvs`,
         // not `records`. Without this branch the function would
         // silently return `ChannelNotFound` for every gateway-mirrored
-        // PV — `ProcessVariable::set` already does the
-        // notify-subscribers fan-out internally so all we need here is
-        // to delegate. The `origin` tag is a no-op for simple PVs
-        // because they don't yet plumb origin through `set`.
+        // PV — `ProcessVariable::set_with_origin` already does the
+        // notify-subscribers fan-out internally (tagging the event with
+        // `origin`, same self-write contract as the record branch) so
+        // all we need here is to delegate.
         let simple = self.inner.simple_pvs.lock().get(name).cloned();
         if let Some(pv) = simple {
-            let _ = origin; // simple PVs don't currently honor origin tagging
-            pv.set(value);
+            pv.set_with_origin(value, origin);
             return Ok(());
         }
 

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -1242,7 +1242,26 @@ impl PvDatabase {
         field: &str,
         value: EpicsValue,
     ) -> CaResult<()> {
+        self.put_record_field_from_ca_no_notify_with_origin(record_name, field, value, 0)
+            .await
+    }
+
+    /// [`Self::put_record_field_from_ca_no_notify`] for an in-process writer
+    /// with a self-write-filtering origin (a ported SNL state machine's
+    /// `DbChannel`): every event the put's synchronous process cascade posts
+    /// is tagged with `origin`, so the writer's own filtered subscriptions
+    /// skip them. The ambient scope is sound here because the body below is
+    /// fully synchronous — there is no await between entering the scope and
+    /// the cascade's last post.
+    pub async fn put_record_field_from_ca_no_notify_with_origin(
+        &self,
+        record_name: &str,
+        field: &str,
+        value: EpicsValue,
+        origin: u64,
+    ) -> CaResult<()> {
         let _record_gate = self.acquire_put_gate(record_name);
+        let _origin_scope = crate::server::record::ambient_write_origin_scope(origin);
         self.put_record_field_from_ca_body(record_name, field, value, NotifyRequest::None)
             .map(|_| ())
     }

--- a/crates/epics-base-rs/src/server/pv.rs
+++ b/crates/epics-base-rs/src/server/pv.rs
@@ -1,4 +1,4 @@
-// RTEMS-EXEC-MODEL-ALLOW(22): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(23): checked - these run and pass in the feature-ON suite.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};

--- a/crates/epics-base-rs/src/server/pv.rs
+++ b/crates/epics-base-rs/src/server/pv.rs
@@ -193,11 +193,16 @@ pub struct MonitorEvent {
     /// `ignore_origin` can filter out self-triggered events.
     /// Used to prevent sequencer write-back loops.
     ///
-    /// **Scope**: Currently tagged on `put_pv_and_post_with_origin` events only.
-    /// Events from `process_record_with_links` (process path) always have
-    /// origin=0. If a future sequencer needs to filter process-path events
-    /// too, origin tagging can be extended to the process path by passing
-    /// origin through `ProcessOutcome` or `process_record_with_links`.
+    /// **Scope**: tagged explicitly by the `put_*_post` tier
+    /// (`put_pv_and_post_with_origin`, records and simple PVs alike), and
+    /// inherited by every post inside the `put_*_process` tier's
+    /// synchronous put+process cascade through the thread-local ambient
+    /// write origin (`AmbientWriteOriginScope`) — both record funnels
+    /// (`notify_field_with_origin`, `notify_from_snapshot`) and the
+    /// simple-PV funnel (`ProcessVariable::deliver`) apply the same
+    /// inheritance rule. Posts from work a cascade merely spawned (async
+    /// record completions, driver pollers) run outside any scope and stay
+    /// origin 0.
     pub origin: u64,
     /// The `DBE_*` event class(es) this post carries — C attaches the
     /// posting mask to each event's field log (`db_field_log.mask`,
@@ -604,6 +609,15 @@ impl ProcessVariable {
 
     /// Set a new value and notify all subscribers.
     pub fn set(&self, new_value: EpicsValue) {
+        self.set_with_origin(new_value, 0);
+    }
+
+    /// [`Self::set`] tagged with the writer's origin: the value post carries
+    /// `origin` so an origin-aware consumer can recognise (and skip) the
+    /// writer's own event — the simple-PV side of the
+    /// `put_pv_and_post_with_origin` self-write contract. Origin 0 is the
+    /// untagged default (never filtered).
+    pub fn set_with_origin(&self, new_value: EpicsValue, origin: u64) {
         {
             let mut val = self.value.write();
             *val = new_value.clone();
@@ -612,7 +626,7 @@ impl ProcessVariable {
         // the bare-PV default so a stale full-snapshot's metadata does
         // not linger on a value the client never stamped.
         *self.posted_meta.write() = None;
-        self.notify_subscribers(new_value);
+        self.notify_subscribers(new_value, origin);
     }
 
     /// Set value from a full snapshot (value + alarm + timestamp) and notify
@@ -647,8 +661,19 @@ impl ProcessVariable {
     /// class differs per caller, nothing else. The snapshot is built once
     /// by the caller (one timestamp per logical event) and cloned per
     /// subscriber.
-    fn deliver(&self, post: crate::server::recgbl::EventMask, snapshot: Snapshot) {
+    fn deliver(&self, post: crate::server::recgbl::EventMask, snapshot: Snapshot, origin: u64) {
         use crate::server::database::filters::FilteredMonitorEvent;
+        // Same ambient-origin inheritance as the record funnels
+        // (`notify_field_with_origin` / `notify_from_snapshot`): a post
+        // carrying no origin of its own inherits the current thread's
+        // ambient write origin, so a simple PV written from inside an
+        // in-process writer's synchronous put cascade tags its event
+        // with the writer's origin too. 0 outside any scope.
+        let origin = if origin != 0 {
+            origin
+        } else {
+            crate::server::record::ambient_write_origin()
+        };
         let mut subs = self.subscribers.lock();
         // Remove subscribers whose consumer has been dropped.
         subs.retain(|sub| !sub.is_closed());
@@ -666,7 +691,7 @@ impl ProcessVariable {
             }
             let event = MonitorEvent {
                 snapshot: snapshot.clone(),
-                origin: 0,
+                origin,
                 mask: post,
             };
             // The channel-filter chain may suppress this event (e.g.
@@ -703,7 +728,7 @@ impl ProcessVariable {
         let mut snapshot = Snapshot::new(value, status, severity, crate::runtime::time::now_wall());
         self.apply_metadata(&mut snapshot);
         // ALARM|LOG so DBE_LOG (archiver) subscribers receive alarm events.
-        self.deliver(EventMask::ALARM | EventMask::LOG, snapshot);
+        self.deliver(EventMask::ALARM | EventMask::LOG, snapshot, 0);
     }
 
     /// Post a `DBE_PROPERTY` monitor event carrying the decoded upstream
@@ -728,16 +753,17 @@ impl ProcessVariable {
     pub async fn post_property(&self, mut snapshot: Snapshot) {
         use crate::server::recgbl::EventMask;
         self.apply_metadata(&mut snapshot);
-        self.deliver(EventMask::PROPERTY, snapshot);
+        self.deliver(EventMask::PROPERTY, snapshot, 0);
     }
 
-    /// Notify all subscribers of a new value.
-    fn notify_subscribers(&self, value: EpicsValue) {
+    /// Notify all subscribers of a new value, tagged with the writer's
+    /// `origin` (0 = untagged).
+    fn notify_subscribers(&self, value: EpicsValue, origin: u64) {
         use crate::server::recgbl::EventMask;
         let mut snapshot = Snapshot::new(value, 0, 0, crate::runtime::time::now_wall());
         self.apply_metadata(&mut snapshot);
         // VALUE|LOG so DBE_LOG (archiver) subscribers receive value events.
-        self.deliver(EventMask::VALUE | EventMask::LOG, snapshot);
+        self.deliver(EventMask::VALUE | EventMask::LOG, snapshot, origin);
     }
 
     /// Notify all subscribers using a pre-built Snapshot (value + alarm +
@@ -754,6 +780,7 @@ impl ProcessVariable {
         self.deliver(
             EventMask::VALUE | EventMask::LOG | EventMask::ALARM,
             snapshot,
+            0,
         );
     }
 
@@ -1287,6 +1314,35 @@ mod metadata_tests {
 
     fn pv() -> ProcessVariable {
         ProcessVariable::new("m:pv".into(), EpicsValue::Double(1.0))
+    }
+
+    /// `set_with_origin` tags the value event with the writer's origin,
+    /// plain `set` stays untagged, and a plain `set` inside an
+    /// `AmbientWriteOriginScope` inherits the scope's origin — the
+    /// simple-PV side of the record funnels' inheritance rule.
+    #[tokio::test]
+    async fn set_with_origin_tags_the_value_event() {
+        const DBE_VALUE: u16 = 1;
+        let pv = pv();
+        let mut rx = pv
+            .add_subscriber(1, DbFieldType::Double, DBE_VALUE)
+            .expect("subscriber added");
+
+        pv.set(EpicsValue::Double(2.0));
+        assert_eq!(rx.try_recv().expect("plain set posts").origin, 0);
+
+        pv.set_with_origin(EpicsValue::Double(3.0), 77);
+        assert_eq!(rx.try_recv().expect("tagged set posts").origin, 77);
+
+        {
+            let _scope = crate::server::record::ambient_write_origin_scope(88);
+            pv.set(EpicsValue::Double(4.0));
+        }
+        assert_eq!(
+            rx.try_recv().expect("ambient-scoped set posts").origin,
+            88,
+            "an originless simple-PV post inside an ambient scope must inherit it"
+        );
     }
 
     /// A bare PV serves no metadata until a proxy installs it; after

--- a/crates/epics-base-rs/src/server/record/mod.rs
+++ b/crates/epics-base-rs/src/server/record/mod.rs
@@ -34,11 +34,11 @@ pub use menu_choices::{
     shared_menu_choices,
 };
 pub use pini::PiniMode;
-pub(crate) use record_instance::value_as_dbr_string;
 pub use record_instance::{
     AlarmAck, AmbientWriteOriginScope, DeferredNotifyPut, NotifyWaitSet, PactExit,
     ProcessCompletion, RecordInstance, ambient_write_origin_scope,
 };
+pub(crate) use record_instance::{ambient_write_origin, value_as_dbr_string};
 pub use record_trait::{
     ArrayMonitorPost, Asl, CommonFieldPutResult, ConstantInitLink, CyclePostMask,
     EPICS_TIME_EVENT_DEVICE_TIME, FieldDeclaration, FieldDesc, FieldMetadataOverride,

--- a/crates/epics-base-rs/src/server/record/mod.rs
+++ b/crates/epics-base-rs/src/server/record/mod.rs
@@ -36,7 +36,8 @@ pub use menu_choices::{
 pub use pini::PiniMode;
 pub(crate) use record_instance::value_as_dbr_string;
 pub use record_instance::{
-    AlarmAck, DeferredNotifyPut, NotifyWaitSet, PactExit, ProcessCompletion, RecordInstance,
+    AlarmAck, AmbientWriteOriginScope, DeferredNotifyPut, NotifyWaitSet, PactExit,
+    ProcessCompletion, RecordInstance, ambient_write_origin_scope,
 };
 pub use record_trait::{
     ArrayMonitorPost, Asl, CommonFieldPutResult, ConstantInitLink, CyclePostMask,

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -41,6 +41,46 @@ const DBCOMMON_NOMOD: &[&str] = &[
     "PUTF", "RPRO", "TIME", "UTAG",
 ];
 
+thread_local! {
+    /// The origin tag applied to every event posted from the current
+    /// thread's synchronous put+process cascade when the poster itself
+    /// passes origin 0. Set only by [`AmbientWriteOriginScope`], read only
+    /// by [`RecordInstance::notify_field_with_origin`]. An in-process
+    /// writer (a ported SNL state machine) uses this so the whole
+    /// synchronous consequence of its put — the direct field post AND the
+    /// process-cycle posts, FLNK cascade included — carries its origin and
+    /// is filtered from its own subscriptions, while posts from work the
+    /// cascade merely *spawned* (a motor poller on another task) stay
+    /// untagged and visible to it.
+    static AMBIENT_WRITE_ORIGIN: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII scope for [`AMBIENT_WRITE_ORIGIN`]. Sound only around code with no
+/// `.await` inside: the tag is thread-local, so crossing an await point
+/// would both leak it to interleaved tasks and lose it on work-stealing.
+/// The put paths that use it (`put_record_field_from_ca_no_notify_with_origin`)
+/// wrap a fully synchronous body.
+pub struct AmbientWriteOriginScope {
+    prev: u64,
+}
+
+/// Enter an ambient-origin scope; the previous value is restored on drop
+/// (scopes nest).
+pub fn ambient_write_origin_scope(origin: u64) -> AmbientWriteOriginScope {
+    let prev = AMBIENT_WRITE_ORIGIN.with(|c| c.replace(origin));
+    AmbientWriteOriginScope { prev }
+}
+
+impl Drop for AmbientWriteOriginScope {
+    fn drop(&mut self) {
+        AMBIENT_WRITE_ORIGIN.with(|c| c.set(self.prev));
+    }
+}
+
+fn ambient_write_origin() -> u64 {
+    AMBIENT_WRITE_ORIGIN.with(|c| c.get())
+}
+
 /// Put-notify completion wait-set — the C `dbNotify.c` `processNotify`
 /// waitList analogue (`dbNotifyAdd` / `dbNotifyCompletion`).
 ///
@@ -4887,6 +4927,12 @@ impl RecordInstance {
         use crate::server::database::filters::FilteredMonitorEvent;
         use crate::server::recgbl::EventMask;
 
+        // Same ambient-origin inheritance as `notify_field_with_origin`:
+        // a process cycle driven by an in-process writer's put tags its
+        // posts with the writer's origin, so the writer's own filtered
+        // subscriptions do not hear its cascade. 0 outside any scope.
+        let origin = ambient_write_origin();
+
         for (field, value, posting_mask) in &snapshot.changed_fields {
             let posting_mask = *posting_mask;
             if let Some(subs) = self.subscribers.get(field) {
@@ -4904,7 +4950,7 @@ impl RecordInstance {
                     if !posting_mask.is_empty() && sub_mask.intersects(posting_mask) {
                         let event = MonitorEvent {
                             snapshot: mon_snap.clone(),
-                            origin: 0,
+                            origin,
                             mask: posting_mask,
                         };
                         // Server-side filter chain (3.15.7). Empty chain
@@ -4964,6 +5010,16 @@ impl RecordInstance {
         origin: u64,
     ) {
         use crate::server::database::filters::FilteredMonitorEvent;
+        // A poster that carries no origin of its own inherits the ambient
+        // one (0 outside any scope): this is how every post inside an
+        // SNL writer's synchronous put+process cascade gets the writer's
+        // tag without threading a parameter through the whole processing
+        // machinery. An explicit origin always wins.
+        let origin = if origin != 0 {
+            origin
+        } else {
+            ambient_write_origin()
+        };
         // A value-class post publishes the field to its DBE_VALUE/DBE_LOG
         // subscribers, exactly as C's `dbPut` does for the put field
         // (dbAccess.c:1414) — record it so the next process cycle's

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -77,7 +77,11 @@ impl Drop for AmbientWriteOriginScope {
     }
 }
 
-fn ambient_write_origin() -> u64 {
+/// The current thread's ambient write origin (0 outside any scope).
+/// `pub(crate)` so the simple-PV posting funnel
+/// (`ProcessVariable::deliver`) applies the same inheritance rule as the
+/// two record funnels in this file.
+pub(crate) fn ambient_write_origin() -> u64 {
     AMBIENT_WRITE_ORIGIN.with(|c| c.get())
 }
 

--- a/crates/epics-base-rs/tests/snl_process_put_origin.rs
+++ b/crates/epics-base-rs/tests/snl_process_put_origin.rs
@@ -1,0 +1,87 @@
+//! The `put_*_process` tier must carry the writer's origin into every event
+//! its synchronous put+process cascade posts, so an SNL state machine's
+//! origin-filtered subscriptions do not hear the machine's own puts.
+//!
+//! Regression shape: the optics-rs SNL ports write setpoint PVs they also
+//! monitor. Under `put_*_post` the events carried the channel origin and the
+//! `DbMultiMonitor` filter dropped them; when the ports moved to the
+//! `put_*_process` tier (seq pvPut = dbPutField parity) the origin was not
+//! plumbed, every self-put came back as a fresh monitor event, and the kohzu
+//! state machine re-triggered itself into an unbounded event storm
+//! (clamp → rollback → clamp ping-pong, measured on the mini-beamline
+//! example 2026-07-24).
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::database::db_access::{DbChannel, DbSubscription};
+use epics_base_rs::server::records::ao::AoRecord;
+
+const WRITER: u64 = 4242;
+
+async fn setup() -> PvDatabase {
+    let db = PvDatabase::new();
+    db.add_record("SP", Box::new(AoRecord::default()))
+        .await
+        .unwrap();
+    db
+}
+
+/// The writer's own filtered subscription must NOT see its `put_f64_process`:
+/// the process-cycle VAL post carries the channel's origin.
+#[tokio::test]
+async fn process_put_is_invisible_to_its_own_origin() {
+    let db = setup().await;
+    let mut own = DbSubscription::subscribe_filtered(&db, "SP.VAL", WRITER)
+        .await
+        .expect("VAL is a served field");
+
+    let ch = DbChannel::with_origin(&db, "SP.VAL", WRITER);
+    ch.put_f64_process(7.5).await.unwrap();
+
+    assert_eq!(ch.get_f64().await, 7.5, "the put itself must still land");
+    assert!(
+        own.try_recv_event().is_err(),
+        "a process-tier self-put must be filtered by the writer's own origin"
+    );
+}
+
+/// The same put MUST stay visible to everyone else: a subscription with a
+/// different (or no) filter origin receives the process-cycle post.
+#[tokio::test]
+async fn process_put_is_visible_to_other_origins() {
+    let db = setup().await;
+    let mut other = DbSubscription::subscribe_filtered(&db, "SP.VAL", WRITER + 1)
+        .await
+        .expect("VAL is a served field");
+    let mut unfiltered = DbSubscription::subscribe(&db, "SP.VAL")
+        .await
+        .expect("VAL is a served field");
+
+    let ch = DbChannel::with_origin(&db, "SP.VAL", WRITER);
+    ch.put_f64_process(3.25).await.unwrap();
+
+    let ev = other
+        .try_recv_event()
+        .expect("a different filter origin must receive the post");
+    assert_eq!(ev.snapshot.value.to_f64(), Some(3.25));
+    let ev = unfiltered
+        .try_recv_event()
+        .expect("an unfiltered subscriber must receive the post");
+    assert_eq!(ev.snapshot.value.to_f64(), Some(3.25));
+}
+
+/// An origin-less channel keeps today's behavior: origin 0 is never filtered.
+#[tokio::test]
+async fn originless_process_put_reaches_a_filtered_subscription() {
+    let db = setup().await;
+    let mut sub = DbSubscription::subscribe_filtered(&db, "SP.VAL", WRITER)
+        .await
+        .expect("VAL is a served field");
+
+    let ch = DbChannel::new(&db, "SP.VAL");
+    ch.put_f64_process(1.5).await.unwrap();
+
+    let ev = sub
+        .try_recv_event()
+        .expect("an origin-0 put must not be filtered");
+    assert_eq!(ev.snapshot.value.to_f64(), Some(1.5));
+}

--- a/crates/epics-base-rs/tests/snl_process_put_origin.rs
+++ b/crates/epics-base-rs/tests/snl_process_put_origin.rs
@@ -11,6 +11,8 @@
 //! (clamp → rollback → clamp ping-pong, measured on the mini-beamline
 //! example 2026-07-24).
 
+// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
+
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::database::db_access::{DbChannel, DbSubscription};
 use epics_base_rs::server::records::ao::AoRecord;

--- a/crates/optics-rs/src/snl/filter_drive.rs
+++ b/crates/optics-rs/src/snl/filter_drive.rs
@@ -441,18 +441,18 @@ pub async fn run(
     let n = config.num_filters;
 
     // Connect global PVs
-    let ch_status = DbChannel::new(&db, &format!("{pr}Status"));
-    let ch_trans = DbChannel::new(&db, &format!("{pr}Transmission"));
-    let ch_trans_up = DbChannel::new(&db, &format!("{pr}TransmissionUp"));
-    let ch_trans_down = DbChannel::new(&db, &format!("{pr}TransmissionDown"));
-    let ch_mask = DbChannel::new(&db, &format!("{pr}FilterMask"));
-    let ch_energy = DbChannel::new(&db, &format!("{pr}Energy"));
-    let ch_msg = DbChannel::new(&db, &format!("{pr}Message"));
-    let _ch_setpt = DbChannel::new(&db, &format!("{pr}TransmissionSetpoint"));
-    let ch_step_up = DbChannel::new(&db, &format!("{pr}TransmissionStepUp"));
-    let ch_step_down = DbChannel::new(&db, &format!("{pr}TransmissionStepDown"));
-    let _ch_mask_setpt = DbChannel::new(&db, &format!("{pr}FilterMaskSetpoint"));
-    let ch_wait_time = DbChannel::new(&db, &format!("{pr}WaitTime"));
+    let ch_status = DbChannel::with_origin(&db, &format!("{pr}Status"), my_origin);
+    let ch_trans = DbChannel::with_origin(&db, &format!("{pr}Transmission"), my_origin);
+    let ch_trans_up = DbChannel::with_origin(&db, &format!("{pr}TransmissionUp"), my_origin);
+    let ch_trans_down = DbChannel::with_origin(&db, &format!("{pr}TransmissionDown"), my_origin);
+    let ch_mask = DbChannel::with_origin(&db, &format!("{pr}FilterMask"), my_origin);
+    let ch_energy = DbChannel::with_origin(&db, &format!("{pr}Energy"), my_origin);
+    let ch_msg = DbChannel::with_origin(&db, &format!("{pr}Message"), my_origin);
+    let _ch_setpt = DbChannel::with_origin(&db, &format!("{pr}TransmissionSetpoint"), my_origin);
+    let ch_step_up = DbChannel::with_origin(&db, &format!("{pr}TransmissionStepUp"), my_origin);
+    let ch_step_down = DbChannel::with_origin(&db, &format!("{pr}TransmissionStepDown"), my_origin);
+    let _ch_mask_setpt = DbChannel::with_origin(&db, &format!("{pr}FilterMaskSetpoint"), my_origin);
+    let ch_wait_time = DbChannel::with_origin(&db, &format!("{pr}WaitTime"), my_origin);
 
     // Per-blade channels
     let mut ch_thick: Vec<DbChannel> = Vec::new();
@@ -464,13 +464,41 @@ pub async fn run(
     let mut ch_enbl: Vec<DbChannel> = Vec::new();
 
     for i in 1..=n {
-        ch_thick.push(DbChannel::new(&db, &config.blade_pv(i, "Thickness")));
-        ch_mater.push(DbChannel::new(&db, &config.blade_pv(i, "Material")));
-        ch_blade_trans.push(DbChannel::new(&db, &config.blade_pv(i, "Transmission")));
-        ch_set.push(DbChannel::new(&db, &config.blade_pv(i, "Set")));
-        ch_outget.push(DbChannel::new(&db, &config.blade_pv(i, "OutGet")));
-        ch_lock.push(DbChannel::new(&db, &config.blade_pv(i, "Lock")));
-        ch_enbl.push(DbChannel::new(&db, &config.blade_pv(i, "Enable")));
+        ch_thick.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "Thickness"),
+            my_origin,
+        ));
+        ch_mater.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "Material"),
+            my_origin,
+        ));
+        ch_blade_trans.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "Transmission"),
+            my_origin,
+        ));
+        ch_set.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "Set"),
+            my_origin,
+        ));
+        ch_outget.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "OutGet"),
+            my_origin,
+        ));
+        ch_lock.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "Lock"),
+            my_origin,
+        ));
+        ch_enbl.push(DbChannel::with_origin(
+            &db,
+            &config.blade_pv(i, "Enable"),
+            my_origin,
+        ));
     }
 
     // Build multi-monitor
@@ -503,15 +531,17 @@ pub async fn run(
     ctrl.recalculate();
 
     // Publish initial values
-    let _ = ch_trans.put_f64(ctrl.transmission).await;
-    let _ = ch_trans_up.put_f64(ctrl.transmission_up).await;
-    let _ = ch_trans_down.put_f64(ctrl.transmission_down).await;
-    let _ = ch_mask.put_i16(ctrl.filter_mask as i32 as i16).await;
+    let _ = ch_trans.put_f64_process(ctrl.transmission).await;
+    let _ = ch_trans_up.put_f64_process(ctrl.transmission_up).await;
+    let _ = ch_trans_down.put_f64_process(ctrl.transmission_down).await;
+    let _ = ch_mask
+        .put_i16_process(ctrl.filter_mask as i32 as i16)
+        .await;
     for (ch_bt, blade) in ch_blade_trans.iter().zip(ctrl.blades.iter()).take(n) {
-        let _ = ch_bt.put_f64(blade.transmission).await;
+        let _ = ch_bt.put_f64_process(blade.transmission).await;
     }
-    let _ = ch_msg.put_string("Initialised").await;
-    let _ = ch_status.put_i16(0_i16).await;
+    let _ = ch_msg.put_string_process("Initialised").await;
+    let _ = ch_status.put_i16_process(0_i16).await;
 
     tracing::info!("filter_drive state machine running for {pr}");
 
@@ -562,7 +592,7 @@ pub async fn run(
                 }
 
                 FilterDriveEvent::TransmissionSetpoint(setpt) => {
-                    let _ = ch_status.put_i16(1_i16).await;
+                    let _ = ch_status.put_i16_process(1_i16).await;
                     let changes = ctrl.execute_action(FilterAction::SetTransmission, setpt, 0);
                     let wait_time = {
                         let v = ch_wait_time.get_f64().await;
@@ -570,12 +600,12 @@ pub async fn run(
                     };
                     apply_filter_changes(&ch_set, &changes, wait_time).await;
                     ctrl.recalculate();
-                    let _ = ch_status.put_i16(0_i16).await;
+                    let _ = ch_status.put_i16_process(0_i16).await;
                 }
 
                 FilterDriveEvent::StepUp => {
-                    let _ = ch_step_up.put_i16(0_i16).await;
-                    let _ = ch_status.put_i16(1_i16).await;
+                    let _ = ch_step_up.put_i16_process(0_i16).await;
+                    let _ = ch_status.put_i16_process(1_i16).await;
                     let changes = ctrl.execute_action(FilterAction::StepUp, 0.0, 0);
                     let wait_time = {
                         let v = ch_wait_time.get_f64().await;
@@ -583,12 +613,12 @@ pub async fn run(
                     };
                     apply_filter_changes(&ch_set, &changes, wait_time).await;
                     ctrl.recalculate();
-                    let _ = ch_status.put_i16(0_i16).await;
+                    let _ = ch_status.put_i16_process(0_i16).await;
                 }
 
                 FilterDriveEvent::StepDown => {
-                    let _ = ch_step_down.put_i16(0_i16).await;
-                    let _ = ch_status.put_i16(1_i16).await;
+                    let _ = ch_step_down.put_i16_process(0_i16).await;
+                    let _ = ch_status.put_i16_process(1_i16).await;
                     let changes = ctrl.execute_action(FilterAction::StepDown, 0.0, 0);
                     let wait_time = {
                         let v = ch_wait_time.get_f64().await;
@@ -596,11 +626,11 @@ pub async fn run(
                     };
                     apply_filter_changes(&ch_set, &changes, wait_time).await;
                     ctrl.recalculate();
-                    let _ = ch_status.put_i16(0_i16).await;
+                    let _ = ch_status.put_i16_process(0_i16).await;
                 }
 
                 FilterDriveEvent::FilterMaskSetpoint(mask) => {
-                    let _ = ch_status.put_i16(1_i16).await;
+                    let _ = ch_status.put_i16_process(1_i16).await;
                     let changes = ctrl.execute_action(FilterAction::SetFilterMask, 0.0, mask);
                     let wait_time = {
                         let v = ch_wait_time.get_f64().await;
@@ -608,18 +638,20 @@ pub async fn run(
                     };
                     apply_filter_changes(&ch_set, &changes, wait_time).await;
                     ctrl.recalculate();
-                    let _ = ch_status.put_i16(0_i16).await;
+                    let _ = ch_status.put_i16_process(0_i16).await;
                 }
             }
 
             // Publish updated values
-            let _ = ch_trans.put_f64(ctrl.transmission).await;
-            let _ = ch_trans_up.put_f64(ctrl.transmission_up).await;
-            let _ = ch_trans_down.put_f64(ctrl.transmission_down).await;
-            let _ = ch_mask.put_i16(ctrl.filter_mask as i32 as i16).await;
-            let _ = ch_msg.put_string(ctrl.message.as_str()).await;
+            let _ = ch_trans.put_f64_process(ctrl.transmission).await;
+            let _ = ch_trans_up.put_f64_process(ctrl.transmission_up).await;
+            let _ = ch_trans_down.put_f64_process(ctrl.transmission_down).await;
+            let _ = ch_mask
+                .put_i16_process(ctrl.filter_mask as i32 as i16)
+                .await;
+            let _ = ch_msg.put_string_process(ctrl.message.as_str()).await;
             for (ch_bt, blade) in ch_blade_trans.iter().zip(ctrl.blades.iter()).take(n) {
-                let _ = ch_bt.put_f64(blade.transmission).await;
+                let _ = ch_bt.put_f64_process(blade.transmission).await;
             }
         }
     }
@@ -633,7 +665,7 @@ async fn apply_filter_changes(ch_set: &[DbChannel], changes: &[(usize, bool)], w
     let mut any_insert = false;
     for &(idx, inserted) in changes {
         if inserted {
-            let _ = ch_set[idx].put_i16(1).await;
+            let _ = ch_set[idx].put_i16_process(1).await;
             any_insert = true;
         }
     }
@@ -645,7 +677,7 @@ async fn apply_filter_changes(ch_set: &[DbChannel], changes: &[(usize, bool)], w
     let mut any_remove = false;
     for &(idx, inserted) in changes {
         if !inserted {
-            let _ = ch_set[idx].put_i16(0).await;
+            let _ = ch_set[idx].put_i16_process(0).await;
             any_remove = true;
         }
     }

--- a/crates/optics-rs/src/snl/hr_ctl.rs
+++ b/crates/optics-rs/src/snl/hr_ctl.rs
@@ -542,12 +542,12 @@ pub async fn run(
         op_mode,
         geom,
     );
-    let _ = ch_phi1_rdbk.put_f64_post(rdbk.phi1_rdbk).await;
-    let _ = ch_theta1_rdbk.put_f64_post(rdbk.theta1_rdbk).await;
-    let _ = ch_phi2_rdbk.put_f64_post(rdbk.phi2_rdbk).await;
-    let _ = ch_theta2_rdbk.put_f64_post(rdbk.theta2_rdbk).await;
-    let _ = ch_lambda_rdbk.put_f64_post(rdbk.lambda_rdbk).await;
-    let _ = ch_e_rdbk.put_f64_post(rdbk.e_rdbk).await;
+    let _ = ch_phi1_rdbk.put_f64_process(rdbk.phi1_rdbk).await;
+    let _ = ch_theta1_rdbk.put_f64_process(rdbk.theta1_rdbk).await;
+    let _ = ch_phi2_rdbk.put_f64_process(rdbk.phi2_rdbk).await;
+    let _ = ch_theta2_rdbk.put_f64_process(rdbk.theta2_rdbk).await;
+    let _ = ch_lambda_rdbk.put_f64_process(rdbk.lambda_rdbk).await;
+    let _ = ch_e_rdbk.put_f64_process(rdbk.e_rdbk).await;
 
     let _ = ch_msg1.put_string("HR Control Ready").await;
     let _ = ch_msg2.put_string(" ").await;
@@ -668,13 +668,13 @@ pub async fn run(
                 op_mode,
                 geom,
             );
-            let _ = ch_phi1_rdbk.put_f64_post(rdbk.phi1_rdbk).await;
-            let _ = ch_theta1_rdbk.put_f64_post(rdbk.theta1_rdbk).await;
-            let _ = ch_lambda_rdbk.put_f64_post(rdbk.lambda_rdbk).await;
-            let _ = ch_e_rdbk.put_f64_post(rdbk.e_rdbk).await;
+            let _ = ch_phi1_rdbk.put_f64_process(rdbk.phi1_rdbk).await;
+            let _ = ch_theta1_rdbk.put_f64_process(rdbk.theta1_rdbk).await;
+            let _ = ch_lambda_rdbk.put_f64_process(rdbk.lambda_rdbk).await;
+            let _ = ch_e_rdbk.put_f64_process(rdbk.e_rdbk).await;
             if op_mode != HrOpMode::Single {
-                let _ = ch_phi2_rdbk.put_f64_post(rdbk.phi2_rdbk).await;
-                let _ = ch_theta2_rdbk.put_f64_post(rdbk.theta2_rdbk).await;
+                let _ = ch_phi2_rdbk.put_f64_process(rdbk.phi2_rdbk).await;
+                let _ = ch_theta2_rdbk.put_f64_process(rdbk.theta2_rdbk).await;
             }
         } else if changed_pv == pv_world_off {
             world_off = ch_world_off.get_f64().await;
@@ -799,13 +799,13 @@ pub async fn run(
             op_mode,
             geom,
         );
-        let _ = ch_phi1_rdbk.put_f64_post(rdbk.phi1_rdbk).await;
-        let _ = ch_theta1_rdbk.put_f64_post(rdbk.theta1_rdbk).await;
-        let _ = ch_lambda_rdbk.put_f64_post(rdbk.lambda_rdbk).await;
-        let _ = ch_e_rdbk.put_f64_post(rdbk.e_rdbk).await;
+        let _ = ch_phi1_rdbk.put_f64_process(rdbk.phi1_rdbk).await;
+        let _ = ch_theta1_rdbk.put_f64_process(rdbk.theta1_rdbk).await;
+        let _ = ch_lambda_rdbk.put_f64_process(rdbk.lambda_rdbk).await;
+        let _ = ch_e_rdbk.put_f64_process(rdbk.e_rdbk).await;
         if op_mode != HrOpMode::Single {
-            let _ = ch_phi2_rdbk.put_f64_post(rdbk.phi2_rdbk).await;
-            let _ = ch_theta2_rdbk.put_f64_post(rdbk.theta2_rdbk).await;
+            let _ = ch_phi2_rdbk.put_f64_process(rdbk.phi2_rdbk).await;
+            let _ = ch_theta2_rdbk.put_f64_process(rdbk.theta2_rdbk).await;
         }
 
         // -- Calc motor movements --
@@ -891,13 +891,13 @@ pub async fn run(
                     op_mode,
                     geom,
                 );
-                let _ = ch_phi1_rdbk.put_f64_post(rdbk.phi1_rdbk).await;
-                let _ = ch_theta1_rdbk.put_f64_post(rdbk.theta1_rdbk).await;
-                let _ = ch_lambda_rdbk.put_f64_post(rdbk.lambda_rdbk).await;
-                let _ = ch_e_rdbk.put_f64_post(rdbk.e_rdbk).await;
+                let _ = ch_phi1_rdbk.put_f64_process(rdbk.phi1_rdbk).await;
+                let _ = ch_theta1_rdbk.put_f64_process(rdbk.theta1_rdbk).await;
+                let _ = ch_lambda_rdbk.put_f64_process(rdbk.lambda_rdbk).await;
+                let _ = ch_e_rdbk.put_f64_process(rdbk.e_rdbk).await;
                 if op_mode != HrOpMode::Single {
-                    let _ = ch_phi2_rdbk.put_f64_post(rdbk.phi2_rdbk).await;
-                    let _ = ch_theta2_rdbk.put_f64_post(rdbk.theta2_rdbk).await;
+                    let _ = ch_phi2_rdbk.put_f64_process(rdbk.phi2_rdbk).await;
+                    let _ = ch_theta2_rdbk.put_f64_process(rdbk.theta2_rdbk).await;
                 }
 
                 let d1_done = ch_phi1_dmov.get_i16().await != 0;

--- a/crates/optics-rs/src/snl/hr_ctl.rs
+++ b/crates/optics-rs/src/snl/hr_ctl.rs
@@ -332,104 +332,122 @@ pub async fn run(
     let my_origin = alloc_origin();
 
     // -- Create channels --
-    let _ch_debug = DbChannel::new(&db, &config.pv_no_underscore("CtlDebug"));
-    let ch_msg1 = DbChannel::new(&db, &config.pv("SeqMsg1SI"));
-    let ch_msg2 = DbChannel::new(&db, &config.pv("SeqMsg2SI"));
-    let ch_alert = DbChannel::new(&db, &config.pv("AlertBO"));
-    let ch_oper_ack = DbChannel::new(&db, &config.pv("OperAckBO"));
-    let ch_put_vals = DbChannel::new(&db, &config.pv("PutBO"));
-    let ch_auto_mode = DbChannel::new(&db, &config.pv("ModeBO"));
-    let ch_op_mode = DbChannel::new(&db, &config.pv("Mode2MO"));
-    let ch_geom = DbChannel::new(&db, &config.pv_no_underscore("_GeomMO"));
-    let ch_moving = DbChannel::new(&db, &config.pv("Moving"));
+    let _ch_debug = DbChannel::with_origin(&db, &config.pv_no_underscore("CtlDebug"), my_origin);
+    let ch_msg1 = DbChannel::with_origin(&db, &config.pv("SeqMsg1SI"), my_origin);
+    let ch_msg2 = DbChannel::with_origin(&db, &config.pv("SeqMsg2SI"), my_origin);
+    let ch_alert = DbChannel::with_origin(&db, &config.pv("AlertBO"), my_origin);
+    let ch_oper_ack = DbChannel::with_origin(&db, &config.pv("OperAckBO"), my_origin);
+    let ch_put_vals = DbChannel::with_origin(&db, &config.pv("PutBO"), my_origin);
+    let ch_auto_mode = DbChannel::with_origin(&db, &config.pv("ModeBO"), my_origin);
+    let ch_op_mode = DbChannel::with_origin(&db, &config.pv("Mode2MO"), my_origin);
+    let ch_geom = DbChannel::with_origin(&db, &config.pv_no_underscore("_GeomMO"), my_origin);
+    let ch_moving = DbChannel::with_origin(&db, &config.pv("Moving"), my_origin);
 
     // Crystal 1
-    let ch_h1 = DbChannel::new(&db, &config.pv("H1AO"));
-    let ch_k1 = DbChannel::new(&db, &config.pv("K1AO"));
-    let ch_l1 = DbChannel::new(&db, &config.pv("L1AO"));
-    let ch_a1 = DbChannel::new(&db, &config.pv("A1AO"));
-    let ch_d1 = DbChannel::new(&db, &config.pv("2d1AO"));
+    let ch_h1 = DbChannel::with_origin(&db, &config.pv("H1AO"), my_origin);
+    let ch_k1 = DbChannel::with_origin(&db, &config.pv("K1AO"), my_origin);
+    let ch_l1 = DbChannel::with_origin(&db, &config.pv("L1AO"), my_origin);
+    let ch_a1 = DbChannel::with_origin(&db, &config.pv("A1AO"), my_origin);
+    let ch_d1 = DbChannel::with_origin(&db, &config.pv("2d1AO"), my_origin);
 
     // Crystal 2
-    let ch_h2 = DbChannel::new(&db, &config.pv("H2AO"));
-    let ch_k2 = DbChannel::new(&db, &config.pv("K2AO"));
-    let ch_l2 = DbChannel::new(&db, &config.pv("L2AO"));
-    let ch_a2 = DbChannel::new(&db, &config.pv("A2AO"));
-    let ch_d2 = DbChannel::new(&db, &config.pv("2d2AO"));
+    let ch_h2 = DbChannel::with_origin(&db, &config.pv("H2AO"), my_origin);
+    let ch_k2 = DbChannel::with_origin(&db, &config.pv("K2AO"), my_origin);
+    let ch_l2 = DbChannel::with_origin(&db, &config.pv("L2AO"), my_origin);
+    let ch_a2 = DbChannel::with_origin(&db, &config.pv("A2AO"), my_origin);
+    let ch_d2 = DbChannel::with_origin(&db, &config.pv("2d2AO"), my_origin);
 
     // Energy / lambda
     let ch_e = DbChannel::with_origin(&db, &config.pv("EAO"), my_origin);
-    let _ch_e_hi = DbChannel::new(&db, &config.pv("EAO.DRVH"));
-    let _ch_e_lo = DbChannel::new(&db, &config.pv("EAO.DRVL"));
+    let _ch_e_hi = DbChannel::with_origin(&db, &config.pv("EAO.DRVH"), my_origin);
+    let _ch_e_lo = DbChannel::with_origin(&db, &config.pv("EAO.DRVL"), my_origin);
     let ch_e_rdbk = DbChannel::with_origin(&db, &config.pv("ERdbkAO"), my_origin);
 
     let ch_lambda = DbChannel::with_origin(&db, &config.pv("LambdaAO"), my_origin);
-    let _ch_lambda_hi = DbChannel::new(&db, &config.pv("LambdaAO.DRVH"));
-    let _ch_lambda_lo = DbChannel::new(&db, &config.pv("LambdaAO.DRVL"));
+    let _ch_lambda_hi = DbChannel::with_origin(&db, &config.pv("LambdaAO.DRVH"), my_origin);
+    let _ch_lambda_lo = DbChannel::with_origin(&db, &config.pv("LambdaAO.DRVL"), my_origin);
     let ch_lambda_rdbk = DbChannel::with_origin(&db, &config.pv("LambdaRdbkAO"), my_origin);
 
     // Theta 1/2
     let ch_theta1 = DbChannel::with_origin(&db, &config.pv("Theta1AO"), my_origin);
-    let _ch_theta1_hi = DbChannel::new(&db, &config.pv("Theta1AO.DRVH"));
-    let _ch_theta1_lo = DbChannel::new(&db, &config.pv("Theta1AO.DRVL"));
+    let _ch_theta1_hi = DbChannel::with_origin(&db, &config.pv("Theta1AO.DRVH"), my_origin);
+    let _ch_theta1_lo = DbChannel::with_origin(&db, &config.pv("Theta1AO.DRVL"), my_origin);
     let ch_theta1_rdbk = DbChannel::with_origin(&db, &config.pv("Theta1RdbkAO"), my_origin);
 
     let ch_theta2 = DbChannel::with_origin(&db, &config.pv("Theta2AO"), my_origin);
-    let _ch_theta2_hi = DbChannel::new(&db, &config.pv("Theta2AO.DRVH"));
-    let _ch_theta2_lo = DbChannel::new(&db, &config.pv("Theta2AO.DRVL"));
+    let _ch_theta2_hi = DbChannel::with_origin(&db, &config.pv("Theta2AO.DRVH"), my_origin);
+    let _ch_theta2_lo = DbChannel::with_origin(&db, &config.pv("Theta2AO.DRVL"), my_origin);
     let ch_theta2_rdbk = DbChannel::with_origin(&db, &config.pv("Theta2RdbkAO"), my_origin);
 
     // Phi 1/2
     let ch_phi1 = DbChannel::with_origin(&db, &config.pv("phi1AO"), my_origin);
-    let ch_phi1_off = DbChannel::new(&db, &config.pv("phi1OffAO"));
-    let _ch_phi1_hi = DbChannel::new(&db, &config.pv("phi1AO.DRVH"));
-    let _ch_phi1_lo = DbChannel::new(&db, &config.pv("phi1AO.DRVL"));
+    let ch_phi1_off = DbChannel::with_origin(&db, &config.pv("phi1OffAO"), my_origin);
+    let _ch_phi1_hi = DbChannel::with_origin(&db, &config.pv("phi1AO.DRVH"), my_origin);
+    let _ch_phi1_lo = DbChannel::with_origin(&db, &config.pv("phi1AO.DRVL"), my_origin);
     let ch_phi1_rdbk = DbChannel::with_origin(&db, &config.pv("phi1RdbkAO"), my_origin);
 
     let ch_phi2 = DbChannel::with_origin(&db, &config.pv("phi2AO"), my_origin);
-    let ch_phi2_off = DbChannel::new(&db, &config.pv("phi2OffAO"));
-    let _ch_phi2_hi = DbChannel::new(&db, &config.pv("phi2AO.DRVH"));
-    let _ch_phi2_lo = DbChannel::new(&db, &config.pv("phi2AO.DRVL"));
+    let ch_phi2_off = DbChannel::with_origin(&db, &config.pv("phi2OffAO"), my_origin);
+    let _ch_phi2_hi = DbChannel::with_origin(&db, &config.pv("phi2AO.DRVH"), my_origin);
+    let _ch_phi2_lo = DbChannel::with_origin(&db, &config.pv("phi2AO.DRVL"), my_origin);
     let ch_phi2_rdbk = DbChannel::with_origin(&db, &config.pv("phi2RdbkAO"), my_origin);
 
     // Echo PVs
-    let ch_phi1_mot_name = DbChannel::new(&db, &config.pv("phi1PvSI"));
-    let ch_phi2_mot_name = DbChannel::new(&db, &config.pv("phi2PvSI"));
-    let _ch_phi1_cmd_echo = DbChannel::new(&db, &config.pv("phi1CmdAO"));
-    let _ch_phi2_cmd_echo = DbChannel::new(&db, &config.pv("phi2CmdAO"));
-    let ch_phi1_rdbk_echo = DbChannel::new(&db, &config.pv("phi1RdbkAI"));
-    let ch_phi2_rdbk_echo = DbChannel::new(&db, &config.pv("phi2RdbkAI"));
-    let ch_phi1_dmov_echo = DbChannel::new(&db, &config.pv("phi1DmovBI"));
-    let ch_phi2_dmov_echo = DbChannel::new(&db, &config.pv("phi2DmovBI"));
+    let ch_phi1_mot_name = DbChannel::with_origin(&db, &config.pv("phi1PvSI"), my_origin);
+    let ch_phi2_mot_name = DbChannel::with_origin(&db, &config.pv("phi2PvSI"), my_origin);
+    let _ch_phi1_cmd_echo = DbChannel::with_origin(&db, &config.pv("phi1CmdAO"), my_origin);
+    let _ch_phi2_cmd_echo = DbChannel::with_origin(&db, &config.pv("phi2CmdAO"), my_origin);
+    let ch_phi1_rdbk_echo = DbChannel::with_origin(&db, &config.pv("phi1RdbkAI"), my_origin);
+    let ch_phi2_rdbk_echo = DbChannel::with_origin(&db, &config.pv("phi2RdbkAI"), my_origin);
+    let ch_phi1_dmov_echo = DbChannel::with_origin(&db, &config.pv("phi1DmovBI"), my_origin);
+    let ch_phi2_dmov_echo = DbChannel::with_origin(&db, &config.pv("phi2DmovBI"), my_origin);
 
     // Motor records
-    let ch_phi1_mot_stop = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".STOP"));
-    let ch_phi2_mot_stop = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".STOP"));
-    let ch_phi1_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".DMOV"));
-    let ch_phi2_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".DMOV"));
-    let ch_phi1_hls = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".HLS"));
-    let ch_phi1_lls = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".LLS"));
-    let ch_phi2_hls = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".HLS"));
-    let ch_phi2_lls = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".LLS"));
+    let ch_phi1_mot_stop =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".STOP"), my_origin);
+    let ch_phi2_mot_stop =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".STOP"), my_origin);
+    let ch_phi1_dmov =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".DMOV"), my_origin);
+    let ch_phi2_dmov =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".DMOV"), my_origin);
+    let ch_phi1_hls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".HLS"), my_origin);
+    let ch_phi1_lls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".LLS"), my_origin);
+    let ch_phi2_hls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".HLS"), my_origin);
+    let ch_phi2_lls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".LLS"), my_origin);
 
-    let ch_phi1_set_ao = DbChannel::new(&db, &config.pv("phi1SetAO"));
-    let ch_phi2_set_ao = DbChannel::new(&db, &config.pv("phi2SetAO"));
+    let ch_phi1_set_ao = DbChannel::with_origin(&db, &config.pv("phi1SetAO"), my_origin);
+    let ch_phi2_set_ao = DbChannel::with_origin(&db, &config.pv("phi2SetAO"), my_origin);
 
-    let _ch_phi1_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".HLM"));
-    let _ch_phi1_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".LLM"));
-    let _ch_phi2_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".HLM"));
-    let _ch_phi2_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".LLM"));
+    let _ch_phi1_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".HLM"), my_origin);
+    let _ch_phi1_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".LLM"), my_origin);
+    let _ch_phi2_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".HLM"), my_origin);
+    let _ch_phi2_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".LLM"), my_origin);
 
-    let ch_phi1_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ""));
-    let ch_phi2_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ""));
-    let ch_phi1_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_phi1, ".RBV"));
-    let ch_phi2_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_phi2, ".RBV"));
+    let ch_phi1_mot_cmd =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ""), my_origin);
+    let ch_phi2_mot_cmd =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ""), my_origin);
+    let ch_phi1_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi1, ".RBV"), my_origin);
+    let ch_phi2_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_phi2, ".RBV"), my_origin);
 
-    let ch_world_off = DbChannel::new(&db, &config.pv("worldOffAO"));
-    let _ch_use_set = DbChannel::new(&db, &config.pv("UseSetBO"));
+    let ch_world_off = DbChannel::with_origin(&db, &config.pv("worldOffAO"), my_origin);
+    let _ch_use_set = DbChannel::with_origin(&db, &config.pv("UseSetBO"), my_origin);
 
-    let _ch_theta_min = DbChannel::new(&db, &config.pv_no_underscore("_thetaMin"));
-    let _ch_theta_max = DbChannel::new(&db, &config.pv_no_underscore("_thetaMax"));
+    let _ch_theta_min =
+        DbChannel::with_origin(&db, &config.pv_no_underscore("_thetaMin"), my_origin);
+    let _ch_theta_max =
+        DbChannel::with_origin(&db, &config.pv_no_underscore("_thetaMax"), my_origin);
 
     // Build multi-monitor for all event-driving PVs
     let monitored_pvs: Vec<String> = vec![
@@ -466,14 +484,14 @@ pub async fn run(
     );
 
     // -- Initialize --
-    let _ = ch_put_vals.put_i16(0).await;
-    let _ = ch_auto_mode.put_i16(0).await;
-    let _ = ch_oper_ack.put_i16(0).await;
+    let _ = ch_put_vals.put_i16_process(0).await;
+    let _ = ch_auto_mode.put_i16_process(0).await;
+    let _ = ch_oper_ack.put_i16_process(0).await;
 
     let phi1_name = format!("{}{}", config.prefix, config.m_phi1);
     let phi2_name = format!("{}{}", config.prefix, config.m_phi2);
-    let _ = ch_phi1_mot_name.put_string(&phi1_name).await;
-    let _ = ch_phi2_mot_name.put_string(&phi2_name).await;
+    let _ = ch_phi1_mot_name.put_string_process(&phi1_name).await;
+    let _ = ch_phi2_mot_name.put_string_process(&phi2_name).await;
 
     // Read crystal parameters
     let mut h1 = ch_h1.get_f64().await;
@@ -481,14 +499,14 @@ pub async fn run(
     let mut l1 = ch_l1.get_f64().await;
     let mut a1 = ch_a1.get_f64().await;
     let (mut d1, _, _) = calc_2d_spacing(a1, h1, k1, l1);
-    let _ = ch_d1.put_f64(d1).await;
+    let _ = ch_d1.put_f64_process(d1).await;
 
     let mut h2 = ch_h2.get_f64().await;
     let mut k2 = ch_k2.get_f64().await;
     let mut l2 = ch_l2.get_f64().await;
     let mut a2 = ch_a2.get_f64().await;
     let (mut d2, _, _) = calc_2d_spacing(a2, h2, k2, l2);
-    let _ = ch_d2.put_f64(d2).await;
+    let _ = ch_d2.put_f64_process(d2).await;
 
     let mut op_mode = HrOpMode::from_i16(ch_op_mode.get_i16().await);
     let mut geom = HrGeometry::from_i16(ch_geom.get_i16().await);
@@ -506,8 +524,8 @@ pub async fn run(
 
     let mut phi1_val = motor_to_phi(phi1_mot_rdbk, phi1_off, world_off_deg);
     let mut theta1_val = phi1_val;
-    let _ = ch_phi1.put_f64(phi1_val).await;
-    let _ = ch_theta1.put_f64(theta1_val).await;
+    let _ = ch_phi1.put_f64_process(phi1_val).await;
+    let _ = ch_theta1.put_f64_process(theta1_val).await;
 
     let mut phi2_val = match geom {
         HrGeometry::Nested => motor_to_phi(phi2_mot_rdbk, phi2_off, world_off_deg),
@@ -517,18 +535,18 @@ pub async fn run(
         HrGeometry::Nested => phi2_val - phi1_val - theta1_val,
         HrGeometry::Symmetric => phi2_val,
     };
-    let _ = ch_phi2.put_f64(phi2_val).await;
-    let _ = ch_theta2.put_f64(theta2_val).await;
+    let _ = ch_phi2.put_f64_process(phi2_val).await;
+    let _ = ch_theta2.put_f64_process(theta2_val).await;
 
     // Compute initial lambda/E from theta1
     let mut lambda_val = d1 * (theta1_val * D2R).sin();
-    let _ = ch_lambda.put_f64(lambda_val).await;
+    let _ = ch_lambda.put_f64_process(lambda_val).await;
     let mut e_val = if lambda_val > 0.0 {
         HC / lambda_val
     } else {
         0.0
     };
-    let _ = ch_e.put_f64(e_val).await;
+    let _ = ch_e.put_f64_process(e_val).await;
 
     // Initial readback
     let rdbk = calc_readback(
@@ -549,8 +567,8 @@ pub async fn run(
     let _ = ch_lambda_rdbk.put_f64_process(rdbk.lambda_rdbk).await;
     let _ = ch_e_rdbk.put_f64_process(rdbk.e_rdbk).await;
 
-    let _ = ch_msg1.put_string("HR Control Ready").await;
-    let _ = ch_msg2.put_string(" ").await;
+    let _ = ch_msg1.put_string_process("HR Control Ready").await;
+    let _ = ch_msg2.put_string_process(" ").await;
 
     info!(
         "HR controller initialized for {}HR{}",
@@ -601,7 +619,7 @@ pub async fn run(
             if (new_e - e_val).abs() > 1e-15 {
                 e_val = new_e;
                 lambda_val = HC / e_val;
-                let _ = ch_lambda.put_f64(lambda_val).await;
+                let _ = ch_lambda.put_f64_process(lambda_val).await;
                 proceed_to_theta_changed = true;
             }
         } else if changed_pv == pv_lambda {
@@ -627,9 +645,9 @@ pub async fn run(
             a1 = ch_a1.get_f64().await;
             let (d, _, _) = calc_2d_spacing(a1, h1, k1, l1);
             d1 = d;
-            let _ = ch_d1.put_f64(d1).await;
+            let _ = ch_d1.put_f64_process(d1).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
         } else if changed_pv == pv_h2
             || changed_pv == pv_k2
             || changed_pv == pv_l2
@@ -641,9 +659,9 @@ pub async fn run(
             a2 = ch_a2.get_f64().await;
             let (d, _, _) = calc_2d_spacing(a2, h2, k2, l2);
             d2 = d;
-            let _ = ch_d2.put_f64(d2).await;
+            let _ = ch_d2.put_f64_process(d2).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
         } else if changed_pv == pv_put_vals {
             if new_val as i16 != 0 {
                 proceed_to_theta_changed = true;
@@ -652,9 +670,9 @@ pub async fn run(
             auto_mode = new_val as i16 != 0;
         } else if changed_pv == pv_oper_ack {
             if new_val as i16 != 0 {
-                let _ = ch_alert.put_i16(0).await;
-                let _ = ch_msg1.put_string(" ").await;
-                let _ = ch_msg2.put_string(" ").await;
+                let _ = ch_alert.put_i16_process(0).await;
+                let _ = ch_msg1.put_string_process(" ").await;
+                let _ = ch_msg2.put_string_process(" ").await;
             }
         } else if changed_pv == pv_phi1_mot_rbv || changed_pv == pv_phi2_mot_rbv {
             let rdbk = calc_readback(
@@ -688,16 +706,16 @@ pub async fn run(
         } else if changed_pv == pv_op_mode {
             op_mode = HrOpMode::from_i16(new_val as i16);
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_msg2.put_string_process("Set to Manual Mode").await;
         } else if changed_pv == pv_geom {
             geom = HrGeometry::from_i16(new_val as i16);
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
             let _ = ch_msg1
-                .put_string("New geometry. Switch Phi 2 motor dir.")
+                .put_string_process("New geometry. Switch Phi 2 motor dir.")
                 .await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_alert.put_i16_process(1).await;
         }
 
         if !proceed_to_theta_changed {
@@ -707,14 +725,14 @@ pub async fn run(
         // -- Lambda changed processing --
         if d1 > 0.0 && lambda_val > d1 {
             let _ = ch_msg1
-                .put_string("Wavelength > 2d spacing of crystal 1.")
+                .put_string_process("Wavelength > 2d spacing of crystal 1.")
                 .await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_alert.put_i16_process(1).await;
         } else if d2 > 0.0 && lambda_val > d2 && op_mode != HrOpMode::Single {
             let _ = ch_msg1
-                .put_string("Wavelength > 2d spacing of crystal 2.")
+                .put_string_process("Wavelength > 2d spacing of crystal 2.")
                 .await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_alert.put_i16_process(1).await;
         } else {
             // Compute theta from lambda
             match op_mode {
@@ -722,7 +740,7 @@ pub async fn run(
                     if d1 > 0.0 {
                         theta1_val = (lambda_val / d1).asin() * R2D;
                     }
-                    let _ = ch_theta1.put_f64(theta1_val).await;
+                    let _ = ch_theta1.put_f64_process(theta1_val).await;
                 }
                 HrOpMode::TwoLocked => {
                     if d1 > 0.0 {
@@ -731,14 +749,14 @@ pub async fn run(
                     if d2 > 0.0 {
                         theta2_val = (lambda_val / d2).asin() * R2D;
                     }
-                    let _ = ch_theta1.put_f64(theta1_val).await;
-                    let _ = ch_theta2.put_f64(theta2_val).await;
+                    let _ = ch_theta1.put_f64_process(theta1_val).await;
+                    let _ = ch_theta2.put_f64_process(theta2_val).await;
                 }
                 HrOpMode::TwoIndependent => {
                     if d2 > 0.0 {
                         theta2_val = (lambda_val / d2).asin() * R2D;
                     }
-                    let _ = ch_theta2.put_f64(theta2_val).await;
+                    let _ = ch_theta2.put_f64_process(theta2_val).await;
                 }
             }
         }
@@ -775,17 +793,17 @@ pub async fn run(
                 };
             }
         }
-        let _ = ch_phi1.put_f64(phi1_val).await;
+        let _ = ch_phi1.put_f64_process(phi1_val).await;
         if op_mode != HrOpMode::Single {
-            let _ = ch_phi2.put_f64(phi2_val).await;
+            let _ = ch_phi2.put_f64_process(phi2_val).await;
         }
-        let _ = ch_lambda.put_f64(lambda_val).await;
+        let _ = ch_lambda.put_f64_process(lambda_val).await;
         e_val = if lambda_val > 0.0 {
             HC / lambda_val
         } else {
             0.0
         };
-        let _ = ch_e.put_f64(e_val).await;
+        let _ = ch_e.put_f64_process(e_val).await;
 
         // Update readbacks
         let rdbk = calc_readback(
@@ -812,24 +830,24 @@ pub async fn run(
         if use_set_mode {
             let phi1_mot_cur = ch_phi1_mot_rbv.get_f64().await;
             phi1_off = phi1_val - phi1_mot_cur / D2UR;
-            let _ = ch_phi1_off.put_f64(phi1_off).await;
+            let _ = ch_phi1_off.put_f64_process(phi1_off).await;
             if op_mode != HrOpMode::Single {
                 let phi2_mot_cur = ch_phi2_mot_rbv.get_f64().await;
                 phi2_off = phi2_val - phi2_mot_cur / D2UR;
-                let _ = ch_phi2_off.put_f64(phi2_off).await;
+                let _ = ch_phi2_off.put_f64_process(phi2_off).await;
             }
-            let _ = ch_put_vals.put_i16(0).await;
+            let _ = ch_put_vals.put_i16_process(0).await;
         }
 
         let phi1_mot_desired = phi_to_motor(phi1_val, phi1_off, world_off_deg);
-        let _ = ch_phi1_set_ao.put_f64(phi1_mot_desired).await;
+        let _ = ch_phi1_set_ao.put_f64_process(phi1_mot_desired).await;
 
         let phi2_mot_desired = if op_mode != HrOpMode::Single {
             let v = match geom {
                 HrGeometry::Nested => phi_to_motor(phi2_val, phi2_off, world_off_deg),
                 HrGeometry::Symmetric => phi2_to_motor_symmetric(phi2_val, phi2_off, world_off_deg),
             };
-            let _ = ch_phi2_set_ao.put_f64(v).await;
+            let _ = ch_phi2_set_ao.put_f64_process(v).await;
             v
         } else {
             0.0
@@ -842,7 +860,7 @@ pub async fn run(
             if op_mode != HrOpMode::Single {
                 let _ = ch_phi2_mot_cmd.put_f64_process(phi2_mot_desired).await;
             }
-            let _ = ch_put_vals.put_i16(0).await;
+            let _ = ch_put_vals.put_i16_process(0).await;
             _caused_move = true;
 
             // Wait for motors
@@ -852,14 +870,14 @@ pub async fn run(
                 // Check limit switches
                 if ch_phi1_hls.get_i16().await != 0 || ch_phi1_lls.get_i16().await != 0 {
                     let _ = ch_msg1
-                        .put_string("Theta 1 motor hit a limit switch!")
+                        .put_string_process("Theta 1 motor hit a limit switch!")
                         .await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
-                    let _ = ch_phi1_mot_stop.put_i16(1).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
+                    let _ = ch_phi1_mot_stop.put_i16_process(1).await;
                     if op_mode != HrOpMode::Single {
-                        let _ = ch_phi2_mot_stop.put_i16(1).await;
+                        let _ = ch_phi2_mot_stop.put_i16_process(1).await;
                     }
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     break;
@@ -868,13 +886,13 @@ pub async fn run(
                     && (ch_phi2_hls.get_i16().await != 0 || ch_phi2_lls.get_i16().await != 0)
                 {
                     let _ = ch_msg1
-                        .put_string("Theta 2 motor hit a limit switch!")
+                        .put_string_process("Theta 2 motor hit a limit switch!")
                         .await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
-                    let _ = ch_phi1_mot_stop.put_i16(1).await;
-                    let _ = ch_phi2_mot_stop.put_i16(1).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
+                    let _ = ch_phi1_mot_stop.put_i16_process(1).await;
+                    let _ = ch_phi2_mot_stop.put_i16_process(1).await;
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     break;
                 }
@@ -911,21 +929,21 @@ pub async fn run(
                 }
             }
             _caused_move = false;
-            let _ = ch_moving.put_i16(0).await;
+            let _ = ch_moving.put_i16_process(0).await;
         }
 
         // Echo updates
         let _ = ch_phi1_rdbk_echo
-            .put_f64(ch_phi1_mot_rbv.get_f64().await)
+            .put_f64_process(ch_phi1_mot_rbv.get_f64().await)
             .await;
         let _ = ch_phi2_rdbk_echo
-            .put_f64(ch_phi2_mot_rbv.get_f64().await)
+            .put_f64_process(ch_phi2_mot_rbv.get_f64().await)
             .await;
         let _ = ch_phi1_dmov_echo
-            .put_i16(ch_phi1_dmov.get_i16().await)
+            .put_i16_process(ch_phi1_dmov.get_i16().await)
             .await;
         let _ = ch_phi2_dmov_echo
-            .put_i16(ch_phi2_dmov.get_i16().await)
+            .put_i16_process(ch_phi2_dmov.get_i16().await)
             .await;
     }
 }

--- a/crates/optics-rs/src/snl/kohzu_ctl.rs
+++ b/crates/optics-rs/src/snl/kohzu_ctl.rs
@@ -376,121 +376,143 @@ pub async fn run(
     let my_origin = alloc_origin();
 
     // -- Create channels for all PVs (direct database access, available immediately) --
-    let ch_debug = DbChannel::new(&db, &config.pv("KohzuCtlDebug"));
-    let ch_seq_msg1 = DbChannel::new(&db, &config.pv("KohzuSeqMsg1SI"));
-    let ch_seq_msg2 = DbChannel::new(&db, &config.pv("KohzuSeqMsg2SI"));
-    let ch_alert = DbChannel::new(&db, &config.pv("KohzuAlertBO"));
-    let ch_oper_ack = DbChannel::new(&db, &config.pv("KohzuOperAckBO"));
-    let ch_put_vals = DbChannel::new(&db, &config.pv("KohzuPutBO"));
-    let ch_auto_mode = DbChannel::new(&db, &config.pv("KohzuModeBO"));
-    let ch_cc_mode = DbChannel::new(&db, &config.pv("KohzuMode2MO"));
-    let ch_moving = DbChannel::new(&db, &config.pv("KohzuMoving"));
+    let ch_debug = DbChannel::with_origin(&db, &config.pv("KohzuCtlDebug"), my_origin);
+    let ch_seq_msg1 = DbChannel::with_origin(&db, &config.pv("KohzuSeqMsg1SI"), my_origin);
+    let ch_seq_msg2 = DbChannel::with_origin(&db, &config.pv("KohzuSeqMsg2SI"), my_origin);
+    let ch_alert = DbChannel::with_origin(&db, &config.pv("KohzuAlertBO"), my_origin);
+    let ch_oper_ack = DbChannel::with_origin(&db, &config.pv("KohzuOperAckBO"), my_origin);
+    let ch_put_vals = DbChannel::with_origin(&db, &config.pv("KohzuPutBO"), my_origin);
+    let ch_auto_mode = DbChannel::with_origin(&db, &config.pv("KohzuModeBO"), my_origin);
+    let ch_cc_mode = DbChannel::with_origin(&db, &config.pv("KohzuMode2MO"), my_origin);
+    let ch_moving = DbChannel::with_origin(&db, &config.pv("KohzuMoving"), my_origin);
 
     // Crystal parameters
-    let ch_h = DbChannel::new(&db, &config.pv("BraggHAO"));
-    let ch_k = DbChannel::new(&db, &config.pv("BraggKAO"));
-    let ch_l = DbChannel::new(&db, &config.pv("BraggLAO"));
-    let ch_a = DbChannel::new(&db, &config.pv("BraggAAO"));
-    let ch_d = DbChannel::new(&db, &config.pv("Bragg2dSpacingAO"));
+    let ch_h = DbChannel::with_origin(&db, &config.pv("BraggHAO"), my_origin);
+    let ch_k = DbChannel::with_origin(&db, &config.pv("BraggKAO"), my_origin);
+    let ch_l = DbChannel::with_origin(&db, &config.pv("BraggLAO"), my_origin);
+    let ch_a = DbChannel::with_origin(&db, &config.pv("BraggAAO"), my_origin);
+    let ch_d = DbChannel::with_origin(&db, &config.pv("Bragg2dSpacingAO"), my_origin);
 
     // Energy / lambda / theta set points
     let ch_e = DbChannel::with_origin(&db, &config.pv("BraggEAO"), my_origin);
-    let ch_e_hi = DbChannel::new(&db, &config.pv("BraggEAO.DRVH"));
-    let ch_e_lo = DbChannel::new(&db, &config.pv("BraggEAO.DRVL"));
+    let ch_e_hi = DbChannel::with_origin(&db, &config.pv("BraggEAO.DRVH"), my_origin);
+    let ch_e_lo = DbChannel::with_origin(&db, &config.pv("BraggEAO.DRVL"), my_origin);
     let ch_e_rdbk = DbChannel::with_origin(&db, &config.pv("BraggERdbkAO"), my_origin);
 
     let ch_lambda = DbChannel::with_origin(&db, &config.pv("BraggLambdaAO"), my_origin);
-    let ch_lambda_hi = DbChannel::new(&db, &config.pv("BraggLambdaAO.DRVH"));
-    let ch_lambda_lo = DbChannel::new(&db, &config.pv("BraggLambdaAO.DRVL"));
+    let ch_lambda_hi = DbChannel::with_origin(&db, &config.pv("BraggLambdaAO.DRVH"), my_origin);
+    let ch_lambda_lo = DbChannel::with_origin(&db, &config.pv("BraggLambdaAO.DRVL"), my_origin);
     let ch_lambda_rdbk = DbChannel::with_origin(&db, &config.pv("BraggLambdaRdbkAO"), my_origin);
 
     let ch_theta = DbChannel::with_origin(&db, &config.pv("BraggThetaAO"), my_origin);
-    let ch_theta_hi = DbChannel::new(&db, &config.pv("BraggThetaAO.DRVH"));
-    let ch_theta_lo = DbChannel::new(&db, &config.pv("BraggThetaAO.DRVL"));
+    let ch_theta_hi = DbChannel::with_origin(&db, &config.pv("BraggThetaAO.DRVH"), my_origin);
+    let ch_theta_lo = DbChannel::with_origin(&db, &config.pv("BraggThetaAO.DRVL"), my_origin);
     let ch_theta_rdbk = DbChannel::with_origin(&db, &config.pv("BraggThetaRdbkAO"), my_origin);
 
     // Soft echo PVs
-    let ch_theta_mot_name = DbChannel::new(&db, &config.pv("KohzuThetaPvSI"));
-    let ch_y_mot_name = DbChannel::new(&db, &config.pv("KohzuYPvSI"));
-    let ch_z_mot_name = DbChannel::new(&db, &config.pv("KohzuZPvSI"));
+    let ch_theta_mot_name = DbChannel::with_origin(&db, &config.pv("KohzuThetaPvSI"), my_origin);
+    let ch_y_mot_name = DbChannel::with_origin(&db, &config.pv("KohzuYPvSI"), my_origin);
+    let ch_z_mot_name = DbChannel::with_origin(&db, &config.pv("KohzuZPvSI"), my_origin);
 
-    let _ch_theta_cmd_echo = DbChannel::new(&db, &config.pv("KohzuThetaCmdAO"));
-    let _ch_y_cmd_echo = DbChannel::new(&db, &config.pv("KohzuYCmdAO"));
-    let _ch_z_cmd_echo = DbChannel::new(&db, &config.pv("KohzuZCmdAO"));
-    let ch_theta_rdbk_echo = DbChannel::new(&db, &config.pv("KohzuThetaRdbkAI"));
-    let ch_y_rdbk_echo = DbChannel::new(&db, &config.pv("KohzuYRdbkAI"));
-    let ch_z_rdbk_echo = DbChannel::new(&db, &config.pv("KohzuZRdbkAI"));
-    let ch_theta_vel_echo = DbChannel::new(&db, &config.pv("KohzuThetaVelAI"));
-    let ch_y_vel_echo = DbChannel::new(&db, &config.pv("KohzuYVelAI"));
-    let ch_z_vel_echo = DbChannel::new(&db, &config.pv("KohzuZVelAI"));
-    let ch_theta_dmov_echo = DbChannel::new(&db, &config.pv("KohzuThetaDmovBI"));
-    let ch_y_dmov_echo = DbChannel::new(&db, &config.pv("KohzuYDmovBI"));
-    let ch_z_dmov_echo = DbChannel::new(&db, &config.pv("KohzuZDmovBI"));
+    let _ch_theta_cmd_echo = DbChannel::with_origin(&db, &config.pv("KohzuThetaCmdAO"), my_origin);
+    let _ch_y_cmd_echo = DbChannel::with_origin(&db, &config.pv("KohzuYCmdAO"), my_origin);
+    let _ch_z_cmd_echo = DbChannel::with_origin(&db, &config.pv("KohzuZCmdAO"), my_origin);
+    let ch_theta_rdbk_echo = DbChannel::with_origin(&db, &config.pv("KohzuThetaRdbkAI"), my_origin);
+    let ch_y_rdbk_echo = DbChannel::with_origin(&db, &config.pv("KohzuYRdbkAI"), my_origin);
+    let ch_z_rdbk_echo = DbChannel::with_origin(&db, &config.pv("KohzuZRdbkAI"), my_origin);
+    let ch_theta_vel_echo = DbChannel::with_origin(&db, &config.pv("KohzuThetaVelAI"), my_origin);
+    let ch_y_vel_echo = DbChannel::with_origin(&db, &config.pv("KohzuYVelAI"), my_origin);
+    let ch_z_vel_echo = DbChannel::with_origin(&db, &config.pv("KohzuZVelAI"), my_origin);
+    let ch_theta_dmov_echo = DbChannel::with_origin(&db, &config.pv("KohzuThetaDmovBI"), my_origin);
+    let ch_y_dmov_echo = DbChannel::with_origin(&db, &config.pv("KohzuYDmovBI"), my_origin);
+    let ch_z_dmov_echo = DbChannel::with_origin(&db, &config.pv("KohzuZDmovBI"), my_origin);
 
     // Motor records
-    let ch_theta_mot_stop = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".STOP"));
-    let ch_y_stop = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".STOP"));
-    let ch_z_stop = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".STOP"));
+    let ch_theta_mot_stop =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".STOP"), my_origin);
+    let ch_y_stop = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".STOP"), my_origin);
+    let ch_z_stop = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".STOP"), my_origin);
 
-    let ch_theta_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".DMOV"));
-    let ch_y_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".DMOV"));
-    let ch_z_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".DMOV"));
+    let ch_theta_dmov =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".DMOV"), my_origin);
+    let ch_y_dmov = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".DMOV"), my_origin);
+    let ch_z_dmov = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".DMOV"), my_origin);
 
-    let ch_theta_hls = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".HLS"));
-    let ch_theta_lls = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".LLS"));
-    let ch_y_hls = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".HLS"));
-    let ch_y_lls = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".LLS"));
-    let ch_z_hls = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".HLS"));
-    let ch_z_lls = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".LLS"));
+    let ch_theta_hls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".HLS"), my_origin);
+    let ch_theta_lls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".LLS"), my_origin);
+    let ch_y_hls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".HLS"), my_origin);
+    let ch_y_lls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".LLS"), my_origin);
+    let ch_z_hls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".HLS"), my_origin);
+    let ch_z_lls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".LLS"), my_origin);
 
-    let ch_theta_set_ao = DbChannel::new(&db, &config.pv("KohzuThetaSetAO"));
-    let ch_y_set_ao = DbChannel::new(&db, &config.pv("KohzuYSetAO"));
-    let ch_z_set_ao = DbChannel::new(&db, &config.pv("KohzuZSetAO"));
-    let ch_y_set_hi = DbChannel::new(&db, &config.pv("KohzuYSetAO.DRVH"));
-    let ch_y_set_lo = DbChannel::new(&db, &config.pv("KohzuYSetAO.DRVL"));
+    let ch_theta_set_ao = DbChannel::with_origin(&db, &config.pv("KohzuThetaSetAO"), my_origin);
+    let ch_y_set_ao = DbChannel::with_origin(&db, &config.pv("KohzuYSetAO"), my_origin);
+    let ch_z_set_ao = DbChannel::with_origin(&db, &config.pv("KohzuZSetAO"), my_origin);
+    let ch_y_set_hi = DbChannel::with_origin(&db, &config.pv("KohzuYSetAO.DRVH"), my_origin);
+    let ch_y_set_lo = DbChannel::with_origin(&db, &config.pv("KohzuYSetAO.DRVL"), my_origin);
 
-    let ch_theta_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".HLM"));
-    let ch_theta_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".LLM"));
-    let ch_y_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".HLM"));
-    let ch_y_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".LLM"));
-    let ch_z_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".HLM"));
-    let ch_z_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".LLM"));
+    let ch_theta_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".HLM"), my_origin);
+    let ch_theta_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".LLM"), my_origin);
+    let ch_y_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".HLM"), my_origin);
+    let ch_y_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".LLM"), my_origin);
+    let ch_z_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".HLM"), my_origin);
+    let ch_z_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".LLM"), my_origin);
 
-    let ch_theta_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ""));
-    let ch_y_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_y, ""));
-    let ch_z_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_z, ""));
+    let ch_theta_mot_cmd =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ""), my_origin);
+    let ch_y_mot_cmd = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ""), my_origin);
+    let ch_z_mot_cmd = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ""), my_origin);
 
-    let ch_theta_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".VELO"));
-    let ch_y_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".VELO"));
-    let ch_z_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".VELO"));
+    let ch_theta_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".VELO"), my_origin);
+    let ch_y_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".VELO"), my_origin);
+    let ch_z_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".VELO"), my_origin);
 
-    let ch_theta_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".RBV"));
-    let ch_y_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".RBV"));
-    let ch_z_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".RBV"));
+    let ch_theta_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".RBV"), my_origin);
+    let ch_y_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".RBV"), my_origin);
+    let ch_z_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".RBV"), my_origin);
 
-    let _ch_use_set = DbChannel::new(&db, &config.pv("KohzuUseSetBO"));
-    let ch_theta_mot_set = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".SET"));
-    let ch_y_mot_set = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".SET"));
-    let ch_z_mot_set = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".SET"));
+    let _ch_use_set = DbChannel::with_origin(&db, &config.pv("KohzuUseSetBO"), my_origin);
+    let ch_theta_mot_set =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".SET"), my_origin);
+    let ch_y_mot_set =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".SET"), my_origin);
+    let ch_z_mot_set =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".SET"), my_origin);
 
-    let ch_speed_ctrl = DbChannel::new(&db, &config.pv("KohzuSpeedCtrl"));
+    let ch_speed_ctrl = DbChannel::with_origin(&db, &config.pv("KohzuSpeedCtrl"), my_origin);
 
-    let ch_y_offset = DbChannel::new(&db, &config.pv("Kohzu_yOffsetAO"));
-    let ch_y_offset_hi = DbChannel::new(&db, &config.pv("Kohzu_yOffsetAO.DRVH"));
-    let ch_y_offset_lo = DbChannel::new(&db, &config.pv("Kohzu_yOffsetAO.DRVL"));
+    let ch_y_offset = DbChannel::with_origin(&db, &config.pv("Kohzu_yOffsetAO"), my_origin);
+    let ch_y_offset_hi = DbChannel::with_origin(&db, &config.pv("Kohzu_yOffsetAO.DRVH"), my_origin);
+    let ch_y_offset_lo = DbChannel::with_origin(&db, &config.pv("Kohzu_yOffsetAO.DRVL"), my_origin);
 
     // Tweak (inc/dec) feature: ± step buttons for E / lambda / theta.
     // C kohzuCtl.st:734-797 (state tweak): each button adds ± the matching
     // step value, limit-checks, and resets the pressed BO to 0.
-    let ch_e_tweak_val = DbChannel::new(&db, &config.pv("BraggETweakAI"));
-    let ch_e_inc = DbChannel::new(&db, &config.pv("BraggEIncBO"));
-    let ch_e_dec = DbChannel::new(&db, &config.pv("BraggEDecBO"));
-    let ch_lambda_tweak_val = DbChannel::new(&db, &config.pv("BraggLambdaTweakAI"));
-    let ch_lambda_inc = DbChannel::new(&db, &config.pv("BraggLambdaIncBO"));
-    let ch_lambda_dec = DbChannel::new(&db, &config.pv("BraggLambdaDecBO"));
-    let ch_theta_tweak_val = DbChannel::new(&db, &config.pv("BraggThetaTweakAI"));
-    let ch_theta_inc = DbChannel::new(&db, &config.pv("BraggThetaIncBO"));
-    let ch_theta_dec = DbChannel::new(&db, &config.pv("BraggThetaDecBO"));
+    let ch_e_tweak_val = DbChannel::with_origin(&db, &config.pv("BraggETweakAI"), my_origin);
+    let ch_e_inc = DbChannel::with_origin(&db, &config.pv("BraggEIncBO"), my_origin);
+    let ch_e_dec = DbChannel::with_origin(&db, &config.pv("BraggEDecBO"), my_origin);
+    let ch_lambda_tweak_val =
+        DbChannel::with_origin(&db, &config.pv("BraggLambdaTweakAI"), my_origin);
+    let ch_lambda_inc = DbChannel::with_origin(&db, &config.pv("BraggLambdaIncBO"), my_origin);
+    let ch_lambda_dec = DbChannel::with_origin(&db, &config.pv("BraggLambdaDecBO"), my_origin);
+    let ch_theta_tweak_val =
+        DbChannel::with_origin(&db, &config.pv("BraggThetaTweakAI"), my_origin);
+    let ch_theta_inc = DbChannel::with_origin(&db, &config.pv("BraggThetaIncBO"), my_origin);
+    let ch_theta_dec = DbChannel::with_origin(&db, &config.pv("BraggThetaDecBO"), my_origin);
 
     // Build a poll-based monitor for all PVs that drive state changes.
     // DbMonitor replaces CA subscribe+select — it polls the in-process database.
@@ -532,28 +554,28 @@ pub async fn run(
     let theta_name = format!("{}{}", config.prefix, config.m_theta);
     let y_name = format!("{}{}", config.prefix, config.m_y);
     let z_name = format!("{}{}", config.prefix, config.m_z);
-    let _ = ch_theta_mot_name.put_string(&theta_name).await;
-    let _ = ch_y_mot_name.put_string(&y_name).await;
-    let _ = ch_z_mot_name.put_string(&z_name).await;
+    let _ = ch_theta_mot_name.put_string_process(&theta_name).await;
+    let _ = ch_y_mot_name.put_string_process(&y_name).await;
+    let _ = ch_z_mot_name.put_string_process(&z_name).await;
 
     // Initialize geometry-specific y offset limits
     match geom {
         Geometry::Standard => {
-            let _ = ch_y_offset_hi.put_f64(17.5 + 0.000001).await;
-            let _ = ch_y_offset_lo.put_f64(17.5 - 0.000001).await;
-            let _ = ch_y_offset.put_f64(17.5).await;
-            let _ = ch_y_set_hi.put_f64(0.0).await;
-            let _ = ch_y_set_lo.put_f64(-35.0).await;
+            let _ = ch_y_offset_hi.put_f64_process(17.5 + 0.000001).await;
+            let _ = ch_y_offset_lo.put_f64_process(17.5 - 0.000001).await;
+            let _ = ch_y_offset.put_f64_process(17.5).await;
+            let _ = ch_y_set_hi.put_f64_process(0.0).await;
+            let _ = ch_y_set_lo.put_f64_process(-35.0).await;
         }
         Geometry::Alternate => {
-            let _ = ch_y_set_hi.put_f64(60.0).await;
-            let _ = ch_y_set_lo.put_f64(0.0).await;
+            let _ = ch_y_set_hi.put_f64_process(60.0).await;
+            let _ = ch_y_set_lo.put_f64_process(0.0).await;
         }
     }
 
-    let _ = ch_put_vals.put_i16(0).await;
-    let _ = ch_auto_mode.put_i16(0).await;
-    let _ = ch_oper_ack.put_i16(0).await;
+    let _ = ch_put_vals.put_i16_process(0).await;
+    let _ = ch_auto_mode.put_i16_process(0).await;
+    let _ = ch_oper_ack.put_i16_process(0).await;
 
     // Read initial crystal parameters and compute 2d spacing
     let mut h = ch_h.get_f64().await;
@@ -561,24 +583,24 @@ pub async fn run(
     let mut l = ch_l.get_f64().await;
     let mut a = ch_a.get_f64().await;
     let (mut two_d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
-    let _ = ch_d.put_f64(two_d).await;
-    let _ = ch_seq_msg1.put_string(msg).await;
+    let _ = ch_d.put_f64_process(two_d).await;
+    let _ = ch_seq_msg1.put_string_process(msg).await;
     // C calc2dSpacing sets opAlert from the forbidden-reflection check (1/0).
-    let _ = ch_alert.put_i16(forbidden as i16).await;
+    let _ = ch_alert.put_i16_process(forbidden as i16).await;
 
     // Read motor limits and compute theta/energy limits
     let mut theta_mot_hi = ch_theta_mot_hilim.get_f64().await;
     let mut theta_mot_lo = ch_theta_mot_lolim.get_f64().await;
     let (mut theta_hi, mut theta_lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
-    let _ = ch_theta_hi.put_f64(theta_hi).await;
-    let _ = ch_theta_lo.put_f64(theta_lo).await;
+    let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+    let _ = ch_theta_lo.put_f64_process(theta_lo).await;
 
     let (e_hi, e_lo, lambda_hi, lambda_lo) =
         compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-    let _ = ch_e_hi.put_f64(e_hi).await;
-    let _ = ch_e_lo.put_f64(e_lo).await;
-    let _ = ch_lambda_hi.put_f64(lambda_hi).await;
-    let _ = ch_lambda_lo.put_f64(lambda_lo).await;
+    let _ = ch_e_hi.put_f64_process(e_hi).await;
+    let _ = ch_e_lo.put_f64_process(e_lo).await;
+    let _ = ch_lambda_hi.put_f64_process(lambda_hi).await;
+    let _ = ch_lambda_lo.put_f64_process(lambda_lo).await;
 
     // Check motor limits
     let theta_mot_rdbk = ch_theta_mot_rbv.get_f64().await;
@@ -609,11 +631,11 @@ pub async fn run(
 
     // Set initial theta from motor readback
     let mut theta_val = theta_mot_rdbk;
-    let _ = ch_theta.put_f64(theta_val).await;
+    let _ = ch_theta.put_f64_process(theta_val).await;
     let mut lambda_val = theta_to_lambda(theta_val, two_d);
-    let _ = ch_lambda.put_f64(lambda_val).await;
+    let _ = ch_lambda.put_f64_process(lambda_val).await;
     let mut e_val = lambda_to_energy(lambda_val);
-    let _ = ch_e.put_f64(e_val).await;
+    let _ = ch_e.put_f64_process(e_val).await;
 
     let mut auto_mode: bool = false;
     let mut use_set_mode: bool = false;
@@ -630,8 +652,8 @@ pub async fn run(
     let mut last_y_set = calc_y_position(geom, theta_val, y_offset_val);
     let mut last_z_set = calc_z_position(geom, theta_val, y_offset_val);
 
-    let _ = ch_seq_msg1.put_string("Kohzu Control Ready").await;
-    let _ = ch_seq_msg2.put_string(" ").await;
+    let _ = ch_seq_msg1.put_string_process("Kohzu Control Ready").await;
+    let _ = ch_seq_msg2.put_string_process(" ").await;
 
     info!("Kohzu controller initialized for {}", config.prefix);
 
@@ -696,14 +718,16 @@ pub async fn run(
             if (new_e - e_val).abs() > 1e-12 {
                 e_val = new_e;
                 lambda_val = energy_to_lambda(e_val);
-                let _ = ch_lambda.put_f64(lambda_val).await;
+                let _ = ch_lambda.put_f64_process(lambda_val).await;
 
                 if lambda_val > two_d {
-                    let _ = ch_seq_msg1.put_string("Wavelength > 2d spacing.").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Wavelength > 2d spacing.")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                     theta_val = th;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                 }
                 proceed_to_theta_changed = true;
             }
@@ -712,11 +736,13 @@ pub async fn run(
             if (new_l - lambda_val).abs() > 1e-12 {
                 lambda_val = new_l;
                 if lambda_val > two_d {
-                    let _ = ch_seq_msg1.put_string("Wavelength > 2d spacing.").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Wavelength > 2d spacing.")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                     theta_val = th;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                 }
                 proceed_to_theta_changed = true;
             }
@@ -737,23 +763,27 @@ pub async fn run(
                 let e_lo = ch_e_lo.get_f64().await;
                 if temp >= e_lo && temp <= e_hi {
                     e_val = temp;
-                    let _ = ch_e.put_f64(e_val).await;
+                    let _ = ch_e.put_f64_process(e_val).await;
                     lambda_val = energy_to_lambda(e_val);
-                    let _ = ch_lambda.put_f64(lambda_val).await;
+                    let _ = ch_lambda.put_f64_process(lambda_val).await;
                     if lambda_val > two_d {
-                        let _ = ch_seq_msg1.put_string("Wavelength > 2d spacing.").await;
-                        let _ = ch_alert.put_i16(1).await;
+                        let _ = ch_seq_msg1
+                            .put_string_process("Wavelength > 2d spacing.")
+                            .await;
+                        let _ = ch_alert.put_i16_process(1).await;
                     } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                         theta_val = th;
-                        let _ = ch_theta.put_f64(theta_val).await;
+                        let _ = ch_theta.put_f64_process(theta_val).await;
                     }
                     proceed_to_theta_changed = true;
                 } else {
-                    let _ = ch_seq_msg1.put_string("E tweak exceeds limit").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("E tweak exceeds limit")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 }
                 let reset = if inc { &ch_e_inc } else { &ch_e_dec };
-                let _ = reset.put_i16(0).await;
+                let _ = reset.put_i16_process(0).await;
             }
         } else if changed_pv == pv_lambda_inc || changed_pv == pv_lambda_dec {
             // C kohzuCtl.st:756-775 — lambda tweak by ± LTweakVal, limit-checked,
@@ -766,21 +796,25 @@ pub async fn run(
                 let l_lo = ch_lambda_lo.get_f64().await;
                 if temp >= l_lo && temp <= l_hi {
                     lambda_val = temp;
-                    let _ = ch_lambda.put_f64(lambda_val).await;
+                    let _ = ch_lambda.put_f64_process(lambda_val).await;
                     if lambda_val > two_d {
-                        let _ = ch_seq_msg1.put_string("Wavelength > 2d spacing.").await;
-                        let _ = ch_alert.put_i16(1).await;
+                        let _ = ch_seq_msg1
+                            .put_string_process("Wavelength > 2d spacing.")
+                            .await;
+                        let _ = ch_alert.put_i16_process(1).await;
                     } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                         theta_val = th;
-                        let _ = ch_theta.put_f64(theta_val).await;
+                        let _ = ch_theta.put_f64_process(theta_val).await;
                     }
                     proceed_to_theta_changed = true;
                 } else {
-                    let _ = ch_seq_msg1.put_string("Lambda tweak exceeds limit").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Lambda tweak exceeds limit")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 }
                 let reset = if inc { &ch_lambda_inc } else { &ch_lambda_dec };
-                let _ = reset.put_i16(0).await;
+                let _ = reset.put_i16_process(0).await;
             }
         } else if changed_pv == pv_theta_inc || changed_pv == pv_theta_dec {
             // C kohzuCtl.st:777-796 — theta tweak by ± thTweakVal, limit-checked,
@@ -791,87 +825,89 @@ pub async fn run(
                 let temp = theta_val + step * if inc { 1.0 } else { -1.0 };
                 if temp >= theta_lo && temp <= theta_hi {
                     theta_val = temp;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                     proceed_to_theta_changed = true;
                 } else {
-                    let _ = ch_seq_msg1.put_string("Theta tweak exceeds limit").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Theta tweak exceeds limit")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 }
                 let reset = if inc { &ch_theta_inc } else { &ch_theta_dec };
-                let _ = reset.put_i16(0).await;
+                let _ = reset.put_i16_process(0).await;
             }
         } else if changed_pv == pv_h {
             h = ch_h.get_f64().await;
             let (d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
             two_d = d;
-            let _ = ch_d.put_f64(two_d).await;
-            let _ = ch_seq_msg1.put_string(msg).await;
+            let _ = ch_d.put_f64_process(two_d).await;
+            let _ = ch_seq_msg1.put_string_process(msg).await;
             // C kohzuCtl_calc2dSpacing (kohzuCtl.st:1410-1421) sets opAlert from the
             // (H,K,L) parity check and dInputChanged pvPuts it (kohzuCtl.st:817):
             // forbidden -> 1, valid -> 0 (cleared on return to a valid reflection).
-            let _ = ch_alert.put_i16(forbidden as i16).await;
+            let _ = ch_alert.put_i16_process(forbidden as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_k {
             k = ch_k.get_f64().await;
             let (d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
             two_d = d;
-            let _ = ch_d.put_f64(two_d).await;
-            let _ = ch_seq_msg1.put_string(msg).await;
+            let _ = ch_d.put_f64_process(two_d).await;
+            let _ = ch_seq_msg1.put_string_process(msg).await;
             // C kohzuCtl_calc2dSpacing (kohzuCtl.st:1410-1421) sets opAlert from the
             // (H,K,L) parity check and dInputChanged pvPuts it (kohzuCtl.st:817):
             // forbidden -> 1, valid -> 0 (cleared on return to a valid reflection).
-            let _ = ch_alert.put_i16(forbidden as i16).await;
+            let _ = ch_alert.put_i16_process(forbidden as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_l {
             l = ch_l.get_f64().await;
             let (d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
             two_d = d;
-            let _ = ch_d.put_f64(two_d).await;
-            let _ = ch_seq_msg1.put_string(msg).await;
+            let _ = ch_d.put_f64_process(two_d).await;
+            let _ = ch_seq_msg1.put_string_process(msg).await;
             // C kohzuCtl_calc2dSpacing (kohzuCtl.st:1410-1421) sets opAlert from the
             // (H,K,L) parity check and dInputChanged pvPuts it (kohzuCtl.st:817):
             // forbidden -> 1, valid -> 0 (cleared on return to a valid reflection).
-            let _ = ch_alert.put_i16(forbidden as i16).await;
+            let _ = ch_alert.put_i16_process(forbidden as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_a {
             a = ch_a.get_f64().await;
             let (d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
             two_d = d;
-            let _ = ch_d.put_f64(two_d).await;
-            let _ = ch_seq_msg1.put_string(msg).await;
+            let _ = ch_d.put_f64_process(two_d).await;
+            let _ = ch_seq_msg1.put_string_process(msg).await;
             // C kohzuCtl_calc2dSpacing (kohzuCtl.st:1410-1421) sets opAlert from the
             // (H,K,L) parity check and dInputChanged pvPuts it (kohzuCtl.st:817):
             // forbidden -> 1, valid -> 0 (cleared on return to a valid reflection).
-            let _ = ch_alert.put_i16(forbidden as i16).await;
+            let _ = ch_alert.put_i16_process(forbidden as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_put_vals {
             let pv = new_val as i16;
             if pv != 0 {
@@ -883,14 +919,14 @@ pub async fn run(
             cc_mode = CrystalMode::from_i16(new_val as i16);
         } else if changed_pv == pv_oper_ack {
             if new_val as i16 != 0 {
-                let _ = ch_alert.put_i16(0).await;
-                let _ = ch_seq_msg1.put_string(" ").await;
-                let _ = ch_seq_msg2.put_string(" ").await;
-                let _ = ch_oper_ack.put_i16(0).await;
+                let _ = ch_alert.put_i16_process(0).await;
+                let _ = ch_seq_msg1.put_string_process(" ").await;
+                let _ = ch_seq_msg2.put_string_process(" ").await;
+                let _ = ch_oper_ack.put_i16_process(0).await;
             }
         } else if changed_pv == pv_theta_mot_rbv {
             let rbv = new_val;
-            let _ = ch_theta_rdbk_echo.put_f64(rbv).await;
+            let _ = ch_theta_rdbk_echo.put_f64_process(rbv).await;
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = if lambda_rdbk_val > 0.0 {
@@ -906,40 +942,40 @@ pub async fn run(
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
             theta_hi = hi;
             theta_lo = lo;
-            let _ = ch_theta_hi.put_f64(theta_hi).await;
-            let _ = ch_theta_lo.put_f64(theta_lo).await;
+            let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+            let _ = ch_theta_lo.put_f64_process(theta_lo).await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_theta_lolim {
             theta_mot_lo = new_val;
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
             theta_hi = hi;
             theta_lo = lo;
-            let _ = ch_theta_hi.put_f64(theta_hi).await;
-            let _ = ch_theta_lo.put_f64(theta_lo).await;
+            let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+            let _ = ch_theta_lo.put_f64_process(theta_lo).await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_y_offset {
             y_offset_val = new_val;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
             let _ = ch_seq_msg1
-                .put_string(&format!("y offset changed to {:.4}", y_offset_val))
+                .put_string_process(&format!("y offset changed to {:.4}", y_offset_val))
                 .await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             proceed_to_theta_changed = true;
         } else if changed_pv == pv_use_set {
             use_set_mode = new_val as i16 != 0;
             let set_val = if use_set_mode { 1i16 } else { 0i16 };
-            let _ = ch_theta_mot_set.put_i16(set_val).await;
-            let _ = ch_y_mot_set.put_i16(set_val).await;
-            let _ = ch_z_mot_set.put_i16(set_val).await;
+            let _ = ch_theta_mot_set.put_i16_process(set_val).await;
+            let _ = ch_y_mot_set.put_i16_process(set_val).await;
+            let _ = ch_z_mot_set.put_i16_process(set_val).await;
         }
 
         if !proceed_to_theta_changed {
@@ -952,12 +988,14 @@ pub async fn run(
         let (clamped_theta, was_clamped) = clamp_theta(theta_val, theta_lo, theta_hi);
         if was_clamped {
             theta_val = clamped_theta;
-            let _ = ch_seq_msg1.put_string("Theta constrained to LIMIT").await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_seq_msg1
+                .put_string_process("Theta constrained to LIMIT")
+                .await;
+            let _ = ch_alert.put_i16_process(1).await;
             if risk_averse {
                 auto_mode = false;
-                let _ = ch_auto_mode.put_i16(0).await;
-                let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+                let _ = ch_auto_mode.put_i16_process(0).await;
+                let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             } else {
                 // C kohzuCtl.st:889-891 — outside risk-averse mode a theta-limit
                 // hit sets willViolateLimit, so the whole command is rolled back.
@@ -967,9 +1005,9 @@ pub async fn run(
 
         // Recompute lambda and E from theta
         lambda_val = theta_to_lambda(theta_val, two_d);
-        let _ = ch_lambda.put_f64(lambda_val).await;
+        let _ = ch_lambda.put_f64_process(lambda_val).await;
         e_val = lambda_to_energy(lambda_val);
-        let _ = ch_e.put_f64(e_val).await;
+        let _ = ch_e.put_f64_process(e_val).await;
 
         // Update readbacks
         let current_rbv = ch_theta_mot_rbv.get_f64().await;
@@ -985,9 +1023,9 @@ pub async fn run(
         let y_mot_desired = calc_y_position(geom, theta_val, y_offset_val);
         let z_mot_desired = calc_z_position(geom, theta_val, y_offset_val);
 
-        let _ = ch_theta_set_ao.put_f64(theta_mot_desired).await;
-        let _ = ch_y_set_ao.put_f64(y_mot_desired).await;
-        let _ = ch_z_set_ao.put_f64(z_mot_desired).await;
+        let _ = ch_theta_set_ao.put_f64_process(theta_mot_desired).await;
+        let _ = ch_y_set_ao.put_f64_process(y_mot_desired).await;
+        let _ = ch_z_set_ao.put_f64_process(z_mot_desired).await;
 
         // Check Y and Z limits
         let y_hi = ch_y_mot_hilim.get_f64().await;
@@ -1000,18 +1038,20 @@ pub async fn run(
                 "Y soft limit exceeded: want={:.3}, range=[{:.3}, {:.3}]",
                 y_mot_desired, y_lo, y_hi
             );
-            let _ = ch_seq_msg1.put_string(&detail).await;
+            let _ = ch_seq_msg1.put_string_process(&detail).await;
             if ch_debug.get_i16().await > 0 {
                 eprintln!(
                     "kohzuCtl: move blocked by Y soft limit (want={:.6}, lo={:.6}, hi={:.6}, theta={:.6}, E={:.6})",
                     y_mot_desired, y_lo, y_hi, theta_val, e_val
                 );
             }
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_alert.put_i16_process(1).await;
             if risk_averse {
                 auto_mode = false;
-                let _ = ch_auto_mode.put_i16(0).await;
-                let _ = ch_seq_msg2.put_string("Setting to Manual Mode").await;
+                let _ = ch_auto_mode.put_i16_process(0).await;
+                let _ = ch_seq_msg2
+                    .put_string_process("Setting to Manual Mode")
+                    .await;
             } else {
                 will_violate = true;
             }
@@ -1021,18 +1061,20 @@ pub async fn run(
                 "Z soft limit exceeded: want={:.3}, range=[{:.3}, {:.3}]",
                 z_mot_desired, z_lo, z_hi
             );
-            let _ = ch_seq_msg1.put_string(&detail).await;
+            let _ = ch_seq_msg1.put_string_process(&detail).await;
             if ch_debug.get_i16().await > 0 {
                 eprintln!(
                     "kohzuCtl: move blocked by Z soft limit (want={:.6}, lo={:.6}, hi={:.6}, theta={:.6}, E={:.6})",
                     z_mot_desired, z_lo, z_hi, theta_val, e_val
                 );
             }
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_alert.put_i16_process(1).await;
             if risk_averse {
                 auto_mode = false;
-                let _ = ch_auto_mode.put_i16(0).await;
-                let _ = ch_seq_msg2.put_string("Setting to Manual Mode").await;
+                let _ = ch_auto_mode.put_i16_process(0).await;
+                let _ = ch_seq_msg2
+                    .put_string_process("Setting to Manual Mode")
+                    .await;
             } else {
                 will_violate = true;
             }
@@ -1046,20 +1088,20 @@ pub async fn run(
             e_val = prev_e;
             theta_val = prev_theta;
             lambda_val = prev_lambda;
-            let _ = ch_e.put_f64(e_val).await;
-            let _ = ch_theta.put_f64(theta_val).await;
-            let _ = ch_lambda.put_f64(lambda_val).await;
-            let _ = ch_theta_set_ao.put_f64(last_theta_set).await;
-            let _ = ch_y_set_ao.put_f64(last_y_set).await;
-            let _ = ch_z_set_ao.put_f64(last_z_set).await;
-            let _ = ch_seq_msg2.put_string("Command ignored").await;
+            let _ = ch_e.put_f64_process(e_val).await;
+            let _ = ch_theta.put_f64_process(theta_val).await;
+            let _ = ch_lambda.put_f64_process(lambda_val).await;
+            let _ = ch_theta_set_ao.put_f64_process(last_theta_set).await;
+            let _ = ch_y_set_ao.put_f64_process(last_y_set).await;
+            let _ = ch_z_set_ao.put_f64_process(last_z_set).await;
+            let _ = ch_seq_msg2.put_string_process("Command ignored").await;
             if ch_debug.get_i16().await > 0 {
                 eprintln!(
                     "kohzuCtl: command ignored (limit violation); reverted to E={:.3} theta={:.3}",
                     e_val, theta_val
                 );
             }
-            let _ = ch_moving.put_i16(0).await;
+            let _ = ch_moving.put_i16_process(0).await;
             continue;
         }
 
@@ -1073,7 +1115,7 @@ pub async fn run(
         // -- Move motors if in auto or put mode --
         let put_requested = ch_put_vals.get_i16().await != 0;
         if auto_mode || put_requested || use_set_mode {
-            let _ = ch_moving.put_i16(1).await;
+            let _ = ch_moving.put_i16_process(1).await;
 
             // Save the pre-coordination motor speeds so they can be restored
             // once the move finishes. C `kohzuCtl.st` saves oldThSpeed/
@@ -1104,12 +1146,12 @@ pub async fn run(
                 let (new_th, new_y, new_z) = coordinate_speeds(
                     th_delta, y_delta, z_delta, th_speed, y_speed, z_speed, cc_mode,
                 );
-                let _ = ch_theta_mot_velo.put_f64(new_th).await;
+                let _ = ch_theta_mot_velo.put_f64_process(new_th).await;
                 if !cc_mode.y_frozen() {
-                    let _ = ch_y_mot_velo.put_f64(new_y).await;
+                    let _ = ch_y_mot_velo.put_f64_process(new_y).await;
                 }
                 if !cc_mode.z_frozen() {
-                    let _ = ch_z_mot_velo.put_f64(new_z).await;
+                    let _ = ch_z_mot_velo.put_f64_process(new_z).await;
                 }
             }
 
@@ -1135,7 +1177,7 @@ pub async fn run(
                 }
             }
 
-            let _ = ch_put_vals.put_i16(0).await;
+            let _ = ch_put_vals.put_i16_process(0).await;
             _caused_move = true;
 
             // Wait for motors done, while still accepting new setpoints.
@@ -1154,11 +1196,11 @@ pub async fn run(
                         let th_hls = ch_theta_hls.get_i16().await;
                         let th_lls = ch_theta_lls.get_i16().await;
                         if th_hls != 0 || th_lls != 0 {
-                            let _ = ch_seq_msg1.put_string("Theta Motor hit a limit switch!").await;
-                            let _ = ch_alert.put_i16(1).await;
+                            let _ = ch_seq_msg1.put_string_process("Theta Motor hit a limit switch!").await;
+                            let _ = ch_alert.put_i16_process(1).await;
                             auto_mode = false;
-                            let _ = ch_auto_mode.put_i16(0).await;
-                            let _ = ch_seq_msg2.put_string("Setting to Manual Mode").await;
+                            let _ = ch_auto_mode.put_i16_process(0).await;
+                            let _ = ch_seq_msg2.put_string_process("Setting to Manual Mode").await;
                             let _ = ch_theta_mot_stop.put_i16_process(1).await;
                             let _ = ch_y_stop.put_i16_process(1).await;
                             let _ = ch_z_stop.put_i16_process(1).await;
@@ -1169,11 +1211,11 @@ pub async fn run(
                             let y_hls = ch_y_hls.get_i16().await;
                             let y_lls = ch_y_lls.get_i16().await;
                             if y_hls != 0 || y_lls != 0 {
-                                let _ = ch_seq_msg1.put_string("Y Motor hit a limit switch!").await;
-                                let _ = ch_alert.put_i16(1).await;
+                                let _ = ch_seq_msg1.put_string_process("Y Motor hit a limit switch!").await;
+                                let _ = ch_alert.put_i16_process(1).await;
                                 auto_mode = false;
-                                let _ = ch_auto_mode.put_i16(0).await;
-                                let _ = ch_seq_msg2.put_string("Setting to Manual Mode").await;
+                                let _ = ch_auto_mode.put_i16_process(0).await;
+                                let _ = ch_seq_msg2.put_string_process("Setting to Manual Mode").await;
                                 let _ = ch_theta_mot_stop.put_i16_process(1).await;
                                 let _ = ch_y_stop.put_i16_process(1).await;
                                 let _ = ch_z_stop.put_i16_process(1).await;
@@ -1185,11 +1227,11 @@ pub async fn run(
                             let z_hls = ch_z_hls.get_i16().await;
                             let z_lls = ch_z_lls.get_i16().await;
                             if z_hls != 0 || z_lls != 0 {
-                                let _ = ch_seq_msg1.put_string("Z Motor hit a limit switch!").await;
-                                let _ = ch_alert.put_i16(1).await;
+                                let _ = ch_seq_msg1.put_string_process("Z Motor hit a limit switch!").await;
+                                let _ = ch_alert.put_i16_process(1).await;
                                 auto_mode = false;
-                                let _ = ch_auto_mode.put_i16(0).await;
-                                let _ = ch_seq_msg2.put_string("Setting to Manual Mode").await;
+                                let _ = ch_auto_mode.put_i16_process(0).await;
+                                let _ = ch_seq_msg2.put_string_process("Setting to Manual Mode").await;
                                 let _ = ch_theta_mot_stop.put_i16_process(1).await;
                                 let _ = ch_y_stop.put_i16_process(1).await;
                                 let _ = ch_z_stop.put_i16_process(1).await;
@@ -1227,7 +1269,7 @@ pub async fn run(
                                 || changed_pv_new == pv_use_set
                             {
                                 let _ = ch_seq_msg2
-                                    .put_string("Control change deferred until move completes")
+                                    .put_string_process("Control change deferred until move completes")
                                     .await;
                             }
                             continue;
@@ -1265,7 +1307,7 @@ pub async fn run(
                             lambda_val = theta_to_lambda(theta_val, two_d);
                             e_val = lambda_to_energy(lambda_val);
                         }
-                        let _ = ch_moving.put_i16(0).await;
+                        let _ = ch_moving.put_i16_process(0).await;
                         retarget = true;
                         break;
                     }
@@ -1279,18 +1321,18 @@ pub async fn run(
             // next move clean, so coordinated speeds never compound across
             // retargets.
             if speeds_coordinated {
-                let _ = ch_theta_mot_velo.put_f64(old_th_speed).await;
+                let _ = ch_theta_mot_velo.put_f64_process(old_th_speed).await;
                 if !cc_mode.y_frozen() {
-                    let _ = ch_y_mot_velo.put_f64(old_y_speed).await;
+                    let _ = ch_y_mot_velo.put_f64_process(old_y_speed).await;
                 }
                 if !cc_mode.z_frozen() {
-                    let _ = ch_z_mot_velo.put_f64(old_z_speed).await;
+                    let _ = ch_z_mot_velo.put_f64_process(old_z_speed).await;
                 }
             }
 
             // If retarget, recalculate and immediately re-enter move logic
             if retarget {
-                let _ = ch_seq_msg1.put_string("Retargeting...").await;
+                let _ = ch_seq_msg1.put_string_process("Retargeting...").await;
                 pending_retarget = true;
                 _caused_move = false;
                 continue;
@@ -1308,25 +1350,37 @@ pub async fn run(
             let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
             // Assert done
-            let _ = ch_moving.put_i16(0).await;
+            let _ = ch_moving.put_i16_process(0).await;
         }
 
         // Update echo PVs
         let _ = ch_theta_rdbk_echo
-            .put_f64(ch_theta_mot_rbv.get_f64().await)
+            .put_f64_process(ch_theta_mot_rbv.get_f64().await)
             .await;
-        let _ = ch_y_rdbk_echo.put_f64(ch_y_mot_rbv.get_f64().await).await;
-        let _ = ch_z_rdbk_echo.put_f64(ch_z_mot_rbv.get_f64().await).await;
+        let _ = ch_y_rdbk_echo
+            .put_f64_process(ch_y_mot_rbv.get_f64().await)
+            .await;
+        let _ = ch_z_rdbk_echo
+            .put_f64_process(ch_z_mot_rbv.get_f64().await)
+            .await;
         let _ = ch_theta_vel_echo
-            .put_f64(ch_theta_mot_velo.get_f64().await)
+            .put_f64_process(ch_theta_mot_velo.get_f64().await)
             .await;
-        let _ = ch_y_vel_echo.put_f64(ch_y_mot_velo.get_f64().await).await;
-        let _ = ch_z_vel_echo.put_f64(ch_z_mot_velo.get_f64().await).await;
+        let _ = ch_y_vel_echo
+            .put_f64_process(ch_y_mot_velo.get_f64().await)
+            .await;
+        let _ = ch_z_vel_echo
+            .put_f64_process(ch_z_mot_velo.get_f64().await)
+            .await;
         let _ = ch_theta_dmov_echo
-            .put_i16(ch_theta_dmov.get_i16().await)
+            .put_i16_process(ch_theta_dmov.get_i16().await)
             .await;
-        let _ = ch_y_dmov_echo.put_i16(ch_y_dmov.get_i16().await).await;
-        let _ = ch_z_dmov_echo.put_i16(ch_z_dmov.get_i16().await).await;
+        let _ = ch_y_dmov_echo
+            .put_i16_process(ch_y_dmov.get_i16().await)
+            .await;
+        let _ = ch_z_dmov_echo
+            .put_i16_process(ch_z_dmov.get_i16().await)
+            .await;
     }
 }
 

--- a/crates/optics-rs/src/snl/kohzu_ctl.rs
+++ b/crates/optics-rs/src/snl/kohzu_ctl.rs
@@ -603,9 +603,9 @@ pub async fn run(
     } else {
         0.0
     };
-    let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-    let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-    let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+    let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+    let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+    let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
     // Set initial theta from motor readback
     let mut theta_val = theta_mot_rdbk;
@@ -898,9 +898,9 @@ pub async fn run(
             } else {
                 0.0
             };
-            let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-            let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-            let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+            let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+            let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+            let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
         } else if changed_pv == pv_theta_hilim {
             theta_mot_hi = new_val;
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
@@ -976,9 +976,9 @@ pub async fn run(
         theta_rdbk_val = current_rbv;
         lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
         e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-        let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-        let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-        let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+        let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+        let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+        let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
         // -- Calculate motor movements --
         let theta_mot_desired = theta_val;
@@ -1203,9 +1203,9 @@ pub async fn run(
                         theta_rdbk_val = rbv;
                         lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
                         e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-                        let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-                        let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-                        let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+                        let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+                        let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+                        let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
                         if th_dmov != 0 && y_dmov != 0 && z_dmov != 0 {
                             break;
@@ -1303,9 +1303,9 @@ pub async fn run(
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-            let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-            let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-            let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+            let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+            let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+            let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
             // Assert done
             let _ = ch_moving.put_i16(0).await;

--- a/crates/optics-rs/src/snl/kohzu_ctl_soft.rs
+++ b/crates/optics-rs/src/snl/kohzu_ctl_soft.rs
@@ -445,9 +445,9 @@ pub async fn run(
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-            let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-            let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-            let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+            let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+            let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+            let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
         } else if changed_pv == pv_theta_hilim {
             theta_mot_hi = new_val;
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
@@ -520,9 +520,9 @@ pub async fn run(
         theta_rdbk_val = current_rbv;
         lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
         e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-        let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-        let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-        let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+        let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+        let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+        let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
         // -- Calc movements --
         let theta_mot_desired = theta_val;
@@ -684,9 +684,9 @@ pub async fn run(
                 theta_rdbk_val = rbv;
                 lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
                 e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-                let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-                let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-                let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+                let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+                let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+                let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
                 if th_dmov != 0 && y_dmov != 0 && z_dmov != 0 {
                     break;
@@ -712,9 +712,9 @@ pub async fn run(
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-            let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-            let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-            let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+            let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+            let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+            let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
             let _ = ch_moving.put_i16(0).await;
         }
 

--- a/crates/optics-rs/src/snl/kohzu_ctl_soft.rs
+++ b/crates/optics-rs/src/snl/kohzu_ctl_soft.rs
@@ -103,107 +103,128 @@ pub async fn run(
     let my_origin = alloc_origin();
 
     // -- Create channels --
-    let _ch_debug = DbChannel::new(&db, &config.mono_pv("CtlDebug"));
-    let ch_seq_msg1 = DbChannel::new(&db, &config.mono_pv("SeqMsg1"));
-    let ch_seq_msg2 = DbChannel::new(&db, &config.mono_pv("SeqMsg2"));
-    let ch_alert = DbChannel::new(&db, &config.mono_pv("Alert"));
-    let ch_oper_ack = DbChannel::new(&db, &config.mono_pv("OperAck"));
-    let ch_put_vals = DbChannel::new(&db, &config.mono_pv("Put"));
-    let ch_auto_mode = DbChannel::new(&db, &config.mono_pv("Mode"));
-    let ch_cc_mode = DbChannel::new(&db, &config.mono_pv("Mode2"));
-    let ch_moving = DbChannel::new(&db, &config.mono_pv("Moving"));
+    let _ch_debug = DbChannel::with_origin(&db, &config.mono_pv("CtlDebug"), my_origin);
+    let ch_seq_msg1 = DbChannel::with_origin(&db, &config.mono_pv("SeqMsg1"), my_origin);
+    let ch_seq_msg2 = DbChannel::with_origin(&db, &config.mono_pv("SeqMsg2"), my_origin);
+    let ch_alert = DbChannel::with_origin(&db, &config.mono_pv("Alert"), my_origin);
+    let ch_oper_ack = DbChannel::with_origin(&db, &config.mono_pv("OperAck"), my_origin);
+    let ch_put_vals = DbChannel::with_origin(&db, &config.mono_pv("Put"), my_origin);
+    let ch_auto_mode = DbChannel::with_origin(&db, &config.mono_pv("Mode"), my_origin);
+    let ch_cc_mode = DbChannel::with_origin(&db, &config.mono_pv("Mode2"), my_origin);
+    let ch_moving = DbChannel::with_origin(&db, &config.mono_pv("Moving"), my_origin);
 
     // Crystal parameters
-    let ch_h = DbChannel::new(&db, &config.mono_pv("H"));
-    let ch_k = DbChannel::new(&db, &config.mono_pv("K"));
-    let ch_l = DbChannel::new(&db, &config.mono_pv("L"));
-    let ch_a = DbChannel::new(&db, &config.mono_pv("A"));
-    let ch_d = DbChannel::new(&db, &config.mono_pv("2dSpacing"));
+    let ch_h = DbChannel::with_origin(&db, &config.mono_pv("H"), my_origin);
+    let ch_k = DbChannel::with_origin(&db, &config.mono_pv("K"), my_origin);
+    let ch_l = DbChannel::with_origin(&db, &config.mono_pv("L"), my_origin);
+    let ch_a = DbChannel::with_origin(&db, &config.mono_pv("A"), my_origin);
+    let ch_d = DbChannel::with_origin(&db, &config.mono_pv("2dSpacing"), my_origin);
 
     // Energy / lambda / theta
-    let ch_e = DbChannel::new(&db, &config.mono_pv("E"));
-    let ch_e_hi = DbChannel::new(&db, &config.mono_pv("E.HLM"));
-    let ch_e_lo = DbChannel::new(&db, &config.mono_pv("E.LLM"));
-    let ch_e_rdbk = DbChannel::new(&db, &config.mono_pv("ERdbk"));
+    let ch_e = DbChannel::with_origin(&db, &config.mono_pv("E"), my_origin);
+    let ch_e_hi = DbChannel::with_origin(&db, &config.mono_pv("E.HLM"), my_origin);
+    let ch_e_lo = DbChannel::with_origin(&db, &config.mono_pv("E.LLM"), my_origin);
+    let ch_e_rdbk = DbChannel::with_origin(&db, &config.mono_pv("ERdbk"), my_origin);
 
-    let ch_lambda = DbChannel::new(&db, &config.mono_pv("Lambda"));
-    let ch_lambda_hi = DbChannel::new(&db, &config.mono_pv("Lambda.HLM"));
-    let ch_lambda_lo = DbChannel::new(&db, &config.mono_pv("Lambda.LLM"));
-    let ch_lambda_rdbk = DbChannel::new(&db, &config.mono_pv("LambdaRdbk"));
+    let ch_lambda = DbChannel::with_origin(&db, &config.mono_pv("Lambda"), my_origin);
+    let ch_lambda_hi = DbChannel::with_origin(&db, &config.mono_pv("Lambda.HLM"), my_origin);
+    let ch_lambda_lo = DbChannel::with_origin(&db, &config.mono_pv("Lambda.LLM"), my_origin);
+    let ch_lambda_rdbk = DbChannel::with_origin(&db, &config.mono_pv("LambdaRdbk"), my_origin);
 
-    let ch_theta = DbChannel::new(&db, &config.mono_pv("Theta"));
-    let ch_theta_hi = DbChannel::new(&db, &config.mono_pv("Theta.HLM"));
-    let ch_theta_lo = DbChannel::new(&db, &config.mono_pv("Theta.LLM"));
-    let ch_theta_rdbk = DbChannel::new(&db, &config.mono_pv("ThetaRdbk"));
+    let ch_theta = DbChannel::with_origin(&db, &config.mono_pv("Theta"), my_origin);
+    let ch_theta_hi = DbChannel::with_origin(&db, &config.mono_pv("Theta.HLM"), my_origin);
+    let ch_theta_lo = DbChannel::with_origin(&db, &config.mono_pv("Theta.LLM"), my_origin);
+    let ch_theta_rdbk = DbChannel::with_origin(&db, &config.mono_pv("ThetaRdbk"), my_origin);
 
     // Soft echo PVs
-    let ch_theta_mot_name = DbChannel::new(&db, &config.mono_pv("ThetaPv"));
-    let ch_y_mot_name = DbChannel::new(&db, &config.mono_pv("YPv"));
-    let ch_z_mot_name = DbChannel::new(&db, &config.mono_pv("ZPv"));
+    let ch_theta_mot_name = DbChannel::with_origin(&db, &config.mono_pv("ThetaPv"), my_origin);
+    let ch_y_mot_name = DbChannel::with_origin(&db, &config.mono_pv("YPv"), my_origin);
+    let ch_z_mot_name = DbChannel::with_origin(&db, &config.mono_pv("ZPv"), my_origin);
 
-    let _ch_theta_cmd_echo = DbChannel::new(&db, &config.mono_pv("ThetaCmd"));
-    let _ch_y_cmd_echo = DbChannel::new(&db, &config.mono_pv("YCmd"));
-    let _ch_z_cmd_echo = DbChannel::new(&db, &config.mono_pv("ZCmd"));
-    let ch_theta_rdbk_echo = DbChannel::new(&db, &config.mono_pv("ThetaMotRdbk"));
-    let ch_y_rdbk_echo = DbChannel::new(&db, &config.mono_pv("YRdbk"));
-    let ch_z_rdbk_echo = DbChannel::new(&db, &config.mono_pv("ZRdbk"));
-    let ch_theta_vel_echo = DbChannel::new(&db, &config.mono_pv("ThetaVel"));
-    let ch_y_vel_echo = DbChannel::new(&db, &config.mono_pv("YVel"));
-    let ch_z_vel_echo = DbChannel::new(&db, &config.mono_pv("ZVel"));
-    let ch_theta_dmov_echo = DbChannel::new(&db, &config.mono_pv("ThetaDmov"));
-    let ch_y_dmov_echo = DbChannel::new(&db, &config.mono_pv("YDmov"));
-    let ch_z_dmov_echo = DbChannel::new(&db, &config.mono_pv("ZDmov"));
+    let _ch_theta_cmd_echo = DbChannel::with_origin(&db, &config.mono_pv("ThetaCmd"), my_origin);
+    let _ch_y_cmd_echo = DbChannel::with_origin(&db, &config.mono_pv("YCmd"), my_origin);
+    let _ch_z_cmd_echo = DbChannel::with_origin(&db, &config.mono_pv("ZCmd"), my_origin);
+    let ch_theta_rdbk_echo =
+        DbChannel::with_origin(&db, &config.mono_pv("ThetaMotRdbk"), my_origin);
+    let ch_y_rdbk_echo = DbChannel::with_origin(&db, &config.mono_pv("YRdbk"), my_origin);
+    let ch_z_rdbk_echo = DbChannel::with_origin(&db, &config.mono_pv("ZRdbk"), my_origin);
+    let ch_theta_vel_echo = DbChannel::with_origin(&db, &config.mono_pv("ThetaVel"), my_origin);
+    let ch_y_vel_echo = DbChannel::with_origin(&db, &config.mono_pv("YVel"), my_origin);
+    let ch_z_vel_echo = DbChannel::with_origin(&db, &config.mono_pv("ZVel"), my_origin);
+    let ch_theta_dmov_echo = DbChannel::with_origin(&db, &config.mono_pv("ThetaDmov"), my_origin);
+    let ch_y_dmov_echo = DbChannel::with_origin(&db, &config.mono_pv("YDmov"), my_origin);
+    let ch_z_dmov_echo = DbChannel::with_origin(&db, &config.mono_pv("ZDmov"), my_origin);
 
     // Motor records
-    let ch_theta_mot_stop = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".STOP"));
-    let ch_y_stop = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".STOP"));
-    let ch_z_stop = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".STOP"));
+    let ch_theta_mot_stop =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".STOP"), my_origin);
+    let ch_y_stop = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".STOP"), my_origin);
+    let ch_z_stop = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".STOP"), my_origin);
 
-    let ch_theta_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".DMOV"));
-    let ch_y_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".DMOV"));
-    let ch_z_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".DMOV"));
+    let ch_theta_dmov =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".DMOV"), my_origin);
+    let ch_y_dmov = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".DMOV"), my_origin);
+    let ch_z_dmov = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".DMOV"), my_origin);
 
-    let ch_theta_hls = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".HLS"));
-    let ch_theta_lls = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".LLS"));
-    let ch_y_hls = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".HLS"));
-    let ch_y_lls = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".LLS"));
-    let ch_z_hls = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".HLS"));
-    let ch_z_lls = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".LLS"));
+    let ch_theta_hls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".HLS"), my_origin);
+    let ch_theta_lls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".LLS"), my_origin);
+    let ch_y_hls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".HLS"), my_origin);
+    let ch_y_lls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".LLS"), my_origin);
+    let ch_z_hls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".HLS"), my_origin);
+    let ch_z_lls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".LLS"), my_origin);
 
-    let ch_theta_set_ao = DbChannel::new(&db, &config.mono_pv("ThetaSet"));
-    let ch_y_set_ao = DbChannel::new(&db, &config.mono_pv("YSet"));
-    let ch_z_set_ao = DbChannel::new(&db, &config.mono_pv("ZSet"));
-    let ch_y_set_hi = DbChannel::new(&db, &config.mono_pv("YSet.DRVH"));
-    let ch_y_set_lo = DbChannel::new(&db, &config.mono_pv("YSet.DRVL"));
+    let ch_theta_set_ao = DbChannel::with_origin(&db, &config.mono_pv("ThetaSet"), my_origin);
+    let ch_y_set_ao = DbChannel::with_origin(&db, &config.mono_pv("YSet"), my_origin);
+    let ch_z_set_ao = DbChannel::with_origin(&db, &config.mono_pv("ZSet"), my_origin);
+    let ch_y_set_hi = DbChannel::with_origin(&db, &config.mono_pv("YSet.DRVH"), my_origin);
+    let ch_y_set_lo = DbChannel::with_origin(&db, &config.mono_pv("YSet.DRVL"), my_origin);
 
-    let ch_theta_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".HLM"));
-    let ch_theta_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".LLM"));
-    let ch_y_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".HLM"));
-    let ch_y_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".LLM"));
-    let ch_z_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".HLM"));
-    let ch_z_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".LLM"));
+    let ch_theta_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".HLM"), my_origin);
+    let ch_theta_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".LLM"), my_origin);
+    let ch_y_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".HLM"), my_origin);
+    let ch_y_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".LLM"), my_origin);
+    let ch_z_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".HLM"), my_origin);
+    let ch_z_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".LLM"), my_origin);
 
-    let ch_theta_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ""));
-    let ch_y_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_y, ""));
-    let ch_z_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_z, ""));
+    let ch_theta_mot_cmd =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ""), my_origin);
+    let ch_y_mot_cmd = DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ""), my_origin);
+    let ch_z_mot_cmd = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ""), my_origin);
 
-    let ch_theta_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".VELO"));
-    let ch_y_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".VELO"));
-    let ch_z_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".VELO"));
+    let ch_theta_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".VELO"), my_origin);
+    let ch_y_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".VELO"), my_origin);
+    let ch_z_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".VELO"), my_origin);
 
-    let ch_theta_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".RBV"));
-    let ch_y_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".RBV"));
-    let ch_z_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".RBV"));
+    let ch_theta_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".RBV"), my_origin);
+    let ch_y_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".RBV"), my_origin);
+    let ch_z_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".RBV"), my_origin);
 
-    let _ch_use_set = DbChannel::new(&db, &config.mono_pv("UseSet"));
-    let ch_theta_mot_set = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".SET"));
-    let ch_y_mot_set = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".SET"));
-    let ch_z_mot_set = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".SET"));
+    let _ch_use_set = DbChannel::with_origin(&db, &config.mono_pv("UseSet"), my_origin);
+    let ch_theta_mot_set =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".SET"), my_origin);
+    let ch_y_mot_set =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".SET"), my_origin);
+    let ch_z_mot_set =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".SET"), my_origin);
 
-    let ch_speed_ctrl = DbChannel::new(&db, &config.mono_pv("SpeedCtrl"));
-    let ch_y_offset = DbChannel::new(&db, &config.mono_pv("yOffset"));
-    let ch_y_offset_hi = DbChannel::new(&db, &config.mono_pv("yOffset.DRVH"));
-    let ch_y_offset_lo = DbChannel::new(&db, &config.mono_pv("yOffset.DRVL"));
+    let ch_speed_ctrl = DbChannel::with_origin(&db, &config.mono_pv("SpeedCtrl"), my_origin);
+    let ch_y_offset = DbChannel::with_origin(&db, &config.mono_pv("yOffset"), my_origin);
+    let ch_y_offset_hi = DbChannel::with_origin(&db, &config.mono_pv("yOffset.DRVH"), my_origin);
+    let ch_y_offset_lo = DbChannel::with_origin(&db, &config.mono_pv("yOffset.DRVL"), my_origin);
 
     // Wait for key channels
 
@@ -239,28 +260,28 @@ pub async fn run(
     let theta_name = format!("{}{}", config.prefix, config.m_theta);
     let y_name = format!("{}{}", config.prefix, config.m_y);
     let z_name = format!("{}{}", config.prefix, config.m_z);
-    let _ = ch_theta_mot_name.put_string(&theta_name).await;
-    let _ = ch_y_mot_name.put_string(&y_name).await;
-    let _ = ch_z_mot_name.put_string(&z_name).await;
+    let _ = ch_theta_mot_name.put_string_process(&theta_name).await;
+    let _ = ch_y_mot_name.put_string_process(&y_name).await;
+    let _ = ch_z_mot_name.put_string_process(&z_name).await;
 
     // Geometry init
     match geom {
         Geometry::Standard => {
-            let _ = ch_y_offset_hi.put_f64(17.5 + 0.000001).await;
-            let _ = ch_y_offset_lo.put_f64(17.5 - 0.000001).await;
-            let _ = ch_y_offset.put_f64(17.5).await;
-            let _ = ch_y_set_hi.put_f64(0.0).await;
-            let _ = ch_y_set_lo.put_f64(-35.0).await;
+            let _ = ch_y_offset_hi.put_f64_process(17.5 + 0.000001).await;
+            let _ = ch_y_offset_lo.put_f64_process(17.5 - 0.000001).await;
+            let _ = ch_y_offset.put_f64_process(17.5).await;
+            let _ = ch_y_set_hi.put_f64_process(0.0).await;
+            let _ = ch_y_set_lo.put_f64_process(-35.0).await;
         }
         Geometry::Alternate => {
-            let _ = ch_y_set_hi.put_f64(60.0).await;
-            let _ = ch_y_set_lo.put_f64(0.0).await;
+            let _ = ch_y_set_hi.put_f64_process(60.0).await;
+            let _ = ch_y_set_lo.put_f64_process(0.0).await;
         }
     }
 
-    let _ = ch_put_vals.put_i16(0).await;
-    let _ = ch_auto_mode.put_i16(0).await;
-    let _ = ch_oper_ack.put_i16(0).await;
+    let _ = ch_put_vals.put_i16_process(0).await;
+    let _ = ch_auto_mode.put_i16_process(0).await;
+    let _ = ch_oper_ack.put_i16_process(0).await;
 
     // Crystal parameters
     let mut h = ch_h.get_f64().await;
@@ -268,38 +289,38 @@ pub async fn run(
     let mut l = ch_l.get_f64().await;
     let mut a = ch_a.get_f64().await;
     let (mut two_d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
-    let _ = ch_d.put_f64(two_d).await;
-    let _ = ch_seq_msg1.put_string(msg).await;
+    let _ = ch_d.put_f64_process(two_d).await;
+    let _ = ch_seq_msg1.put_string_process(msg).await;
     // C calc2dSpacing sets opAlert from the forbidden-reflection check (1/0).
-    let _ = ch_alert.put_i16(forbidden as i16).await;
+    let _ = ch_alert.put_i16_process(forbidden as i16).await;
 
     // Theta/energy limits
     let mut theta_mot_hi = ch_theta_mot_hilim.get_f64().await;
     let mut theta_mot_lo = ch_theta_mot_lolim.get_f64().await;
     let (mut theta_hi, mut theta_lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
-    let _ = ch_theta_hi.put_f64(theta_hi).await;
-    let _ = ch_theta_lo.put_f64(theta_lo).await;
+    let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+    let _ = ch_theta_lo.put_f64_process(theta_lo).await;
     let (e_hi, e_lo, l_hi, l_lo) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-    let _ = ch_e_hi.put_f64(e_hi).await;
-    let _ = ch_e_lo.put_f64(e_lo).await;
-    let _ = ch_lambda_hi.put_f64(l_hi).await;
-    let _ = ch_lambda_lo.put_f64(l_lo).await;
+    let _ = ch_e_hi.put_f64_process(e_hi).await;
+    let _ = ch_e_lo.put_f64_process(e_lo).await;
+    let _ = ch_lambda_hi.put_f64_process(l_hi).await;
+    let _ = ch_lambda_lo.put_f64_process(l_lo).await;
 
     // Initial readbacks
     let theta_mot_rdbk = ch_theta_mot_rbv.get_f64().await;
     let mut theta_rdbk_val = theta_mot_rdbk;
     let mut lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
     let mut e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-    let _ = ch_theta_rdbk.put_f64(theta_rdbk_val).await;
-    let _ = ch_lambda_rdbk.put_f64(lambda_rdbk_val).await;
-    let _ = ch_e_rdbk.put_f64(e_rdbk_val).await;
+    let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+    let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+    let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
     let mut theta_val = theta_mot_rdbk;
-    let _ = ch_theta.put_f64(theta_val).await;
+    let _ = ch_theta.put_f64_process(theta_val).await;
     let mut lambda_val = theta_to_lambda(theta_val, two_d);
-    let _ = ch_lambda.put_f64(lambda_val).await;
+    let _ = ch_lambda.put_f64_process(lambda_val).await;
     let mut e_val = lambda_to_energy(lambda_val);
-    let _ = ch_e.put_f64(e_val).await;
+    let _ = ch_e.put_f64_process(e_val).await;
 
     let mut auto_mode = false;
     let mut use_set_mode = false;
@@ -316,8 +337,8 @@ pub async fn run(
     let mut last_y_set = calc_y_position(geom, theta_val, y_offset_val);
     let mut last_z_set = calc_z_position(geom, theta_val, y_offset_val);
 
-    let _ = ch_seq_msg1.put_string("Kohzu Control Ready").await;
-    let _ = ch_seq_msg2.put_string(" ").await;
+    let _ = ch_seq_msg1.put_string_process("Kohzu Control Ready").await;
+    let _ = ch_seq_msg2.put_string_process(" ").await;
 
     info!(
         "Kohzu soft controller initialized for {}{}",
@@ -370,13 +391,15 @@ pub async fn run(
             if (new_e - e_val).abs() > 1e-12 {
                 e_val = new_e;
                 lambda_val = energy_to_lambda(e_val);
-                let _ = ch_lambda.put_f64(lambda_val).await;
+                let _ = ch_lambda.put_f64_process(lambda_val).await;
                 if lambda_val > two_d {
-                    let _ = ch_seq_msg1.put_string("Wavelength > 2d spacing.").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Wavelength > 2d spacing.")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                     theta_val = th;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                 }
                 proceed_to_theta_changed = true;
             }
@@ -385,11 +408,13 @@ pub async fn run(
             if (new_l - lambda_val).abs() > 1e-12 {
                 lambda_val = new_l;
                 if lambda_val > two_d {
-                    let _ = ch_seq_msg1.put_string("Wavelength > 2d spacing.").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Wavelength > 2d spacing.")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                     theta_val = th;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                 }
                 proceed_to_theta_changed = true;
             }
@@ -410,20 +435,20 @@ pub async fn run(
             a = ch_a.get_f64().await;
             let (d, forbidden, msg) = calc_2d_spacing(a, h, k, l);
             two_d = d;
-            let _ = ch_d.put_f64(two_d).await;
-            let _ = ch_seq_msg1.put_string(msg).await;
+            let _ = ch_d.put_f64_process(two_d).await;
+            let _ = ch_seq_msg1.put_string_process(msg).await;
             // C kohzuCtl_soft_calc2dSpacing sets opAlert from the (H,K,L) parity
             // check and pvPuts it (kohzuCtl_soft.st:700,711): forbidden -> 1,
             // valid -> 0 (cleared on return to a valid reflection).
-            let _ = ch_alert.put_i16(forbidden as i16).await;
+            let _ = ch_alert.put_i16_process(forbidden as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_put_vals {
             if new_val as i16 != 0 {
                 proceed_to_theta_changed = true;
@@ -434,14 +459,14 @@ pub async fn run(
             cc_mode = CrystalMode::from_i16(new_val as i16);
         } else if changed_pv == pv_oper_ack {
             if new_val as i16 != 0 {
-                let _ = ch_alert.put_i16(0).await;
-                let _ = ch_seq_msg1.put_string(" ").await;
-                let _ = ch_seq_msg2.put_string(" ").await;
-                let _ = ch_oper_ack.put_i16(0).await;
+                let _ = ch_alert.put_i16_process(0).await;
+                let _ = ch_seq_msg1.put_string_process(" ").await;
+                let _ = ch_seq_msg2.put_string_process(" ").await;
+                let _ = ch_oper_ack.put_i16_process(0).await;
             }
         } else if changed_pv == pv_theta_mot_rbv {
             let rbv = new_val;
-            let _ = ch_theta_rdbk_echo.put_f64(rbv).await;
+            let _ = ch_theta_rdbk_echo.put_f64_process(rbv).await;
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
@@ -453,40 +478,40 @@ pub async fn run(
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
             theta_hi = hi;
             theta_lo = lo;
-            let _ = ch_theta_hi.put_f64(theta_hi).await;
-            let _ = ch_theta_lo.put_f64(theta_lo).await;
+            let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+            let _ = ch_theta_lo.put_f64_process(theta_lo).await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_theta_lolim {
             theta_mot_lo = new_val;
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
             theta_hi = hi;
             theta_lo = lo;
-            let _ = ch_theta_hi.put_f64(theta_hi).await;
-            let _ = ch_theta_lo.put_f64(theta_lo).await;
+            let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+            let _ = ch_theta_lo.put_f64_process(theta_lo).await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_y_offset {
             y_offset_val = new_val;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
             let _ = ch_seq_msg1
-                .put_string(&format!("y offset changed to {:.4}", y_offset_val))
+                .put_string_process(&format!("y offset changed to {:.4}", y_offset_val))
                 .await;
-            let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             proceed_to_theta_changed = true;
         } else if changed_pv == pv_use_set {
             use_set_mode = new_val as i16 != 0;
             let sv = if use_set_mode { 1i16 } else { 0 };
-            let _ = ch_theta_mot_set.put_i16(sv).await;
-            let _ = ch_y_mot_set.put_i16(sv).await;
-            let _ = ch_z_mot_set.put_i16(sv).await;
+            let _ = ch_theta_mot_set.put_i16_process(sv).await;
+            let _ = ch_y_mot_set.put_i16_process(sv).await;
+            let _ = ch_z_mot_set.put_i16_process(sv).await;
         }
 
         if !proceed_to_theta_changed {
@@ -498,12 +523,14 @@ pub async fn run(
         let (clamped_theta, was_clamped) = clamp_theta(theta_val, theta_lo, theta_hi);
         if was_clamped {
             theta_val = clamped_theta;
-            let _ = ch_seq_msg1.put_string("Theta constrained to LIMIT").await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_seq_msg1
+                .put_string_process("Theta constrained to LIMIT")
+                .await;
+            let _ = ch_alert.put_i16_process(1).await;
             if risk_averse {
                 auto_mode = false;
-                let _ = ch_auto_mode.put_i16(0).await;
-                let _ = ch_seq_msg2.put_string("Set to Manual Mode").await;
+                let _ = ch_auto_mode.put_i16_process(0).await;
+                let _ = ch_seq_msg2.put_string_process("Set to Manual Mode").await;
             } else {
                 // C kohzuCtl_soft.st:783-784 — outside risk-averse mode a
                 // theta-limit hit sets willViolateLimit, rolling back the command.
@@ -512,9 +539,9 @@ pub async fn run(
         }
 
         lambda_val = theta_to_lambda(theta_val, two_d);
-        let _ = ch_lambda.put_f64(lambda_val).await;
+        let _ = ch_lambda.put_f64_process(lambda_val).await;
         e_val = lambda_to_energy(lambda_val);
-        let _ = ch_e.put_f64(e_val).await;
+        let _ = ch_e.put_f64_process(e_val).await;
 
         let current_rbv = ch_theta_mot_rbv.get_f64().await;
         theta_rdbk_val = current_rbv;
@@ -528,9 +555,9 @@ pub async fn run(
         let theta_mot_desired = theta_val;
         let y_mot_desired = calc_y_position(geom, theta_val, y_offset_val);
         let z_mot_desired = calc_z_position(geom, theta_val, y_offset_val);
-        let _ = ch_theta_set_ao.put_f64(theta_mot_desired).await;
-        let _ = ch_y_set_ao.put_f64(y_mot_desired).await;
-        let _ = ch_z_set_ao.put_f64(z_mot_desired).await;
+        let _ = ch_theta_set_ao.put_f64_process(theta_mot_desired).await;
+        let _ = ch_y_set_ao.put_f64_process(y_mot_desired).await;
+        let _ = ch_z_set_ao.put_f64_process(z_mot_desired).await;
 
         // Check limits
         let y_hi = ch_y_mot_hilim.get_f64().await;
@@ -539,13 +566,17 @@ pub async fn run(
         let z_lo = ch_z_mot_lolim.get_f64().await;
 
         if !cc_mode.y_frozen() && (y_mot_desired < y_lo || y_mot_desired > y_hi) {
-            let _ = ch_seq_msg1.put_string("Y will exceed soft limits").await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_seq_msg1
+                .put_string_process("Y will exceed soft limits")
+                .await;
+            let _ = ch_alert.put_i16_process(1).await;
             will_violate = true;
         }
         if !cc_mode.z_frozen() && (z_mot_desired < z_lo || z_mot_desired > z_hi) {
-            let _ = ch_seq_msg1.put_string("Z will exceed soft limits").await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_seq_msg1
+                .put_string_process("Z will exceed soft limits")
+                .await;
+            let _ = ch_alert.put_i16_process(1).await;
             will_violate = true;
         }
 
@@ -557,14 +588,14 @@ pub async fn run(
             e_val = prev_e;
             theta_val = prev_theta;
             lambda_val = prev_lambda;
-            let _ = ch_e.put_f64(e_val).await;
-            let _ = ch_theta.put_f64(theta_val).await;
-            let _ = ch_lambda.put_f64(lambda_val).await;
-            let _ = ch_theta_set_ao.put_f64(last_theta_set).await;
-            let _ = ch_y_set_ao.put_f64(last_y_set).await;
-            let _ = ch_z_set_ao.put_f64(last_z_set).await;
-            let _ = ch_seq_msg2.put_string("Command ignored").await;
-            let _ = ch_moving.put_i16(0).await;
+            let _ = ch_e.put_f64_process(e_val).await;
+            let _ = ch_theta.put_f64_process(theta_val).await;
+            let _ = ch_lambda.put_f64_process(lambda_val).await;
+            let _ = ch_theta_set_ao.put_f64_process(last_theta_set).await;
+            let _ = ch_y_set_ao.put_f64_process(last_y_set).await;
+            let _ = ch_z_set_ao.put_f64_process(last_z_set).await;
+            let _ = ch_seq_msg2.put_string_process("Command ignored").await;
+            let _ = ch_moving.put_i16_process(0).await;
             continue;
         }
 
@@ -605,12 +636,12 @@ pub async fn run(
                     z_speed,
                     cc_mode,
                 );
-                let _ = ch_theta_mot_velo.put_f64(new_th).await;
+                let _ = ch_theta_mot_velo.put_f64_process(new_th).await;
                 if !cc_mode.y_frozen() {
-                    let _ = ch_y_mot_velo.put_f64(new_y).await;
+                    let _ = ch_y_mot_velo.put_f64_process(new_y).await;
                 }
                 if !cc_mode.z_frozen() {
-                    let _ = ch_z_mot_velo.put_f64(new_z).await;
+                    let _ = ch_z_mot_velo.put_f64_process(new_z).await;
                 }
             }
 
@@ -629,7 +660,7 @@ pub async fn run(
                 }
             }
 
-            let _ = ch_put_vals.put_i16(0).await;
+            let _ = ch_put_vals.put_i16_process(0).await;
             _caused_move = true;
 
             // Wait for motors
@@ -641,11 +672,11 @@ pub async fn run(
 
                 if ch_theta_hls.get_i16().await != 0 || ch_theta_lls.get_i16().await != 0 {
                     let _ = ch_seq_msg1
-                        .put_string("Theta Motor hit a limit switch!")
+                        .put_string_process("Theta Motor hit a limit switch!")
                         .await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
                     let _ = ch_theta_mot_stop.put_i16_process(1).await;
                     let _ = ch_y_stop.put_i16_process(1).await;
                     let _ = ch_z_stop.put_i16_process(1).await;
@@ -655,10 +686,12 @@ pub async fn run(
                 if !cc_mode.y_frozen()
                     && (ch_y_hls.get_i16().await != 0 || ch_y_lls.get_i16().await != 0)
                 {
-                    let _ = ch_seq_msg1.put_string("Y Motor hit a limit switch!").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Y Motor hit a limit switch!")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
                     let _ = ch_theta_mot_stop.put_i16_process(1).await;
                     let _ = ch_y_stop.put_i16_process(1).await;
                     let _ = ch_z_stop.put_i16_process(1).await;
@@ -668,10 +701,12 @@ pub async fn run(
                 if !cc_mode.z_frozen()
                     && (ch_z_hls.get_i16().await != 0 || ch_z_lls.get_i16().await != 0)
                 {
-                    let _ = ch_seq_msg1.put_string("Z Motor hit a limit switch!").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_seq_msg1
+                        .put_string_process("Z Motor hit a limit switch!")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
                     let _ = ch_theta_mot_stop.put_i16_process(1).await;
                     let _ = ch_y_stop.put_i16_process(1).await;
                     let _ = ch_z_stop.put_i16_process(1).await;
@@ -696,12 +731,12 @@ pub async fn run(
             // Restore the pre-coordination motor speeds now the move has
             // stopped (C `kohzuCtl_soft.st` state thetaMotStopped).
             if speeds_coordinated {
-                let _ = ch_theta_mot_velo.put_f64(old_th_speed).await;
+                let _ = ch_theta_mot_velo.put_f64_process(old_th_speed).await;
                 if !cc_mode.y_frozen() {
-                    let _ = ch_y_mot_velo.put_f64(old_y_speed).await;
+                    let _ = ch_y_mot_velo.put_f64_process(old_y_speed).await;
                 }
                 if !cc_mode.z_frozen() {
-                    let _ = ch_z_mot_velo.put_f64(old_z_speed).await;
+                    let _ = ch_z_mot_velo.put_f64_process(old_z_speed).await;
                 }
             }
 
@@ -715,25 +750,37 @@ pub async fn run(
             let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
             let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
             let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
-            let _ = ch_moving.put_i16(0).await;
+            let _ = ch_moving.put_i16_process(0).await;
         }
 
         // Update echoes
         let _ = ch_theta_rdbk_echo
-            .put_f64(ch_theta_mot_rbv.get_f64().await)
+            .put_f64_process(ch_theta_mot_rbv.get_f64().await)
             .await;
-        let _ = ch_y_rdbk_echo.put_f64(ch_y_mot_rbv.get_f64().await).await;
-        let _ = ch_z_rdbk_echo.put_f64(ch_z_mot_rbv.get_f64().await).await;
+        let _ = ch_y_rdbk_echo
+            .put_f64_process(ch_y_mot_rbv.get_f64().await)
+            .await;
+        let _ = ch_z_rdbk_echo
+            .put_f64_process(ch_z_mot_rbv.get_f64().await)
+            .await;
         let _ = ch_theta_vel_echo
-            .put_f64(ch_theta_mot_velo.get_f64().await)
+            .put_f64_process(ch_theta_mot_velo.get_f64().await)
             .await;
-        let _ = ch_y_vel_echo.put_f64(ch_y_mot_velo.get_f64().await).await;
-        let _ = ch_z_vel_echo.put_f64(ch_z_mot_velo.get_f64().await).await;
+        let _ = ch_y_vel_echo
+            .put_f64_process(ch_y_mot_velo.get_f64().await)
+            .await;
+        let _ = ch_z_vel_echo
+            .put_f64_process(ch_z_mot_velo.get_f64().await)
+            .await;
         let _ = ch_theta_dmov_echo
-            .put_i16(ch_theta_dmov.get_i16().await)
+            .put_i16_process(ch_theta_dmov.get_i16().await)
             .await;
-        let _ = ch_y_dmov_echo.put_i16(ch_y_dmov.get_i16().await).await;
-        let _ = ch_z_dmov_echo.put_i16(ch_z_dmov.get_i16().await).await;
+        let _ = ch_y_dmov_echo
+            .put_i16_process(ch_y_dmov.get_i16().await)
+            .await;
+        let _ = ch_z_dmov_echo
+            .put_i16_process(ch_z_dmov.get_i16().await)
+            .await;
     }
 }
 

--- a/crates/optics-rs/src/snl/ml_mono_ctl.rs
+++ b/crates/optics-rs/src/snl/ml_mono_ctl.rs
@@ -674,9 +674,9 @@ pub async fn run(
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-            let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-            let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-            let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+            let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+            let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+            let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
         } else if changed_pv == pv_theta2_mot_rbv {
             let _ = ch_theta2_rdbk_echo.put_f64(new_val).await;
         } else if changed_pv == pv_theta_hilim {
@@ -759,9 +759,9 @@ pub async fn run(
         theta_rdbk_val = current_rbv;
         lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
         e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-        let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-        let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-        let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+        let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+        let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+        let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
         // -- Calc movements --
         let theta_mot_desired = theta_val;
@@ -862,9 +862,9 @@ pub async fn run(
                 theta_rdbk_val = rbv;
                 lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
                 e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-                let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-                let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-                let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+                let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+                let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+                let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
                 let _ = ch_theta_rdbk_echo.put_f64(rbv).await;
                 let _ = ch_theta2_rdbk_echo
                     .put_f64(ch_theta2_mot_rbv.get_f64().await)
@@ -894,9 +894,9 @@ pub async fn run(
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-            let _ = ch_theta_rdbk.put_f64_post(theta_rdbk_val).await;
-            let _ = ch_lambda_rdbk.put_f64_post(lambda_rdbk_val).await;
-            let _ = ch_e_rdbk.put_f64_post(e_rdbk_val).await;
+            let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+            let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+            let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
             let _ = ch_moving.put_i16(0).await;
         }
 

--- a/crates/optics-rs/src/snl/ml_mono_ctl.rs
+++ b/crates/optics-rs/src/snl/ml_mono_ctl.rs
@@ -268,112 +268,136 @@ pub async fn run(
     let my_origin = alloc_origin();
 
     // -- Create channels --
-    let _ch_debug = DbChannel::new(&db, &config.pv("CtlDebug"));
-    let ch_msg1 = DbChannel::new(&db, &config.pv("SeqMsg1"));
-    let ch_msg2 = DbChannel::new(&db, &config.pv("SeqMsg2"));
-    let ch_alert = DbChannel::new(&db, &config.pv("Alert"));
-    let ch_oper_ack = DbChannel::new(&db, &config.pv("OperAck"));
-    let ch_put_vals = DbChannel::new(&db, &config.pv("Put"));
-    let ch_auto_mode = DbChannel::new(&db, &config.pv("Mode"));
-    let ch_cc_mode = DbChannel::new(&db, &config.pv("Mode2"));
-    let ch_moving = DbChannel::new(&db, &config.pv("Moving"));
+    let _ch_debug = DbChannel::with_origin(&db, &config.pv("CtlDebug"), my_origin);
+    let ch_msg1 = DbChannel::with_origin(&db, &config.pv("SeqMsg1"), my_origin);
+    let ch_msg2 = DbChannel::with_origin(&db, &config.pv("SeqMsg2"), my_origin);
+    let ch_alert = DbChannel::with_origin(&db, &config.pv("Alert"), my_origin);
+    let ch_oper_ack = DbChannel::with_origin(&db, &config.pv("OperAck"), my_origin);
+    let ch_put_vals = DbChannel::with_origin(&db, &config.pv("Put"), my_origin);
+    let ch_auto_mode = DbChannel::with_origin(&db, &config.pv("Mode"), my_origin);
+    let ch_cc_mode = DbChannel::with_origin(&db, &config.pv("Mode2"), my_origin);
+    let ch_moving = DbChannel::with_origin(&db, &config.pv("Moving"), my_origin);
 
     // D-spacing parameters
-    let ch_order = DbChannel::new(&db, &config.pv("Order"));
-    let ch_d = DbChannel::new(&db, &config.pv("D"));
+    let ch_order = DbChannel::with_origin(&db, &config.pv("Order"), my_origin);
+    let ch_d = DbChannel::with_origin(&db, &config.pv("D"), my_origin);
 
     // Energy / lambda / theta
-    let ch_e = DbChannel::new(&db, &config.pv("E"));
-    let ch_e_hi = DbChannel::new(&db, &config.pv("E.DRVH"));
-    let ch_e_lo = DbChannel::new(&db, &config.pv("E.DRVL"));
-    let ch_e_rdbk = DbChannel::new(&db, &config.pv("ERdbk"));
+    let ch_e = DbChannel::with_origin(&db, &config.pv("E"), my_origin);
+    let ch_e_hi = DbChannel::with_origin(&db, &config.pv("E.DRVH"), my_origin);
+    let ch_e_lo = DbChannel::with_origin(&db, &config.pv("E.DRVL"), my_origin);
+    let ch_e_rdbk = DbChannel::with_origin(&db, &config.pv("ERdbk"), my_origin);
 
-    let ch_lambda = DbChannel::new(&db, &config.pv("Lambda"));
-    let ch_lambda_hi = DbChannel::new(&db, &config.pv("Lambda.DRVH"));
-    let ch_lambda_lo = DbChannel::new(&db, &config.pv("Lambda.DRVL"));
-    let ch_lambda_rdbk = DbChannel::new(&db, &config.pv("LambdaRdbk"));
+    let ch_lambda = DbChannel::with_origin(&db, &config.pv("Lambda"), my_origin);
+    let ch_lambda_hi = DbChannel::with_origin(&db, &config.pv("Lambda.DRVH"), my_origin);
+    let ch_lambda_lo = DbChannel::with_origin(&db, &config.pv("Lambda.DRVL"), my_origin);
+    let ch_lambda_rdbk = DbChannel::with_origin(&db, &config.pv("LambdaRdbk"), my_origin);
 
-    let ch_theta = DbChannel::new(&db, &config.pv("Theta"));
-    let ch_theta_hi = DbChannel::new(&db, &config.pv("Theta.DRVH"));
-    let ch_theta_lo = DbChannel::new(&db, &config.pv("Theta.DRVL"));
-    let ch_theta_rdbk = DbChannel::new(&db, &config.pv("ThetaRdbk"));
+    let ch_theta = DbChannel::with_origin(&db, &config.pv("Theta"), my_origin);
+    let ch_theta_hi = DbChannel::with_origin(&db, &config.pv("Theta.DRVH"), my_origin);
+    let ch_theta_lo = DbChannel::with_origin(&db, &config.pv("Theta.DRVL"), my_origin);
+    let ch_theta_rdbk = DbChannel::with_origin(&db, &config.pv("ThetaRdbk"), my_origin);
 
     // Echo PVs
-    let ch_theta_mot_name = DbChannel::new(&db, &config.pv("ThetaPv"));
-    let ch_theta2_mot_name = DbChannel::new(&db, &config.pv("Theta2Pv"));
-    let ch_z_mot_name = DbChannel::new(&db, &config.pv("ZPv"));
-    let ch_y_mot_name = DbChannel::new(&db, &config.pv("YPv"));
+    let ch_theta_mot_name = DbChannel::with_origin(&db, &config.pv("ThetaPv"), my_origin);
+    let ch_theta2_mot_name = DbChannel::with_origin(&db, &config.pv("Theta2Pv"), my_origin);
+    let ch_z_mot_name = DbChannel::with_origin(&db, &config.pv("ZPv"), my_origin);
+    let ch_y_mot_name = DbChannel::with_origin(&db, &config.pv("YPv"), my_origin);
 
-    let _ch_theta_cmd_echo = DbChannel::new(&db, &config.pv("ThetaCmd"));
-    let _ch_theta2_cmd_echo = DbChannel::new(&db, &config.pv("Theta2Cmd"));
-    let _ch_z_cmd_echo = DbChannel::new(&db, &config.pv("ZCmd"));
-    let ch_theta_rdbk_echo = DbChannel::new(&db, &config.pv("ThetaRdbkEcho"));
-    let ch_theta2_rdbk_echo = DbChannel::new(&db, &config.pv("Theta2RdbkEcho"));
-    let ch_z_rdbk_echo = DbChannel::new(&db, &config.pv("ZRdbk"));
-    let ch_theta_vel_echo = DbChannel::new(&db, &config.pv("ThetaVel"));
-    let ch_theta2_vel_echo = DbChannel::new(&db, &config.pv("Theta2Vel"));
-    let ch_z_vel_echo = DbChannel::new(&db, &config.pv("ZVel"));
-    let ch_theta_dmov_echo = DbChannel::new(&db, &config.pv("ThetaDmov"));
-    let ch_theta2_dmov_echo = DbChannel::new(&db, &config.pv("Theta2Dmov"));
-    let ch_z_dmov_echo = DbChannel::new(&db, &config.pv("ZDmov"));
+    let _ch_theta_cmd_echo = DbChannel::with_origin(&db, &config.pv("ThetaCmd"), my_origin);
+    let _ch_theta2_cmd_echo = DbChannel::with_origin(&db, &config.pv("Theta2Cmd"), my_origin);
+    let _ch_z_cmd_echo = DbChannel::with_origin(&db, &config.pv("ZCmd"), my_origin);
+    let ch_theta_rdbk_echo = DbChannel::with_origin(&db, &config.pv("ThetaRdbkEcho"), my_origin);
+    let ch_theta2_rdbk_echo = DbChannel::with_origin(&db, &config.pv("Theta2RdbkEcho"), my_origin);
+    let ch_z_rdbk_echo = DbChannel::with_origin(&db, &config.pv("ZRdbk"), my_origin);
+    let ch_theta_vel_echo = DbChannel::with_origin(&db, &config.pv("ThetaVel"), my_origin);
+    let ch_theta2_vel_echo = DbChannel::with_origin(&db, &config.pv("Theta2Vel"), my_origin);
+    let ch_z_vel_echo = DbChannel::with_origin(&db, &config.pv("ZVel"), my_origin);
+    let ch_theta_dmov_echo = DbChannel::with_origin(&db, &config.pv("ThetaDmov"), my_origin);
+    let ch_theta2_dmov_echo = DbChannel::with_origin(&db, &config.pv("Theta2Dmov"), my_origin);
+    let ch_z_dmov_echo = DbChannel::with_origin(&db, &config.pv("ZDmov"), my_origin);
 
     // Motor records
-    let ch_theta_mot_stop = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".STOP"));
-    let ch_theta2_mot_stop = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".STOP"));
-    let ch_z_stop = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".STOP"));
+    let ch_theta_mot_stop =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".STOP"), my_origin);
+    let ch_theta2_mot_stop =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".STOP"), my_origin);
+    let ch_z_stop = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".STOP"), my_origin);
 
-    let ch_theta_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".DMOV"));
-    let ch_theta2_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".DMOV"));
-    let ch_z_dmov = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".DMOV"));
+    let ch_theta_dmov =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".DMOV"), my_origin);
+    let ch_theta2_dmov =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".DMOV"), my_origin);
+    let ch_z_dmov = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".DMOV"), my_origin);
 
-    let ch_theta_hls = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".HLS"));
-    let ch_theta_lls = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".LLS"));
-    let ch_theta2_hls = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".HLS"));
-    let ch_theta2_lls = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".LLS"));
-    let ch_z_hls = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".HLS"));
-    let ch_z_lls = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".LLS"));
+    let ch_theta_hls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".HLS"), my_origin);
+    let ch_theta_lls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".LLS"), my_origin);
+    let ch_theta2_hls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".HLS"), my_origin);
+    let ch_theta2_lls =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".LLS"), my_origin);
+    let ch_z_hls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".HLS"), my_origin);
+    let ch_z_lls = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".LLS"), my_origin);
 
-    let ch_theta_set = DbChannel::new(&db, &config.pv("ThetaSet"));
-    let ch_theta2_set = DbChannel::new(&db, &config.pv("Theta2Set"));
-    let ch_z_set = DbChannel::new(&db, &config.pv("ZSet"));
+    let ch_theta_set = DbChannel::with_origin(&db, &config.pv("ThetaSet"), my_origin);
+    let ch_theta2_set = DbChannel::with_origin(&db, &config.pv("Theta2Set"), my_origin);
+    let ch_z_set = DbChannel::with_origin(&db, &config.pv("ZSet"), my_origin);
 
-    let ch_theta_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".HLM"));
-    let ch_theta_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".LLM"));
-    let ch_z_mot_hilim = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".HLM"));
-    let ch_z_mot_lolim = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".LLM"));
+    let ch_theta_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".HLM"), my_origin);
+    let ch_theta_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".LLM"), my_origin);
+    let ch_z_mot_hilim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".HLM"), my_origin);
+    let ch_z_mot_lolim =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".LLM"), my_origin);
 
-    let ch_theta_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ""));
-    let ch_theta2_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ""));
-    let ch_z_mot_cmd = DbChannel::new(&db, &config.motor_pv(&config.m_z, ""));
+    let ch_theta_mot_cmd =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ""), my_origin);
+    let ch_theta2_mot_cmd =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ""), my_origin);
+    let ch_z_mot_cmd = DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ""), my_origin);
 
-    let ch_theta_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".VELO"));
-    let ch_theta2_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".VELO"));
-    let ch_z_mot_velo = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".VELO"));
+    let ch_theta_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".VELO"), my_origin);
+    let ch_theta2_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".VELO"), my_origin);
+    let ch_z_mot_velo =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".VELO"), my_origin);
 
-    let ch_theta_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".RBV"));
-    let ch_theta2_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".RBV"));
-    let ch_z_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".RBV"));
-    let ch_y_mot_rbv = DbChannel::new(&db, &config.motor_pv(&config.m_y, ".RBV"));
+    let ch_theta_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".RBV"), my_origin);
+    let ch_theta2_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".RBV"), my_origin);
+    let ch_z_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".RBV"), my_origin);
+    let ch_y_mot_rbv =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_y, ".RBV"), my_origin);
 
-    let _ch_use_set = DbChannel::new(&db, &config.pv("UseSet"));
-    let ch_theta_mot_set_flag = DbChannel::new(&db, &config.motor_pv(&config.m_theta, ".SET"));
-    let ch_theta2_mot_set_flag = DbChannel::new(&db, &config.motor_pv(&config.m_theta2, ".SET"));
-    let ch_z_mot_set_flag = DbChannel::new(&db, &config.motor_pv(&config.m_z, ".SET"));
+    let _ch_use_set = DbChannel::with_origin(&db, &config.pv("UseSet"), my_origin);
+    let ch_theta_mot_set_flag =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta, ".SET"), my_origin);
+    let ch_theta2_mot_set_flag =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_theta2, ".SET"), my_origin);
+    let ch_z_mot_set_flag =
+        DbChannel::with_origin(&db, &config.motor_pv(&config.m_z, ".SET"), my_origin);
 
-    let ch_y_offset = DbChannel::new(&db, &config.pv("_yOffset"));
+    let ch_y_offset = DbChannel::with_origin(&db, &config.pv("_yOffset"), my_origin);
 
     // Tweak (inc/dec) feature: ± step buttons for E / lambda / theta.
     // C ml_monoCtl.st:710-773 (state tweak): each button adds ± the matching
     // step value, limit-checks, and resets the pressed BO to 0.
-    let ch_e_tweak_val = DbChannel::new(&db, &config.pv("ETweak"));
-    let ch_e_inc = DbChannel::new(&db, &config.pv("EInc"));
-    let ch_e_dec = DbChannel::new(&db, &config.pv("EDec"));
-    let ch_lambda_tweak_val = DbChannel::new(&db, &config.pv("LambdaTweak"));
-    let ch_lambda_inc = DbChannel::new(&db, &config.pv("LambdaInc"));
-    let ch_lambda_dec = DbChannel::new(&db, &config.pv("LambdaDec"));
-    let ch_theta_tweak_val = DbChannel::new(&db, &config.pv("ThetaTweak"));
-    let ch_theta_inc = DbChannel::new(&db, &config.pv("ThetaInc"));
-    let ch_theta_dec = DbChannel::new(&db, &config.pv("ThetaDec"));
+    let ch_e_tweak_val = DbChannel::with_origin(&db, &config.pv("ETweak"), my_origin);
+    let ch_e_inc = DbChannel::with_origin(&db, &config.pv("EInc"), my_origin);
+    let ch_e_dec = DbChannel::with_origin(&db, &config.pv("EDec"), my_origin);
+    let ch_lambda_tweak_val = DbChannel::with_origin(&db, &config.pv("LambdaTweak"), my_origin);
+    let ch_lambda_inc = DbChannel::with_origin(&db, &config.pv("LambdaInc"), my_origin);
+    let ch_lambda_dec = DbChannel::with_origin(&db, &config.pv("LambdaDec"), my_origin);
+    let ch_theta_tweak_val = DbChannel::with_origin(&db, &config.pv("ThetaTweak"), my_origin);
+    let ch_theta_inc = DbChannel::with_origin(&db, &config.pv("ThetaInc"), my_origin);
+    let ch_theta_dec = DbChannel::with_origin(&db, &config.pv("ThetaDec"), my_origin);
 
     // Wait for key channels
 
@@ -414,51 +438,51 @@ pub async fn run(
     let theta2_name = format!("{}{}", config.prefix, config.m_theta2);
     let z_name = format!("{}{}", config.prefix, config.m_z);
     let y_name = format!("{}{}", config.prefix, config.m_y);
-    let _ = ch_theta_mot_name.put_string(&theta_name).await;
-    let _ = ch_theta2_mot_name.put_string(&theta2_name).await;
-    let _ = ch_z_mot_name.put_string(&z_name).await;
-    let _ = ch_y_mot_name.put_string(&y_name).await;
+    let _ = ch_theta_mot_name.put_string_process(&theta_name).await;
+    let _ = ch_theta2_mot_name.put_string_process(&theta2_name).await;
+    let _ = ch_z_mot_name.put_string_process(&z_name).await;
+    let _ = ch_y_mot_name.put_string_process(&y_name).await;
 
-    let _ = ch_y_offset.put_f64(config.y_offset).await;
-    let _ = ch_put_vals.put_i16(0).await;
-    let _ = ch_auto_mode.put_i16(0).await;
-    let _ = ch_oper_ack.put_i16(0).await;
+    let _ = ch_y_offset.put_f64_process(config.y_offset).await;
+    let _ = ch_put_vals.put_i16_process(0).await;
+    let _ = ch_auto_mode.put_i16_process(0).await;
+    let _ = ch_oper_ack.put_i16_process(0).await;
 
     // D-spacing
     let mut order_val = ch_order.get_f64().await;
     let mut d_val = ch_d.get_f64().await;
     let (mut two_d, err, msg) = calc_2d_spacing(d_val, order_val);
-    let _ = ch_msg1.put_string(msg).await;
+    let _ = ch_msg1.put_string_process(msg).await;
     // C calc2dSpacing sets opAlert from the Order<1 check (1/0).
-    let _ = ch_alert.put_i16(err as i16).await;
+    let _ = ch_alert.put_i16_process(err as i16).await;
 
     // Theta limits
     let mut theta_mot_hi = ch_theta_mot_hilim.get_f64().await;
     let mut theta_mot_lo = ch_theta_mot_lolim.get_f64().await;
     let (mut theta_hi, mut theta_lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
-    let _ = ch_theta_hi.put_f64(theta_hi).await;
-    let _ = ch_theta_lo.put_f64(theta_lo).await;
+    let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+    let _ = ch_theta_lo.put_f64_process(theta_lo).await;
     let (e_hi, e_lo, l_hi, l_lo) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-    let _ = ch_e_hi.put_f64(e_hi).await;
-    let _ = ch_e_lo.put_f64(e_lo).await;
-    let _ = ch_lambda_hi.put_f64(l_hi).await;
-    let _ = ch_lambda_lo.put_f64(l_lo).await;
+    let _ = ch_e_hi.put_f64_process(e_hi).await;
+    let _ = ch_e_lo.put_f64_process(e_lo).await;
+    let _ = ch_lambda_hi.put_f64_process(l_hi).await;
+    let _ = ch_lambda_lo.put_f64_process(l_lo).await;
 
     // Initial readback
     let theta_mot_rdbk = ch_theta_mot_rbv.get_f64().await;
     let mut theta_rdbk_val = theta_mot_rdbk;
     let mut lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
     let mut e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
-    let _ = ch_theta_rdbk.put_f64(theta_rdbk_val).await;
-    let _ = ch_lambda_rdbk.put_f64(lambda_rdbk_val).await;
-    let _ = ch_e_rdbk.put_f64(e_rdbk_val).await;
+    let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
+    let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
+    let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
 
     let mut theta_val = theta_mot_rdbk;
-    let _ = ch_theta.put_f64(theta_val).await;
+    let _ = ch_theta.put_f64_process(theta_val).await;
     let mut lambda_val = theta_to_lambda(theta_val, two_d);
-    let _ = ch_lambda.put_f64(lambda_val).await;
+    let _ = ch_lambda.put_f64_process(lambda_val).await;
     let mut e_val = lambda_to_energy(lambda_val);
-    let _ = ch_e.put_f64(e_val).await;
+    let _ = ch_e.put_f64_process(e_val).await;
 
     let mut auto_mode = false;
     let mut use_set_mode = false;
@@ -466,8 +490,8 @@ pub async fn run(
     let mut y_offset_val = config.y_offset;
     let mut _caused_move = false;
 
-    let _ = ch_msg1.put_string("ml_mono Control Ready").await;
-    let _ = ch_msg2.put_string(" ").await;
+    let _ = ch_msg1.put_string_process("ml_mono Control Ready").await;
+    let _ = ch_msg2.put_string_process(" ").await;
 
     info!("ML mono controller initialized for {}", config.prefix);
 
@@ -518,13 +542,13 @@ pub async fn run(
             if (new_e - e_val).abs() > 1e-12 {
                 e_val = new_e;
                 lambda_val = energy_to_lambda(e_val);
-                let _ = ch_lambda.put_f64(lambda_val).await;
+                let _ = ch_lambda.put_f64_process(lambda_val).await;
                 if lambda_val > two_d {
-                    let _ = ch_msg1.put_string("Wavelength > 2d spacing.").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1.put_string_process("Wavelength > 2d spacing.").await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                     theta_val = th;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                 }
                 proceed_to_theta_changed = true;
             }
@@ -533,11 +557,11 @@ pub async fn run(
             if (new_l - lambda_val).abs() > 1e-12 {
                 lambda_val = new_l;
                 if lambda_val > two_d {
-                    let _ = ch_msg1.put_string("Wavelength > 2d spacing.").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1.put_string_process("Wavelength > 2d spacing.").await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                     theta_val = th;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                 }
                 proceed_to_theta_changed = true;
             }
@@ -558,23 +582,23 @@ pub async fn run(
                 let e_lo = ch_e_lo.get_f64().await;
                 if temp >= e_lo && temp <= e_hi {
                     e_val = temp;
-                    let _ = ch_e.put_f64(e_val).await;
+                    let _ = ch_e.put_f64_process(e_val).await;
                     lambda_val = energy_to_lambda(e_val);
-                    let _ = ch_lambda.put_f64(lambda_val).await;
+                    let _ = ch_lambda.put_f64_process(lambda_val).await;
                     if lambda_val > two_d {
-                        let _ = ch_msg1.put_string("Wavelength > 2d spacing.").await;
-                        let _ = ch_alert.put_i16(1).await;
+                        let _ = ch_msg1.put_string_process("Wavelength > 2d spacing.").await;
+                        let _ = ch_alert.put_i16_process(1).await;
                     } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                         theta_val = th;
-                        let _ = ch_theta.put_f64(theta_val).await;
+                        let _ = ch_theta.put_f64_process(theta_val).await;
                     }
                     proceed_to_theta_changed = true;
                 } else {
-                    let _ = ch_msg1.put_string("E tweak exceeds limit").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1.put_string_process("E tweak exceeds limit").await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 }
                 let reset = if inc { &ch_e_inc } else { &ch_e_dec };
-                let _ = reset.put_i16(0).await;
+                let _ = reset.put_i16_process(0).await;
             }
         } else if changed_pv == pv_lambda_inc || changed_pv == pv_lambda_dec {
             // C ml_monoCtl.st:732-751 — lambda tweak by ± LTweakVal, limit-checked.
@@ -586,21 +610,23 @@ pub async fn run(
                 let l_lo = ch_lambda_lo.get_f64().await;
                 if temp >= l_lo && temp <= l_hi {
                     lambda_val = temp;
-                    let _ = ch_lambda.put_f64(lambda_val).await;
+                    let _ = ch_lambda.put_f64_process(lambda_val).await;
                     if lambda_val > two_d {
-                        let _ = ch_msg1.put_string("Wavelength > 2d spacing.").await;
-                        let _ = ch_alert.put_i16(1).await;
+                        let _ = ch_msg1.put_string_process("Wavelength > 2d spacing.").await;
+                        let _ = ch_alert.put_i16_process(1).await;
                     } else if let Some(th) = lambda_to_theta(lambda_val, two_d) {
                         theta_val = th;
-                        let _ = ch_theta.put_f64(theta_val).await;
+                        let _ = ch_theta.put_f64_process(theta_val).await;
                     }
                     proceed_to_theta_changed = true;
                 } else {
-                    let _ = ch_msg1.put_string("Lambda tweak exceeds limit").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1
+                        .put_string_process("Lambda tweak exceeds limit")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 }
                 let reset = if inc { &ch_lambda_inc } else { &ch_lambda_dec };
-                let _ = reset.put_i16(0).await;
+                let _ = reset.put_i16_process(0).await;
             }
         } else if changed_pv == pv_theta_inc || changed_pv == pv_theta_dec {
             // C ml_monoCtl.st:753-772 — theta tweak by ± thTweakVal, limit-checked.
@@ -610,49 +636,51 @@ pub async fn run(
                 let temp = theta_val + step * if inc { 1.0 } else { -1.0 };
                 if temp >= theta_lo && temp <= theta_hi {
                     theta_val = temp;
-                    let _ = ch_theta.put_f64(theta_val).await;
+                    let _ = ch_theta.put_f64_process(theta_val).await;
                     proceed_to_theta_changed = true;
                 } else {
-                    let _ = ch_msg1.put_string("Theta tweak exceeds limit").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1
+                        .put_string_process("Theta tweak exceeds limit")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                 }
                 let reset = if inc { &ch_theta_inc } else { &ch_theta_dec };
-                let _ = reset.put_i16(0).await;
+                let _ = reset.put_i16_process(0).await;
             }
         } else if changed_pv == pv_order {
             order_val = ch_order.get_f64().await;
             let (td, err, msg) = calc_2d_spacing(d_val, order_val);
             two_d = td;
-            let _ = ch_msg1.put_string(msg).await;
+            let _ = ch_msg1.put_string_process(msg).await;
             // C ml_monoCtl_calc2dSpacing (ml_monoCtl.st:1321-1322) sets opAlert
             // from the Order<1 check and dInputChanged pvPuts it
             // (ml_monoCtl.st:792): bad Order -> 1, valid -> 0 (cleared on return).
-            let _ = ch_alert.put_i16(err as i16).await;
+            let _ = ch_alert.put_i16_process(err as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_d {
             d_val = ch_d.get_f64().await;
             let (td, err, msg) = calc_2d_spacing(d_val, order_val);
             two_d = td;
-            let _ = ch_msg1.put_string(msg).await;
+            let _ = ch_msg1.put_string_process(msg).await;
             // C ml_monoCtl_calc2dSpacing (ml_monoCtl.st:1321-1322) sets opAlert
             // from the Order<1 check and dInputChanged pvPuts it
             // (ml_monoCtl.st:792): bad Order -> 1, valid -> 0 (cleared on return).
-            let _ = ch_alert.put_i16(err as i16).await;
+            let _ = ch_alert.put_i16_process(err as i16).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_msg2.put_string_process("Set to Manual Mode").await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_put_vals {
             if new_val as i16 != 0 {
                 proceed_to_theta_changed = true;
@@ -663,14 +691,14 @@ pub async fn run(
             cc_mode = MlMonoMode::from_i16(new_val as i16);
         } else if changed_pv == pv_oper_ack {
             if new_val as i16 != 0 {
-                let _ = ch_alert.put_i16(0).await;
-                let _ = ch_msg1.put_string(" ").await;
-                let _ = ch_msg2.put_string(" ").await;
-                let _ = ch_oper_ack.put_i16(0).await;
+                let _ = ch_alert.put_i16_process(0).await;
+                let _ = ch_msg1.put_string_process(" ").await;
+                let _ = ch_msg2.put_string_process(" ").await;
+                let _ = ch_oper_ack.put_i16_process(0).await;
             }
         } else if changed_pv == pv_theta_mot_rbv {
             let rbv = new_val;
-            let _ = ch_theta_rdbk_echo.put_f64(rbv).await;
+            let _ = ch_theta_rdbk_echo.put_f64_process(rbv).await;
             theta_rdbk_val = rbv;
             lambda_rdbk_val = theta_to_lambda(theta_rdbk_val, two_d);
             e_rdbk_val = lambda_to_energy(lambda_rdbk_val);
@@ -678,39 +706,39 @@ pub async fn run(
             let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
             let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
         } else if changed_pv == pv_theta2_mot_rbv {
-            let _ = ch_theta2_rdbk_echo.put_f64(new_val).await;
+            let _ = ch_theta2_rdbk_echo.put_f64_process(new_val).await;
         } else if changed_pv == pv_theta_hilim {
             theta_mot_hi = new_val;
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
             theta_hi = hi;
             theta_lo = lo;
-            let _ = ch_theta_hi.put_f64(theta_hi).await;
-            let _ = ch_theta_lo.put_f64(theta_lo).await;
+            let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+            let _ = ch_theta_lo.put_f64_process(theta_lo).await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_theta_lolim {
             theta_mot_lo = new_val;
             let (hi, lo) = compute_theta_limits(theta_mot_hi, theta_mot_lo);
             theta_hi = hi;
             theta_lo = lo;
-            let _ = ch_theta_hi.put_f64(theta_hi).await;
-            let _ = ch_theta_lo.put_f64(theta_lo).await;
+            let _ = ch_theta_hi.put_f64_process(theta_hi).await;
+            let _ = ch_theta_lo.put_f64_process(theta_lo).await;
             let (eh, el, lh, ll) = compute_energy_lambda_limits(two_d, theta_hi, theta_lo);
-            let _ = ch_e_hi.put_f64(eh).await;
-            let _ = ch_e_lo.put_f64(el).await;
-            let _ = ch_lambda_hi.put_f64(lh).await;
-            let _ = ch_lambda_lo.put_f64(ll).await;
+            let _ = ch_e_hi.put_f64_process(eh).await;
+            let _ = ch_e_lo.put_f64_process(el).await;
+            let _ = ch_lambda_hi.put_f64_process(lh).await;
+            let _ = ch_lambda_lo.put_f64_process(ll).await;
         } else if changed_pv == pv_y_offset {
             y_offset_val = new_val;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
             let _ = ch_msg1
-                .put_string(&format!("y offset changed to {:.4}", y_offset_val))
+                .put_string_process(&format!("y offset changed to {:.4}", y_offset_val))
                 .await;
-            let _ = ch_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_msg2.put_string_process("Set to Manual Mode").await;
             proceed_to_theta_changed = true;
         } else if changed_pv == pv_y_mot_rbv {
             // C ml_monoCtl.st:1204-1207 (yMotRdbk_mon): a Y-motor readback change
@@ -721,20 +749,20 @@ pub async fn run(
             // so mirror that here (a self put_f64 posts no monitor event, so the
             // recompute is driven inline rather than via a yOffset re-trigger).
             y_offset_val = new_val;
-            let _ = ch_y_offset.put_f64(y_offset_val).await;
+            let _ = ch_y_offset.put_f64_process(y_offset_val).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
             let _ = ch_msg1
-                .put_string(&format!("y offset changed to {:.4}", y_offset_val))
+                .put_string_process(&format!("y offset changed to {:.4}", y_offset_val))
                 .await;
-            let _ = ch_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_msg2.put_string_process("Set to Manual Mode").await;
             proceed_to_theta_changed = true;
         } else if changed_pv == pv_use_set {
             use_set_mode = new_val as i16 != 0;
             let sv = if use_set_mode { 1i16 } else { 0 };
-            let _ = ch_theta_mot_set_flag.put_i16(sv).await;
-            let _ = ch_theta2_mot_set_flag.put_i16(sv).await;
-            let _ = ch_z_mot_set_flag.put_i16(sv).await;
+            let _ = ch_theta_mot_set_flag.put_i16_process(sv).await;
+            let _ = ch_theta2_mot_set_flag.put_i16_process(sv).await;
+            let _ = ch_z_mot_set_flag.put_i16_process(sv).await;
         }
 
         if !proceed_to_theta_changed {
@@ -743,17 +771,19 @@ pub async fn run(
 
         // -- Theta changed --
         if theta_val <= theta_lo || theta_val >= theta_hi {
-            let _ = ch_msg1.put_string("Theta constrained to LIMIT").await;
-            let _ = ch_alert.put_i16(1).await;
+            let _ = ch_msg1
+                .put_string_process("Theta constrained to LIMIT")
+                .await;
+            let _ = ch_alert.put_i16_process(1).await;
             auto_mode = false;
-            let _ = ch_auto_mode.put_i16(0).await;
-            let _ = ch_msg2.put_string("Set to Manual Mode").await;
+            let _ = ch_auto_mode.put_i16_process(0).await;
+            let _ = ch_msg2.put_string_process("Set to Manual Mode").await;
         }
 
         lambda_val = theta_to_lambda(theta_val, two_d);
-        let _ = ch_lambda.put_f64(lambda_val).await;
+        let _ = ch_lambda.put_f64_process(lambda_val).await;
         e_val = lambda_to_energy(lambda_val);
-        let _ = ch_e.put_f64(e_val).await;
+        let _ = ch_e.put_f64_process(e_val).await;
 
         let current_rbv = ch_theta_mot_rbv.get_f64().await;
         theta_rdbk_val = current_rbv;
@@ -768,20 +798,22 @@ pub async fn run(
         let theta2_mot_desired = theta_val;
         let z_mot_desired = calc_z_position(theta_val, y_offset_val);
 
-        let _ = ch_theta_set.put_f64(theta_mot_desired).await;
-        let _ = ch_theta2_set.put_f64(theta2_mot_desired).await;
-        let _ = ch_z_set.put_f64(z_mot_desired).await;
+        let _ = ch_theta_set.put_f64_process(theta_mot_desired).await;
+        let _ = ch_theta2_set.put_f64_process(theta2_mot_desired).await;
+        let _ = ch_z_set.put_f64_process(z_mot_desired).await;
 
         // Check Z limits
         if !cc_mode.z_frozen() {
             let z_hi = ch_z_mot_hilim.get_f64().await;
             let z_lo = ch_z_mot_lolim.get_f64().await;
             if z_mot_desired < z_lo || z_mot_desired > z_hi {
-                let _ = ch_msg1.put_string("Z will exceed soft limits").await;
-                let _ = ch_msg2.put_string("Setting to Manual Mode").await;
-                let _ = ch_alert.put_i16(1).await;
+                let _ = ch_msg1
+                    .put_string_process("Z will exceed soft limits")
+                    .await;
+                let _ = ch_msg2.put_string_process("Setting to Manual Mode").await;
+                let _ = ch_alert.put_i16_process(1).await;
                 auto_mode = false;
-                let _ = ch_auto_mode.put_i16(0).await;
+                let _ = ch_auto_mode.put_i16_process(0).await;
             }
         }
 
@@ -808,10 +840,10 @@ pub async fn run(
                 z_speed,
                 cc_mode,
             );
-            let _ = ch_theta_mot_velo.put_f64(new_th).await;
-            let _ = ch_theta2_mot_velo.put_f64(new_th).await;
+            let _ = ch_theta_mot_velo.put_f64_process(new_th).await;
+            let _ = ch_theta2_mot_velo.put_f64_process(new_th).await;
             if !cc_mode.z_frozen() {
-                let _ = ch_z_mot_velo.put_f64(new_z).await;
+                let _ = ch_z_mot_velo.put_f64_process(new_z).await;
             }
 
             let _ = ch_theta_mot_cmd.put_f64_process(theta_mot_desired).await;
@@ -819,7 +851,7 @@ pub async fn run(
             if !cc_mode.z_frozen() {
                 let _ = ch_z_mot_cmd.put_f64_process(z_mot_desired).await;
             }
-            let _ = ch_put_vals.put_i16(0).await;
+            let _ = ch_put_vals.put_i16_process(0).await;
             _caused_move = true;
 
             // Wait for motors
@@ -834,10 +866,12 @@ pub async fn run(
                     || ch_theta2_hls.get_i16().await != 0
                     || ch_theta2_lls.get_i16().await != 0
                 {
-                    let _ = ch_msg1.put_string("Theta Motor hit a limit switch!").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1
+                        .put_string_process("Theta Motor hit a limit switch!")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
                     let _ = ch_theta_mot_stop.put_i16_process(1).await;
                     let _ = ch_theta2_mot_stop.put_i16_process(1).await;
                     let _ = ch_z_stop.put_i16_process(1).await;
@@ -847,10 +881,12 @@ pub async fn run(
                 if !cc_mode.z_frozen()
                     && (ch_z_hls.get_i16().await != 0 || ch_z_lls.get_i16().await != 0)
                 {
-                    let _ = ch_msg1.put_string("Z Motor hit a limit switch!").await;
-                    let _ = ch_alert.put_i16(1).await;
+                    let _ = ch_msg1
+                        .put_string_process("Z Motor hit a limit switch!")
+                        .await;
+                    let _ = ch_alert.put_i16_process(1).await;
                     auto_mode = false;
-                    let _ = ch_auto_mode.put_i16(0).await;
+                    let _ = ch_auto_mode.put_i16_process(0).await;
                     let _ = ch_theta_mot_stop.put_i16_process(1).await;
                     let _ = ch_theta2_mot_stop.put_i16_process(1).await;
                     let _ = ch_z_stop.put_i16_process(1).await;
@@ -865,9 +901,9 @@ pub async fn run(
                 let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
                 let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
                 let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
-                let _ = ch_theta_rdbk_echo.put_f64(rbv).await;
+                let _ = ch_theta_rdbk_echo.put_f64_process(rbv).await;
                 let _ = ch_theta2_rdbk_echo
-                    .put_f64(ch_theta2_mot_rbv.get_f64().await)
+                    .put_f64_process(ch_theta2_mot_rbv.get_f64().await)
                     .await;
 
                 if th_dmov != 0 && th2_dmov != 0 && z_dmov != 0 {
@@ -879,10 +915,10 @@ pub async fn run(
             // stopped (C `ml_monoCtl.st` state thetaMotStopped,
             // ml_monoCtl.st:1049-1054). Theta2 tracks Theta's speed and is
             // restored alongside it.
-            let _ = ch_theta_mot_velo.put_f64(old_th_speed).await;
-            let _ = ch_theta2_mot_velo.put_f64(old_th2_speed).await;
+            let _ = ch_theta_mot_velo.put_f64_process(old_th_speed).await;
+            let _ = ch_theta2_mot_velo.put_f64_process(old_th2_speed).await;
             if !cc_mode.z_frozen() {
-                let _ = ch_z_mot_velo.put_f64(old_z_speed).await;
+                let _ = ch_z_mot_velo.put_f64_process(old_z_speed).await;
             }
 
             if _caused_move {
@@ -897,36 +933,42 @@ pub async fn run(
             let _ = ch_theta_rdbk.put_f64_process(theta_rdbk_val).await;
             let _ = ch_lambda_rdbk.put_f64_process(lambda_rdbk_val).await;
             let _ = ch_e_rdbk.put_f64_process(e_rdbk_val).await;
-            let _ = ch_moving.put_i16(0).await;
+            let _ = ch_moving.put_i16_process(0).await;
         }
 
         // Update echoes
         let _ = ch_theta_rdbk_echo
-            .put_f64(ch_theta_mot_rbv.get_f64().await)
+            .put_f64_process(ch_theta_mot_rbv.get_f64().await)
             .await;
         let _ = ch_theta2_rdbk_echo
-            .put_f64(ch_theta2_mot_rbv.get_f64().await)
+            .put_f64_process(ch_theta2_mot_rbv.get_f64().await)
             .await;
-        let _ = ch_z_rdbk_echo.put_f64(ch_z_mot_rbv.get_f64().await).await;
+        let _ = ch_z_rdbk_echo
+            .put_f64_process(ch_z_mot_rbv.get_f64().await)
+            .await;
         let _ = ch_theta_vel_echo
-            .put_f64(ch_theta_mot_velo.get_f64().await)
+            .put_f64_process(ch_theta_mot_velo.get_f64().await)
             .await;
         let _ = ch_theta2_vel_echo
-            .put_f64(ch_theta2_mot_velo.get_f64().await)
+            .put_f64_process(ch_theta2_mot_velo.get_f64().await)
             .await;
-        let _ = ch_z_vel_echo.put_f64(ch_z_mot_velo.get_f64().await).await;
+        let _ = ch_z_vel_echo
+            .put_f64_process(ch_z_mot_velo.get_f64().await)
+            .await;
         let _ = ch_theta_dmov_echo
-            .put_i16(ch_theta_dmov.get_i16().await)
+            .put_i16_process(ch_theta_dmov.get_i16().await)
             .await;
         let _ = ch_theta2_dmov_echo
-            .put_i16(ch_theta2_dmov.get_i16().await)
+            .put_i16_process(ch_theta2_dmov.get_i16().await)
             .await;
-        let _ = ch_z_dmov_echo.put_i16(ch_z_dmov.get_i16().await).await;
+        let _ = ch_z_dmov_echo
+            .put_i16_process(ch_z_dmov.get_i16().await)
+            .await;
 
         // Update y offset from readback
         let y_rbv = ch_y_mot_rbv.get_f64().await;
         y_offset_val = y_rbv;
-        let _ = ch_y_offset.put_f64(y_offset_val).await;
+        let _ = ch_y_offset.put_f64_process(y_offset_val).await;
     }
 }
 

--- a/crates/optics-rs/src/snl/orient.rs
+++ b/crates/optics-rs/src/snl/orient.rs
@@ -798,42 +798,42 @@ pub async fn run(
     let p = &config.prefix;
 
     // Connect motor channels
-    let ch_mot_tth = DbChannel::new(&db, &config.motor_tth);
-    let ch_mot_th = DbChannel::new(&db, &config.motor_th);
-    let ch_mot_chi = DbChannel::new(&db, &config.motor_chi);
-    let ch_mot_phi = DbChannel::new(&db, &config.motor_phi);
+    let ch_mot_tth = DbChannel::with_origin(&db, &config.motor_tth, my_origin);
+    let ch_mot_th = DbChannel::with_origin(&db, &config.motor_th, my_origin);
+    let ch_mot_chi = DbChannel::with_origin(&db, &config.motor_chi, my_origin);
+    let ch_mot_phi = DbChannel::with_origin(&db, &config.motor_phi, my_origin);
 
     // Motor readback channels
-    let ch_mot_tth_rbv = DbChannel::new(&db, &config.motor_tth_rbv());
-    let ch_mot_th_rbv = DbChannel::new(&db, &config.motor_th_rbv());
-    let ch_mot_chi_rbv = DbChannel::new(&db, &config.motor_chi_rbv());
-    let ch_mot_phi_rbv = DbChannel::new(&db, &config.motor_phi_rbv());
+    let ch_mot_tth_rbv = DbChannel::with_origin(&db, &config.motor_tth_rbv(), my_origin);
+    let ch_mot_th_rbv = DbChannel::with_origin(&db, &config.motor_th_rbv(), my_origin);
+    let ch_mot_chi_rbv = DbChannel::with_origin(&db, &config.motor_chi_rbv(), my_origin);
+    let ch_mot_phi_rbv = DbChannel::with_origin(&db, &config.motor_phi_rbv(), my_origin);
 
     // HKL channels
-    let ch_h = DbChannel::new(&db, &format!("{p}H"));
-    let ch_k = DbChannel::new(&db, &format!("{p}K"));
-    let ch_l = DbChannel::new(&db, &format!("{p}L"));
-    let ch_h_rbv = DbChannel::new(&db, &format!("{p}H_RBV"));
-    let ch_k_rbv = DbChannel::new(&db, &format!("{p}K_RBV"));
-    let ch_l_rbv = DbChannel::new(&db, &format!("{p}L_RBV"));
+    let ch_h = DbChannel::with_origin(&db, &format!("{p}H"), my_origin);
+    let ch_k = DbChannel::with_origin(&db, &format!("{p}K"), my_origin);
+    let ch_l = DbChannel::with_origin(&db, &format!("{p}L"), my_origin);
+    let ch_h_rbv = DbChannel::with_origin(&db, &format!("{p}H_RBV"), my_origin);
+    let ch_k_rbv = DbChannel::with_origin(&db, &format!("{p}K_RBV"), my_origin);
+    let ch_l_rbv = DbChannel::with_origin(&db, &format!("{p}L_RBV"), my_origin);
 
     // Trial angle channels
-    let ch_tth = DbChannel::new(&db, &format!("{p}TTH"));
-    let ch_th = DbChannel::new(&db, &format!("{p}TH"));
-    let ch_chi = DbChannel::new(&db, &format!("{p}CHI"));
-    let ch_phi = DbChannel::new(&db, &format!("{p}PHI"));
+    let ch_tth = DbChannel::with_origin(&db, &format!("{p}TTH"), my_origin);
+    let ch_th = DbChannel::with_origin(&db, &format!("{p}TH"), my_origin);
+    let ch_chi = DbChannel::with_origin(&db, &format!("{p}CHI"), my_origin);
+    let ch_phi = DbChannel::with_origin(&db, &format!("{p}PHI"), my_origin);
 
     // Energy / lambda
-    let ch_energy = DbChannel::new(&db, &format!("{p}energy"));
-    let _ch_lambda = DbChannel::new(&db, &format!("{p}lambda"));
+    let ch_energy = DbChannel::with_origin(&db, &format!("{p}energy"), my_origin);
+    let _ch_lambda = DbChannel::with_origin(&db, &format!("{p}lambda"), my_origin);
 
     // Crystal params
-    let ch_a = DbChannel::new(&db, &format!("{p}a"));
-    let ch_b = DbChannel::new(&db, &format!("{p}b"));
-    let ch_c = DbChannel::new(&db, &format!("{p}c"));
-    let ch_alpha = DbChannel::new(&db, &format!("{p}alpha"));
-    let ch_beta = DbChannel::new(&db, &format!("{p}beta"));
-    let ch_gamma = DbChannel::new(&db, &format!("{p}gamma"));
+    let ch_a = DbChannel::with_origin(&db, &format!("{p}a"), my_origin);
+    let ch_b = DbChannel::with_origin(&db, &format!("{p}b"), my_origin);
+    let ch_c = DbChannel::with_origin(&db, &format!("{p}c"), my_origin);
+    let ch_alpha = DbChannel::with_origin(&db, &format!("{p}alpha"), my_origin);
+    let ch_beta = DbChannel::with_origin(&db, &format!("{p}beta"), my_origin);
+    let ch_gamma = DbChannel::with_origin(&db, &format!("{p}gamma"), my_origin);
 
     // Computed-matrix element display PVs. C copies the A0 / OMTX arrays into
     // the per-element PVs {P}A0_11..A0_33 / {P}OMTX_11..OMTX_33 and pvPut's each
@@ -841,20 +841,24 @@ pub async fn run(
     // display readouts, so a posting put (value + monitor, no process) is the
     // C-faithful call.
     let ch_a0: [[DbChannel; 3]; 3] = std::array::from_fn(|i| {
-        std::array::from_fn(|j| DbChannel::new(&db, &format!("{p}A0_{}{}", i + 1, j + 1)))
+        std::array::from_fn(|j| {
+            DbChannel::with_origin(&db, &format!("{p}A0_{}{}", i + 1, j + 1), my_origin)
+        })
     });
     let ch_omtx: [[DbChannel; 3]; 3] = std::array::from_fn(|i| {
-        std::array::from_fn(|j| DbChannel::new(&db, &format!("{p}OMTX_{}{}", i + 1, j + 1)))
+        std::array::from_fn(|j| {
+            DbChannel::with_origin(&db, &format!("{p}OMTX_{}{}", i + 1, j + 1), my_origin)
+        })
     });
 
     // Mode, busy, message
-    let _ch_mode = DbChannel::new(&db, &format!("{p}Mode"));
-    let ch_busy = DbChannel::new(&db, &format!("{p}Busy"));
-    let ch_msg = DbChannel::new(&db, &format!("{p}Msg"));
-    let _ch_mot_put = DbChannel::new(&db, &format!("{p}motPut"));
-    let _ch_mot_get = DbChannel::new(&db, &format!("{p}motGet"));
-    let ch_mot_put_auto = DbChannel::new(&db, &format!("{p}motPut_Auto"));
-    let ch_mot_get_auto = DbChannel::new(&db, &format!("{p}motGet_Auto"));
+    let _ch_mode = DbChannel::with_origin(&db, &format!("{p}Mode"), my_origin);
+    let ch_busy = DbChannel::with_origin(&db, &format!("{p}Busy"), my_origin);
+    let ch_msg = DbChannel::with_origin(&db, &format!("{p}Msg"), my_origin);
+    let _ch_mot_put = DbChannel::with_origin(&db, &format!("{p}motPut"), my_origin);
+    let _ch_mot_get = DbChannel::with_origin(&db, &format!("{p}motGet"), my_origin);
+    let ch_mot_put_auto = DbChannel::with_origin(&db, &format!("{p}motPut_Auto"), my_origin);
+    let ch_mot_get_auto = DbChannel::with_origin(&db, &format!("{p}motGet_Auto"), my_origin);
 
     // Build multi-monitor
     let monitored_pvs: Vec<String> = vec![
@@ -924,7 +928,7 @@ pub async fn run(
     ctrl.recalc_a0();
     ctrl.recalc_omtx();
 
-    let _ = ch_msg.put_string("Orient initialized").await;
+    let _ = ch_msg.put_string_process("Orient initialized").await;
     tracing::info!("orient state machine running for {p}");
 
     // PV name constants
@@ -1031,7 +1035,7 @@ pub async fn run(
 
             // Apply actions
             if let Some(msg) = &actions.message {
-                let _ = ch_msg.put_string(msg.as_str()).await;
+                let _ = ch_msg.put_string_process(msg.as_str()).await;
             }
             if let Some(a0) = actions.write_a0 {
                 // C: A0[i][j] -> {P}A0_ij, pvPut each (orient_st.st:497-503,
@@ -1051,15 +1055,15 @@ pub async fn run(
                 }
             }
             if let Some(hkl) = actions.write_hkl {
-                let _ = ch_h.put_f64(hkl[0]).await;
-                let _ = ch_k.put_f64(hkl[1]).await;
-                let _ = ch_l.put_f64(hkl[2]).await;
+                let _ = ch_h.put_f64_process(hkl[0]).await;
+                let _ = ch_k.put_f64_process(hkl[1]).await;
+                let _ = ch_l.put_f64_process(hkl[2]).await;
             }
             if let Some(ang) = actions.write_angles {
-                let _ = ch_tth.put_f64(ang[0]).await;
-                let _ = ch_th.put_f64(ang[1]).await;
-                let _ = ch_chi.put_f64(ang[2]).await;
-                let _ = ch_phi.put_f64(ang[3]).await;
+                let _ = ch_tth.put_f64_process(ang[0]).await;
+                let _ = ch_th.put_f64_process(ang[1]).await;
+                let _ = ch_chi.put_f64_process(ang[2]).await;
+                let _ = ch_phi.put_f64_process(ang[3]).await;
             }
             if let Some(motors) = actions.drive_motors {
                 let _ = ch_mot_tth.put_f64_process(motors[0]).await;
@@ -1069,12 +1073,12 @@ pub async fn run(
                 ctrl.waiting_for_motors = true;
             }
             if let Some(b) = actions.busy_changed {
-                let _ = ch_busy.put_i16(if b { 1 } else { 0 }).await;
+                let _ = ch_busy.put_i16_process(if b { 1 } else { 0 }).await;
             }
             if let Some(rbv) = actions.write_hkl_rbv {
-                let _ = ch_h_rbv.put_f64(rbv[0]).await;
-                let _ = ch_k_rbv.put_f64(rbv[1]).await;
-                let _ = ch_l_rbv.put_f64(rbv[2]).await;
+                let _ = ch_h_rbv.put_f64_process(rbv[0]).await;
+                let _ = ch_k_rbv.put_f64_process(rbv[1]).await;
+                let _ = ch_l_rbv.put_f64_process(rbv[2]).await;
             }
         }
     }

--- a/crates/optics-rs/src/snl/orient.rs
+++ b/crates/optics-rs/src/snl/orient.rs
@@ -1038,7 +1038,7 @@ pub async fn run(
                 // 671-679). NOT into {P}a, which is a user lattice-param input.
                 for (i, row) in ch_a0.iter().enumerate() {
                     for (j, ch) in row.iter().enumerate() {
-                        let _ = ch.put_f64_post(a0[i][j]).await;
+                        let _ = ch.put_f64_process(a0[i][j]).await;
                     }
                 }
             }
@@ -1046,7 +1046,7 @@ pub async fn run(
                 // C: OMTX[i][j] -> {P}OMTX_ij, pvPut each (orient_st.st:534-539).
                 for (i, row) in ch_omtx.iter().enumerate() {
                     for (j, ch) in row.iter().enumerate() {
-                        let _ = ch.put_f64_post(omtx[i][j]).await;
+                        let _ = ch.put_f64_process(omtx[i][j]).await;
                     }
                 }
             }

--- a/crates/optics-rs/src/snl/pf4.rs
+++ b/crates/optics-rs/src/snl/pf4.rs
@@ -668,29 +668,29 @@ pub async fn run(
     let b = &config.bank;
 
     // Connect PVs
-    let ch_b1 = DbChannel::new(&db, &format!("{ph}displayBit1{b}"));
-    let ch_b2 = DbChannel::new(&db, &format!("{ph}displayBit2{b}"));
-    let ch_b3 = DbChannel::new(&db, &format!("{ph}displayBit3{b}"));
-    let ch_b4 = DbChannel::new(&db, &format!("{ph}displayBit4{b}"));
-    let ch_trans = DbChannel::new(&db, &format!("{ph}trans{b}"));
-    let ch_inv_trans = DbChannel::new(&db, &format!("{ph}invTrans{b}"));
-    let ch_bankctl = DbChannel::new(&db, &format!("{ph}bank{b}"));
-    let _ch_filpos = DbChannel::new(&db, &format!("{ph}fPos{b}"));
-    let ch_select_energy = DbChannel::new(&db, &format!("{ph}useMono"));
-    let ch_local_energy = DbChannel::new(&db, &format!("{ph}E:local"));
-    let ch_filter_al = DbChannel::new(&db, &format!("{ph}filterAl"));
-    let ch_filter_ti = DbChannel::new(&db, &format!("{ph}filterTi"));
-    let ch_filter_glass = DbChannel::new(&db, &format!("{ph}filterGlass"));
+    let ch_b1 = DbChannel::with_origin(&db, &format!("{ph}displayBit1{b}"), my_origin);
+    let ch_b2 = DbChannel::with_origin(&db, &format!("{ph}displayBit2{b}"), my_origin);
+    let ch_b3 = DbChannel::with_origin(&db, &format!("{ph}displayBit3{b}"), my_origin);
+    let ch_b4 = DbChannel::with_origin(&db, &format!("{ph}displayBit4{b}"), my_origin);
+    let ch_trans = DbChannel::with_origin(&db, &format!("{ph}trans{b}"), my_origin);
+    let ch_inv_trans = DbChannel::with_origin(&db, &format!("{ph}invTrans{b}"), my_origin);
+    let ch_bankctl = DbChannel::with_origin(&db, &format!("{ph}bank{b}"), my_origin);
+    let _ch_filpos = DbChannel::with_origin(&db, &format!("{ph}fPos{b}"), my_origin);
+    let ch_select_energy = DbChannel::with_origin(&db, &format!("{ph}useMono"), my_origin);
+    let ch_local_energy = DbChannel::with_origin(&db, &format!("{ph}E:local"), my_origin);
+    let ch_filter_al = DbChannel::with_origin(&db, &format!("{ph}filterAl"), my_origin);
+    let ch_filter_ti = DbChannel::with_origin(&db, &format!("{ph}filterTi"), my_origin);
+    let ch_filter_glass = DbChannel::with_origin(&db, &format!("{ph}filterGlass"), my_origin);
 
-    let ch_f1 = DbChannel::new(&db, &format!("{ph}f1{b}"));
-    let ch_f2 = DbChannel::new(&db, &format!("{ph}f2{b}"));
-    let ch_f3 = DbChannel::new(&db, &format!("{ph}f3{b}"));
-    let ch_f4 = DbChannel::new(&db, &format!("{ph}f4{b}"));
+    let ch_f1 = DbChannel::with_origin(&db, &format!("{ph}f1{b}"), my_origin);
+    let ch_f2 = DbChannel::with_origin(&db, &format!("{ph}f2{b}"), my_origin);
+    let ch_f3 = DbChannel::with_origin(&db, &format!("{ph}f3{b}"), my_origin);
+    let ch_f4 = DbChannel::with_origin(&db, &format!("{ph}f4{b}"), my_origin);
 
-    let ch_z1 = DbChannel::new(&db, &format!("{ph}Z1{b}"));
-    let ch_z2 = DbChannel::new(&db, &format!("{ph}Z2{b}"));
-    let ch_z3 = DbChannel::new(&db, &format!("{ph}Z3{b}"));
-    let ch_z4 = DbChannel::new(&db, &format!("{ph}Z4{b}"));
+    let ch_z1 = DbChannel::with_origin(&db, &format!("{ph}Z1{b}"), my_origin);
+    let ch_z2 = DbChannel::with_origin(&db, &format!("{ph}Z2{b}"), my_origin);
+    let ch_z3 = DbChannel::with_origin(&db, &format!("{ph}Z3{b}"), my_origin);
+    let ch_z4 = DbChannel::with_origin(&db, &format!("{ph}Z4{b}"), my_origin);
 
     // Build multi-monitor
     let monitored_pvs: Vec<String> = vec![
@@ -808,29 +808,29 @@ pub async fn run(
             if let Some(bits) = actions.set_bits {
                 // Insert first, then remove (as per original SNL)
                 if bits[0] {
-                    let _ = ch_b1.put_i16(1_i16).await;
+                    let _ = ch_b1.put_i16_process(1_i16).await;
                 }
                 if bits[1] {
-                    let _ = ch_b2.put_i16(1_i16).await;
+                    let _ = ch_b2.put_i16_process(1_i16).await;
                 }
                 if bits[2] {
-                    let _ = ch_b3.put_i16(1_i16).await;
+                    let _ = ch_b3.put_i16_process(1_i16).await;
                 }
                 if bits[3] {
-                    let _ = ch_b4.put_i16(1_i16).await;
+                    let _ = ch_b4.put_i16_process(1_i16).await;
                 }
                 sleep(Duration::from_millis(200)).await;
                 if !bits[0] {
-                    let _ = ch_b1.put_i16(0_i16).await;
+                    let _ = ch_b1.put_i16_process(0_i16).await;
                 }
                 if !bits[1] {
-                    let _ = ch_b2.put_i16(0_i16).await;
+                    let _ = ch_b2.put_i16_process(0_i16).await;
                 }
                 if !bits[2] {
-                    let _ = ch_b3.put_i16(0_i16).await;
+                    let _ = ch_b3.put_i16_process(0_i16).await;
                 }
                 if !bits[3] {
-                    let _ = ch_b4.put_i16(0_i16).await;
+                    let _ = ch_b4.put_i16_process(0_i16).await;
                 }
             }
         }

--- a/crates/optics-rs/src/snl/pf4.rs
+++ b/crates/optics-rs/src/snl/pf4.rs
@@ -846,19 +846,19 @@ async fn apply_pf4_actions(
     ch_filter_glass: &DbChannel,
 ) {
     if let Some(t) = actions.write_transmission {
-        let _ = ch_trans.put_f64_post(t).await;
+        let _ = ch_trans.put_f64_process(t).await;
     }
     if let Some(t) = actions.write_inv_transmission {
-        let _ = ch_inv_trans.put_f64_post(t).await;
+        let _ = ch_inv_trans.put_f64_process(t).await;
     }
     if let Some(t) = actions.write_filter_al {
-        let _ = ch_filter_al.put_f64_post(t).await;
+        let _ = ch_filter_al.put_f64_process(t).await;
     }
     if let Some(t) = actions.write_filter_ti {
-        let _ = ch_filter_ti.put_f64_post(t).await;
+        let _ = ch_filter_ti.put_f64_process(t).await;
     }
     if let Some(t) = actions.write_filter_glass {
-        let _ = ch_filter_glass.put_f64_post(t).await;
+        let _ = ch_filter_glass.put_f64_process(t).await;
     }
 }
 


### PR DESCRIPTION
C seq `pvPut` is `dbPutField`: write + process + post. The optics-rs SNL ports translated many pvPut sites as plain puts (write only) or put-and-post (no process), so written records never processed — visible as `mini:BraggERdbkAO` stuck at `UDF INVALID` and readbacks invisible to CA monitors on the mini-beamline example.

Three commits:

- **b790b168** — the 70 `put_*_post` pvPut sites → `put_*_process` (fire-and-forget dbPutField parity).
- **cc322d4f** — the remaining 526 plain `put_f64`/`put_i16`/`put_string` sites → `put_*_process`, plus the structural piece that makes this safe: a thread-local ambient write-origin scope in epics-base-rs so every event a put's synchronous process cascade posts carries the writer's origin. Without it the conversion re-enables an SNL self-echo storm (kohzu clamp/rollback ping-pong, measured 46k events/12s); with it a state machine's filtered monitors skip its own cascade while async work it spawned (motor pollers) stays visible.
- **ab1e63d4** — the simple-PV branch of `put_pv_and_post_with_origin` had silently dropped the origin; `ProcessVariable::deliver` now applies the same inheritance rule.

Verified live on `examples/mini-beamline`: no idle event storm; a commanded kohzu move ramps `dcm:theta` with externally visible, alarm-clean `ThetaRdbk`/`ERdbk` tracking (E lands on target); an HKL change reposts the recomputed 2d spacing. `CaChannel` wire-put sites are already dbPutField server-side and are unchanged.

Tests: `epics-base-rs/tests/snl_process_put_origin.rs` (self-put invisible to own origin / visible to others / originless unfiltered), `pv.rs` origin-tagging unit test. Full workspace `clippy -D warnings` + nextest 10196/10196 green.