### PR TITLE
refactor(tests): backend-selected #[epics_test] driver and suite migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "dashmap",
  "ed25519-dalek",
  "epics-base-rs",
+ "epics-macros-rs",
  "epics-rtems-boot",
  "futures-util",
  "hickory-client",
@@ -1101,6 +1102,7 @@ name = "epics-libcom-rs"
 version = "0.24.3"
 dependencies = [
  "chrono",
+ "epics-macros-rs",
  "hostname",
  "if-addrs",
  "libc",

--- a/crates/ad-plugins-rs/tests/ioc_asyn_commands.rs
+++ b/crates/ad-plugins-rs/tests/ioc_asyn_commands.rs
@@ -14,11 +14,14 @@ use epics_base_rs::server::iocsh::IocShell;
 fn shell_with_ad_ioc_startup_commands(ioc: &AdIoc) -> IocShell {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let db = Arc::new(PvDatabase::new());
-    let handle = rt.handle().clone();
+    let bridge = {
+        let _guard = rt.enter();
+        epics_base_rs::runtime::task::BlockingBridge::capture()
+    };
     // The shell's command handlers block on this runtime; it must outlive them.
     std::mem::forget(rt);
 
-    let shell = IocShell::new(db, handle);
+    let shell = IocShell::new(db, bridge);
     for def in ioc.app().startup_commands() {
         shell.register(def.clone());
     }

--- a/crates/asyn-rs/src/iocsh.rs
+++ b/crates/asyn-rs/src/iocsh.rs
@@ -3251,8 +3251,11 @@ mod tests {
         use epics_base_rs::server::database::PvDatabase;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
-        let handle = rt.handle().clone();
-        let ctx = CommandContext::new(db, handle);
+        let bridge = {
+            let _guard = rt.enter();
+            epics_base_rs::runtime::task::BlockingBridge::capture()
+        };
+        let ctx = CommandContext::new(db, bridge);
         std::mem::forget(rt);
         ctx
     }

--- a/crates/asyn-rs/tests/iocsh_port_is_traceable.rs
+++ b/crates/asyn-rs/tests/iocsh_port_is_traceable.rs
@@ -24,8 +24,11 @@ use epics_base_rs::server::iocsh::registry::{ArgValue, CommandContext, CommandDe
 
 fn make_ctx() -> CommandContext {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let handle = rt.handle().clone();
-    let ctx = CommandContext::new(Arc::new(PvDatabase::new()), handle);
+    let bridge = {
+        let _guard = rt.enter();
+        epics_base_rs::runtime::task::BlockingBridge::capture()
+    };
+    let ctx = CommandContext::new(Arc::new(PvDatabase::new()), bridge);
     // The context borrows the runtime for the life of the command; the test
     // process exits before the leak matters.
     std::mem::forget(rt);

--- a/crates/asyn-rs/tests/ip_server_port_accepts.rs
+++ b/crates/asyn-rs/tests/ip_server_port_accepts.rs
@@ -22,8 +22,11 @@ use epics_base_rs::server::iocsh::registry::{ArgValue, CommandContext, CommandDe
 
 fn make_ctx() -> CommandContext {
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let handle = rt.handle().clone();
-    let ctx = CommandContext::new(Arc::new(PvDatabase::new()), handle);
+    let bridge = {
+        let _guard = rt.enter();
+        epics_base_rs::runtime::task::BlockingBridge::capture()
+    };
+    let ctx = CommandContext::new(Arc::new(PvDatabase::new()), bridge);
     std::mem::forget(rt);
     ctx
 }

--- a/crates/epics-base-rs/src/lib.rs
+++ b/crates/epics-base-rs/src/lib.rs
@@ -22,6 +22,13 @@
     clippy::useless_conversion
 )]
 
+// `epics-macros-rs` attribute expansions refer to this crate as
+// `::epics_base_rs` (the spelling that is correct in downstream crates and in
+// this package's own integration tests/bins, where `crate` would name the
+// wrong crate). This alias makes the same spelling resolve inside the library
+// target itself, so one expansion works everywhere.
+extern crate self as epics_base_rs;
+
 /// The upstream EPICS Base release this crate ports — C's
 /// `EPICS_VERSION_FULL`.
 ///

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use crate::error::{CaError, CaResult};
@@ -410,7 +408,7 @@ mod access_checked_tests {
     use super::*;
     use std::sync::Arc;
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn open_gate_grants_read_write() {
         let gate = AccessGate::open();
         let checked = gate.check("any:pv", "h", "u", "anonymous", "").await;
@@ -420,7 +418,7 @@ mod access_checked_tests {
         assert_eq!(checked.pv_name(), "any:pv");
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn required_gate_with_no_acf_attached_is_permissive() {
         let cell = crate::server::access_security::new_acf_cell(None);
         let resolver: AsgAslResolver =
@@ -430,7 +428,7 @@ mod access_checked_tests {
         assert_eq!(checked.level(), AccessLevel::ReadWrite);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn required_gate_with_acf_denies_unprivileged_peer() {
         let cfg = parse_acf(
             r#"
@@ -2908,7 +2906,7 @@ ASG(LOCKED)    { }
     /// with an `INP*` resolver installed, a CALC-gated rule
     /// grants when the expression is true, denies when false, denies on
     /// a bad input, and denies when no resolver is installed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn calc_gated_rule_evaluates_against_inp_resolver() {
         use std::sync::Arc;
         let cfg =

--- a/crates/epics-base-rs/src/server/autosave/save_file.rs
+++ b/crates/epics-base-rs/src/server/autosave/save_file.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::path::Path;
 
 use crate::types::EpicsValue;
@@ -539,7 +537,7 @@ mod tests {
     /// `save/restore` banner (the banner a C IOC expects) and is
     /// still readable by the Rust reader — the array form
     /// round-trips through `parse_c_array_line`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn c_compat_save_file_has_c_banner_and_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("c.sav");
@@ -577,7 +575,7 @@ mod tests {
     }
 
     /// M6: native mode still writes the autosave-rs banner.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn native_save_file_keeps_native_banner() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("native.sav");

--- a/crates/epics-base-rs/src/server/autosave/startup.rs
+++ b/crates/epics-base-rs/src/server/autosave/startup.rs
@@ -1,5 +1,4 @@
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(2): sync tests that hand-build their own tokio runtime; run and pass in the feature-ON suite.
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};

--- a/crates/epics-base-rs/src/server/autosave/verify.rs
+++ b/crates/epics-base-rs/src/server/autosave/verify.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::path::Path;
 
 use crate::server::database::PvDatabase;
@@ -153,7 +151,7 @@ mod tests {
     /// file into an empty `Vec` and the report claimed everything
     /// was fine — hiding exactly the corruption `asVerify` exists to
     /// catch.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn verify_on_corrupt_save_file_is_error() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("corrupt.sav");
@@ -176,7 +174,7 @@ mod tests {
 
     /// H4: a well-formed save file (with `<END>`) still verifies
     /// normally — the corruption guard does not break the happy path.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn verify_on_valid_save_file_succeeds() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ok.sav");

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(10): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use crate::error::{CaError, CaResult};
@@ -2342,7 +2340,7 @@ mod tests {
     /// downstream subscribers — without the simple-PV branch, every
     /// upstream event was silently dropped and the gateway delivered
     /// no monitors.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_pv_and_post_handles_simple_pv() {
         let db = PvDatabase::new();
         db.add_pv("gw:test", EpicsValue::Double(0.0)).await.unwrap();
@@ -2363,7 +2361,7 @@ mod tests {
     /// PR #336 silently returned `ChannelNotFound`. A later fix closed
     /// `get_record` but the same defect was hiding in field_io.rs.
     /// All four CA-server-and-bridge entry points must accept aliases.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn field_io_entry_points_accept_aliases() {
         use crate::server::records::ai::AiRecord;
 
@@ -2406,7 +2404,7 @@ mod tests {
     /// Covers the `put_pv` (`put_pv_inner`) and `put_pv_and_post` coercion
     /// sites; the CA field-put path (`put_record_field_from_ca_inner`) shares
     /// the identical `coerce_write_value` helper.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn write_path_menu_label_resolves_against_field_menu() {
         use crate::server::records::sel::SelRecord;
 
@@ -2441,7 +2439,7 @@ mod tests {
     /// installed limits/units, and a `DBE_PROPERTY` subscriber must NOT
     /// have received anything (nothing *changed* yet). An unknown / record
     /// name is rejected with `ChannelNotFound`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn set_pv_metadata_installs_without_posting() {
         use crate::error::CaError;
         use crate::server::snapshot::{DisplayInfo, Snapshot};
@@ -2499,7 +2497,7 @@ mod tests {
     /// `DBE_PROPERTY` subscribers only. This is the DB-routing layer the
     /// gateway's property monitor drives on every upstream `DBE_PROPERTY`
     /// event. An unknown / record name is rejected with `ChannelNotFound`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn post_pv_property_refreshes_and_posts_property_event() {
         use crate::error::CaError;
         use crate::server::snapshot::{DisplayInfo, Snapshot};
@@ -2579,7 +2577,7 @@ mod tests {
     /// only consulted `inner.records` directly. Also exercises the
     /// canonical-name normalisation that protects subsequent
     /// `process_record_with_links` / `update_scan_index` calls.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_record_field_from_ca_accepts_alias() {
         use crate::server::records::ai::AiRecord;
 
@@ -2608,7 +2606,7 @@ mod tests {
     /// Pre-fix the ack field posted only itself with DBE_VALUE|DBE_LOG, so no
     /// alarm-mask subscriber observed the acknowledgement, and the post fired
     /// on every put regardless of whether `ackt` changed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alarm_ack_put_posts_record_wide_dbe_alarm() {
         use crate::server::recgbl::EventMask;
         use crate::server::records::ai::AiRecord;
@@ -2677,7 +2675,7 @@ mod tests {
     /// runtime enum re-propagation drives (devAsynInt32.c callbackEnum). A
     /// `DBE_VALUE`-only subscriber on the same field must NOT receive it:
     /// re-keying enum strings is a property change, not a value change.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn post_property_fields_writes_and_posts_dbe_property_only() {
         use crate::server::recgbl::EventMask;
         use crate::server::records::mbbi::MbbiRecord;
@@ -2734,7 +2732,7 @@ mod tests {
     /// the reprocess cycle for a non-`pp` VAL, so the operator's write fired
     /// no monitor at all. calc's VAL is not in its `pp` field set, so the
     /// immediate post is the only event that can fire.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ca_put_to_non_pp_val_posts_monitor() {
         use crate::server::database::db_access::DbSubscription;
         use crate::server::records::calc::CalcRecord;
@@ -2752,7 +2750,7 @@ mod tests {
             .await
             .expect("CA put to CALC1.VAL must succeed");
 
-        let got = tokio::time::timeout(std::time::Duration::from_secs(1), sub.recv_f64())
+        let got = crate::runtime::task::timeout(std::time::Duration::from_secs(1), sub.recv_f64())
             .await
             .expect("a DBE_VALUE monitor must fire for a direct VAL put to a non-pp record");
         assert_eq!(got, Some(5.0));
@@ -2771,7 +2769,7 @@ mod tests {
     /// Before the fix the producer parked the newest value in a side coalesce
     /// slot and `next_event`, finding it set, discarded the whole queued backlog
     /// — the burst came out as one event instead of {1..=appended-1, N}.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r8_22_db_burst_keeps_earlier_distinct_updates() {
         use crate::server::database::db_access::DbSubscription;
         use crate::server::event_queue::{event_que_size, events_per_que};
@@ -2799,7 +2797,8 @@ mod tests {
         // last event has nothing queued and times out, ending collection.
         let mut seq = Vec::new();
         while let Ok(Some(v)) =
-            tokio::time::timeout(std::time::Duration::from_millis(200), sub.recv_f64()).await
+            crate::runtime::task::timeout(std::time::Duration::from_millis(200), sub.recv_f64())
+                .await
         {
             seq.push(v);
         }

--- a/crates/epics-base-rs/src/server/database/link_set.rs
+++ b/crates/epics-base-rs/src/server/database/link_set.rs
@@ -46,8 +46,6 @@
 //! db.register_link_set("pva", Arc::new(MyLset { ... })).await;
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 
 use crate::types::EpicsValue;
@@ -539,7 +537,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn register_and_lookup() {
         let mut reg = LinkSetRegistry::new();
         assert!(reg.is_empty());

--- a/crates/epics-base-rs/src/server/database/links.rs
+++ b/crates/epics-base-rs/src/server/database/links.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(20): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -3192,7 +3190,7 @@ mod out_link_put_fail_tests {
     /// processed. The PP OUT link below carries a write that fails, so the
     /// code returns before `processTarget` and `VAL` stays `0.0`; processing
     /// the target unconditionally would make it `7.0`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pp_out_link_failed_write_does_not_process_target() {
         let db = PvDatabase::new();
         db.add_record("TGT", Box::new(CalcRecord::new("7")))
@@ -3249,7 +3247,7 @@ mod out_link_put_fail_tests {
     ///
     /// The port used to reject the put, which suppressed both the destination's
     /// alarm and its `PP` processing.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pp_out_link_empty_array_alarms_target_and_still_processes_it() {
         use crate::server::recgbl::alarm_status;
 
@@ -3354,7 +3352,7 @@ mod nonlocal_db_link_write_tests {
     /// pre-fix code called `put_pv_already_locked` on a name that does
     /// not exist locally; the write was silently dropped. The recording
     /// lset must now capture the value.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn nonlocal_db_out_link_writes_through_external_put() {
         let db = PvDatabase::new();
         let puts = Arc::new(Mutex::new(Vec::new()));
@@ -3395,7 +3393,7 @@ mod nonlocal_db_link_write_tests {
     /// A local OUT-link write must NOT divert to the external put path —
     /// the locality dispatch only reroutes non-local targets. The local
     /// record receives the value; the lset records nothing.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn local_db_out_link_writes_local_not_external() {
         let db = PvDatabase::new();
         let puts = Arc::new(Mutex::new(Vec::new()));
@@ -3465,7 +3463,7 @@ mod nonlocal_db_link_write_tests {
     /// the registered lset's `scan_forward` — the FWD-link twin of
     /// `write_external_pv` for OUT writes (C `dbScanFwdLink` →
     /// `lset->scanForward`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn external_forward_link_dispatches_through_scan_forward() {
         let db = PvDatabase::new();
         let forwards = Arc::new(Mutex::new(Vec::new()));
@@ -3491,7 +3489,7 @@ mod nonlocal_db_link_write_tests {
     /// non-DB FLNK dispatch the DB-only `flnk_name` filter previously
     /// dropped. C `recGblFwdLink` runs `dbScanFwdLink` for every FLNK
     /// regardless of link kind.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn record_processing_fires_external_forward_link() {
         let db = PvDatabase::new();
         let forwards = Arc::new(Mutex::new(Vec::new()));
@@ -3532,7 +3530,7 @@ mod nonlocal_db_link_write_tests {
     /// `recGblSetSevrMsg(LINK_ALARM, INVALID_ALARM, "Disconn")`, which
     /// writes `nsta`/`nsev`/`namsg` (promoted by the next
     /// `recGblResetAlarms`, matching the C late-set inside `recGblFwdLink`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn disconnected_external_forward_link_raises_pending_link_invalid() {
         let db = PvDatabase::new();
         let forwards = Arc::new(Mutex::new(Vec::new()));
@@ -3597,7 +3595,7 @@ mod cp_link_locality_tests {
     /// EVERY link, CP or not; `setup_cp_links` only registers the trigger.
     /// The rewrite used to live inside `setup_cp_links`, which is why it
     /// reached CP/CPP links alone.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cp_link_to_nonlocal_target_forced_external() {
         let db = PvDatabase::new();
         db.add_record("HOLDER", Box::new(AiRecord::new(0.0)))
@@ -3631,7 +3629,7 @@ mod cp_link_locality_tests {
     /// neither `initialize_link_locality` nor `setup_cp_links` may rewrite
     /// its `parsed_inp` to `Ca`, and it must NOT be registered as an external
     /// CP link.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cp_link_to_local_target_stays_db() {
         let db = PvDatabase::new();
         db.add_record("SRC", Box::new(AiRecord::new(1.0)))
@@ -3677,7 +3675,7 @@ mod external_link_pv_name_tests {
     /// link. iocInit's own console counts are per link FIELD and therefore
     /// disagree by construction — `rtems-ca-ioc`'s banner used to compare a
     /// registry count against nothing at all and print `0`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn declared_external_pvs_are_deduped_direction_agnostic_and_sorted() {
         let db = PvDatabase::new();
         for (name, rec) in [
@@ -3714,7 +3712,7 @@ mod external_link_pv_name_tests {
     /// A database with no external link declares the empty set — the case
     /// the banner reports as `0/0`, which is a healthy boot, not a failure
     /// to connect.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_database_with_no_external_link_declares_none() {
         let db = PvDatabase::new();
         db.add_record("PLAIN", Box::new(AiRecord::new(0.0)))
@@ -3740,7 +3738,7 @@ mod nonlocal_db_link_read_tests {
     /// to a non-local target must read the remote value, not return
     /// `None`. Pre-fix the `Db` read arm read only the local DB (`get_pv`)
     /// and dropped the non-local target.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn plain_nonlocal_db_link_reads_via_external_resolver() {
         let db = PvDatabase::new();
         // Stand-in for the calink/pvalink lset: resolve OTHER:PV remotely.
@@ -3769,7 +3767,7 @@ mod nonlocal_db_link_read_tests {
     /// `read_link_with_alarm`; the same locality rule must hold there, so
     /// a non-local target reads the remote value and surfaces no
     /// local-record alarm.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn nonlocal_db_link_value_and_alarm_via_external() {
         let db = PvDatabase::new();
         db.set_external_resolver(Arc::new(|name: &str| {
@@ -3795,7 +3793,7 @@ mod nonlocal_db_link_read_tests {
 
     /// Owner path: a Db link whose target IS a local record still reads
     /// the local database and never consults the external resolver.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn local_db_link_reads_local_not_external() {
         let db = PvDatabase::new();
         db.add_pv("SRC", EpicsValue::Double(7.0)).await.unwrap();
@@ -3838,7 +3836,7 @@ mod link_metadata_tests {
     /// This is the case that decides the oracle's `field(INPA,"5")` records:
     /// C's answer is neither a propagated limit nor a DBF-type-range default.
     /// The caller keeps its pre-filled buffer.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn constant_link_reports_no_metadata() {
         let db = PvDatabase::new();
         let mut visited = HashSet::new();
@@ -3859,7 +3857,7 @@ mod link_metadata_tests {
     /// `ai` supplies every numeric slot, and `aiRecord.c::get_graphic_double`
     /// serves VAL from `prec->hopr`/`prec->lopr`. `dbDbGetGraphicLimits`
     /// returns those verbatim (`dbDbLink.c:280-295`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_link_to_supported_field_propagates_target_limits() {
         let db = PvDatabase::new();
         let mut src = AiRecord::new(1.0);
@@ -3889,7 +3887,7 @@ mod link_metadata_tests {
     /// `get_graphics`/`get_control` `memset` to zero (`dbAccess.c:241-242`,
     /// `:281-283`) while `get_alarm` seeds `{epicsNAN×4}` and assigns
     /// unconditionally (`dbAccess.c:290,317-330`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_link_to_unsupported_field_yields_c_defaults_not_none() {
         let db = PvDatabase::new();
         db.add_record("STR", Box::new(StringoutRecord::new("hello")))
@@ -3931,7 +3929,7 @@ mod link_metadata_tests {
     /// Pins that the no-support default is decided per slot, not per record:
     /// the graphic limits still come from the target's own support while the
     /// alarm limits fall back to NaN.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_link_alarm_default_is_per_slot_not_per_record() {
         let db = PvDatabase::new();
         db.add_record("WF", Box::new(WaveformRecord::new(8, DbFieldType::Double)))
@@ -3960,7 +3958,7 @@ mod link_metadata_tests {
     /// its `S_dbLib_badLink` initialiser and writes nothing
     /// (`dbDbLink.c:239-261`) — without it, a record that sources its own
     /// metadata from an input link pointing back at itself recurses forever.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn revisited_db_link_target_is_refused() {
         let db = PvDatabase::new();
         db.add_record("SRC", Box::new(AiRecord::new(1.0)))
@@ -3991,7 +3989,7 @@ mod link_metadata_tests {
     /// A db link naming a field the target record does not have has no
     /// `dbAddr` in C — `dbNameToAddr` fails at link-init time, so no lset is
     /// installed and `dbGetGraphicLimits` returns `S_db_noLSET`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_link_to_missing_field_reports_no_metadata() {
         let db = PvDatabase::new();
         db.add_record("SRC", Box::new(AiRecord::new(1.0)))

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(24): checked - these run and pass in the feature-ON suite.
-
 pub mod db_access;
 mod field_io;
 pub mod filters;
@@ -1002,7 +1000,7 @@ impl PvDatabase {
         if total == 0 {
             return (0, 0);
         }
-        // `std::time::Instant`, not `tokio::time::Instant`: the sleep below
+        // `std::time::Instant`, not `crate::runtime::task::Instant`: the sleep below
         // is the runtime seam, whose clock is std's on both backends. Reading
         // the deadline off tokio's clock made the two disagree — under
         // `start_paused` tokio's clock advances only when the runtime decides
@@ -1453,7 +1451,7 @@ impl PvDatabase {
     /// have yet.
     ///
     /// This used to be papered over by starting each such future with a
-    /// `tokio::task::yield_now()`, on the assumption that yielding hands the
+    /// `crate::runtime::task::yield_now()`, on the assumption that yielding hands the
     /// thread back to the in-progress `add_record`. That assumption holds only
     /// on a current-thread runtime: on a multi-thread one the yield can return
     /// before the insert lands, and under `rtems-exec-model` the init runs on
@@ -2246,13 +2244,13 @@ mod tests {
     /// Drives the wait_for_external_links time-budget tests below.
     struct DelayedConnectLset {
         names: Vec<String>,
-        connect_at: tokio::time::Instant,
+        connect_at: crate::runtime::task::Instant,
     }
 
     #[async_trait::async_trait]
     impl link_set::LinkSet for DelayedConnectLset {
         fn is_connected(&self, _: &str) -> bool {
-            tokio::time::Instant::now() >= self.connect_at
+            crate::runtime::task::Instant::now() >= self.connect_at
         }
         fn get_cached_value(&self, _: &str) -> Option<EpicsValue> {
             None
@@ -2265,7 +2263,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_for_external_links_returns_zero_zero_when_no_lsets() {
         let db = PvDatabase::new();
         let (c, t) = db
@@ -2274,7 +2272,7 @@ mod tests {
         assert_eq!((c, t), (0, 0));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_for_external_links_connected_quickly() {
         let db = PvDatabase::new();
         // Local-target forced-CA links (dbChannelTest==0 → isLocal): these
@@ -2283,7 +2281,7 @@ mod tests {
         db.add_pv("pv:B", EpicsValue::Long(0)).await.unwrap();
         let lset = Arc::new(DelayedConnectLset {
             names: vec!["pv:A".to_string(), "pv:B".to_string()],
-            connect_at: tokio::time::Instant::now(),
+            connect_at: crate::runtime::task::Instant::now(),
         });
         // Registered under "ca": the iocInit wait is CA-facility only, so
         // the working set comes from the "ca" link set (these forced-CA
@@ -2295,7 +2293,7 @@ mod tests {
         assert_eq!((c, t), (2, 2));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_for_external_links_returns_partial_on_timeout() {
         let db = PvDatabase::new();
         // Local target so the link is in the init-wait set (dbLink.c:130);
@@ -2304,10 +2302,10 @@ mod tests {
         db.add_pv("slow:pv", EpicsValue::Long(0)).await.unwrap();
         let lset = Arc::new(DelayedConnectLset {
             names: vec!["slow:pv".to_string()],
-            connect_at: tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+            connect_at: crate::runtime::task::Instant::now() + std::time::Duration::from_secs(60),
         });
         db.register_link_set("ca", lset).await;
-        let started = tokio::time::Instant::now();
+        let started = crate::runtime::task::Instant::now();
         let (c, t) = db
             .wait_for_external_links(std::time::Duration::from_millis(250))
             .await;
@@ -2330,16 +2328,16 @@ mod tests {
     /// must not block on it. An areaDetector `test CP MS` placeholder — a CP
     /// link to a PV that exists nowhere — must drop straight through, leaving
     /// the link to connect (or dangle) asynchronously and silently, like C.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_for_external_links_skips_nonlocal_targets() {
         let db = PvDatabase::new();
         // "test" has no local record and would never connect.
         let lset = Arc::new(DelayedConnectLset {
             names: vec!["test".to_string()],
-            connect_at: tokio::time::Instant::now() + std::time::Duration::from_secs(60),
+            connect_at: crate::runtime::task::Instant::now() + std::time::Duration::from_secs(60),
         });
         db.register_link_set("ca", lset).await;
-        let started = tokio::time::Instant::now();
+        let started = crate::runtime::task::Instant::now();
         let (c, t) = db
             .wait_for_external_links(std::time::Duration::from_secs(10))
             .await;
@@ -2357,7 +2355,7 @@ mod tests {
 
     // epics-base PR #336 — alias parsing + lookup integration tests.
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alias_resolves_through_find_entry() {
         let db = PvDatabase::new();
         db.add_record(
@@ -2380,14 +2378,14 @@ mod tests {
         assert!(!db.has_name("NOT:THERE").await);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alias_target_must_exist() {
         let db = PvDatabase::new();
         let err = db.add_alias("DANGLING", "MISSING_TARGET").await;
         assert!(err.is_err(), "alias to missing target must be rejected");
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alias_collision_with_existing_record_rejected() {
         let db = PvDatabase::new();
         db.add_record(
@@ -2409,7 +2407,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_record_resolves_alias() {
         // Regression: get_record must transparently resolve
         // aliases so dbpf / dbgf / dbpr / CA put paths see the same
@@ -2437,7 +2435,7 @@ mod tests {
     /// `LINR >= 3` conversion resolves — without any explicit per-call-site
     /// `install_breaktable_registry`. This covers the dbCreateRecord and
     /// inline-record creation paths that previously skipped the install.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn add_record_installs_breaktable_registry_from_snapshot() {
         let db = PvDatabase::new();
         let ramp = crate::server::cvt_bpt::BrkTable::build(
@@ -2465,7 +2463,7 @@ mod tests {
     /// records added before dbLoadRecords; merge-reloads repointing LINR) can
     /// still resolve `LINR >= 3`. Without the re-install the record keeps an
     /// empty registry and never linearises.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn add_breaktables_reinstalls_registry_into_existing_records() {
         let db = PvDatabase::new();
         // Record added while the registry is still empty: add_record installs
@@ -2489,7 +2487,7 @@ mod tests {
         assert_eq!(inst.record.get_field("VAL"), Some(EpicsValue::Double(5.0)));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_record_no_resolve_skips_alias_table() {
         // Strict variant must NOT see aliases — keeps the canonical
         // distinction available for builder code paths.
@@ -2509,7 +2507,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn register_cp_link_normalises_alias_to_canonical() {
         // Regression: CP link registration must store the
         // canonical record names. dispatch_cp_targets looks up by
@@ -2543,7 +2541,7 @@ mod tests {
         assert!(alias_lookup.is_empty());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn aliases_for_record_returns_sorted_targets_only() {
         let db = PvDatabase::new();
         db.add_record(
@@ -2573,7 +2571,7 @@ mod tests {
         assert!(db.aliases_for_record("MISSING").is_empty());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn all_alias_names_returns_registered_aliases() {
         let db = PvDatabase::new();
         db.add_record(
@@ -2592,7 +2590,7 @@ mod tests {
         assert!(!aliases.contains(&"TARGET".to_string()));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn complete_async_record_accepts_alias() {
         // Invariant audit: complete_async_record (the
         // entry point used by async device-support callbacks to
@@ -2614,7 +2612,7 @@ mod tests {
         db.complete_async_record("TARGET").await.unwrap();
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_record_accepts_alias() {
         // Regression: process_record must accept an alias
         // name. Pre-fix it walked `inner.records` directly.
@@ -2635,7 +2633,7 @@ mod tests {
         assert!(db.process_record("MISSING").await.is_err());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_record_with_links_accepts_alias_and_avoids_cycle() {
         // Regression: process_record_with_links normalises
         // the alias so that (a) the records-map lookup hits and
@@ -2667,7 +2665,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alias_duplicate_rejected() {
         let db = PvDatabase::new();
         db.add_record(
@@ -2687,7 +2685,7 @@ mod tests {
     /// refuse to silently replace an existing registration. Mirrors
     /// epics-base C IOC which treats a duplicate `dbLoadRecords` name
     /// as a fatal load error.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn add_pv_and_add_record_reject_duplicates_across_namespaces() {
         use crate::server::records::ai::AiRecord;
 
@@ -2733,7 +2731,7 @@ mod tests {
     /// that pointed AT it. Otherwise the alias name stays
     /// "registered" forever and `add_pv` / `add_record` rejecting
     /// reuse causes a permanent name leak.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn remove_record_purges_dangling_aliases() {
         use crate::server::records::ai::AiRecord;
 
@@ -2762,7 +2760,7 @@ mod tests {
     /// `add_alias` must reject collisions with
     /// every namespace, including simple PVs (which the pre-fix
     /// code missed).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn add_alias_rejects_simple_pv_collision() {
         use crate::server::records::ai::AiRecord;
 
@@ -2780,24 +2778,27 @@ mod tests {
     /// exactly one succeeds. Pre-fix the two methods grabbed
     /// different write locks first, opening a cross-lock-order
     /// deadlock window.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn concurrent_add_pv_and_add_record_do_not_deadlock() {
         use crate::server::records::ai::AiRecord;
 
         let db = std::sync::Arc::new(PvDatabase::new());
         let db1 = db.clone();
         let db2 = db.clone();
-        let h1 = tokio::spawn(async move { db1.add_pv("RACE", EpicsValue::Double(1.0)).await });
-        let h2 =
-            tokio::spawn(async move { db2.add_record("RACE", Box::new(AiRecord::new(0.0))).await });
+        let h1 = crate::runtime::task::spawn(async move {
+            db1.add_pv("RACE", EpicsValue::Double(1.0)).await
+        });
+        let h2 = crate::runtime::task::spawn(async move {
+            db2.add_record("RACE", Box::new(AiRecord::new(0.0))).await
+        });
         // Both complete within a reasonable bound — pre-fix this
         // could hang because T1 holds simple_pvs.write and waits
         // for records.read while T2 holds records.write and waits
         // for simple_pvs.read.
-        let r1 = tokio::time::timeout(std::time::Duration::from_secs(2), h1)
+        let r1 = crate::runtime::task::timeout(std::time::Duration::from_secs(2), h1)
             .await
             .expect("add_pv must not block on add_record");
-        let r2 = tokio::time::timeout(std::time::Duration::from_secs(2), h2)
+        let r2 = crate::runtime::task::timeout(std::time::Duration::from_secs(2), h2)
             .await
             .expect("add_record must not block on add_pv");
         let r1 = r1.unwrap();
@@ -2810,7 +2811,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn existence_gate_blocks_cached_simple_pv_per_request() {
         // A cached simple PV must re-pass the installed existence gate on
         // both the search (`has_name_from`) and create (`find_entry_from`)
@@ -2871,7 +2872,7 @@ mod tests {
     /// its monitor opened at iocInit. Enumerating the canonical
     /// `common.inp` storage fixes it; C `dbpvar`/`dbcar` likewise dump
     /// every link field including device-support INP/OUT.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn record_link_fields_surfaces_device_support_inp() {
         use crate::server::record::ParsedLink;
         use crate::server::records::ai::AiRecord;

--- a/crates/epics-base-rs/src/server/event_queue.rs
+++ b/crates/epics-base-rs/src/server/event_queue.rs
@@ -77,8 +77,6 @@
 //!   its last delivery (pre-existing deliberate deviation, 446e0d4a); the
 //!   surviving *value* is C's.
 
-// RTEMS-EXEC-MODEL-ALLOW(12): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::Mutex;
@@ -745,7 +743,7 @@ mod tests {
     /// Boundary `npend == 0`: C appends (`dbEvent.c:832-852`) — there is no last
     /// log to replace — even under flow control, and flags the ring's
     /// empty→non-empty transition (C `firstEventFlag`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn npend_zero_appends_even_under_flow_control() {
         let user = EventUser::new();
         user.flow_ctrl_on();
@@ -765,7 +763,7 @@ mod tests {
     /// Boundary `npend > 0` with flow control ON: C replaces `*pLastLog` in
     /// place (`dbEvent.c:812-820`). The queue does not grow and no duplicate is
     /// created — which is exactly why the reader stays suspended.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn npend_positive_under_flow_control_replaces_in_place() {
         let user = EventUser::new();
         user.flow_ctrl_on();
@@ -788,7 +786,7 @@ mod tests {
     /// Boundary `npend > 0`, flow control OFF, ring space ABOVE the threshold:
     /// C appends (`dbEvent.c:832-852`), so distinct updates each get their own
     /// entry and each is delivered.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ring_space_above_threshold_appends_distinct_entries() {
         let user = EventUser::new();
         let (sink, mut reader) = attach(&user, 1);
@@ -808,7 +806,7 @@ mod tests {
     /// {earlier distinct backlog…, coalesced tail}. The old primitive parked the
     /// newest event in a side slot and the consumer then discarded the whole
     /// backlog, delivering only the newest.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ring_space_at_threshold_replaces_only_the_last_entry() {
         let user = EventUser::new();
         let (sink, mut reader) = attach(&user, 1);
@@ -843,7 +841,7 @@ mod tests {
     /// reader: a subscription torn down with entries still queued (C
     /// `event_remove` per entry, `dbEvent.c:542-558`). Teardown drains through
     /// the same accounting the reader uses, so the counters cannot drift.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn detach_with_queued_entries_keeps_the_duplicate_count_symmetric() {
         let user = EventUser::new();
         let (sink, reader) = attach(&user, 1);
@@ -864,7 +862,7 @@ mod tests {
     /// Producer gone with entries still queued: the reader drains them and only
     /// then sees end-of-stream — the `mpsc` contract every consumer was written
     /// against.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn producer_drop_drains_then_ends_the_stream() {
         let user = EventUser::new();
         let (sink, mut reader) = attach(&user, 1);
@@ -880,7 +878,7 @@ mod tests {
     /// A reader suspended by EVENTS_OFF wakes on EVENTS_ON without needing a
     /// further post (C signals `ppendsem` from `db_event_flow_ctrl_mode_off`).
     /// A lost wake here would strand the monitor for good.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn flow_ctrl_off_wakes_a_suspended_reader() {
         let user = Arc::new(EventUser::new());
         user.flow_ctrl_on();
@@ -888,11 +886,11 @@ mod tests {
         sink.post(ev(1));
         sink.post(ev(2)); // replaces in place: still one entry, no duplicate
         let u2 = user.clone();
-        let waker = tokio::spawn(async move {
-            tokio::task::yield_now().await;
+        let waker = crate::runtime::task::spawn(async move {
+            crate::runtime::task::yield_now().await;
             u2.flow_ctrl_off();
         });
-        let got = tokio::time::timeout(std::time::Duration::from_secs(2), reader.recv())
+        let got = crate::runtime::task::timeout(std::time::Duration::from_secs(2), reader.recv())
             .await
             .expect("EVENTS_ON must wake the suspended reader")
             .expect("the held entry is delivered");
@@ -908,7 +906,7 @@ mod tests {
     ///
     /// The per-subscription queues this replaced evaluated the gate per monitor,
     /// so A stayed suspended until EVENTS_ON.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn duplicate_on_a_sibling_subscription_releases_the_events_off_drain() {
         let user = EventUser::new();
         let (sink_a, mut reader_a) = attach(&user, 1);
@@ -924,7 +922,7 @@ mod tests {
         assert_eq!(reader_a.queue().n_duplicates(), 1);
 
         user.flow_ctrl_on();
-        let got = tokio::time::timeout(std::time::Duration::from_secs(2), reader_a.recv())
+        let got = crate::runtime::task::timeout(std::time::Duration::from_secs(2), reader_a.recv())
             .await
             .expect("a duplicate anywhere on the queue must release the drain")
             .expect("A's entry is delivered");
@@ -934,7 +932,7 @@ mod tests {
     /// The complement of the boundary above — EVENTS_OFF with the queue holding
     /// NO duplicate on any subscription: every reader on it suspends, and
     /// EVENTS_ON releases them all.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn flow_control_without_duplicates_suspends_every_reader_on_the_queue() {
         let user = EventUser::new();
         user.flow_ctrl_on();
@@ -953,7 +951,7 @@ mod tests {
     /// Boundary `quota == size - EVENT_ENTRIES`: C chains a new queue rather than
     /// overbooking the ring (`dbEvent.c:446-469`), so a circuit's monitors past
     /// the cap share a *different* `nDuplicates`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn quota_exhaustion_chains_a_second_queue() {
         let user = EventUser::new();
         let cap = event_que_size() / EVENT_ENTRIES - 1;
@@ -978,7 +976,7 @@ mod tests {
     /// C releases the cancelled monitor's quota (`dbEvent.c:999-1002`), so the
     /// freed slot is reusable — the next attach lands back on the first queue
     /// instead of chaining forever.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn detaching_a_monitor_releases_its_quota() {
         let user = EventUser::new();
         let cap = event_que_size() / EVENT_ENTRIES - 1;
@@ -996,7 +994,7 @@ mod tests {
 
     /// Teardown symmetry on a SHARED queue: cancelling one monitor removes only
     /// its own duplicates from the queue-level count; its sibling's stay.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn detaching_one_monitor_leaves_a_siblings_duplicates_counted() {
         let user = EventUser::new();
         let (sink_a, reader_a) = attach(&user, 1);

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -638,7 +638,7 @@ impl IocApplication {
         #[cfg(target_os = "rtems")]
         crate::runtime::task::background_init();
 
-        let handle = tokio::runtime::Handle::current();
+        let bridge = crate::runtime::task::BlockingBridge::capture();
 
         let Self {
             port,
@@ -689,7 +689,7 @@ impl IocApplication {
         // use Handle::block_on() which panics inside the tokio runtime context.
         if let Some(script) = startup_script {
             let db1 = db.clone();
-            let h1 = handle.clone();
+            let b1 = bridge.clone();
 
             let (tx, rx) = crate::runtime::sync::oneshot::channel();
             std::thread::Builder::new()
@@ -704,7 +704,7 @@ impl IocApplication {
                     let _ = crate::runtime::task::enter_ioc_thread(
                         crate::runtime::task::ThreadPriority::Iocsh,
                     );
-                    let shell = iocsh::IocShell::new(db1, h1);
+                    let shell = iocsh::IocShell::new(db1, b1);
                     for cmd in startup_commands {
                         shell.register(cmd);
                     }
@@ -1064,7 +1064,7 @@ impl IocApplication {
         let pending = db.take_after_ioc_running();
         if !pending.is_empty() {
             let db1 = db.clone();
-            let h1 = handle.clone();
+            let b1 = bridge.clone();
             let shell_cmds_clone = shell_commands.clone();
             let (tx, rx) = crate::runtime::sync::oneshot::channel();
             std::thread::Builder::new()
@@ -1076,7 +1076,7 @@ impl IocApplication {
                     let _ = crate::runtime::task::enter_ioc_thread(
                         crate::runtime::task::ThreadPriority::Iocsh,
                     );
-                    let shell = iocsh::IocShell::new(db1, h1);
+                    let shell = iocsh::IocShell::new(db1, b1);
                     for cmd in shell_cmds_clone {
                         shell.register(cmd);
                     }
@@ -1632,7 +1632,11 @@ mod tests {
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
-        let shell = iocsh::IocShell::new(db, rt.handle().clone());
+        let bridge = {
+            let _guard = rt.enter();
+            crate::runtime::task::BlockingBridge::capture()
+        };
+        let shell = iocsh::IocShell::new(db, bridge);
         shell.register(db_load_group_startup_command());
 
         // Two distinct group files (the command probes existence early).

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(1): a sync test that hand-builds its own tokio runtime; runs and passes in the feature-ON suite.
 //! IOC Application — st.cmd-style startup for Rust IOCs.
 //!
 //! Provides a 2-phase IOC lifecycle matching the C++ EPICS pattern:
@@ -21,8 +22,6 @@
 //!     .run(my_protocol_runner)
 //!     .await
 //! ```
-
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -1434,7 +1433,7 @@ mod io_intr_scan_add_tests {
     /// `recGblRecordError` and **demoted to `menuScanPassive`**. It must not be
     /// left claiming I/O Intr, and must not stay in the I/O Intr scan bucket
     /// that `scanpiol` reports from.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn io_intr_without_device_support_is_demoted_to_passive() {
         let db = Arc::new(PvDatabase::new());
         db.add_record("NODEV", Box::new(AiRecord::new(0.0)))
@@ -1473,7 +1472,7 @@ mod io_intr_scan_add_tests {
     /// yields a NULL scan list) is the same failure exit — log and demote. The
     /// port collapses those three C cases into "the device offers no
     /// `io_intr_receiver`", so this covers all of them.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn io_intr_with_device_but_no_interrupt_source_is_demoted_to_passive() {
         use crate::error::CaResult;
         use crate::server::device_support::DeviceSupport;
@@ -1523,7 +1522,7 @@ mod io_intr_scan_add_tests {
 
     /// The demotion is scoped to the failure exits: a record that was never on
     /// I/O Intr is untouched by the pass.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_passive_record_is_not_touched_by_the_io_intr_pass() {
         let db = Arc::new(PvDatabase::new());
         db.add_record("PASV", Box::new(AiRecord::new(0.0)))
@@ -1766,7 +1765,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn test_ioc_application_empty() {
         // An empty IocApplication with no script or records should start and stop cleanly
         // We can't easily test run() because it blocks on REPL, so test the wiring functions
@@ -1776,7 +1775,7 @@ mod tests {
         assert_eq!(count, 0);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn test_wire_device_support_no_dtyp() {
         use crate::server::records::ai::AiRecord;
 
@@ -1796,7 +1795,7 @@ mod tests {
     /// only patched the IocBuilder path; without this fix, IOCs
     /// loaded entirely through iocsh `dbLoadRecords` lose every
     /// `info()` tag the driver depends on (e.g. asyn `asyn:READBACK`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wire_device_support_forwards_info_tags_to_driver() {
         use crate::server::device_support::{DeviceReadOutcome, DeviceSupport};
         use crate::server::record::ScanType;
@@ -1874,7 +1873,7 @@ mod tests {
     /// first. This walked `all_record_names()` when that returned `HashMap`
     /// keys, so binding ran in hash order — not load order, and not even
     /// stable across runs of the same binary.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wire_device_support_binds_in_database_load_order() {
         use crate::server::device_support::{DeviceReadOutcome, DeviceSupport};
         use crate::server::records::ai::AiRecord;
@@ -1950,7 +1949,7 @@ mod tests {
     /// `newOutputCallbackValue` readback branch and never calls
     /// `processCallbackOutput`'s `write()` on a callback cycle; a
     /// put/FLNK/scan cycle still writes the setpoint.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn readback_output_cycle_reads_back_and_skips_device_write() {
         use crate::server::device_support::{DeviceReadOutcome, DeviceSupport};
         use crate::server::record::ScanType;

--- a/crates/epics-base-rs/src/server/ioc_builder.rs
+++ b/crates/epics-base-rs/src/server/ioc_builder.rs
@@ -4,8 +4,6 @@
 //! record type factories, subroutine registrations, and autosave config,
 //! then materialises a populated [`PvDatabase`] in a single async `build()`.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -447,7 +445,7 @@ mod tests {
     /// an alias on the resulting `PvDatabase` so that lookup by the
     /// alias resolves to the same record as lookup by the canonical
     /// name. Pre-fix, `ioc_builder` discarded `def.aliases`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_string_registers_aliases() {
         let db_content = r#"
 record(ai, "REAL:NAME") {
@@ -475,7 +473,7 @@ record(ai, "REAL:NAME") {
     /// stored on the resulting RecordInstance. Pre-fix, no consumer
     /// existed for `def.info_tags` — every record's `info` map was
     /// silently empty after build.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_string_populates_info_tags() {
         let db_content = r#"
 record(ai, "AI:WITH:INFO") {
@@ -503,7 +501,7 @@ record(ai, "AI:WITH:INFO") {
     /// `LINR` names it must, after `build()`, resolve the name to its
     /// `menuConvert` index AND convert raw -> eng through the installed
     /// registry. Proves the full loader -> registry -> record wiring.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn db_string_breaktable_linr_resolves_and_converts() {
         let db_content = r#"
 breaktable(ramp) {
@@ -541,7 +539,7 @@ record(ai, "AI:BPT") {
     /// `universal_asyn_factory`, areaDetector plugin dispatch) only
     /// attach when records are loaded through IocApplication's
     /// startup-script path, never the pure-Rust IocBuilder path.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn dynamic_device_factory_attaches_when_static_missing() {
         use crate::server::device_support::{DeviceReadOutcome, DeviceSupport};
         use crate::server::record::ScanType;
@@ -593,7 +591,7 @@ record(ai, "AI:DYN") {
     /// factory wins for matching DTYPs; non-matching DTYPs fall
     /// through to previously registered factories. Mirrors
     /// `IocApplication::register_dynamic_device_support` chaining.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn dynamic_factories_chain_lifo_with_fallthrough() {
         use crate::server::device_support::{DeviceReadOutcome, DeviceSupport};
         use crate::server::record::ScanType;

--- a/crates/epics-base-rs/src/server/iocsh/access_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/access_commands.rs
@@ -538,8 +538,11 @@ mod tests {
     fn make_ctx() -> (Arc<PvDatabase>, CommandContext) {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
-        let handle = rt.handle().clone();
-        let ctx = CommandContext::new(db.clone(), handle);
+        let bridge = {
+            let _guard = rt.enter();
+            crate::runtime::task::BlockingBridge::capture()
+        };
+        let ctx = CommandContext::new(db.clone(), bridge);
         std::mem::forget(rt);
         (db, ctx)
     }

--- a/crates/epics-base-rs/src/server/iocsh/access_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/access_commands.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(1): a sync test that hand-builds its own tokio runtime; runs and passes in the feature-ON suite.
 //! Access-security iocsh commands — the `as*` family.
 //!
 //! C registers the whole `as*` command family in
@@ -10,8 +11,6 @@
 //! `asSetSubstitutions`, and the parsed [`AccessSecurityConfig`]
 //! activated by `asInit`. The C flow is identical: `asSetFilename`
 //! has "no immediate effect", `asInit` does the (re)load.
-
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
 
 use std::sync::Mutex;
 

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -1,5 +1,4 @@
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): a sync test that hand-builds its own tokio runtime; runs and passes in the feature-ON suite.
 use std::collections::HashMap;
 
 use super::registry::*;

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -1910,8 +1910,11 @@ mod tests {
     fn make_ctx() -> (Arc<PvDatabase>, CommandContext) {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
-        let handle = rt.handle().clone();
-        let ctx = CommandContext::new(db.clone(), handle);
+        let bridge = {
+            let _guard = rt.enter();
+            crate::runtime::task::BlockingBridge::capture()
+        };
+        let ctx = CommandContext::new(db.clone(), bridge);
         // Leak the runtime so it stays alive for the test
         std::mem::forget(rt);
         (db, ctx)

--- a/crates/epics-base-rs/src/server/iocsh/core_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/core_commands.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(1): a sync test that hand-builds its own tokio runtime; runs and passes in the feature-ON suite.
 //! Core iocsh commands beyond the database/record family.
 //!
 //! a stock `st.cmd` relies on a set of core commands
@@ -7,8 +8,6 @@
 //! implementable in-process; `iocshCmd` / `iocshRun` / `on` are
 //! handled directly in `IocShell::execute_line` because they need
 //! the shell itself, not just a `CommandContext`.
-
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
 
 use super::registry::*;
 

--- a/crates/epics-base-rs/src/server/iocsh/core_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/core_commands.rs
@@ -266,8 +266,11 @@ mod tests {
     fn make_ctx() -> CommandContext {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
-        let handle = rt.handle().clone();
-        let ctx = CommandContext::new(db, handle);
+        let bridge = {
+            let _guard = rt.enter();
+            crate::runtime::task::BlockingBridge::capture()
+        };
+        let ctx = CommandContext::new(db, bridge);
         std::mem::forget(rt);
         ctx
     }

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -46,7 +46,11 @@ pub struct IocShell {
 
 impl IocShell {
     /// Create a new shell with built-in commands registered.
-    pub fn new(db: Arc<PvDatabase>, handle: tokio::runtime::Handle) -> Self {
+    ///
+    /// `bridge` carries the runtime access the shell's blocking thread needs;
+    /// capture it where the runtime is known (`BlockingBridge::capture()` on
+    /// the async setup path).
+    pub fn new(db: Arc<PvDatabase>, bridge: crate::runtime::task::BlockingBridge) -> Self {
         let mut registry = CommandRegistry::new();
         commands::register_builtins(&mut registry);
         // C `iocshRegisterCommon` publishes the base version and target arch as
@@ -55,7 +59,7 @@ impl IocShell {
         crate::runtime::env::register_iocsh_env_vars();
         Self {
             registry: Arc::new(RwLock::new(registry)),
-            ctx: CommandContext::new(db, handle),
+            ctx: CommandContext::new(db, bridge),
             on_error: std::cell::Cell::new(OnError::Continue),
         }
     }
@@ -721,14 +725,17 @@ mod tests {
     fn make_shell() -> IocShell {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
-        let handle = rt.handle().clone();
+        let bridge = {
+            let _guard = rt.enter();
+            crate::runtime::task::BlockingBridge::capture()
+        };
         rt.block_on(async {
             db.add_record("TEST_REC", Box::new(AiRecord::new(42.0)))
                 .await
                 .unwrap();
         });
         std::mem::forget(rt);
-        IocShell::new(db, handle)
+        IocShell::new(db, bridge)
     }
 
     /// C `iocshRegisterCommon` publishes the base version and the target arch

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -1,5 +1,4 @@
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): a sync test that hand-builds its own tokio runtime; runs and passes in the feature-ON suite.
 mod access_commands;
 mod commands;
 mod core_commands;

--- a/crates/epics-base-rs/src/server/iocsh/registry.rs
+++ b/crates/epics-base-rs/src/server/iocsh/registry.rs
@@ -87,16 +87,16 @@ impl CommandDef {
 /// Sync→async bridge for commands running on a blocking thread.
 pub struct CommandContext {
     db: Arc<PvDatabase>,
-    handle: tokio::runtime::Handle,
+    bridge: crate::runtime::task::BlockingBridge,
     /// Output writer — defaults to stdout, redirected to a file by `>` / `>>`.
     output: std::cell::RefCell<Box<dyn std::io::Write>>,
 }
 
 impl CommandContext {
-    pub fn new(db: Arc<PvDatabase>, handle: tokio::runtime::Handle) -> Self {
+    pub fn new(db: Arc<PvDatabase>, bridge: crate::runtime::task::BlockingBridge) -> Self {
         Self {
             db,
-            handle,
+            bridge,
             output: std::cell::RefCell::new(Box::new(std::io::stdout())),
         }
     }
@@ -106,9 +106,11 @@ impl CommandContext {
         &self.db
     }
 
-    /// Access the tokio runtime handle (e.g., for spawning tasks from iocsh commands).
-    pub fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        &self.handle
+    /// The captured runtime access — for spawning tasks or blocking on async
+    /// work from iocsh command handlers (which run on the blocking shell
+    /// thread, where the tokio backend's runtime is otherwise unreachable).
+    pub fn bridge(&self) -> &crate::runtime::task::BlockingBridge {
+        &self.bridge
     }
 
     /// Print a line to the current output (stdout or redirected file).
@@ -154,11 +156,7 @@ impl CommandContext {
     /// # Panics
     /// Panics if called from within a tokio runtime thread.
     pub fn block_on<F: std::future::Future>(&self, future: F) -> F::Output {
-        assert!(
-            tokio::runtime::Handle::try_current().is_err(),
-            "CommandContext::block_on() must not be called from a tokio runtime thread"
-        );
-        self.handle.block_on(future)
+        self.bridge.block_on(future)
     }
 }
 

--- a/crates/epics-base-rs/src/server/pv.rs
+++ b/crates/epics-base-rs/src/server/pv.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(23): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
@@ -1012,7 +1010,7 @@ mod mask_gate_tests {
     /// a later `snapshot()` (the GET path) reflects them — not just the
     /// live monitor fan-out. A subsequent value-only `set()` carries no
     /// explicit metadata and must revert the snapshot to NO_ALARM.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn set_snapshot_metadata_persists_then_value_set_clears() {
         let pv = pv();
 
@@ -1046,7 +1044,7 @@ mod mask_gate_tests {
 
     /// a `DBE_ALARM`-only subscriber must not receive a plain
     /// value set, but must receive an alarm post.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alarm_only_subscriber_skips_value_post() {
         let pv = pv();
         let mut rx = pv
@@ -1066,7 +1064,7 @@ mod mask_gate_tests {
 
     /// a `DBE_VALUE`-only subscriber must not receive a
     /// `post_alarm`, but must receive value sets.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn value_only_subscriber_skips_alarm_post() {
         let pv = pv();
         let mut rx = pv
@@ -1096,7 +1094,7 @@ mod mask_gate_tests {
     }
 
     /// A DBE_LOG (archiver) subscriber must receive a set_snapshot post.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn log_subscriber_receives_snapshot_post() {
         let pv = pv();
         let mut rx = pv
@@ -1110,7 +1108,7 @@ mod mask_gate_tests {
     }
 
     /// A DBE_ALARM-only subscriber must receive a set_snapshot post.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn alarm_only_subscriber_receives_snapshot_post() {
         let pv = pv();
         let mut rx = pv
@@ -1124,7 +1122,7 @@ mod mask_gate_tests {
     }
 
     /// A DBE_VALUE subscriber must still receive a set_snapshot post.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn value_subscriber_receives_snapshot_post() {
         let pv = pv();
         let mut rx = pv
@@ -1138,7 +1136,7 @@ mod mask_gate_tests {
     }
 
     /// A `DBE_VALUE | DBE_ALARM` subscriber receives both event classes.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn both_classes_receive_both_posts() {
         let pv = pv();
         let mut rx = pv
@@ -1153,7 +1151,7 @@ mod mask_gate_tests {
     /// A DBE_LOG-only subscriber (archiver) must receive both value
     /// events and alarm events.  Pre-fix: VALUE-only / ALARM-only post masks
     /// never intersected DBE_LOG(2), so archivers received silence.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn br_r52_log_subscriber_receives_value_and_alarm_events() {
         const DBE_LOG: u16 = 2;
         let pv = pv();
@@ -1175,7 +1173,7 @@ mod mask_gate_tests {
     /// Every delivered event carries its post's `DBE_*` class — the
     /// per-event mask C attaches to the field log (`db_field_log.mask`)
     /// and pvxs narrows monitor decoding with (`groupsource.cpp:331-337`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_event_carries_post_class_mask() {
         use crate::server::recgbl::EventMask;
         let pv = pv();
@@ -1201,7 +1199,7 @@ mod mask_gate_tests {
     /// displaced event's class and its own: the displaced *value* is gone (C
     /// frees the field log), but a narrow consumer must still learn that an
     /// ALARM-class change happened inside the coalesced tail.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn in_place_replacement_accumulates_event_class_masks() {
         use crate::server::event_queue::{event_que_size, events_per_que};
         use crate::server::recgbl::EventMask;
@@ -1252,7 +1250,7 @@ mod mask_gate_tests {
     /// the consumer, finding it set, discarded the ENTIRE queued backlog and
     /// delivered only that newest value — so a 200-post burst came out as a
     /// single event instead of {1..107, 200}.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r8_22_pv_burst_keeps_earlier_distinct_updates() {
         use crate::server::event_queue::{event_que_size, events_per_que};
         use std::time::Duration;
@@ -1272,7 +1270,7 @@ mod mask_gate_tests {
         }
         let mut seq = Vec::new();
         while let Ok(Some(snap)) =
-            tokio::time::timeout(Duration::from_millis(200), sub.recv_snapshot()).await
+            crate::runtime::task::timeout(Duration::from_millis(200), sub.recv_snapshot()).await
         {
             seq.push(snap.value.to_f64().expect("double value"));
         }
@@ -1320,7 +1318,7 @@ mod metadata_tests {
     /// plain `set` stays untagged, and a plain `set` inside an
     /// `AmbientWriteOriginScope` inherits the scope's origin — the
     /// simple-PV side of the record funnels' inheritance rule.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn set_with_origin_tags_the_value_event() {
         const DBE_VALUE: u16 = 1;
         let pv = pv();
@@ -1347,7 +1345,7 @@ mod metadata_tests {
 
     /// A bare PV serves no metadata until a proxy installs it; after
     /// `set_metadata`, the GET snapshot carries the shadow DBR_GR/DBR_CTRL.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn set_metadata_serves_on_get_snapshot() {
         let pv = pv();
         assert!(
@@ -1367,7 +1365,7 @@ mod metadata_tests {
 
     /// A CTRL-type monitor must see the installed limits on every value
     /// event, not only the initial GET — value posts carry the metadata.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn installed_metadata_rides_value_posts() {
         const DBE_VALUE: u16 = 1;
         let pv = pv();
@@ -1385,7 +1383,7 @@ mod metadata_tests {
 
     /// `apply_metadata` only supplies fields the caller left absent: a
     /// gateway snapshot that already carries its own display wins.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn apply_metadata_does_not_clobber_caller_metadata() {
         const DBE_VALUE: u16 = 1;
         let pv = pv();
@@ -1413,7 +1411,7 @@ mod metadata_tests {
 
     /// `post_property` reaches DBE_PROPERTY subscribers (carrying the
     /// metadata) and not DBE_VALUE-only subscribers.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn post_property_reaches_only_property_subscribers() {
         const DBE_VALUE: u16 = 1;
         const DBE_PROPERTY: u16 = 8;
@@ -1455,7 +1453,7 @@ mod metadata_tests {
     /// (`gatePv.cc:2413-2438`); a downstream `DBE_PROPERTY` monitor must
     /// see `severity=MAJOR` and the upstream timestamp, even though only
     /// metadata changed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn post_property_preserves_upstream_alarm_and_timestamp() {
         const DBE_PROPERTY: u16 = 8;
         const MAJOR: u16 = 2; // epicsSevMajor
@@ -1507,7 +1505,7 @@ mod read_hook_tests {
     /// No hook installed (the default for every record-backed and cached
     /// PV): `read_snapshot` is exactly `snapshot` wrapped in `Ok` — the
     /// stored value, byte-for-byte unchanged.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn read_snapshot_without_hook_equals_snapshot() {
         let pv = pv();
         let read = pv.read_snapshot().await.expect("no-hook read never errors");
@@ -1519,7 +1517,7 @@ mod read_hook_tests {
     /// With a hook installed (no-cache mode), the GET value comes fresh
     /// from the hook, NOT from the stored shadow value — the stored value
     /// stays a stale sentinel that the hook overrides.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn read_snapshot_fires_hook_for_fresh_value() {
         let pv = pv();
         // Stored shadow value is a sentinel the hook must override.
@@ -1544,7 +1542,7 @@ mod read_hook_tests {
 
     /// A hook failure propagates so the server can answer `ECA_GETFAIL`,
     /// matching C ca-gateway forwarding each read to the IOC.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn read_snapshot_propagates_hook_error() {
         let pv = pv();
         pv.set_read_hook(Arc::new(|| Box::pin(async { Err(CaError::Disconnected) })));
@@ -1591,7 +1589,7 @@ mod read_hook_tests {
     /// The read hook is GET-path only: `snapshot` (monitor fan-out, the
     /// initial monitor event, access-rights re-posts) keeps serving the
     /// stored value even when a hook is installed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn snapshot_ignores_read_hook() {
         let pv = pv();
         pv.set(EpicsValue::Double(7.0));
@@ -1616,7 +1614,7 @@ mod read_hook_tests {
     /// Fresh value + upstream alarm/time ride from the hook; the shadow's
     /// installed *property* metadata (display/control/enum) — which a
     /// `DBR_TIME_*` event does not carry — is overlaid for those fields.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn read_snapshot_carries_shadow_metadata() {
         let pv = pv();
         pv.set_metadata(PvMetadata {
@@ -1658,7 +1656,7 @@ mod read_hook_tests {
     /// a bare value and `read_snapshot` grafted it onto the stored
     /// snapshot, so the GET reported the new value with a stale or default
     /// status/severity/timestamp.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn read_snapshot_carries_upstream_alarm_not_shadow() {
         use std::time::{Duration, UNIX_EPOCH};
         let pv = pv();

--- a/crates/epics-base-rs/src/server/status_pv.rs
+++ b/crates/epics-base-rs/src/server/status_pv.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(1): block_on_sync's current-thread-runtime refusal needs an ambient tokio runtime; runs and passes in the feature-ON suite.
 //! Status PVs — the few numbers an operator can read off a target that has no
 //! shell.
 //!
@@ -84,8 +85,6 @@
 //!   computed as free + used (`osdMemUsage.c:73`); here it is
 //!   [`MemUsage::total`](epics_rtems_boot::stats::MemUsage::total), arithmetic
 //!   on the two numbers the kernel actually reported.
-
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -555,6 +554,10 @@ mod tests {
 
     /// A pusher that cannot publish says so and stops, rather than spinning
     /// through ticks that all fail the same way.
+    ///
+    /// `#[tokio::test]`, not `#[epics_test]`: the point of this test is the
+    /// ambient current-thread tokio runtime — the exact context
+    /// `block_on_sync` refuses. The census marker accounts for it.
     #[tokio::test]
     async fn a_pusher_that_cannot_publish_retires() {
         // A current-thread runtime is exactly the context `block_on_sync`

--- a/crates/epics-base-rs/tests/aao_constant_dol.rs
+++ b/crates/epics-base-rs/tests/aao_constant_dol.rs
@@ -20,8 +20,6 @@
 //! Boundaries: constant array DOL vs constant scalar DOL vs real link DOL; and
 //! closed_loop vs supervisory (C returns before the load in supervisory).
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -64,7 +62,7 @@ async fn build() -> std::sync::Arc<epics_base_rs::server::database::PvDatabase> 
 }
 
 /// The constant array is in VAL before any process, NORD = 3, UDF clear.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_array_dol_is_loaded_at_init() {
     let db = build().await;
 
@@ -82,7 +80,7 @@ async fn constant_array_dol_is_loaded_at_init() {
 
 /// A constant SCALAR DOL is a one-element load (`dbPutConvertJSON` on "7.5"
 /// yields nRequest = 1), landing in element 0 — the same rule as R15-79.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_scalar_dol_is_one_element() {
     let db = build().await;
 
@@ -95,7 +93,7 @@ async fn constant_scalar_dol_is_one_element() {
 
 /// Supervisory mode does not source VAL from DOL at all — C `fetchValue`
 /// returns on its first line (`if (prec->omsl != menuOmslclosed_loop) return 0`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn supervisory_mode_ignores_the_constant_dol() {
     let db = build().await;
 
@@ -112,7 +110,7 @@ async fn supervisory_mode_ignores_the_constant_dol() {
 
 /// The loaded constant reaches the OUT target on process, and the process
 /// cycle does not re-fetch the constant over a client caput to VAL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn loaded_constant_writes_out_and_is_not_re_fetched() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/aao_dol_read_failure_aborts.rs
+++ b/crates/epics-base-rs/tests/aao_dol_read_failure_aborts.rs
@@ -31,8 +31,6 @@
 //! Boundaries: dead DOL vs live DOL; OUT target written / not written; FLNK
 //! fired / not fired; pending alarm vs committed alarm.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -101,7 +99,7 @@ async fn process(db: &epics_base_rs::server::database::PvDatabase, rec: &str) {
 }
 
 /// The whole cycle is abandoned: no OUT write, no forward link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn dead_dol_writes_nothing_out_and_does_not_fire_flnk() {
     let db = build().await;
     // A value a client left in the aao — the stale VAL C refuses to write out.
@@ -130,7 +128,7 @@ async fn dead_dol_writes_nothing_out_and_does_not_fire_flnk() {
 /// `dbGetLink` raised LINK/INVALID, but the abort skipped `monitor` — so
 /// `recGblResetAlarms` never ran and the alarm is still PENDING (nsta/nsev),
 /// not committed to STAT/SEVR.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn dead_dol_raises_a_pending_link_alarm() {
     let db = build().await;
     process(&db, "AAO:DEAD").await;
@@ -163,7 +161,7 @@ async fn dead_dol_raises_a_pending_link_alarm() {
 
 /// The contrast case: a live DOL fetch runs the full cycle — VAL from DOL, OUT
 /// written, FLNK fired.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn live_dol_completes_the_cycle() {
     let db = build().await;
     db.put_pv("FLNK:SRC", EpicsValue::DoubleArray(vec![42.0]))
@@ -191,7 +189,7 @@ async fn live_dol_completes_the_cycle() {
 
 /// The abort is per-cycle state, not sticky: once the DOL source exists, the
 /// next cycle completes normally.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn cycle_resumes_when_the_dol_source_returns() {
     let db = build().await;
     process(&db, "AAO:DEAD").await;

--- a/crates/epics-base-rs/tests/acalcout_amask_posts_on_write.rs
+++ b/crates/epics-base-rs/tests/acalcout_amask_posts_on_write.rs
@@ -22,8 +22,6 @@
 //! array this cycle", which is what an aCalcout-driven waveform client waits on;
 //! a second identical process must therefore not go silent.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -55,7 +53,7 @@ async fn acalcout(db: &PvDatabase, name: &str, calc: &str) {
 /// process. The second process changes nothing, so the framework's change
 /// detection posted nothing — but AMASK bit 0 is set on that cycle too, and C
 /// posts AA from the bit alone.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c5_a_stored_array_posts_even_when_the_value_did_not_change() {
     let db = PvDatabase::new();
     acalcout(&db, "P1", "AA:=BB*2;SUM(AA)").await;
@@ -100,7 +98,7 @@ async fn r11_c5_a_stored_array_posts_even_when_the_value_did_not_change() {
 /// The mask is per-cycle, not sticky: an expression that stores nothing leaves
 /// AMASK 0 (`aCalcPerform.c:326` zeroes it at entry), so the write-gated post
 /// must stop with it. Without this the fix would post AA forever after one store.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c5_an_array_that_was_not_stored_this_cycle_does_not_post() {
     let db = PvDatabase::new();
     acalcout(&db, "P2", "AA:=BB*2;SUM(AA)").await;
@@ -143,7 +141,7 @@ async fn r11_c5_an_array_that_was_not_stored_this_cycle_does_not_post() {
 
 /// Only the flagged arrays post. `CC := AA` sets bit 2; BB (bit 1) is read, not
 /// written, and must stay silent.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c5_only_the_flagged_arrays_post() {
     let db = PvDatabase::new();
     acalcout(&db, "P3", "CC:=BB;SUM(CC)").await;

--- a/crates/epics-base-rs/tests/acalcout_array_input_links.rs
+++ b/crates/epics-base-rs/tests/acalcout_array_input_links.rs
@@ -15,8 +15,6 @@
 //!     destination: `dbGetLink(..., DBR_DOUBLE, pvalue, 0, 0)`)
 //!   * scalar source -> scalar field, unchanged (negative control)
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -47,7 +45,7 @@ async fn wf_source(db: &PvDatabase, name: &str, data: Vec<f64>) {
 
 /// INAA -> a 5-element waveform, CALC="SUM(AA)". Compiled C (aCalcPerform,
 /// arraySize 5, AA=[1..5]): dresult=15.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_61_array_input_link_populates_aa() {
     let db = PvDatabase::new();
     wf_source(&db, "WF", vec![1.0, 2.0, 3.0, 4.0, 5.0]).await;
@@ -73,7 +71,7 @@ async fn r11_61_array_input_link_populates_aa() {
 
 /// A source shorter than the record's element count zero-fills the tail
 /// (C: `for (j=nRequest; j<numElements; j++) (*pavalue)[j] = 0;`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_61_short_array_source_zero_fills_the_tail() {
     let db = PvDatabase::new();
     wf_source(&db, "WF2", vec![7.0, 8.0]).await;
@@ -98,7 +96,7 @@ async fn r11_61_short_array_source_zero_fills_the_tail() {
 
 /// An array source feeding a SCALAR value field is a one-element destination in
 /// C — it takes element 0, not nothing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_61_array_source_into_scalar_field_takes_element_zero() {
     let db = PvDatabase::new();
     wf_source(&db, "WF3", vec![4.0, 99.0, 99.0]).await;
@@ -115,7 +113,7 @@ async fn r11_61_array_source_into_scalar_field_takes_element_zero() {
 }
 
 /// Negative control: a scalar source still lands as a scalar Double.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_61_scalar_source_unchanged() {
     let db = PvDatabase::new();
     db.add_record(

--- a/crates/epics-base-rs/tests/acalcout_array_post_masks.rs
+++ b/crates/epics-base-rs/tests/acalcout_array_post_masks.rs
@@ -32,8 +32,6 @@
 //! DBE_LOG`: one event instead of two, and the AMASK event carrying an alarm bit
 //! C never puts on it.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -88,7 +86,7 @@ async fn subscribe_aa(db: &PvDatabase) -> epics_base_rs::server::event_queue::Ev
 /// AA is in BOTH masks: the link delivered a changed array (NEWM bit 0) and the
 /// expression stored into it (AMASK bit 0). C posts it twice — `afterCalc` with
 /// a literal DBE_VALUE|DBE_LOG, then `monitor()` with the alarm bit folded in.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_a5_an_array_in_both_masks_is_posted_twice_with_the_two_c_masks() {
     let db = PvDatabase::new();
     // `AA := AA + 0` stores AA (AMASK bit 0) without altering the fetched value.
@@ -129,7 +127,7 @@ async fn w10_a5_an_array_in_both_masks_is_posted_twice_with_the_two_c_masks() {
 
 /// The AMASK half alone: the expression stores into CC, no link feeds it. Even on
 /// an alarm-transition cycle the post carries no alarm bit.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_a5_an_amask_only_array_posts_a_literal_value_log() {
     let db = PvDatabase::new();
     acalcout_with(&db, "CC:=AA+0;SUM(AA)").await;

--- a/crates/epics-base-rs/tests/acalcout_arrays_never_post_on_change.rs
+++ b/crates/epics-base-rs/tests/acalcout_arrays_never_post_on_change.rs
@@ -30,8 +30,6 @@
 //! process — storing nothing into AA, fetching nothing into it — emitted a post
 //! C never makes.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -50,7 +48,7 @@ async fn process(db: &PvDatabase, rec: &str) {
 /// CC is written by nobody: no expression stores into it (AMASK bit clear) and
 /// no INCC link feeds it (NEWM bit clear). A caput moves it; the next process
 /// must stay silent on CC.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_a6_a_caput_array_is_not_reposted_by_the_next_process() {
     let db = PvDatabase::new();
     let mut a = AcalcoutRecord::new();

--- a/crates/epics-base-rs/tests/acalcout_ivov_severity_gate.rs
+++ b/crates/epics-base-rs/tests/acalcout_ivov_severity_gate.rs
@@ -17,8 +17,6 @@
 //! IVOA=Set_output_to_IVOV. Severity is the framework's — the record may not
 //! re-derive it from a private flag.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -67,7 +65,7 @@ impl Record for OutProbe {
 
 /// A LIMIT alarm at INVALID severity — no calc failure anywhere — must still
 /// take C's IVOA=Set_output_to_IVOV arm.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c15_a_limit_driven_invalid_still_substitutes_ivov() {
     let db = PvDatabase::new();
 
@@ -129,7 +127,7 @@ async fn r11_c15_a_limit_driven_invalid_still_substitutes_ivov() {
 /// The output decision remains the record's: OOPT=Never means C never reaches
 /// `execOutput`, so the IVOV substitution must not run either (VAL/AVAL keep the
 /// calculated value and nothing is written to OUT).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c15_a_non_outputting_cycle_does_not_substitute_ivov() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/acalcout_newm_input_change.rs
+++ b/crates/epics-base-rs/tests/acalcout_newm_input_change.rs
@@ -25,8 +25,6 @@
 //! zeroes it. It is NOT the same mask — AMASK is the arrays the EXPRESSION stored
 //! into (`aCalcPerform.c:487`), NEWM the arrays the LINK changed.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -70,7 +68,7 @@ async fn wf_into_aa(db: &PvDatabase, data: Vec<f64>) {
 /// field = the caput value) differs from the fetched value, so NEWM bit 0 is set
 /// and `monitor()` posts AA. Change detection alone sees the same value it last
 /// posted and says nothing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c4_a_link_that_reverts_a_caput_still_posts_aa() {
     let db = PvDatabase::new();
     wf_into_aa(&db, vec![1.0, 2.0, 3.0, 4.0]).await;
@@ -128,7 +126,7 @@ async fn r11_c4_a_link_that_reverts_a_caput_still_posts_aa() {
 /// NEWM is per-cycle: `monitor()` zeroes it (`:1036`). A cycle whose link delivers
 /// nothing new must not re-post — this is the control that the mask is taken, not
 /// accumulated.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c4_an_unchanged_link_value_does_not_post_aa() {
     let db = PvDatabase::new();
     wf_into_aa(&db, vec![1.0, 2.0, 3.0, 4.0]).await;
@@ -165,7 +163,7 @@ async fn r11_c4_an_unchanged_link_value_does_not_post_aa() {
 /// NEWM tracks the LINK, not the client. A caput to AA sets no NEWM bit — C only
 /// ever writes `newm` in `fetch_values`. (The put posts on its own path; what must
 /// not happen is the next process cycle re-posting it from a NEWM bit.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c4_a_caput_alone_sets_no_newm_bit() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/acalcout_nuse_clamp.rs
+++ b/crates/epics-base-rs/tests/acalcout_nuse_clamp.rs
@@ -26,8 +26,6 @@
 //! Boundaries: NUSE < NELM (nothing happens), NUSE == NELM (the edge: not
 //! illegal), NUSE > NELM through each of C's three sites.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::EventMask;
 use epics_base_rs::server::record::Record;
@@ -64,7 +62,7 @@ async fn process(db: &PvDatabase) {
 /// *"Make sure.  Autosave is capable of setting NUSE to an illegal value."*
 /// Here the field store is written directly, exactly as a restore does, and the
 /// next cycle must repair AND post it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_process_time_clamp_posts_the_corrected_nuse() {
     let db = acalcout_db(4, 2).await;
     assert_eq!(nuse(&db).await, 2, "legal at init");
@@ -92,7 +90,7 @@ async fn the_process_time_clamp_posts_the_corrected_nuse() {
 /// `special(NUSE)` — C clamps, posts a bare `DBE_VALUE`, and returns -1, so the
 /// PUT FAILS. The client is told its value was illegal instead of the record
 /// silently rewriting it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_of_an_illegal_nuse_is_refused_and_the_clamped_value_is_posted() {
     let db = acalcout_db(4, 0).await;
 
@@ -113,7 +111,7 @@ async fn a_put_of_an_illegal_nuse_is_refused_and_the_clamped_value_is_posted() {
 }
 
 /// A LEGAL put is unaffected — the refusal is not a blanket rejection of NUSE.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_legal_nuse_put_succeeds() {
     let db = acalcout_db(10, 0).await;
 
@@ -124,7 +122,7 @@ async fn a_legal_nuse_put_succeeds() {
 }
 
 /// The edge: `NUSE == NELM` is NOT illegal — C's test is `>`, not `>=`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nuse_equal_to_nelm_is_legal() {
     let db = acalcout_db(4, 0).await;
 
@@ -140,7 +138,7 @@ async fn nuse_equal_to_nelm_is_legal() {
 /// verbatim and `init_record` clamps once, against the FINAL nelm. Clamping in
 /// the store instead measured NUSE against the default NELM of 1 and silently
 /// turned 5 into 1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nuse_listed_before_nelm_survives_the_load() {
     let db = acalcout_db(10, 5).await; // the helper puts NELM first, so do it by hand
     assert_eq!(nuse(&db).await, 5);

--- a/crates/epics-base-rs/tests/acalcout_odly_holds_pact.rs
+++ b/crates/epics-base-rs/tests/acalcout_odly_holds_pact.rs
@@ -14,8 +14,6 @@
 //! carries a `ReprocessAfter`) — so a foreign `dbProcess` during the delay
 //! bails at the PACT entry guard instead of firing the deferred OUT early.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -64,7 +62,7 @@ impl Record for OutProbe {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_odly_holds_pact_foreign_process_does_not_fire_early() {
     let db = PvDatabase::new();
 
@@ -148,7 +146,7 @@ async fn acalcout_odly_holds_pact_foreign_process_does_not_fire_early() {
 /// (C `aCalcoutRecord.c` execOutput line 924, reached on the continuation at
 /// line 428), NOT on the delaying cycle. A direct get of VAL during the ODLY
 /// window must still show the calc-fail value, not IVOV.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_odly_ivov_substitutes_on_continuation_not_delaying_cycle() {
     let db = PvDatabase::new();
 
@@ -234,7 +232,7 @@ async fn acalcout_odly_ivov_substitutes_on_continuation_not_delaying_cycle() {
 /// the OUT write. So with Don't_drive + OOPT-fires + ODLY>0 the record still
 /// pulses DLYA and holds PACT across the delay; the OUT write simply never
 /// fires (delaying cycle or continuation).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_odly_dont_drive_still_defers() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/acalcout_out_target_nelm_buffer.rs
+++ b/crates/epics-base-rs/tests/acalcout_out_target_nelm_buffer.rs
@@ -24,8 +24,6 @@
 //! - external target, metadata count > 1    → array buffer
 //! - external target, no metadata (C failed dbCaGetNelements) → scalar
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
@@ -172,7 +170,7 @@ async fn process(db: &PvDatabase, name: &str) {
 
 /// Scalar local target, DOPT=Use OCAL: effective nelm 1 → `&pcalc->oval`
 /// (devaCalcoutSoft.c:87) → the target receives IVOV, not the stale OAV[0].
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ivov_reaches_a_scalar_target_under_use_ocal() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -194,7 +192,7 @@ async fn ivov_reaches_a_scalar_target_under_use_ocal() {
 
 /// Array local target, DOPT=Use OCAL: effective nelm > 1 → `pcalc->oav`
 /// — IVOV touched only OVAL, so the target receives the STALE OAV.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ivov_bypasses_an_array_target_under_use_ocal() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -216,7 +214,7 @@ async fn ivov_bypasses_an_array_target_under_use_ocal() {
 
 /// DOPT=Use VAL: the buffer is `&val`/`aval`, which IVOV never touches —
 /// C's substitution is a no-op and the computed value is driven.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ivov_is_a_no_op_under_use_val() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -239,7 +237,7 @@ async fn ivov_is_a_no_op_under_use_val() {
 /// 1-element SOURCE (NELM=1), array target: C's clamp
 /// `i = (nuse>0 ? nuse : nelm) = 1` forces nelm to 1 ⇒ `&oval` ⇒ the
 /// array target still receives the scalar buffer, i.e. IVOV.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_single_element_source_picks_the_scalar_buffer() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -261,7 +259,7 @@ async fn a_single_element_source_picks_the_scalar_buffer() {
 
 /// External target reporting element_count=3 (`dbCaGetNelements`
 /// succeeded): array buffer — the stale OAV reaches the lset put.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_external_array_target_gets_the_array_buffer() {
     let db = PvDatabase::new();
     let last_put = Arc::new(Mutex::new(None));
@@ -288,7 +286,7 @@ async fn an_external_array_target_gets_the_array_buffer() {
 
 /// External target with NO metadata — C's `dbCaGetNelements` fails and
 /// `nelm` keeps its initializer 1 (devaCalcoutSoft.c:68) ⇒ scalar buffer.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_unresolved_external_target_defaults_to_the_scalar_buffer() {
     let db = PvDatabase::new();
     let last_put = Arc::new(Mutex::new(None));

--- a/crates/epics-base-rs/tests/acalcout_store_backs.rs
+++ b/crates/epics-base-rs/tests/acalcout_store_backs.rs
@@ -13,8 +13,6 @@
 //! Every expectation below is the output of a driver compiled from
 //! `/home/stevek/work/epics-modules/calc/calcApp/src/{aCalcPerform,aCalcPostfix,calcUtil}.c`.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -51,7 +49,7 @@ async fn acalcout(db: &PvDatabase, name: &str, calc: &str) {
 
 /// Compiled C, arraySize 4, AA=[9,9,9,9], BB=[1,2,3,4], `AA:=BB*2;SUM(AA)`:
 ///   status=0 amask=0x1 dresult=20 AA=[2,4,6,8]
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_9_array_store_writes_the_record_field_and_sets_amask() {
     let db = PvDatabase::new();
     acalcout(&db, "S1", "AA:=BB*2;SUM(AA)").await;
@@ -75,7 +73,7 @@ async fn r11_9_array_store_writes_the_record_field_and_sets_amask() {
 /// (`aCalcPerform.c:485`, `pd[j] = ps->d`) — it is not `toArray`'d and it does not
 /// go to the scalar variable of the same letter. Compiled C, `AA:=5;SUM(AA)`:
 /// AA=[5,5,5,5], dresult=20, amask=0x1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_9_a_scalar_stored_into_an_array_variable_is_broadcast() {
     let db = PvDatabase::new();
     acalcout(&db, "S2", "AA:=5;SUM(AA)").await;
@@ -96,7 +94,7 @@ async fn r11_9_a_scalar_stored_into_an_array_variable_is_broadcast() {
 }
 
 /// Two array stores set two bits. Compiled C, `CC:=AA;DD:=BB;0`: amask=0xc.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_9_amask_carries_one_bit_per_stored_array() {
     let db = PvDatabase::new();
     acalcout(&db, "S3", "CC:=AA;DD:=BB;0").await;
@@ -122,7 +120,7 @@ async fn r11_9_amask_carries_one_bit_per_stored_array() {
 /// C zeroes `*amask` at the top of every aCalcPerform (`:326`), and the pointer it
 /// is handed IS the record's field. So an expression that stores nothing leaves
 /// AMASK 0 — even right after a process that set it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_9_amask_is_reset_each_process_not_accumulated() {
     let db = PvDatabase::new();
     acalcout(&db, "S4", "AA:=BB*2;SUM(AA)").await;
@@ -151,7 +149,7 @@ async fn r11_9_amask_is_reset_each_process_not_accumulated() {
 /// A scalar store writes A..L and does NOT touch AMASK — the mask is about ARRAY
 /// fields only (C sets it in `STORE_AA..LL` and `A_ASTORE`, never in `STORE_A..P`).
 /// Compiled C, `A:=SUM(BB);A`: dresult=10, A=10, amask=0x0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_9_scalar_store_writes_the_field_but_not_amask() {
     let db = PvDatabase::new();
     acalcout(&db, "S5", "A:=SUM(BB);A").await;
@@ -173,7 +171,7 @@ async fn r11_9_scalar_store_writes_the_field_but_not_amask() {
 ///
 /// `AA:=BB*2;SQRT(CC-1)` — CC is all zeros, so every element of `CC-1` is negative
 /// and the ARRAY SQRT domain guard sets status -1 (`:775-812`), after AA is written.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_9_stores_survive_a_failing_expression() {
     let db = PvDatabase::new();
     acalcout(&db, "S6", "AA:=BB*2;SQRT(CC-1)").await;

--- a/crates/epics-base-rs/tests/add_record_runs_init_passes.rs
+++ b/crates/epics-base-rs/tests/add_record_runs_init_passes.rs
@@ -22,8 +22,6 @@
 //! `recGblResetAlarms` does. That is what makes an `MS` consumer inherit
 //! INVALID from a source that has not processed yet.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::alarm_status;
 use epics_base_rs::server::record::{AlarmSeverity, Record};
@@ -35,7 +33,7 @@ use epics_base_rs::types::EpicsValue;
 
 /// The `doInitRecord0` prologue: a record born UDF=1/STAT=UDF advertises the
 /// UDFS severity from creation, on the programmatic path too.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn add_record_runs_the_init_udf_prologue() {
     let db = PvDatabase::new();
     db.add_record("AI", Box::new(AiRecord::new(0.0)))
@@ -57,7 +55,7 @@ async fn add_record_runs_the_init_udf_prologue() {
 /// CALC_ERR_NULL_ARG → -1), so a default `calcout` inits with CLCV = -1 and a
 /// compiled one with 0. A record created through `add_record` never ran the
 /// pass, so both came up 0 — "healthy" for an expression C calls invalid.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn add_record_runs_init_record_pass_zero() {
     let db = PvDatabase::new();
     db.add_record("CO_EMPTY", Box::new(CalcoutRecord::default()))
@@ -84,7 +82,7 @@ async fn add_record_runs_init_record_pass_zero() {
 
 /// The post-init UDF tail (R17-66's owner) rides along: it is part of the same
 /// passes, so `add_record` gets it too.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn add_record_runs_the_post_init_udf_tail() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/array_nord_at_init.rs
+++ b/crates/epics-base-rs/tests/array_nord_at_init.rs
@@ -41,8 +41,6 @@
 //! (NELM == 1 / NELM > 1) — the two axes that decide which of the three rules
 //! above is the one that answers.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -95,7 +93,7 @@ record(subArray,"S:CONST") { field(FTVL,"DOUBLE") field(MALM,"5") field(NELM,"2"
 
 /// Every row of the measured table, in one pass over one loaded database — the
 /// same `.db` the softIoc was given.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r21_nord_at_init_matches_the_soft_dset() {
     let db = db_of(DB).await;
 
@@ -133,7 +131,7 @@ async fn r21_nord_at_init_matches_the_soft_dset() {
 /// The NELM=1 seed is the thing the three dsets disagree about, so it gets its
 /// own case: same NELM, same (absent) link, three different answers, and each
 /// answer is its dset's.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r21_the_nelm_one_seed_survives_only_on_aai() {
     let db = db_of(DB).await;
     assert_eq!(nord_udf(&db, "W:BARE").await.0, 0, "devWfSoft zeroes it");

--- a/crates/epics-base-rs/tests/array_put_posts_nord.rs
+++ b/crates/epics-base-rs/tests/array_put_posts_nord.rs
@@ -39,8 +39,6 @@
 //! field's own `dbPut` post and the next scan is ten seconds away. NORD is the
 //! only thing the subscriber hears — which is exactly why losing it matters.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::event_queue::EventReader;
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -83,7 +81,7 @@ fn drain(rx: &mut EventReader) -> Vec<EpicsValue> {
 
 /// The finding's own probe: a `caput -a` of three elements onto an
 /// unprocessed waveform must post NORD = 3 to a NORD subscriber.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_ca_array_put_posts_nord() {
     let db = build().await;
 
@@ -104,7 +102,7 @@ async fn a_ca_array_put_posts_nord() {
 
 /// subArray's NORD is DBF_LONG, and its VAL put is the INP-driven slice, so it
 /// gets its own case rather than riding the loop above.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_ca_array_put_posts_nord_on_subarray() {
     let db = build().await;
     let mut rx = nord_sub(&db, "SS").await;
@@ -119,7 +117,7 @@ async fn a_ca_array_put_posts_nord_on_subarray() {
 /// The other silent route: `put_pv` is the `dbPutLink` `dbPut`. An OUT link
 /// that lands an array on a waveform posts NORD in C even when the link is NPP
 /// and the target never processes.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_db_link_write_posts_nord() {
     let db = build().await;
     let mut rx = nord_sub(&db, "WL").await;
@@ -138,7 +136,7 @@ async fn a_db_link_write_posts_nord() {
 /// The `if (nord != prec->nord)` half of the C source: an array put that does
 /// not move NORD posts nothing. Without this the fix would turn every put into
 /// a NORD event and flood the subscriber it is meant to serve.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_that_does_not_move_nord_posts_nothing() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/array_record_constant_input_link.rs
+++ b/crates/epics-base-rs/tests/array_record_constant_input_link.rs
@@ -23,8 +23,6 @@
 //! Boundaries: constant array INP vs unset INP vs real DB INP; before-first-
 //! process vs after; NORD and UDF on each.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -79,7 +77,7 @@ async fn process(db: &epics_base_rs::server::database::PvDatabase, rec: &str) {
 
 /// The constant array is in VAL before any process, with NORD = element count
 /// and UDF clear (C `dbLoadLinkArray` -> `nord = nRequest; udf = FALSE`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_array_inp_is_loaded_at_init() {
     let db = build().await;
 
@@ -103,7 +101,7 @@ async fn constant_array_inp_is_loaded_at_init() {
 }
 
 /// Process must not re-apply the constant over data a client put into VAL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_inp_is_not_re_applied_at_process() {
     let db = build().await;
 
@@ -128,7 +126,7 @@ async fn constant_inp_is_not_re_applied_at_process() {
 /// The common case: an UNSET INP is a constant link (`dbLink.c:220`), so a
 /// device-fed / client-fed array record keeps the data it was given across
 /// scans. This is the case the pre-fix port wiped on every process.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unset_inp_does_not_wipe_client_data() {
     let db = build().await;
 
@@ -146,7 +144,7 @@ async fn unset_inp_does_not_wipe_client_data() {
 }
 
 /// A REAL input link is unaffected: it still reads its source every cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn real_db_inp_still_reads_every_cycle() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/array_record_count_field_types.rs
+++ b/crates/epics-base-rs/tests/array_record_count_field_types.rs
@@ -36,8 +36,6 @@
 //! HG.MDEL  DBF_SHORT      HG.MCNT  DBF_SHORT
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::{DbFieldType, EpicsValue};
@@ -70,7 +68,7 @@ async fn field(db: &PvDatabase, pv: &str) -> EpicsValue {
 
 /// The unsigned-long family: every count / index / offset field on
 /// waveform, aai, aao, subArray and compress.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_count_fields_are_unsigned_long() {
     let db = build().await;
 
@@ -88,7 +86,7 @@ async fn the_count_fields_are_unsigned_long() {
 
 /// The two that are genuinely signed. A blanket "make the counters unsigned"
 /// sweep would have broken these; the dbd distinguishes them.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn subarray_nord_and_compress_inpn_stay_signed_long() {
     let db = build().await;
 
@@ -102,7 +100,7 @@ async fn subarray_nord_and_compress_inpn_stay_signed_long() {
 }
 
 /// histogram's counters are the 16-bit pair, and NELM is the unsigned one.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn histogram_nelm_is_ushort_and_mdel_mcnt_are_short() {
     let db = build().await;
 
@@ -123,7 +121,7 @@ async fn histogram_nelm_is_ushort_and_mdel_mcnt_are_short() {
 /// The point of the declaration: it is what each wire projects the native
 /// type from. This pins the CA half against the `cainfo` transcript above —
 /// DBF_ULONG promotes to DBR_DOUBLE, DBF_USHORT to DBR_LONG, DBF_SHORT stays.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_ca_native_type_matches_the_compiled_ioc() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/array_record_db_load_fields.rs
+++ b/crates/epics-base-rs/tests/array_record_db_load_fields.rs
@@ -16,8 +16,6 @@
 //! framework's async-simulation delay (`processing.rs` reads it through
 //! `get_field("SDLY")`, defaulting an absent field to -1.0 = synchronous).
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -115,7 +113,7 @@ async fn assert_sim_block_loaded(db: &PvDatabase, rec: &str) {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn aai_db_load_carries_sim_and_post_fields() {
     let (db, _) = IocBuilder::new()
         .db_string(DB, &std::collections::HashMap::new())
@@ -126,7 +124,7 @@ async fn aai_db_load_carries_sim_and_post_fields() {
     assert_sim_block_loaded(&db, "ARR:AAI").await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn aao_db_load_carries_sim_and_post_fields() {
     let (db, _) = IocBuilder::new()
         .db_string(DB, &std::collections::HashMap::new())
@@ -137,7 +135,7 @@ async fn aao_db_load_carries_sim_and_post_fields() {
     assert_sim_block_loaded(&db, "ARR:AAO").await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn waveform_db_load_carries_sim_and_post_fields() {
     let (db, _) = IocBuilder::new()
         .db_string(DB, &std::collections::HashMap::new())
@@ -152,7 +150,7 @@ async fn waveform_db_load_carries_sim_and_post_fields() {
 /// branch: with `SIMM=YES` and `SDLY >= 0`, C's `readValue` arms the delayed
 /// callback and holds PACT (`aaiRecord.c:365-374`), so the SIOL value lands
 /// only AFTER the delay — not within the first process call.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn loaded_sdly_defers_the_simulated_aai_read() {
     let (db, _) = IocBuilder::new()
         .db_string(DB, &std::collections::HashMap::new())
@@ -184,7 +182,7 @@ async fn loaded_sdly_defers_the_simulated_aai_read() {
 
     // After the delay the deferred continuation lands the SIOL array.
     for _ in 0..200 {
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(10)).await;
         if field(&db, "ARR:AAI").await == EpicsValue::DoubleArray(vec![10.0, 20.0, 30.0]) {
             return;
         }

--- a/crates/epics-base-rs/tests/array_record_nelm1_nord_seed.rs
+++ b/crates/epics-base-rs/tests/array_record_nelm1_nord_seed.rs
@@ -26,8 +26,6 @@
 //! The full link-shape table is `tests/array_nord_at_init.rs`; this file keeps
 //! the NELM boundary (NELM==1 vs NELM>1) per kind, with no record processed.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -80,7 +78,7 @@ async fn nord(db: &PvDatabase, rec: &str) -> f64 {
 
 /// `aai` is the one kind whose dset leaves the seed alone: its single element IS
 /// the value, and a client reads it before the first process.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nelm1_seeds_nord1_on_aai_and_serves_one_element() {
     let db = build().await;
     assert_eq!(nord(&db, "N1:AAI").await, 1.0, "devAaiSoft keeps the seed");
@@ -94,7 +92,7 @@ async fn nelm1_seeds_nord1_on_aai_and_serves_one_element() {
 /// waveform and aao: the seed does not survive their dsets, so a NELM=1 record
 /// serves a zero-length array until something loads elements into it — exactly
 /// what C serves.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nelm1_keeps_nord_zero_on_waveform_and_aao() {
     let db = build().await;
     for rec in ["N1:WF", "N1:AAO"] {
@@ -111,7 +109,7 @@ async fn nelm1_keeps_nord_zero_on_waveform_and_aao() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nelm_above_one_keeps_nord_zero() {
     let db = build().await;
     for rec in ["N8:WF", "N8:AAI", "N8:AAO"] {
@@ -126,7 +124,7 @@ async fn nelm_above_one_keeps_nord_zero() {
 
 /// subArray has no NELM==1 seed in C (`subArrayRecord.c:101` sets NORD=0
 /// unconditionally) — its NORD comes from the INP slice.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn subarray_nelm1_keeps_nord_zero() {
     let db = build().await;
     assert_eq!(

--- a/crates/epics-base-rs/tests/array_record_scalar_source_into_val.rs
+++ b/crates/epics-base-rs/tests/array_record_scalar_source_into_val.rs
@@ -15,8 +15,6 @@
 //! (link path), On-Change hash across successive scalar updates, and the OUT
 //! target's received type.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -88,7 +86,7 @@ fn onchange_hash_moves_across_scalar_updates() {
 /// End-to-end: `DOL="SETPOINT"` on a closed-loop aao (a scalar ao feeding an
 /// array output). VAL must become a one-element DoubleArray in the NELM
 /// buffer, and the OUT target must receive an ARRAY.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn closed_loop_scalar_dol_feeds_an_array_out_target() {
     const DB: &str = r#"
 record(ao, "SETPOINT") {

--- a/crates/epics-base-rs/tests/array_record_udf.rs
+++ b/crates/epics-base-rs/tests/array_record_udf.rs
@@ -26,8 +26,6 @@
 //! Boundaries: SIOL read failed vs succeeded; UDF set vs UDF alarm raised; the
 //! three unconditional kinds vs subArray.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -60,7 +58,7 @@ record(waveform, "SIM:WF") {
 
 /// A failed SIOL read must still clear UDF, and must not raise any alarm from
 /// UDF (SIMM_ALARM at SIMS=NO_ALARM is the only thing C raises here).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn failed_sim_read_still_clears_udf_on_the_array_kinds() {
     let (db, _) = IocBuilder::new()
         .db_string(DB, &std::collections::HashMap::new())
@@ -128,7 +126,7 @@ fn subarray_keeps_the_status_gated_udf_rules() {
 /// process-time raise that `waveformRecord.c` never calls — is what this record
 /// type genuinely lacks. softIoc, `record(waveform,"UDFWF")` with no INP, never
 /// processed: `STAT=UDF SEVR=INVALID UDF=1`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_undefined_waveform_carries_the_initial_udf_severity() {
     let (db, _) = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/asub_output_links.rs
+++ b/crates/epics-base-rs/tests/asub_output_links.rs
@@ -20,8 +20,6 @@
 //! The port stored OUTA..OUTU and never wrote them: a subroutine's results
 //! reached VALA..VALU (and their CA monitors) but no downstream record.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -95,7 +93,7 @@ async fn asub_db(status: i64) -> PvDatabase {
 }
 
 /// do_sub returns 0 — every configured OUT link is pushed, first to last.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_78_successful_do_sub_pushes_every_output_link() {
     let db = asub_db(0).await;
 
@@ -120,7 +118,7 @@ async fn r9_78_successful_do_sub_pushes_every_output_link() {
 
 /// do_sub returned non-zero — C's `if (!status)` skips the whole push loop, so
 /// no OUT link is written even though VALA..VALU hold fresh values.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_78_failed_do_sub_pushes_nothing() {
     let db = asub_db(3).await;
 
@@ -145,7 +143,7 @@ async fn r9_78_failed_do_sub_pushes_nothing() {
 
 /// A failed INPUT link aborts fetch_values, C's `status` stays non-zero, do_sub
 /// never runs — and the push loop is skipped with it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_78_failed_input_fetch_pushes_nothing() {
     let db = asub_db(0).await;
     {
@@ -172,7 +170,7 @@ async fn r9_78_failed_input_fetch_pushes_nothing() {
 /// link: a subroutine-less aSub with a preset VALA and a wired OUTA drives its
 /// sink. (The real `S_db_BadSub` case is a NON-empty, unregistered SNAM; that
 /// non-zero-status suppression is covered by `r9_78_failed_do_sub_pushes_nothing`.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_78_empty_snam_pushes_output_links() {
     let db = PvDatabase::new();
     db.add_record("SINK_A", Box::new(AiRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/autosave_backup.rs
+++ b/crates/epics-base-rs/tests/autosave_backup.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
 use std::time::Duration;
 
 use epics_base_rs::server::autosave::backup::{
@@ -15,7 +13,7 @@ fn make_entry(name: &str, val: &str) -> SaveEntry {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_savb_created() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");
@@ -42,7 +40,7 @@ async fn test_savb_created() {
     assert!(savb_path.exists());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_rotation() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");
@@ -61,7 +59,7 @@ async fn test_seq_rotation() {
         write_save_file(&sav_path, &[make_entry("PV1", &i.to_string())])
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
         rotate_backups(&sav_path, &config, &mut state)
             .await
             .unwrap();
@@ -73,7 +71,7 @@ async fn test_seq_rotation() {
     assert!(sav_path.with_extension("sav2").exists());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dated_filename() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");
@@ -108,13 +106,15 @@ async fn test_dated_filename() {
     assert_eq!(entries.len(), 1);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_corrupt_sav_fallback_to_savb() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");
 
     // Write corrupt .sav (no END marker)
-    tokio::fs::write(&sav_path, "PV1 1.0\n").await.unwrap();
+    epics_base_rs::runtime::fs::write(&sav_path, "PV1 1.0\n")
+        .await
+        .unwrap();
 
     // Write valid .savB
     let savb_path = sav_path.with_extension("savB");
@@ -127,7 +127,7 @@ async fn test_corrupt_sav_fallback_to_savb() {
     assert_eq!(best.unwrap(), savb_path);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_no_sav_only_savb() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");
@@ -144,14 +144,16 @@ async fn test_no_sav_only_savb() {
     assert_eq!(best.unwrap(), savb_path);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_file_fallback() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");
 
     // Write corrupt .sav and .savB
-    tokio::fs::write(&sav_path, "PV1 1.0\n").await.unwrap();
-    tokio::fs::write(sav_path.with_extension("savB"), "PV1 1.0\n")
+    epics_base_rs::runtime::fs::write(&sav_path, "PV1 1.0\n")
+        .await
+        .unwrap();
+    epics_base_rs::runtime::fs::write(sav_path.with_extension("savB"), "PV1 1.0\n")
         .await
         .unwrap();
 
@@ -168,20 +170,22 @@ async fn test_seq_file_fallback() {
     assert_eq!(best.unwrap(), sav_path.with_extension("sav1"));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_partial_write_corrupt() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("partial.sav");
 
     // Simulate partial write (no END)
-    tokio::fs::write(&path, "PV1 1.0\nPV2 2.0\n").await.unwrap();
+    epics_base_rs::runtime::fs::write(&path, "PV1 1.0\nPV2 2.0\n")
+        .await
+        .unwrap();
 
     let config = BackupConfig::default();
     let best = find_best_save_file(&path, &config).await;
     assert!(best.is_none());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_rotate_preserves_existing() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("test.sav");

--- a/crates/epics-base-rs/tests/autosave_manager.rs
+++ b/crates/epics-base-rs/tests/autosave_manager.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -39,7 +37,7 @@ async fn setup_db() -> Arc<PvDatabase> {
     db
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_periodic_save_set() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("periodic.sav");
@@ -66,7 +64,7 @@ async fn test_periodic_save_set() {
     let handle = mgr.clone().start(db.clone());
 
     // Wait for at least one save cycle
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
     mgr.shutdown();
     let _ = handle.await;
 
@@ -76,7 +74,7 @@ async fn test_periodic_save_set() {
     assert_eq!(entries.len(), 2);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_manual_save() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("manual.sav");
@@ -102,7 +100,7 @@ async fn test_manual_save() {
     assert!(sav_path.exists());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_multiple_sets_independent() {
     let dir = tempfile::tempdir().unwrap();
     let db = setup_db().await;
@@ -139,7 +137,7 @@ async fn test_multiple_sets_independent() {
     assert!(dir.path().join("b.sav").exists());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_restore_all() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("restore_all.sav");
@@ -186,7 +184,7 @@ async fn test_restore_all() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_one_set_failure_no_impact() {
     let dir = tempfile::tempdir().unwrap();
     let db = setup_db().await;
@@ -236,7 +234,7 @@ async fn test_one_set_failure_no_impact() {
     assert_eq!(results[1].1.as_ref().unwrap().restored, 1);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_concurrent_manual_periodic_serialized() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("concurrent.sav");
@@ -265,7 +263,7 @@ async fn test_concurrent_manual_periodic_serialized() {
     // Manual saves while periodic is running
     for _ in 0..5 {
         let _ = mgr.manual_save("concurrent", &db).await;
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(10)).await;
     }
 
     mgr.shutdown();
@@ -277,7 +275,7 @@ async fn test_concurrent_manual_periodic_serialized() {
     assert_eq!(entries.len(), 1);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_shutdown_cleanup() {
     let dir = tempfile::tempdir().unwrap();
     let db = setup_db().await;
@@ -302,17 +300,17 @@ async fn test_shutdown_cleanup() {
     let mgr = Arc::new(mgr);
     let handle = mgr.clone().start(db.clone());
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     mgr.shutdown();
 
     // Should complete within a reasonable time
-    tokio::time::timeout(Duration::from_secs(2), handle)
+    epics_base_rs::runtime::task::timeout(Duration::from_secs(2), handle)
         .await
         .expect("shutdown timed out")
         .unwrap();
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_save_once_failure_updates_stats() {
     let dir = tempfile::tempdir().unwrap();
     let db = setup_db().await;
@@ -340,7 +338,7 @@ async fn test_save_once_failure_updates_stats() {
     assert_eq!(set.stats().error_count.load(Ordering::Relaxed), 1);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_empty_pv_list_noop() {
     let dir = tempfile::tempdir().unwrap();
     let sav_path = dir.path().join("empty.sav");

--- a/crates/epics-base-rs/tests/autosave_request_parsing.rs
+++ b/crates/epics-base-rs/tests/autosave_request_parsing.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::path::PathBuf;
 
 use epics_base_rs::server::autosave::error::AutosaveError;
@@ -26,7 +24,7 @@ fn test_macros_in_pv() {
     assert_eq!(entries[0].expanded_from.as_deref(), Some("$(P)temp.VAL"));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_file_include_relative_path() {
     let dir = tempfile::tempdir().unwrap();
     let sub_dir = dir.path().join("sub");
@@ -48,7 +46,7 @@ async fn test_file_include_relative_path() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_nested_include() {
     let dir = tempfile::tempdir().unwrap();
 
@@ -68,7 +66,7 @@ async fn test_nested_include() {
     assert_eq!(names, vec!["MAIN_PV", "LEVEL1_PV", "LEVEL2_PV"]);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_depth_limit() {
     let dir = tempfile::tempdir().unwrap();
 
@@ -90,7 +88,7 @@ async fn test_depth_limit() {
     ));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_circular_include() {
     let dir = tempfile::tempdir().unwrap();
 
@@ -132,7 +130,7 @@ fn test_request_entry_source_info() {
     assert_eq!(entries[2].line_no, 3);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_include_with_macros() {
     let dir = tempfile::tempdir().unwrap();
 

--- a/crates/epics-base-rs/tests/autosave_save_restore.rs
+++ b/crates/epics-base-rs/tests/autosave_save_restore.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::types::EpicsValue;
 use epics_base_rs::types::PvString;
 
@@ -8,7 +6,7 @@ use epics_base_rs::server::autosave::save_file::{
     write_save_file,
 };
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_write_read_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.sav");
@@ -52,7 +50,7 @@ async fn test_write_read_roundtrip() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_end_marker_validation() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("valid.sav");
@@ -66,26 +64,30 @@ async fn test_end_marker_validation() {
     assert!(validate_save_file(&path).await.unwrap());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_missing_end_marker_corrupt() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("corrupt.sav");
 
     // Write a file without <END>
-    tokio::fs::write(&path, "PV1 1.0\nPV2 2.0\n").await.unwrap();
+    epics_base_rs::runtime::fs::write(&path, "PV1 1.0\nPV2 2.0\n")
+        .await
+        .unwrap();
 
     assert!(!validate_save_file(&path).await.unwrap());
     let result = read_save_file(&path).await.unwrap();
     assert!(result.is_none()); // None = corrupt
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_c_autosave_array_format() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("c_array.sav");
 
     let content = "ARRAY_PV @array@ { \"1.0\" \"2.0\" \"3.0\" }\n<END>\n";
-    tokio::fs::write(&path, content).await.unwrap();
+    epics_base_rs::runtime::fs::write(&path, content)
+        .await
+        .unwrap();
 
     let entries = read_save_file(&path).await.unwrap().unwrap();
     assert_eq!(entries.len(), 1);
@@ -93,7 +95,7 @@ async fn test_c_autosave_array_format() {
     assert_eq!(entries[0].value, "[1.0,2.0,3.0]");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_string_with_special_chars() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("special.sav");
@@ -116,14 +118,16 @@ async fn test_string_with_special_chars() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_windows_line_endings() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("windows.sav");
 
     // Write with \r\n
     let content = "# header\r\nPV1 42\r\nPV2 3.14\r\n<END>\r\n";
-    tokio::fs::write(&path, content).await.unwrap();
+    epics_base_rs::runtime::fs::write(&path, content)
+        .await
+        .unwrap();
 
     let entries = read_save_file(&path).await.unwrap().unwrap();
     assert_eq!(entries.len(), 2);
@@ -131,20 +135,22 @@ async fn test_windows_line_endings() {
     assert_eq!(entries[0].value, "42");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_multiple_header_lines() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("multi_header.sav");
 
     let content = "# autosave V1\n# extra header\n# another\nPV1 1.0\n<END>\n";
-    tokio::fs::write(&path, content).await.unwrap();
+    epics_base_rs::runtime::fs::write(&path, content)
+        .await
+        .unwrap();
 
     let entries = read_save_file(&path).await.unwrap().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].pv_name, "PV1");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_disconnected_pv_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("disconnected.sav");

--- a/crates/epics-base-rs/tests/autosave_verify.rs
+++ b/crates/epics-base-rs/tests/autosave_verify.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::records::ao::AoRecord;
 
@@ -20,7 +18,7 @@ async fn setup_db() -> PvDatabase {
     db
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_verify_all_match() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("match.sav");
@@ -50,7 +48,7 @@ async fn test_verify_all_match() {
     assert!(matches!(results[1].result, MatchResult::Match));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_verify_mismatch() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("mismatch.sav");
@@ -72,7 +70,7 @@ async fn test_verify_mismatch() {
     assert!(matches!(results[0].result, MatchResult::Mismatch { .. }));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_verify_pv_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("notfound.sav");
@@ -94,7 +92,7 @@ async fn test_verify_pv_not_found() {
     assert!(matches!(results[0].result, MatchResult::PvNotFound));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_verify_report_format() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("report.sav");

--- a/crates/epics-base-rs/tests/bpt_linr_converts_like_c.rs
+++ b/crates/epics-base-rs/tests/bpt_linr_converts_like_c.rs
@@ -32,8 +32,6 @@
 //! dbgf T:A.STAT  DBF_STRING:  "SOFT"
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -76,7 +74,7 @@ record(ai, "AI:BPT") {{
 /// value inside the first fitted segment, one deep in the middle, one past the
 /// last breakpoint (C extrapolates on the final slope rather than clamping), and
 /// one on a second table so a single hard-coded table cannot pass.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_standard_linr_converts_to_the_value_the_c_ioc_produces() {
     // (LINR, RVAL, VAL measured on the C softIoc)
     let cases: [(&str, i32, f64); 4] = [
@@ -100,7 +98,7 @@ async fn a_standard_linr_converts_to_the_value_the_c_ioc_produces() {
 /// no table — and the conversion fails rather than inventing one, exactly as C's
 /// `dbFindBrkTable` returning NULL does. Only `typeJ*`/`typeK*` have data, in C
 /// and here.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_menu_convert_name_with_no_shipped_data_still_has_no_table() {
     use epics_base_rs::server::cvt_bpt::BreakTableRegistry;
 
@@ -142,7 +140,7 @@ async fn a_menu_convert_name_with_no_shipped_data_still_has_no_table() {
 /// The vendored tables are seeded by construction, so no load path can produce a
 /// registry that has forgotten them. This is what makes the fix structural
 /// rather than a call someone must remember to make.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn every_registry_holds_the_vendored_tables_from_construction() {
     assert!(!BreakTableRegistryProbe::fresh().is_empty());
     assert!(!BreakTableRegistryProbe::defaulted().is_empty());

--- a/crates/epics-base-rs/tests/busy_test.rs
+++ b/crates/epics-base-rs/tests/busy_test.rs
@@ -1,5 +1,4 @@
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): CaServerBuilder::build binds a tokio::net listener (needs a reactor); runs and passes in the feature-ON suite.
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::busy::BusyRecord;
 use epics_base_rs::types::EpicsValue;
@@ -15,6 +14,9 @@ fn test_register_record_type() {
     drop(builder);
 }
 
+// `#[tokio::test]`, not `#[epics_test]`: `CaServerBuilder::build` binds a
+// `tokio::net` listener, which needs a real reactor on both backends. The
+// census marker accounts for it.
 #[tokio::test]
 async fn test_db_file_load() {
     let db = r#"

--- a/crates/epics-base-rs/tests/busy_val_notify_posts_each_change.rs
+++ b/crates/epics-base-rs/tests/busy_val_notify_posts_each_change.rs
@@ -15,8 +15,6 @@
 //! posted only the first event (VAL=1 "Busy") instead of C's three
 //! (Busy → Illegal_Value(2) → Illegal_Value(3)).
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::event_queue::EventReader;
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -49,7 +47,7 @@ fn drain(rx: &mut EventReader) -> Vec<EpicsValue> {
 /// (1, 2, 3), the repeated 2 coalesced by the `mlst != val` monitor gate. Each
 /// `ca_put_callback` (WRITE_NOTIFY) must complete synchronously so the next one
 /// is not refused with `PutCallbackInProgress`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn busy_val_notify_sequence_posts_each_change() {
     let db = build().await;
     let r = db.get_record("B").unwrap();

--- a/crates/epics-base-rs/tests/c_epics_parity.rs
+++ b/crates/epics-base-rs/tests/c_epics_parity.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(1): a sync test that hand-builds its own tokio runtime; runs and passes in the feature-ON suite.
 //! Tests ported from C EPICS Base test suite.
 //!
 //! Source files:
@@ -8,8 +9,6 @@
 //!   - modules/database/test/ioc/db/recGblCheckDeadbandTest.c
 //!   - modules/database/test/ioc/db/dbDbLinkTest.c
 //!   - modules/database/test/ioc/db/dbPutGetTest.c
-
-// RTEMS-EXEC-MODEL-ALLOW(22): checked - these run and pass in the feature-ON suite.
 
 use std::collections::HashSet;
 
@@ -474,7 +473,7 @@ fn deadband_infinity_handling() {
 // ============================================================
 
 /// C EPICS: testAlarm - alarm propagation through DB links
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn db_link_alarm_propagation() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -551,7 +550,7 @@ fn type_coercion_double_to_long() {
 // ============================================================
 
 /// C EPICS: dbHeaderTest — common fields NAME, DESC, SCAN
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn common_fields_access() {
     let rec = AoRecord::new(0.0);
     let mut inst = RecordInstance::new("TEST:header".to_string(), rec);
@@ -612,7 +611,7 @@ fn record_field_lists_non_empty() {
 // ============================================================
 
 /// C EPICS: testGroup0 — soft channel input reads from source via DB link
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn soft_input_reads_from_db_link() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -648,7 +647,7 @@ fn constant_link_record_init() {
 }
 
 /// C EPICS: testGroup3 — output records write values
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn soft_output_writes_to_db() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1289,7 +1288,7 @@ fn sub_record_field_access() {
 // ============================================================
 
 /// C EPICS: multiple records in database, independent access
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_multiple_records() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1320,7 +1319,7 @@ async fn database_multiple_records() {
 }
 
 /// C EPICS: record not found returns error
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_record_not_found() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1331,7 +1330,7 @@ async fn database_record_not_found() {
 }
 
 /// C EPICS: put to record field via database
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_put_record_field() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1360,7 +1359,7 @@ async fn database_put_record_field() {
 }
 
 /// C EPICS: DISP field blocks CA puts
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_disp_blocks_ca_put() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1384,7 +1383,7 @@ async fn database_disp_blocks_ca_put() {
 }
 
 /// C EPICS: PROC put triggers processing
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_proc_triggers_processing() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1411,7 +1410,7 @@ async fn database_proc_triggers_processing() {
 /// (dbAccess.c:1265) matches the proc field by pointer with no value
 /// check, so `caput REC.PROC 0` force-processes the record exactly like
 /// `caput REC.PROC 1`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_proc_zero_still_triggers_processing() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1440,7 +1439,7 @@ async fn database_proc_zero_still_triggers_processing() {
 /// `dbPut` stores the raw byte in `prec->proc` (retained; C never resets it)
 /// AND `pp(TRUE)` force-processes the record. The byte is served back SIGNED
 /// as `DBR_CHAR` (put-defect cluster PROC), so `caput PROC 255` reads back -1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_proc_stores_byte_and_still_processes() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1480,7 +1479,7 @@ async fn database_proc_stores_byte_and_still_processes() {
 }
 
 /// C EPICS: all record names returned from database
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_all_record_names() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1759,7 +1758,7 @@ fn time_ordering() {
 // ============================================================
 
 /// C EPICS: database can be initialized and cleaned up
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_init_cleanup_cycle() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1785,7 +1784,7 @@ async fn database_init_cleanup_cycle() {
 }
 
 /// C EPICS: process chain doesn't panic on empty database
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn database_process_empty() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1802,7 +1801,7 @@ async fn database_process_empty() {
 
 /// C EPICS: Chain 1 — FLNK record processing chain
 /// Source record processes and triggers target via forward link
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn flnk_chain_processes_target() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1837,7 +1836,7 @@ async fn flnk_chain_processes_target() {
 
 /// C EPICS: Chain 3 — Loop breaking via visited set
 /// Record chain A → B → A should not infinite loop
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn flnk_loop_does_not_infinite_loop() {
     use epics_base_rs::server::database::PvDatabase;
     use std::collections::HashSet;
@@ -1875,7 +1874,7 @@ async fn flnk_loop_does_not_infinite_loop() {
 }
 
 /// C EPICS: Chain 4/5 — RPRO reprocessing prevention
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rpro_reprocessing() {
     use epics_base_rs::server::database::PvDatabase;
     use std::collections::HashSet;
@@ -1909,7 +1908,7 @@ async fn rpro_reprocessing() {
 }
 
 /// C EPICS: Multiple rapid puts to same record
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rapid_puts_to_same_record() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1939,7 +1938,7 @@ async fn rapid_puts_to_same_record() {
 // ============================================================
 
 /// C EPICS: process_record processes and clears UDF
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn process_record_clears_udf() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;
@@ -1966,7 +1965,7 @@ async fn process_record_clears_udf() {
 }
 
 /// C EPICS: PINI=YES processes record at init time
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn pini_flag() {
     use epics_base_rs::server::database::PvDatabase;
     use epics_base_rs::server::record::PiniMode;
@@ -2001,7 +2000,7 @@ async fn pini_flag() {
 // ============================================================
 
 /// C EPICS: independent records don't interfere
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn independent_records_no_interference() {
     use epics_base_rs::server::database::PvDatabase;
     use std::sync::Arc;

--- a/crates/epics-base-rs/tests/calc_assignment_stores_write_back.rs
+++ b/crates/epics-base-rs/tests/calc_assignment_stores_write_back.rs
@@ -21,8 +21,6 @@
 //! accumulates across cycles; it is visible to the second pass of the same
 //! cycle (calcout CALC → OCAL, transform channel → channel).
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -74,7 +72,7 @@ async fn f64_of(db: &PvDatabase, pv: &str) -> f64 {
 
 /// Compiled softIoc, `record(calc)` with `CALC="A:=A+1;A"`, 3 × PROC:
 /// `VAL=1 A=1 / VAL=2 A=2 / VAL=3 A=3`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calc_store_lands_in_a_and_accumulates() {
     let db = build().await;
 
@@ -99,7 +97,7 @@ async fn calc_store_lands_in_a_and_accumulates() {
 /// OCAL reads the A that CALC just stored. First cycle: CALC stores A=1, VAL=1;
 /// OCAL then computes OVAL = A*10 = 10 (not 0, which is what a fresh copy of
 /// the pre-CALC args would give).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_ocal_sees_the_calc_pass_store() {
     let db = build().await;
 
@@ -123,7 +121,7 @@ async fn calcout_ocal_sees_the_calc_pass_store() {
 
 /// sCalc stores both families: `A:=` through `parg` and `AA:=` through `psarg`
 /// (`sCalcPerform.c:888-894`, `strncpy(psarg[op - STORE_AA], ps->s, …)`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_stores_both_the_numeric_and_the_string_arg() {
     let db = build().await;
 
@@ -140,7 +138,7 @@ async fn scalcout_stores_both_the_numeric_and_the_string_arg() {
 }
 
 /// swait: C `swaitRecord.c:409` — `calcPerform(&pwait->a, &pwait->val, rpcl)`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_store_lands_in_a() {
     let db = build().await;
 
@@ -153,7 +151,7 @@ async fn swait_store_lands_in_a() {
 /// transform evaluates its channels in order against ONE arg set
 /// (`transformRecord.c:593`, `sCalcPerform(&ptran->a, 16, …)` per channel), so
 /// channel B's `A:=5` is what channel C's `A+1` fetches in the SAME cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn transform_channel_store_is_visible_to_the_next_channel() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/calc_calc_field_special.rs
+++ b/crates/epics-base-rs/tests/calc_calc_field_special.rs
@@ -10,8 +10,6 @@
 //! return `Ok(())` — the client saw a successful write and the record silently
 //! kept an uncompilable expression.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::error::CaError;
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::records::calc::CalcRecord;
@@ -19,7 +17,7 @@ use epics_base_rs::types::EpicsValue;
 
 const ECA_PUTFAIL: u32 = 160; // (20 << 3) | CA_K_WARNING
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bad_calc_put_is_rejected_but_the_string_is_stored() {
     let db = PvDatabase::new();
     db.add_record("CALCREC", Box::new(CalcRecord::new("A+1")))
@@ -45,7 +43,7 @@ async fn bad_calc_put_is_rejected_but_the_string_is_stored() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn empty_calc_put_is_rejected_like_c_postfix_null_arg() {
     let db = PvDatabase::new();
     db.add_record("CALCEMPTY", Box::new(CalcRecord::new("A+1")))
@@ -61,7 +59,7 @@ async fn empty_calc_put_is_rejected_like_c_postfix_null_arg() {
     assert!(matches!(err, CaError::BadField(_)), "got {err:?}");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn good_calc_put_still_succeeds_and_recompiles() {
     let db = PvDatabase::new();
     db.add_record("CALCOK", Box::new(CalcRecord::new("A+1")))

--- a/crates/epics-base-rs/tests/calc_caller_arg_counts.rs
+++ b/crates/epics-base-rs/tests/calc_caller_arg_counts.rs
@@ -55,8 +55,6 @@
 //! | lnkCalc, asLib ASG | 21           | both allocate `CALCPERFORM_NARGS`     |
 //! | swait              | **12**       | `swaitRecord.c:409` `&pwait->a` = A..L |
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::calc::{
@@ -334,7 +332,7 @@ fn a_count_above_the_array_clamps_to_it() {
 
 /// The record-level case: swait must hand the engine its count, so an `M` in a
 /// live swait's CALC is inert. In C this same database reads and rewrites LA.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_swait_calc_cannot_reach_past_l() {
     let (db, _) = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/calc_family_fetch_gate.rs
+++ b/crates/epics-base-rs/tests/calc_family_fetch_gate.rs
@@ -16,8 +16,6 @@
 //! `dbGetLink` reports failure for, and the framework's link read returns no
 //! value for it.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -52,7 +50,7 @@ async fn sevr(db: &PvDatabase, rec: &str) -> AlarmSeverity {
 /// calc: INPA resolves (A=2), INPB does not. C's fetch reads BOTH (so A still
 /// refreshes) but returns INPB's failure, and `process` skips calcPerform.
 /// CALC="A+1" therefore holds VAL at its previous value instead of computing 3.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_73_calc_freezes_val_when_an_input_link_fails() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(2.0)))
@@ -89,7 +87,7 @@ async fn r9_73_calc_freezes_val_when_an_input_link_fails() {
 
 /// calcout: same gate (calcoutRecord.c:237). The OOPT switch is OUTSIDE the
 /// gate in C, so OOPT=Every_Time still drives OUT — with the FROZEN VAL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_73_calcout_freezes_val_and_outputs_the_frozen_value() {
     let db = PvDatabase::new();
     db.add_record("SINK", Box::new(AiRecord::new(0.0)))
@@ -128,7 +126,7 @@ async fn r9_73_calcout_freezes_val_and_outputs_the_frozen_value() {
 
 /// sCalcout: fetch returns at the first failing numeric link
 /// (sCalcoutRecord.c:885-887), and `process` (356) skips sCalcPerform.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_73_scalcout_freezes_val_when_an_input_link_fails() {
     let db = PvDatabase::new();
 
@@ -153,7 +151,7 @@ async fn r9_73_scalcout_freezes_val_when_an_input_link_fails() {
 
 /// aCalcout: the gate covers doCalc AND afterCalc (aCalcoutRecord.c:399-414),
 /// so on a failed fetch the OOPT decision never happens and OUT is not written.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_73_acalcout_freezes_val_and_writes_no_output() {
     let db = PvDatabase::new();
     db.add_record("SINK", Box::new(AiRecord::new(0.0)))
@@ -192,7 +190,7 @@ async fn r9_73_acalcout_freezes_val_and_writes_no_output() {
 
 /// swait: same gate, plus the `else` arm — READ_ALARM at INVALID severity
 /// (swaitRecord.c:413). The calc family raises nothing on the same failure.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_73_swait_freezes_val_and_raises_read_alarm() {
     let db = PvDatabase::new();
 
@@ -221,7 +219,7 @@ async fn r9_73_swait_freezes_val_and_raises_read_alarm() {
 
 /// The other side of every gate: with all links resolvable the calc runs and
 /// VAL updates. Without this, a fix that simply never calculates would pass.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_73_calc_still_computes_when_every_link_resolves() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(2.0)))

--- a/crates/epics-base-rs/tests/calc_linkstatus_derived.rs
+++ b/crates/epics-base-rs/tests/calc_linkstatus_derived.rs
@@ -16,8 +16,6 @@
 //! model the field at all, so a caget fell through to that same `.dbd` initial),
 //! and neither refused the seed. This drives the whole path through the loader.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -40,7 +38,7 @@ async fn build() -> std::sync::Arc<PvDatabase> {
 
 /// Every link-status field of a default (all-constant-link) record reads
 /// `Constant`(3) through the full DB-load path — NOT the `.dbd` `initial("1")`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn link_status_reads_derived_constant_after_load() {
     let db = build().await;
     let cases: &[(&str, &[&str])] = &[
@@ -62,7 +60,7 @@ async fn link_status_reads_derived_constant_after_load() {
 
 /// A direct client put to a link-status field is refused (C `S_db_noMod`), and
 /// the derived value is unchanged.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn link_status_put_is_refused_and_value_stands() {
     let db = build().await;
     for (rec, f) in [("A", "INAV"), ("S", "IAAV"), ("X", "OAV"), ("X", "IAV")] {

--- a/crates/epics-base-rs/tests/calc_osv_put.rs
+++ b/crates/epics-base-rs/tests/calc_osv_put.rs
@@ -8,8 +8,6 @@
 //! put_accepted C=true, port=false, 6 put classes). The fix makes the declared
 //! `DBF_STRING` type win over the name-based menu.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
 
@@ -17,7 +15,7 @@ const DB: &str = r#"record(scalcout, "S") {}"#;
 
 /// Every put class the oracle exercised on `OSV` is accepted and the string is
 /// stored — the field is a plain `DBF_STRING`, never resolved against a menu.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_osv_accepts_string_and_numeric_puts() {
     let db = IocBuilder::new()
         .db_string(DB, &std::collections::HashMap::new())

--- a/crates/epics-base-rs/tests/calc_udf_put.rs
+++ b/crates/epics-base-rs/tests/calc_udf_put.rs
@@ -21,8 +21,6 @@
 //! UDF -1/255` → C=-1, port=1); this is verified against the C source, not the
 //! running oracle, per the panel's constraints.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::server::record::ProcessCompletion;
@@ -66,7 +64,7 @@ async fn caput_udf(db: &PvDatabase, rec: &str, text: &str) {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_udf_byte_fidelity_across_the_five_boundaries() {
     let db = build().await;
 
@@ -95,7 +93,7 @@ async fn acalcout_udf_byte_fidelity_across_the_five_boundaries() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_udf_byte_fidelity_across_the_five_boundaries() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/calcout_clcv_oclv.rs
+++ b/crates/epics-base-rs/tests/calcout_clcv_oclv.rs
@@ -11,8 +11,6 @@
 //!
 //! Fields are DBF_LONG (calcoutRecord.dbd.pod:729,1049; sCalcoutRecord.dbd:75,438).
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::database::db_access::DbSubscription;
 use epics_base_rs::server::records::acalcout::AcalcoutRecord;
@@ -26,7 +24,7 @@ const POSTFIX_ERR: i32 = -1;
 /// C `db_post_events(prec, &prec->clcv, DBE_VALUE)` (calcoutRecord.c:335) —
 /// CLCV is not `pp(TRUE)`, so `special()`'s explicit post is the ONLY thing
 /// that tells a monitoring client the expression went invalid.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_calc_put_posts_the_clcv_monitor() {
     let db = PvDatabase::new();
     db.add_record("COM", Box::new(CalcoutRecord::default()))
@@ -40,13 +38,14 @@ async fn a_calc_put_posts_the_clcv_monitor() {
         .await
         .unwrap();
 
-    let posted = tokio::time::timeout(std::time::Duration::from_secs(1), sub.recv())
-        .await
-        .expect("special() must post CLCV");
+    let posted =
+        epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(1), sub.recv())
+            .await
+            .expect("special() must post CLCV");
     assert_eq!(posted, Some(EpicsValue::Long(POSTFIX_ERR)));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_bad_calc_put_is_accepted_and_lands_in_clcv() {
     let db = PvDatabase::new();
     db.add_record("CO", Box::new(CalcoutRecord::default()))
@@ -88,7 +87,7 @@ async fn calcout_bad_calc_put_is_accepted_and_lands_in_clcv() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_clcv_oclv_track_scalcpostfix_status() {
     let db = PvDatabase::new();
     db.add_record("SC", Box::new(ScalcoutRecord::default()))
@@ -131,7 +130,7 @@ async fn scalcout_clcv_oclv_track_scalcpostfix_status() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_bad_calc_stores_minus_one_not_a_generic_one() {
     let db = PvDatabase::new();
     db.add_record("AC", Box::new(AcalcoutRecord::default()))

--- a/crates/epics-base-rs/tests/calcout_constant_input_reseed.rs
+++ b/crates/epics-base-rs/tests/calcout_constant_input_reseed.rs
@@ -31,8 +31,6 @@
 //!   - sCalcout/aCalcout NON-numeric inputs, which C's `fieldIndex <= INPL`
 //!     guard excludes -> no re-seed
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::EventMask;
 use epics_base_rs::server::record::Record;
@@ -82,7 +80,7 @@ async fn calcout_db() -> PvDatabase {
 /// The new link is CONSTANT: the value field takes the constant immediately —
 /// no process needed, exactly as the init seed does — and the next calculation
 /// uses it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_put_to_a_constant_inp_reseeds_the_value_field() {
     let db = calcout_db().await;
     assert_eq!(field(&db, "CO", "B").await, EpicsValue::Double(2.0));
@@ -97,7 +95,7 @@ async fn calcout_put_to_a_constant_inp_reseeds_the_value_field() {
 /// C posts the re-seeded value field with a literal `DBE_VALUE`
 /// (`calcoutRecord.c:376`). Nothing else would: `B` is not `pp(TRUE)`, and the
 /// put was to `INPB`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_reseed_posts_the_value_field() {
     let db = calcout_db().await;
     let inst = db.get_record("CO").unwrap();
@@ -116,7 +114,7 @@ async fn calcout_reseed_posts_the_value_field() {
 /// touches nothing (C `dbLoadLink` is a constant-link-only lset entry). The
 /// value field keeps what it had until the LINK delivers — the process-time read
 /// owns it from here on.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_put_of_a_pv_link_does_not_reseed() {
     let db = calcout_db().await;
     let mut src = CalcRecord::new("0");
@@ -135,7 +133,7 @@ async fn calcout_put_of_a_pv_link_does_not_reseed() {
 /// C's `calcRecord::special` (`calcRecord.c:139-157`) handles ONLY `SPC_CALC` —
 /// calc's INPA..INPL are not `special(SPC_MOD)` at all, so a runtime put to a
 /// constant INPn re-seeds nothing. calc must NOT inherit calcout's behaviour.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calc_put_to_a_constant_inp_does_not_reseed() {
     let db = PvDatabase::new();
     let mut c = CalcRecord::new("A+B");
@@ -154,7 +152,7 @@ async fn calc_put_to_a_constant_inp_does_not_reseed() {
 /// STRING input does not — C guards the load with
 /// `if (fieldIndex <= scalcoutRecordINPL)`, and `pvalue = &pcalc->a + lnkIndex`
 /// is a `double *` that cannot address AA at all.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_reseeds_numeric_inputs_only() {
     let db = PvDatabase::new();
     let mut sc = ScalcoutRecord::new();
@@ -179,7 +177,7 @@ async fn scalcout_reseeds_numeric_inputs_only() {
 
 /// aCalcout: same guard (`aCalcoutRecord.c:534`) — the numeric input re-seeds,
 /// the ARRAY input does not.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_reseeds_numeric_inputs_only() {
     let db = PvDatabase::new();
     let mut ac = AcalcoutRecord::new();
@@ -206,7 +204,7 @@ async fn acalcout_reseeds_numeric_inputs_only() {
 /// the anchor (`recGblInitConstantLink` inside a `special()` body) across every
 /// C record in base and synApps calc. Its post carries `DBE_VALUE | DBE_LOG`
 /// (`:718`), unlike the calcout family's bare `DBE_VALUE`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn transform_put_to_a_constant_inp_reseeds_and_posts_value_log() {
     use epics_base_rs::server::records::transform::TransformRecord;
 

--- a/crates/epics-base-rs/tests/calcout_dopt_ocal_udf.rs
+++ b/crates/epics-base-rs/tests/calcout_dopt_ocal_udf.rs
@@ -7,8 +7,6 @@
 //! the Rust udf was VAL-based only (`value_is_undefined` default), so OCAL→NaN
 //! drove NaN to the OUT link with NO_ALARM — a silent-wrong-value divergence.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -17,7 +15,7 @@ use epics_base_rs::server::record::{AlarmSeverity, Record};
 use epics_base_rs::server::records::calcout::CalcoutRecord;
 use epics_base_rs::types::EpicsValue;
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_dopt_use_ocal_nan_oval_raises_udf_alarm() {
     let db = PvDatabase::new();
 
@@ -72,7 +70,7 @@ async fn calcout_dopt_use_ocal_nan_oval_raises_udf_alarm() {
 /// The effective UDF condition is `isnan(VAL) OR isnan(OVAL)`, not OVAL alone.
 /// A first cut of the fix *replaced* the VAL-based udf with the OVAL one and
 /// regressed this path to NO_ALARM; this pins the OR.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_dopt_use_ocal_nan_val_finite_oval_stays_invalid() {
     let db = PvDatabase::new();
 
@@ -109,7 +107,7 @@ async fn calcout_dopt_use_ocal_nan_val_finite_oval_stays_invalid() {
 
 /// Both VAL and OVAL finite on a Use_OVAL output cycle → NO_ALARM. Pins that
 /// the OR fix did not introduce a false-positive UDF when neither is NaN.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_dopt_use_ocal_both_finite_no_alarm() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/calcout_ivov_output_gate.rs
+++ b/crates/epics-base-rs/tests/calcout_ivov_output_gate.rs
@@ -10,8 +10,6 @@
 //! spurious OVAL monitor on a non-output cycle (D3). The fix gates the OVAL
 //! write on the record's `cached_should_output`.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -20,7 +18,7 @@ use epics_base_rs::server::records::calcout::CalcoutRecord;
 use epics_base_rs::types::EpicsValue;
 
 /// Non-output INVALID cycle: OVAL must NOT become IVOV.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_ivov_not_applied_on_non_output_cycle() {
     let db = PvDatabase::new();
 
@@ -65,7 +63,7 @@ async fn calcout_ivov_not_applied_on_non_output_cycle() {
 
 /// Control: when output IS due, IVOA=Set_to_IVOV still clobbers OVAL→IVOV.
 /// Pins that the gate suppresses only non-output cycles, not all of them.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_ivov_applied_on_output_cycle() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/calcout_link_status.rs
+++ b/crates/epics-base-rs/tests/calcout_link_status.rs
@@ -19,8 +19,6 @@
 //!     holds its `CON` default until the first process re-points it through
 //!     `check_alarms`.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -44,7 +42,7 @@ async fn poll_status(db: &PvDatabase, pv: &str, want: i16, label: &str) {
         {
             return;
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!(
         "{label}: {pv} did not reach {want} before timeout (last {:?})",
@@ -60,7 +58,7 @@ async fn read_status(db: &PvDatabase, pv: &str) -> i16 {
         .unwrap_or_else(|| panic!("{pv} not readable as a number"))
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_input_link_status_loc_vs_con() {
     let db = PvDatabase::new();
     // A local target so a DB input link to it resolves to LOC.
@@ -89,7 +87,7 @@ async fn calcout_input_link_status_loc_vs_con() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_input_status_reclassifies_on_special() {
     let db = PvDatabase::new();
     db.add_record("CALC_SP_TGT", Box::new(AoRecord::new(0.0)))
@@ -109,7 +107,7 @@ async fn calcout_input_status_reclassifies_on_special() {
     poll_status(&db, "CALC_SP.INCV", LOC, "INPC repointed to local → LOC").await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_outv_classifies_via_process() {
     let db = PvDatabase::new();
     db.add_record("CALC_OUT_TGT", Box::new(AoRecord::new(0.0)))
@@ -149,7 +147,7 @@ async fn calcout_outv_classifies_via_process() {
 /// common-field/init_record passes on the `.db` load path. A passive,
 /// never-processed calcout loaded with a local OUT link must therefore already
 /// report `OUTV = LOC`; one with an empty OUT link keeps its `CON` default.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_outv_classifies_at_init_via_loader() {
     let db_content = r#"
 record(ao, "INIT_OUT_TGT") {

--- a/crates/epics-base-rs/tests/calcout_oevt_output_event.rs
+++ b/crates/epics-base-rs/tests/calcout_oevt_output_event.rs
@@ -14,8 +14,6 @@
 //! because the OUT write and its event are both suppressed (C execOutput
 //! `nsev >= INVALID` → `break`, no `postEvent`).
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -80,10 +78,10 @@ async fn add_event_sibling(db: &PvDatabase, name: &str, evnt: &str, counter: Arc
 async fn settle(cond: impl Fn() -> bool) {
     for _ in 0..400 {
         if cond() {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(20)).await;
             return;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
     panic!("OEVT event did not fire within timeout");
 }
@@ -91,7 +89,7 @@ async fn settle(cond: impl Fn() -> bool) {
 /// `calcout`: OOPT=Every_Time + OEVT="e1" wakes a `SCAN="Event"`/`EVNT="e1"`
 /// sibling exactly once — with NO OUT link, proving the event posts on the
 /// output cycle independent of OUT connection (C posts after `writeValue`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_oevt_posts_string_event_on_output() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -121,7 +119,7 @@ async fn calcout_oevt_posts_string_event_on_output() {
 /// `calcout`: an INVALID cycle (CALC="0/0" → NaN → UDF) with IVOA=Don't_drive
 /// must NOT post OEVT — the OUT write and its event are both suppressed
 /// (C execOutput `nsev >= INVALID` → `break`, no `postEvent`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_oevt_suppressed_on_dont_drive_invalid() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -158,7 +156,7 @@ async fn calcout_oevt_suppressed_on_dont_drive_invalid() {
     }
 
     // Give any erroneous spawned post time to land, then assert none did.
-    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(60)).await;
     assert_eq!(
         count.load(Ordering::SeqCst),
         0,
@@ -168,7 +166,7 @@ async fn calcout_oevt_suppressed_on_dont_drive_invalid() {
 }
 
 /// `scalcout`: numeric OEVT=5 wakes a `SCAN="Event"`/`EVNT="5"` sibling once.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_oevt_posts_numeric_event_on_output() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -195,7 +193,7 @@ async fn scalcout_oevt_posts_numeric_event_on_output() {
 }
 
 /// `acalcout`: numeric OEVT=7 wakes a `SCAN="Event"`/`EVNT="7"` sibling once.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_oevt_posts_numeric_event_on_output() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -225,7 +223,7 @@ async fn acalcout_oevt_posts_numeric_event_on_output() {
 /// swait has no IVOA field, so OEVT posts whenever output fires — C
 /// swaitRecord.c:797 posts unconditionally after the OUT write / forward
 /// link, the 4th member of the OEVT-output family.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_oevt_posts_numeric_event_on_output() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));

--- a/crates/epics-base-rs/tests/compress_completion_gating.rs
+++ b/crates/epics-base-rs/tests/compress_completion_gating.rs
@@ -12,8 +12,6 @@
 //! compress with N=4, fed one sample per cycle, must fire its FLNK exactly
 //! once over four cycles — on the 4th, when the average is emitted.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -23,7 +21,7 @@ use epics_base_rs::server::records::calc::CalcRecord;
 use epics_base_rs::server::records::compress::CompressRecord;
 use epics_base_rs::types::EpicsValue;
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn compress_fires_flnk_only_on_emit_not_every_cycle() {
     let db = Arc::new(PvDatabase::new());
 

--- a/crates/epics-base-rs/tests/compress_inp_link_connectivity.rs
+++ b/crates/epics-base-rs/tests/compress_inp_link_connectivity.rs
@@ -36,8 +36,6 @@
 //! INP="SRC" : SEVR=NO_ALARM STAT=NO_ALARM  NUSE=2  VAL=7 7   (two processes)
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -81,7 +79,7 @@ async fn nuse(db: &PvDatabase, rec: &str) -> f64 {
 }
 
 /// An unset INP is not a connected link: LINK/INVALID, nothing ingested.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unset_inp_raises_link_invalid_and_ingests_nothing() {
     let db = build().await;
 
@@ -96,7 +94,7 @@ async fn unset_inp_raises_link_invalid_and_ingests_nothing() {
 /// The fabricated-data half: a CONSTANT INP has no lset, so C never samples it.
 /// The port ingested the literal on every process — NUSE climbed and the
 /// buffer filled with a repeated constant that no source ever produced.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_inp_is_not_connected_and_is_never_ingested() {
     let db = build().await;
     process(&db, "C:CONST").await;
@@ -123,7 +121,7 @@ async fn constant_inp_is_not_connected_and_is_never_ingested() {
 }
 
 /// The gate must not fire on a real link — that is the whole record's job.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_connected_db_link_ingests_and_stays_no_alarm() {
     let db = build().await;
 
@@ -148,7 +146,7 @@ async fn a_connected_db_link_ingests_and_stays_no_alarm() {
 /// the link text softIoc reads: `dbgf C:LINK.INP` → `"SRC"`. The record used to
 /// carry a private `inp` field that the loader never wrote and that shadowed
 /// the common one — the port answered `""`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn inp_reads_back_the_link_text() {
     let db = build().await;
 
@@ -166,7 +164,7 @@ async fn inp_reads_back_the_link_text() {
 /// clears it on the next process (C re-derives it every `process()` from
 /// `nsta`/`nsev`, which `recGblResetAlarms` clears each cycle), and a record
 /// whose link goes away raises it again.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_link_alarm_is_re_derived_every_cycle() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/constant_dol_seed_defines_record.rs
+++ b/crates/epics-base-rs/tests/constant_dol_seed_defines_record.rs
@@ -26,8 +26,6 @@
 //! record(stringout,"SO3"){field(DOL,"1.50")} VAL="1.50"  UDF=0
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -65,7 +63,7 @@ async fn sevr(db: &PvDatabase, rec: &str) -> AlarmSeverity {
 
 /// The whole `recGblInitConstantLink(&prec->dol, …) → udf = FALSE` family, one
 /// record per value-type boundary.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_constant_dol_clears_udf_for_every_out_record() {
     let db = build(
         r#"
@@ -113,7 +111,7 @@ async fn a_constant_dol_clears_udf_for_every_out_record() {
 
 /// ao/dfanout use `udf = isnan(val)`, so a NaN constant loads VAL and leaves
 /// the record UNDEFINED (`aoRecord.c:113`, `dfanoutRecord.c:106`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_nan_constant_dol_leaves_the_record_undefined() {
     let db = build(
         r#"
@@ -139,7 +137,7 @@ async fn a_nan_constant_dol_leaves_the_record_undefined() {
 /// bo loads the constant into a temporary and stores its BOOLEAN
 /// (`boRecord.c:147`: `prec->val = !!ival`), so DOL="5" is VAL=1, not 5 — and
 /// DOL="0" still clears UDF (the load SUCCEEDED; the value is simply 0).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_bo_constant_dol_stores_the_boolean_of_the_constant() {
     let db = build(
         r#"
@@ -168,7 +166,7 @@ async fn a_bo_constant_dol_stores_the_boolean_of_the_constant() {
 /// state is derived from the seeded value: ao's OVAL/PVAL/MLST, mbbo's
 /// convert() → RVAL. Pre-fix the iocsh/`dbLoadRecords` path never ran the tail
 /// at all, and the builder path ran it against a VAL of 0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_init_tail_runs_after_the_constant_load() {
     let db = build(
         r#"
@@ -192,7 +190,7 @@ async fn a_init_tail_runs_after_the_constant_load() {
 /// `dbConstLink.c:34-35` — *"constants may contain hex numbers, whereas
 /// database conversions can't"*. softIoc: `record(longout,"LOHEX")
 /// {field(DOL,"0x1f")}` comes up at VAL=31.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_hex_constant_dol_loads_into_an_integer_field() {
     let db = build(r#"record(longout, "LOHEX") { field(DOL, "0x1f") }"#).await;
 
@@ -203,7 +201,7 @@ async fn a_hex_constant_dol_loads_into_an_integer_field() {
 /// A DOL that names a PV is NOT a constant — nothing is seeded and the record
 /// stays undefined until it processes (C: `recGblInitConstantLink` returns
 /// FALSE for a PV_LINK).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_pv_dol_seeds_nothing_and_leaves_udf_set() {
     let db = build(
         r#"

--- a/crates/epics-base-rs/tests/constant_link_never_delivers_at_process.rs
+++ b/crates/epics-base-rs/tests/constant_link_never_delivers_at_process.rs
@@ -24,8 +24,6 @@
 //! vs after a client put (sseq `SELL`), a constant with no init seed at all
 //! (compress `INP`), and the real-link owner path that must keep delivering.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -70,7 +68,7 @@ async fn process(db: &PvDatabase, name: &str) {
 
 /// C `sseqRecord.c:186-191`: a constant `SELL` is loaded into `SELN` once, at
 /// init, by `recGblInitConstantLink(&pR->sell, DBF_USHORT, &pR->seln)`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_sell_seeds_seln_at_init() {
     let db = build().await;
 
@@ -86,7 +84,7 @@ async fn constant_sell_seeds_seln_at_init() {
 /// `caput SELN 5` + process leaves `SELN = 5`, because `dbGetLink` on the
 /// constant writes nothing. The port re-applied the constant every cycle and
 /// reset it to 3 — firing step 3 where C fires step 5.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn client_put_to_seln_survives_a_constant_sell() {
     let db = build().await;
 
@@ -104,7 +102,7 @@ async fn client_put_to_seln_survives_a_constant_sell() {
 
 /// The owner path stays intact: a REAL `SELL` link is re-read every cycle and
 /// overwrites `SELN` (C `dbGetLink` on a DB link — `sseqRecord.c:314-317`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_real_sell_link_still_delivers_every_cycle() {
     let db = build().await;
 
@@ -125,7 +123,7 @@ async fn a_real_sell_link_still_delivers_every_cycle() {
 /// leaves the circular buffer empty. The port's executor was pushing the
 /// constant into the buffer on every cycle — `VAL = [5, 5, 5]` against C's
 /// empty buffer.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_constant_inp_never_fills_a_compress_buffer() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/constant_links_seed_at_init_only.rs
+++ b/crates/epics-base-rs/tests/constant_links_seed_at_init_only.rs
@@ -20,8 +20,6 @@
 //! Pre-fix the port re-applied the constant on every process, so the caput was
 //! destroyed on the next scan and A read 0 before the first process.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::records::calc::CalcRecord;
 use epics_base_rs::server::records::printf::PrintfRecord;
@@ -45,7 +43,7 @@ async fn process(db: &PvDatabase, rec: &str) {
 
 /// The whole rule on one record: seeded at init, never re-delivered, and a
 /// client's put stands.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_input_is_seeded_at_init_and_never_re_applied() {
     let db = PvDatabase::new();
     let mut calc = CalcRecord::new("A+B");
@@ -82,7 +80,7 @@ async fn constant_input_is_seeded_at_init_and_never_re_applied() {
 /// (`AbortOnFirstFailure`), so if a constant read were classified as a failure
 /// the record body would never run. Boundary: constant (success) vs a link to a
 /// missing record (failure).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_constant_input_does_not_gate_the_record_body() {
     let db = PvDatabase::new();
     let mut sel = SelRecord::default();
@@ -110,7 +108,7 @@ async fn a_constant_input_does_not_gate_the_record_body() {
 
 /// seq: constant SELL → SELN and constant DOLn → DOn, both init-only
 /// (`seqRecord.c:121-126`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn seq_seeds_constant_sell_and_doln_at_init() {
     let db = PvDatabase::new();
     let seq = SeqRecord {
@@ -136,7 +134,7 @@ async fn seq_seeds_constant_sell_and_doln_at_init() {
 /// printf is the declared exception: `GET_PRINT` (`printfRecord.c:49-52`)
 /// re-runs `recGblInitConstantLink` on every `doPrintf`, so ITS constants keep
 /// delivering each cycle and its formatted VAL is stable.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn printf_constants_still_deliver_every_cycle() {
     let db = PvDatabase::new();
     let mut p = PrintfRecord::default();

--- a/crates/epics-base-rs/tests/database_tests.rs
+++ b/crates/epics-base-rs/tests/database_tests.rs
@@ -1,6 +1,5 @@
+// RTEMS-EXEC-MODEL-ALLOW(4): three multi-thread-flavored tokio tests plus one hand-built runtime; run and pass in the feature-ON suite.
 #![allow(unused_imports, clippy::all)]
-// RTEMS-EXEC-MODEL-ALLOW(215): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -26,7 +25,7 @@ fn sub_with_snam(snam: &str) -> epics_base_rs::server::records::sub_record::SubR
     rec
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_write_notify_follows_flnk() {
     let db = PvDatabase::new();
     db.add_record("REC_A", Box::new(AoRecord::new(0.0)))
@@ -50,7 +49,7 @@ async fn test_write_notify_follows_flnk() {
     assert!(visited.contains("REC_B"));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_inp_link_processing() {
     let db = PvDatabase::new();
     db.add_record("SOURCE", Box::new(AoRecord::new(42.0)))
@@ -84,7 +83,7 @@ async fn test_inp_link_processing() {
 /// pre-fix path called `read_link_value_soft → get_pv → Err` then
 /// folded the error to `None` and let process() succeed — leaving
 /// downstream alarm consumers blind to the broken link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_soft_inp_read_failure_sets_link_alarm() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::record::AlarmSeverity;
@@ -136,7 +135,7 @@ async fn test_soft_inp_read_failure_sets_link_alarm() {
 ///             sevr, no amsg propagation.
 /// * **MSS** — DEST gets source stat + sevr + amsg.
 /// * **MSI** — same as MS, but only when source.sevr == INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_single_inp_ms_propagates_link_alarm_no_msg() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::record::AlarmSeverity;
@@ -191,7 +190,7 @@ async fn test_single_inp_ms_propagates_link_alarm_no_msg() {
 }
 
 /// MSS propagates source stat + sevr + amsg (PR d0cf47c).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_single_inp_mss_propagates_stat_and_amsg() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::record::AlarmSeverity;
@@ -248,7 +247,7 @@ async fn test_single_inp_mss_propagates_stat_and_amsg() {
 /// are exercised by the INP tests above; both sides share the
 /// `inherit_sevr_msg` helper, so these OUT tests pin the wiring: the OUT
 /// path captures the source's committed alarm and applies it to the DEST.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_out_link_ms_propagates_link_alarm_to_dest() {
     use epics_base_rs::server::recgbl::alarm_status;
 
@@ -312,7 +311,7 @@ async fn test_out_link_ms_propagates_link_alarm_to_dest() {
 /// NMS contrast for the OUT-link inheritance above: a bare `OUT = DST PP`
 /// carries the default NoMaximize switch, so a MAJOR source must NOT
 /// raise the dest's severity.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_out_link_nms_does_not_propagate_alarm_to_dest() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(99.0)))
@@ -356,7 +355,7 @@ async fn test_out_link_nms_does_not_propagate_alarm_to_dest() {
 /// `(None, None)` for any non-Db link, so a connected pva link
 /// carrying a remote MAJOR severity left the owning record at
 /// NO_ALARM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pva_link_propagates_alarm_severity_into_link_alarm() {
     use epics_base_rs::server::database::LinkSet;
     use epics_base_rs::server::recgbl::alarm_status;
@@ -424,7 +423,7 @@ async fn test_pva_link_propagates_alarm_severity_into_link_alarm() {
 /// B2: when the lset reports no alarm severity (`alarm_severity` →
 /// None — e.g. NMS, or remote NO_ALARM), a connected pva link must
 /// NOT raise any alarm on the owning record.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pva_link_no_alarm_when_lset_reports_none() {
     use epics_base_rs::server::database::LinkSet;
     use epics_base_rs::server::record::AlarmSeverity;
@@ -525,7 +524,7 @@ impl epics_base_rs::server::database::LinkSet for CapturingLset {
 /// through the registered lset, matching C `dbLink.c::dbPutLink`
 /// (dbLink.c:434-448), which routes every link write through
 /// `plink->lset->putValue` regardless of DB vs CA link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pva_out_link_writes_value_through_link_set() {
     use std::sync::Mutex;
 
@@ -593,7 +592,7 @@ async fn test_pva_out_link_writes_value_through_link_set() {
 /// A record with a `pva://` OUT link and NO registered link set must
 /// fail gracefully — process() completes without panic, the value is
 /// simply not delivered (C `dbPutLink` returns `S_db_noLSET`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pva_out_link_no_link_set_fails_gracefully() {
     let db = PvDatabase::new();
     // No register_link_set call — the "pva" scheme is unregistered.
@@ -633,7 +632,7 @@ async fn test_pva_out_link_no_link_set_fails_gracefully() {
 /// twin asserts the `Plain` boundary; this asserts `Async`, so the
 /// notify→op mapping (`PvDatabase::external_put_op`) is pinned on both
 /// sides of its single branch.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pva_out_link_put_notify_chain_uses_async_op() {
     use std::sync::Mutex;
 
@@ -709,7 +708,7 @@ async fn test_pva_out_link_put_notify_chain_uses_async_op() {
 /// reset_alarms sees sevr Major→Major (alarm_changed=false) but
 /// amsg "msg1"→"msg2" (amsg_changed=true). The fix posts AMSG for
 /// this case so the subscriber sees the new message.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_mss_propagates_amsg_only_change_posts_amsg_event() {
     use epics_base_rs::server::recgbl::{EventMask, alarm_status};
     use epics_base_rs::server::record::AlarmSeverity;
@@ -795,7 +794,7 @@ async fn test_mss_propagates_amsg_only_change_posts_amsg_event() {
 ///   * an amsg-only pass posts VAL with `DBE_ALARM` alone (the value
 ///     deadband did not fire; `recGbl.c:212` `val_mask = DBE_ALARM`)
 ///     and AMSG with `stat_mask = DBE_ALARM` (`recGbl.c:194/210-211`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_record_posts_carry_per_event_dbe_mask() {
     use epics_base_rs::server::recgbl::{EventMask, alarm_status};
     use epics_base_rs::server::record::AlarmSeverity;
@@ -901,7 +900,7 @@ async fn test_record_posts_carry_per_event_dbe_mask() {
 // change detection and a mask made from the union of the cycle's other posts.
 // A `.UDF` subscriber must see an event only where C's generic `dbPut` posts
 // the field it wrote (dbAccess.c) — i.e. a caput to `.UDF` itself.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_process_cycle_posts_no_udf_event() {
     use epics_base_rs::server::recgbl::{EventMask, alarm_status};
     use epics_base_rs::server::record::AlarmSeverity;
@@ -963,7 +962,7 @@ async fn test_process_cycle_posts_no_udf_event() {
 /// The other side of the R14-63 boundary: a client caput to `.UDF` DOES post,
 /// because C's generic `dbPut` posts the field it wrote. Removing the
 /// synthesized processing-cycle posts must not take this one with it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_caput_to_udf_field_posts_udf_event() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::DbFieldType;
@@ -1019,7 +1018,7 @@ async fn test_caput_to_udf_field_posts_udf_event() {
 /// so any consumer reading PUTF during the process cycle (TPRO
 /// trace, monitor on .PUTF, async-completion path's
 /// "put-driven vs scan-driven" classifier) always saw PUTF=0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_putf_clears_after_synchronous_put_completion() {
     // AoRecord is synchronous Soft Channel (process() returns
     // Complete immediately). The synchronous-completion clear
@@ -1051,7 +1050,7 @@ async fn test_putf_clears_after_synchronous_put_completion() {
 /// `dbAccess.c::dbPutField:1276` sets putf=TRUE; the async device's
 /// completion eventually calls `dbProcess` again, which runs through
 /// `recGblFwdLink` (clears putf).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_putf_survives_async_round_trip_and_clears_on_completion() {
     let db = PvDatabase::new();
     db.add_record("ASYNC_PUTF", Box::new(AsyncRecord { val: 0.0 }))
@@ -1104,7 +1103,7 @@ async fn test_putf_survives_async_round_trip_and_clears_on_completion() {
 /// `complete_async_record` runs its own clear. This test pins the
 /// C-parity invariant: post-put, pre-process, UDF must already be
 /// false on a primary-field write.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_record_field_from_ca_clears_udf_on_primary_field_write() {
     let db = PvDatabase::new();
     db.add_record("UDF_ASYNC", Box::new(AsyncRecord { val: 0.0 }))
@@ -1145,7 +1144,7 @@ async fn test_put_record_field_from_ca_clears_udf_on_primary_field_write() {
 /// receiving a dbPut should carry PUTF=1 during chain processing.
 /// Pre-fix the CP-target dispatch set PUTF=true on every chained
 /// record, smearing put attribution across the entire chain.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_putf_stays_off_for_cp_chained_targets() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(0.0)))
@@ -1184,7 +1183,7 @@ async fn test_putf_stays_off_for_cp_chained_targets() {
 /// attribution and device-support `put-driven vs scan-driven`
 /// classifiers downstream of the OUT link silently observed
 /// scan-driven processing instead of put-driven.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_putf_propagates_through_db_out_link_to_passive_target() {
     let db = PvDatabase::new();
     db.add_record("PUTF_OUT_TGT", Box::new(AoRecord::new(0.0)))
@@ -1243,7 +1242,7 @@ async fn test_putf_propagates_through_db_out_link_to_passive_target() {
 /// and dispatched process — never touched `target.putf`. So even
 /// when the source had `putf=1` from a CA put, the async target
 /// stayed at `putf=0` for the duration of the in-flight cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_putf_propagates_mid_cycle_via_async_target_out_link() {
     let db = PvDatabase::new();
     // Async target: stays pact between process and complete_async.
@@ -1286,7 +1285,7 @@ async fn test_putf_propagates_mid_cycle_via_async_target_out_link() {
 /// Pre-fix the simulation path called both put_field("RVAL", v) AND
 /// set_val(v), so VAL ended up holding raw counts and the operator's
 /// configured EGU conversion was silently bypassed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_simm_raw_input_runs_conversion_chain() {
     let db = PvDatabase::new();
     // Source PV that the ai's SIOL link reads from — provides the
@@ -1345,7 +1344,7 @@ async fn test_simm_raw_input_runs_conversion_chain() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_cycle_detection() {
     let db = PvDatabase::new();
     db.add_record("CYCLE_A", Box::new(AoRecord::new(0.0)))
@@ -1375,7 +1374,7 @@ async fn test_cycle_detection() {
     assert_eq!(visited.len(), 2);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_drvh_drvl_clamp() {
     let mut rec = AoRecord::new(0.0);
     rec.drvh = 100.0;
@@ -1389,7 +1388,7 @@ async fn test_ao_drvh_drvl_clamp() {
     assert!((rec.val - (-50.0)).abs() < 1e-10);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_oroc_rate_limit() {
     let mut rec = AoRecord::new(0.0);
     rec.oroc = 5.0;
@@ -1406,7 +1405,7 @@ async fn test_ao_oroc_rate_limit() {
     assert!((rec.oval - 10.0).abs() < 1e-10, "Second: oval={}", rec.oval);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_omsl_dol() {
     let db = PvDatabase::new();
     db.add_record("SOURCE", Box::new(AoRecord::new(42.0)))
@@ -1430,7 +1429,7 @@ async fn test_ao_omsl_dol() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_oif_incremental() {
     let db = PvDatabase::new();
     db.add_record("DELTA", Box::new(AoRecord::new(10.0)))
@@ -1461,7 +1460,7 @@ async fn test_ao_oif_incremental() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_ivoa_dont_drive() {
     let db = PvDatabase::new();
     db.add_record("TARGET", Box::new(AoRecord::new(0.0)))
@@ -1504,7 +1503,7 @@ async fn test_ao_ivoa_dont_drive() {
 /// land in `common.asl`. `db_loader::apply_fields` feeds every common
 /// field as `EpicsValue::String`; the ASL handler must parse string
 /// numerics or the directive is silently dropped at IOC load.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_db_load_records_asl_field() {
     use epics_base_rs::server::db_loader;
     use epics_base_rs::server::records::ai::AiRecord;
@@ -1546,7 +1545,7 @@ record(ai, "ASLT:LOW") {
     assert_eq!(low.read().common.asl, 0, "absent ASL defaults to 0");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_ivoa_set_to_ivov_writes_oval() {
     use epics_base_rs::server::records::ao::AoRecord;
 
@@ -1589,7 +1588,7 @@ async fn test_ao_ivoa_set_to_ivov_writes_oval() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_bo_ivoa_set_to_ivov_writes_rval() {
     use epics_base_rs::server::records::bo::BoRecord;
 
@@ -1618,7 +1617,7 @@ async fn test_bo_ivoa_set_to_ivov_writes_rval() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calcout_ivoa_set_to_ivov_writes_oval_only() {
     use epics_base_rs::server::records::calcout::CalcoutRecord;
 
@@ -1666,7 +1665,7 @@ async fn test_calcout_ivoa_set_to_ivov_writes_oval_only() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_mode_input() {
     let db = PvDatabase::new();
     db.add_record("SIM_SW", Box::new(AoRecord::new(1.0)))
@@ -1704,7 +1703,7 @@ async fn test_sim_mode_input() {
 /// VAL of 99 trips HIHI, and because HHSV (MAJOR) outranks SIMM (MINOR)
 /// the limit alarm must WIN — the pre-fix direct-commit clobbered it
 /// (and never even evaluated the limit), reporting only MINOR/SIMM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_value_trips_own_limit_and_maximizes_over_simm() {
     use epics_base_rs::server::recgbl::alarm_status;
 
@@ -1753,7 +1752,7 @@ async fn test_sim_value_trips_own_limit_and_maximizes_over_simm() {
 /// `DBE_VALUE|DBE_ALARM` mask and bypassed the MDEL deadband, so a
 /// steady simulated record re-sent its unchanged alarm fields and VAL on
 /// every cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_steady_cycle_does_not_repost_unchanged_fields() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::DbFieldType;
@@ -1829,7 +1828,7 @@ async fn test_sim_steady_cycle_does_not_repost_unchanged_fields() {
 /// `DBE_ALARM`-only `.SEVR` subscriber must NOT be notified — while
 /// STAT's mask carries `DBE_ALARM` when the severity moved. The pre-fix
 /// SIMM tail collapsed both onto a shared `DBE_VALUE|DBE_ALARM` mask.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_alarm_transition_posts_per_field_masks() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::DbFieldType;
@@ -1889,7 +1888,7 @@ async fn test_sim_alarm_transition_posts_per_field_masks() {
 /// deadband throttles simulated values exactly like real reads
 /// (`aiRecord.c` `monitor()`: `delta > mdel`). The pre-fix SIMM tail
 /// posted VAL on every cycle regardless of MDEL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_val_respects_mdel_deadband() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::DbFieldType;
@@ -1948,7 +1947,7 @@ async fn test_sim_val_respects_mdel_deadband() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_mode_toggle() {
     let db = PvDatabase::new();
     db.add_record("SIM_SW", Box::new(AoRecord::new(0.0)))
@@ -1994,7 +1993,7 @@ async fn test_sim_mode_toggle() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_mode_output() {
     let db = PvDatabase::new();
     db.add_record("SIM_SW", Box::new(AoRecord::new(1.0)))
@@ -2029,7 +2028,7 @@ async fn test_sim_mode_output() {
 /// local `ParsedLink::Db` SIOL, so a non-local SIOL read nothing yet
 /// still returned `Simulated` — the record froze with no value. This is
 /// the INPUT twin of the OUT-link locality fallback.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_mode_input_nonlocal_db_siol() {
     use epics_base_rs::server::database::LinkSet;
     struct ValueCaLset(f64);
@@ -2080,7 +2079,7 @@ async fn test_sim_mode_input_nonlocal_db_siol() {
 /// `dbPut`. OUTPUT twin of `test_sim_mode_input_nonlocal_db_siol`; the
 /// pre-fix port special-cased only a local `ParsedLink::Db` SIOL, so a
 /// non-local SIOL write went nowhere.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sim_mode_output_nonlocal_db_siol() {
     use std::sync::Mutex;
 
@@ -2137,7 +2136,7 @@ async fn test_sim_mode_output_nonlocal_db_siol() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sdis_disable_skips_process() {
     let db = PvDatabase::new();
     db.add_record("DISABLE_SW", Box::new(AoRecord::new(1.0)))
@@ -2201,7 +2200,7 @@ async fn test_sdis_disable_skips_process() {
 /// The port used to hand the constant's text back as if the link had delivered
 /// it, which disabled the record permanently. A DB SDIS still refreshes DISA
 /// every cycle — that is the other half of the boundary, asserted below.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_constant_sdis_never_reaches_disa_but_db_sdis_does() {
     let db = PvDatabase::new();
     db.add_record("TARGET", Box::new(AoRecord::new(0.0)))
@@ -2258,7 +2257,7 @@ async fn test_constant_sdis_never_reaches_disa_but_db_sdis_does() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_phas_scan_order() {
     let db = PvDatabase::new();
 
@@ -2352,7 +2351,7 @@ fn test_depth_limit() {
     });
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_disp_blocks_ca_put() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2370,7 +2369,7 @@ async fn test_disp_blocks_ca_put() {
     assert!(matches!(result, Err(CaError::PutDisabled(_))));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_disp_allows_disp_write() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2392,7 +2391,7 @@ async fn test_disp_allows_disp_write() {
     assert!(inst.common.disp == 0);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_disp_bypassed_by_internal_put() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2408,7 +2407,7 @@ async fn test_disp_bypassed_by_internal_put() {
     assert!(result.is_ok());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_proc_triggers_processing() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2424,7 +2423,7 @@ async fn test_proc_triggers_processing() {
     assert!(inst.common.udf == 0);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_proc_works_any_scan() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2449,7 +2448,7 @@ async fn test_proc_works_any_scan() {
 /// AND before the PROC-driven `dbProcess` (`:1265-1277`). `PROC`'s pfield is
 /// not `&precord->disp`, so `caput REC.PROC 1` on a disabled record is
 /// refused and the record does NOT process.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_disp_blocks_proc_and_suppresses_processing() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2481,7 +2480,7 @@ async fn test_disp_blocks_proc_and_suppresses_processing() {
 /// `S_db_noMod` inside `dbPut` (`dbAccess.c:123`), which `dbPutField` only
 /// reaches AFTER the DISP gate — so on a `DISP=1` record the error a client
 /// sees for `caput REC.PACT` is `S_db_putDisabled`, not `S_db_noMod`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_disp_gate_precedes_nomod_rejection() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2500,7 +2499,7 @@ async fn test_disp_gate_precedes_nomod_rejection() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_proc_while_pact() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2515,7 +2514,7 @@ async fn test_proc_while_pact() {
     assert!(inst.common.udf == 0);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_lcnt_ca_write_rejected() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2527,7 +2526,7 @@ async fn test_lcnt_ca_write_rejected() {
     assert!(matches!(result, Err(CaError::ReadOnlyField(_))));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ca_put_scan_index_update() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2589,7 +2588,7 @@ impl epics_base_rs::server::device_support::DeviceSupport for MockDeviceSupport 
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ca_put_no_double_device_write() {
     let db = PvDatabase::new();
     db.add_record("AO_REC", Box::new(AoRecord::new(0.0)))
@@ -2615,7 +2614,7 @@ async fn test_ca_put_no_double_device_write() {
 /// the live case — the motor record emits its retry / backlash-leg /
 /// NTM-stop commands on exactly these passes, and suppressing the write
 /// strands them in the command mailbox (DMOV stuck 0, MIP=RETRY|MOVE).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_readback_cycle_runs_device_write_without_callback_contract() {
     let db = PvDatabase::new();
     db.add_record("AO_CB1", Box::new(AoRecord::new(0.0)))
@@ -2645,7 +2644,7 @@ async fn test_readback_cycle_runs_device_write_without_callback_contract() {
 /// the callback cycle reads the driver value back and must NOT re-write the
 /// setpoint — re-asserting it would re-trigger the driver (AD `Acquire`
 /// loop).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_readback_cycle_suppresses_device_write_with_callback_contract() {
     let db = PvDatabase::new();
     db.add_record("AO_CB2", Box::new(AoRecord::new(0.0)))
@@ -2680,7 +2679,7 @@ async fn test_readback_cycle_suppresses_device_write_with_callback_contract() {
 // `DTYP="Raw Soft Channel"`, MASK set, and a soft INP link must mask
 // the link value into RVAL before the RVAL→VAL convert. The framework
 // must route the INP value to `raw_soft_input` (not `set_val`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_bi_raw_soft_channel_inp_applies_mask() {
     let db = PvDatabase::new();
     db.add_record("SRC_LI", Box::new(LonginRecord::new(0)))
@@ -2723,7 +2722,7 @@ async fn test_bi_raw_soft_channel_inp_applies_mask() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_input_record_no_device_write() {
     let db = PvDatabase::new();
     db.add_record("AI_REC", Box::new(AiRecord::new(0.0)))
@@ -2773,7 +2772,7 @@ impl epics_base_rs::server::device_support::DeviceSupport for UtagDeviceSupport 
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_device_support_utag_adopted_into_common() {
     // A device that reports a userTag via `last_utag()` must have it
     // adopted into `common.utag` when the record is processed, mirroring
@@ -2802,7 +2801,7 @@ async fn test_device_support_utag_adopted_into_common() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_non_passive_output_ca_put_defers_write_until_scan() {
     // C `dbAccess.c::dbPutField:1263-1266` only processes a record on a
     // put when `precord->scan == 0` (Passive). A CA put to a non-Passive
@@ -2842,7 +2841,7 @@ async fn test_non_passive_output_ca_put_defers_write_until_scan() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_proc_triggers_device_write() {
     let db = PvDatabase::new();
     db.add_record("AO_PROC", Box::new(AoRecord::new(0.0)))
@@ -2864,7 +2863,7 @@ async fn test_proc_triggers_device_write() {
 
 // --- Scan Index Fix tests ---
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_phas_change_updates_scan_index() {
     let db = PvDatabase::new();
     db.add_record("REC_A", Box::new(AoRecord::new(0.0)))
@@ -2912,7 +2911,7 @@ async fn test_phas_change_updates_scan_index() {
     assert_eq!(names, vec!["REC_A", "REC_B"]);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_scan_change_preserves_phas() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -2931,7 +2930,7 @@ async fn test_scan_change_preserves_phas() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_phas_change_passive_no_index() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -3041,7 +3040,7 @@ impl Record for AsyncOutRecord {
 /// dbProcess's own PACT guard (bumping LCNT, and after MAX_LOCK raising a
 /// SCAN_ALARM C never raises for a client put) and never set RPRO — the
 /// second value landed in VAL and was never written out.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_to_pact_record_sets_rpro_and_second_value_reaches_device() {
     let db = PvDatabase::new();
     let writes: Arc<std::sync::Mutex<Vec<f64>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -3096,7 +3095,7 @@ async fn test_put_to_pact_record_sets_rpro_and_second_value_reaches_device() {
         if writes.lock().unwrap().len() >= 2 {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(10)).await;
     }
 
     assert_eq!(
@@ -3112,7 +3111,7 @@ async fn test_put_to_pact_record_sets_rpro_and_second_value_reaches_device() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_async_pending_skips_post_process() {
     let db = PvDatabase::new();
     db.add_record("ASYNC", Box::new(AsyncRecord { val: 0.0 }))
@@ -3137,7 +3136,7 @@ async fn test_async_pending_skips_post_process() {
     assert!(inst.common.udf != 0);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_complete_async_record() {
     let db = PvDatabase::new();
     db.add_record("ASYNC", Box::new(AsyncRecord { val: 42.0 }))
@@ -3214,7 +3213,7 @@ impl Record for AsyncAlarmingRecord {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_complete_async_posts_sevr_with_per_field_mask() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::record::AlarmSeverity;
@@ -3283,7 +3282,7 @@ async fn test_complete_async_posts_sevr_with_per_field_mask() {
 // (lcnt counting up); after MAX_LOCK=10 consecutive bails, SCAN_ALARM /
 // INVALID must be raised with "Async in progress" amsg and VAL must be
 // posted with DBE_VALUE|DBE_LOG|DBE_ALARM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pact_entry_guard_silent_bail_until_max_lock() {
     use epics_base_rs::server::record::AlarmSeverity;
 
@@ -3364,7 +3363,7 @@ async fn test_pact_entry_guard_silent_bail_until_max_lock() {
 // TPRO=true does not interfere with the bail decision (lcnt still
 // increments) and (b) RPRO state is preserved through the guard so
 // the diagnostic value is meaningful.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pact_entry_guard_tpro_diagnostic_does_not_change_bail_outcome() {
     let db = PvDatabase::new();
     db.add_record("ASYNC_TPRO", Box::new(AsyncRecord { val: 0.0 }))
@@ -3415,7 +3414,7 @@ async fn test_pact_entry_guard_tpro_diagnostic_does_not_change_bail_outcome() {
 
 // After PACT clears via complete_async_record, the next process must
 // reset lcnt to 0 (mirrors C `else { precord->lcnt = 0; }`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pact_entry_guard_resets_lcnt_after_completion() {
     let db = PvDatabase::new();
     db.add_record("ASYNC_RESET", Box::new(AsyncRecord { val: 0.0 }))
@@ -3460,7 +3459,7 @@ async fn test_pact_entry_guard_resets_lcnt_after_completion() {
 // The foreign-caller guard (FLNK / scan / CA put) is still in
 // effect — `test_pact_entry_guard_silent_bail_until_max_lock` above
 // covers that case.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_reprocess_after_continuation_bypasses_pact_guard() {
     use epics_base_rs::server::record::{ProcessAction, ProcessOutcome, RecordProcessResult};
     use std::sync::Arc;
@@ -3546,7 +3545,7 @@ async fn test_reprocess_after_continuation_bypasses_pact_guard() {
     );
 
     // Wait for the ReprocessAfter timer to fire.
-    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(80)).await;
 
     // Continuation fired: process() ran a second time despite
     // pact=true.
@@ -3596,7 +3595,7 @@ async fn test_reprocess_after_continuation_bypasses_pact_guard() {
 /// while letting through deltas that cross the threshold. Mirrors
 /// the per-subscription filter chain semantics that the JSON-name
 /// parser (future commit) will wire in for real CA channels.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dbnd_filter_drops_subthreshold_changes() {
     use epics_base_rs::server::database::filters::DeadbandFilter;
     use epics_base_rs::server::recgbl::EventMask;
@@ -3662,7 +3661,7 @@ async fn test_dbnd_filter_drops_subthreshold_changes() {
 /// through regardless of the deadband state. Otherwise an alarm
 /// triggered mid-deadband-window would be silenced and clients
 /// would miss the state change.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dbnd_filter_passes_alarm_events() {
     use epics_base_rs::server::database::filters::DeadbandFilter;
     use epics_base_rs::server::recgbl::EventMask;
@@ -3716,7 +3715,7 @@ async fn test_dbnd_filter_passes_alarm_events() {
     rx.try_recv().expect("alarm event passes the filter");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_notify_field_respects_mask() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(42.0)))
@@ -3756,7 +3755,7 @@ async fn test_notify_field_respects_mask() {
 /// check whenever SDIS evaluates to DISV. Pre-fix Rust only
 /// reset nsta/nsev and updated the alarm — rpro/putf leaked into the
 /// next cycle and pending dbNotify completion callbacks stalled.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sdis_disable_clears_rpro_and_putf() {
     let db = PvDatabase::new();
     db.add_record("DIS_SW", Box::new(AoRecord::new(1.0)))
@@ -3798,7 +3797,7 @@ async fn test_sdis_disable_clears_rpro_and_putf() {
 /// disabled record must release its caller. Pre-fix the
 /// put_notify_tx was never fired, stranding the call until socket
 /// disconnect.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sdis_disable_fires_put_notify_completion() {
     let db = PvDatabase::new();
     db.add_record("DIS_NOT_SW", Box::new(AoRecord::new(1.0)))
@@ -3854,7 +3853,7 @@ async fn test_sdis_disable_fires_put_notify_completion() {
 /// Boundary: a fully synchronous chain (originating record + a sync FLNK
 /// target) drains the wait-set within the put call, so the put reports
 /// immediate completion (`Ok(None)`) — no receiver is handed back.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_notify_sync_chain_completes_immediately() {
     let db = PvDatabase::new();
     db.add_record("PN_SYNC_SRC", Box::new(AoRecord::new(0.0)))
@@ -3886,7 +3885,7 @@ async fn test_put_notify_sync_chain_completes_immediately() {
 /// WRITE_NOTIFY done while the async FLNK target was still in flight. Now
 /// the put returns a receiver that fires only when the async target's
 /// `complete_async_record` runs.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_notify_defers_for_async_flnk_target() {
     let db = PvDatabase::new();
     db.add_record("PN_FLNK_SRC", Box::new(AoRecord::new(0.0)))
@@ -3929,7 +3928,7 @@ async fn test_put_notify_defers_for_async_flnk_target() {
 
 /// Boundary: same deferral, reached through an OUT `PP` link instead of
 /// FLNK — the other dispatch edge that calls `processTarget`/`dbNotifyAdd`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_notify_defers_for_async_out_pp_target() {
     let db = PvDatabase::new();
     db.add_record("PN_OUT_SRC", Box::new(AoRecord::new(0.0)))
@@ -3972,7 +3971,7 @@ async fn test_put_notify_defers_for_async_out_pp_target() {
 /// Silently overwriting the wait-set would drop the prior `Sender`, waking
 /// the prior caller's receiver with a `RecvError` the CA dispatcher treats
 /// as success.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_notify_refuses_second_in_flight() {
     let db = PvDatabase::new();
     db.add_record("PN_DBL", Box::new(AsyncRecord { val: 0.0 }))
@@ -4009,7 +4008,7 @@ async fn test_put_notify_refuses_second_in_flight() {
 /// notify slot occupied for the whole async round trip (a motor's
 /// whole motion), refusing every legitimate WRITE_NOTIFY on the record
 /// with PutCallbackInProgress in the meantime.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fire_and_forget_put_parks_no_notify_write_notify_stays_legal() {
     let db = PvDatabase::new();
     db.add_record("PN_FF", Box::new(AsyncRecord { val: 0.0 }))
@@ -4059,7 +4058,7 @@ async fn test_fire_and_forget_put_parks_no_notify_write_notify_stays_legal() {
             break;
         }
         drop(inst);
-        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(1)).await;
     }
     {
         let rec = db.get_record("PN_FF").unwrap();
@@ -4084,7 +4083,7 @@ async fn test_fire_and_forget_put_parks_no_notify_write_notify_stays_legal() {
 /// a WRITE_NOTIFY already parked is accepted (C `dbPutField` carries no
 /// notify state to conflict) and leaves the parked wait-set undisturbed
 /// — it neither steals nor fires the prior caller's completion.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fire_and_forget_put_does_not_disturb_parked_notify() {
     let db = PvDatabase::new();
     db.add_record("PN_FF2", Box::new(AsyncRecord { val: 0.0 }))
@@ -4155,7 +4154,7 @@ impl Record for ScanOnceEmitter {
 /// so `dbNotifyCompletion` does not wait on it. The RTEMS CA driver must
 /// therefore see `ProcessCompletion::Sync` here and reply inline — waiting on
 /// the scanOnce would hang the reply on an unrelated cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scan_once_is_not_joined_to_put_notify_completion() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicU32::new(0));
@@ -4192,9 +4191,9 @@ async fn scan_once_is_not_joined_to_put_notify_completion() {
     // returned: the record is re-processed a second time, off the put's
     // completion path.
     for _ in 0..50 {
-        tokio::task::yield_now().await;
+        epics_base_rs::runtime::task::yield_now().await;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(50)).await;
     assert!(
         count.load(Ordering::SeqCst) >= 2,
         "the scanOnce must run as its own cycle after the put completed, got \
@@ -4207,7 +4206,7 @@ async fn scan_once_is_not_joined_to_put_notify_completion() {
 /// mode. `originating_pending` keys on the instance's parked notify;
 /// a fire-and-forget put parks nothing, so it must fall through to the
 /// guarded clear rather than mistaking an empty slot for "pending".
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fire_and_forget_put_clears_putf_on_sync_completion() {
     let db = PvDatabase::new();
     db.add_record("PN_FF_SYNC", Box::new(AoRecord::new(0.0)))
@@ -4232,7 +4231,7 @@ async fn test_fire_and_forget_put_clears_putf_on_sync_completion() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sdis_disable_notifies_alarm() {
     // C `dbAccess.c:587-592` — the disable branch of `dbProcess` posts:
     //   db_post_events(&precord->stat, DBE_VALUE);            // STAT
@@ -4278,7 +4277,7 @@ async fn test_sdis_disable_notifies_alarm() {
 
 // --- UDF in database context ---
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_udf_cleared_by_process_with_links() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -4303,7 +4302,7 @@ async fn test_udf_cleared_by_process_with_links() {
 ///
 /// UDF is the "did it process" probe — `process_record_with_links` clears it
 /// (see `test_udf_cleared_by_process_with_links`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pini_passes_select_disjoint_menu_choices() {
     use epics_base_rs::server::record::PiniMode;
 
@@ -4374,7 +4373,7 @@ async fn test_pini_passes_select_disjoint_menu_choices() {
 /// record; `status` stays 0, so `dbPut` returns success. The port rejected the
 /// put with an error, so the client saw a write failure and the record's alarm
 /// state was never touched.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_empty_array_into_scalar_is_accepted_and_alarms_the_record() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::record::AlarmSeverity;
@@ -4418,7 +4417,7 @@ async fn test_empty_array_into_scalar_is_accepted_and_alarms_the_record() {
 /// no-op success: C takes the `no_elements > 1` branch (`dbAccess.c:1345`),
 /// clamps `nRequest` to 0 and converts nothing — no alarm. Only the *scalar*
 /// destination alarms. This is the boundary the fix turns on.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_empty_array_into_array_field_is_a_silent_no_op() {
     use epics_base_rs::server::record::AlarmSeverity;
 
@@ -4458,7 +4457,7 @@ async fn test_empty_array_into_array_field_is_a_silent_no_op() {
 /// is written and the put SUCCEEDS. The port passed the array straight to the
 /// record's typed `put_field` arm, which rejected it with `TypeMismatch`, so
 /// the client saw a write failure.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_10_multi_element_array_into_scalar_writes_element_zero() {
     let db = PvDatabase::new();
     db.add_record("ARRPUT", Box::new(AoRecord::new(5.0)))
@@ -4489,7 +4488,7 @@ async fn r6_10_multi_element_array_into_scalar_writes_element_zero() {
 /// the same multi-element array into an **array** field writes every element
 /// (C: `no_elements >= nRequest`, nothing is clamped away). Only a one-element
 /// destination reduces to element 0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_10_multi_element_array_into_array_field_writes_all_elements() {
     let db = PvDatabase::new();
     let wf = epics_base_rs::server::records::waveform::WaveformRecord::new(
@@ -4512,7 +4511,7 @@ async fn r6_10_multi_element_array_into_array_field_writes_all_elements() {
 /// (`caput -a REC.VAL 1 7`); C's clamp leaves `nRequest = 1` and writes it.
 /// Between this and the zero-element case (R6-7, LINK/INVALID alarm, nothing
 /// written) sit the two edges of C's `nRequest` branch.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_10_single_element_array_into_scalar_writes_that_element() {
     let db = PvDatabase::new();
     db.add_record("ONEPUT", Box::new(AoRecord::new(5.0)))
@@ -4535,7 +4534,7 @@ async fn r6_10_single_element_array_into_scalar_writes_that_element() {
 /// coercion path that could not reduce the array, so the value was silently
 /// dropped and VAL kept its stale content. `set_val` now routes through
 /// `put_field_internal`, the single owner of internal-delivery coercion.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_10_array_source_link_into_scalar_val_delivers_element_zero() {
     let db = PvDatabase::new();
     let wf = epics_base_rs::server::records::waveform::WaveformRecord::new(
@@ -4579,7 +4578,7 @@ async fn r6_10_array_source_link_into_scalar_val_delivers_element_zero() {
 /// the failure (`dbpf` prints "PV '%s' not found" and returns -1,
 /// `dbTest.c:787-795`). The port's `put_common_field` fell through to
 /// `Ok(NoChange)`, so a misspelled field was a silent success.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_9_put_to_unknown_field_is_an_error_on_every_entry_point() {
     let db = PvDatabase::new();
     db.add_record("BADFLD", Box::new(AoRecord::new(1.0)))
@@ -4630,7 +4629,7 @@ async fn r6_9_put_to_unknown_field_is_an_error_on_every_entry_point() {
 /// carries `special == SPC_ATTRIBUTE` → `dbPutField` returns the same
 /// `S_db_noMod` (`dbAccess.c:1252-1253`). Neither may silently succeed, and
 /// neither may be reported as "field not found".
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_9_put_to_a_record_attribute_is_read_only_not_not_found() {
     let db = PvDatabase::new();
     db.add_record("ATTRFLD", Box::new(AoRecord::new(1.0)))
@@ -4655,7 +4654,7 @@ async fn r6_9_put_to_a_record_attribute_is_read_only_not_not_found() {
 /// there). On any other record type C has no such field, so the put is an
 /// `S_dbLib_fieldNotFound` like any other unknown name; the port's `OUTN` arm
 /// used to swallow it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r6_9_outn_is_swait_only() {
     use epics_base_rs::server::records::swait::SwaitRecord;
 
@@ -4692,7 +4691,7 @@ async fn r6_9_outn_is_swait_only() {
 /// which under ascending-PHAS order is the highest-PHAS one. The records are
 /// added in descending phase order so that load order alone gives the wrong
 /// answer.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pini_records_process_in_ascending_phas_order() {
     use epics_base_rs::server::record::PiniMode;
 
@@ -4735,7 +4734,7 @@ async fn test_pini_records_process_in_ascending_phas_order() {
 /// to look for the lowest value of PHAS each time" (`iocInit.c:614-619`). A
 /// record moved out of the phase currently being processed must still be picked
 /// up by the pass for its new phase, not dropped.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pini_sweep_covers_every_phase_present() {
     use epics_base_rs::server::record::PiniMode;
 
@@ -4772,7 +4771,7 @@ async fn test_pini_sweep_covers_every_phase_present() {
 /// be rejected rather than silently landing on NO. The pre-fix bool accepted
 /// only `"YES"`/`"1"`/`"true"` and mapped everything else — including the four
 /// real menu choices — to `false`, so `caput REC.PINI RUN` *disabled* PINI.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pini_put_accepts_every_menu_choice_and_rejects_junk() {
     use epics_base_rs::server::record::PiniMode;
 
@@ -4825,7 +4824,7 @@ async fn test_pini_put_accepts_every_menu_choice_and_rejects_junk() {
 /// does not own UDF. Regression guard for the int32-ao udf-on-readback path
 /// (the recurring "int32-ao udf-on-NaN" residual is framework-handled, not
 /// a divergence).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_asyn_readback_clears_udf_via_framework() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -4855,7 +4854,7 @@ async fn test_ao_asyn_readback_clears_udf_via_framework() {
     assert_eq!(g.record.get_field("VAL"), Some(EpicsValue::Double(150.0)));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_udf_not_cleared_by_clears_udf_false() {
     struct NoClearRecord {
         val: f64,
@@ -4918,7 +4917,7 @@ async fn test_udf_not_cleared_by_clears_udf_false() {
 /// at all) + a runtime `put_common_field("INP", ...)`, then assert the value
 /// appeared after `process` — which only passed because the process-time read
 /// re-delivered the constant every cycle, the R15-78 defect.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_constant_inp_link() {
     use epics_base_rs::server::ioc_builder::IocBuilder;
     let (db, _) = IocBuilder::new()
@@ -4962,7 +4961,7 @@ async fn test_constant_inp_link() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_multi_input_db_links() {
     use epics_base_rs::server::records::calc::CalcRecord;
     let db = PvDatabase::new();
@@ -4994,7 +4993,7 @@ async fn test_calc_multi_input_db_links() {
 /// (bare `get_pv`, no PP processing), so a PP input link read a stale
 /// source value. The single-INP path already did this via
 /// `read_link_value_soft`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_multi_input_pp_processes_passive_source() {
     use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -5040,7 +5039,7 @@ async fn test_calc_multi_input_pp_processes_passive_source() {
 /// the engine path. It used to call the reduced `process_local`, which fetched
 /// no INPx, so a direct process of a calc/sub read stale A..U inputs; it now
 /// delegates to the canonical link-fetching engine path.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn process_record_fetches_input_links() {
     use epics_base_rs::server::records::ao::AoRecord;
     use epics_base_rs::server::records::calc::CalcRecord;
@@ -5073,7 +5072,7 @@ async fn process_record_fetches_input_links() {
 /// Defect 3 control: an `NPP` (no-process-passive) multi-input link
 /// must NOT process its passive source — it reads whatever stale
 /// value the source currently holds.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_multi_input_npp_does_not_process_source() {
     use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -5111,7 +5110,7 @@ async fn test_calc_multi_input_npp_does_not_process_source() {
 /// `'0'` failed the guard and `INP="DIRECT.B0"` parsed as a link to a *record*
 /// literally named `"DIRECT.B0"`: it never resolved locally and was re-routed
 /// as an external CA channel, losing lock-set atomicity and PP/MS semantics.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_link_to_digit_bearing_field_is_a_local_db_link() {
     use epics_base_rs::server::record::{DbLink, LinkProcessPolicy, MonitorSwitch, ParsedLink};
     use epics_base_rs::server::records::mbbo_direct::MbboDirectRecord;
@@ -5203,7 +5202,7 @@ async fn test_link_to_digit_bearing_field_is_a_local_db_link() {
 /// defaulted a bare link to `ProcessPassive`, so `BARE_DST` would have
 /// spuriously processed `BARE_SRC` and read 42; after the fix it reads
 /// the stale 0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_multi_input_bare_does_not_process_source() {
     use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -5259,7 +5258,7 @@ async fn test_calc_multi_input_bare_does_not_process_source() {
 ///
 /// This test passing at all proves the fix: a regression re-aborts
 /// the whole test process with a stack overflow.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_pp_link_cycle_terminates() {
     use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -5301,7 +5300,7 @@ async fn test_calc_pp_link_cycle_terminates() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_constant_inputs() {
     use epics_base_rs::server::records::calc::CalcRecord;
     let db = PvDatabase::new();
@@ -5325,7 +5324,7 @@ async fn test_calc_constant_inputs() {
 // ai/ao/longin/longout. The Rust port omitted them — put_field for
 // HIHI silently no-op'd because `common.analog_alarm` was None for
 // rtype="calc".
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_record_has_analog_alarm_limits() {
     use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -5373,7 +5372,7 @@ async fn test_calc_record_has_analog_alarm_limits() {
 // alarm-range integer is exponentially smoothed, so a brief excursion
 // above HIHI does NOT immediately raise the severity until the filter
 // converges.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_calc_record_aftc_filter_delays_alarm() {
     use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -5419,7 +5418,7 @@ async fn test_calc_record_aftc_filter_delays_alarm() {
     assert!(afvl != 0.0, "AFVL must be updated when AFTC > 0");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fanout_all() {
     use epics_base_rs::server::records::fanout::FanoutRecord;
     let db = PvDatabase::new();
@@ -5443,7 +5442,7 @@ async fn test_fanout_all() {
     assert!(visited.contains("TARGET_2"));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fanout_specified() {
     // C parity (fanoutRecord.c:114): SELM=Specified selects the link
     // at index `SELN + OFFS`, 0-based over LNK0..LNKF. With SELN=1,
@@ -5480,7 +5479,7 @@ async fn test_fanout_specified() {
     assert!(!visited.contains("T2"));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dfanout_value_write() {
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
     let db = PvDatabase::new();
@@ -5517,7 +5516,7 @@ async fn test_dfanout_value_write() {
 /// `processing.rs::process_record_with_links_inner`, so a dfanout
 /// configured with OMSL=closed_loop never sourced VAL from DOL —
 /// every cycle silently kept the previously-cached VAL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dfanout_omsl_closed_loop_sources_val_from_dol() {
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
 
@@ -5567,7 +5566,7 @@ async fn test_dfanout_omsl_closed_loop_sources_val_from_dol() {
 /// (default), DOL must NOT be evaluated even if a DOL link is set —
 /// VAL remains under operator control. This pins the gating so a
 /// future refactor cannot silently widen the closed-loop scope.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dfanout_omsl_supervisory_ignores_dol() {
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
 
@@ -5624,7 +5623,7 @@ async fn define_val(db: &PvDatabase, name: &str) {
 /// cycle's committed SEVR and the VAL monitor post. After ONE process, a
 /// broken OUT link must leave SEVR=INVALID / STAT=LINK — proving the
 /// same-cycle fold (a one-cycle-late latch would read NO_ALARM here).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dfanout_out_link_write_failure_raises_link_alarm() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
@@ -5674,7 +5673,7 @@ async fn test_dfanout_out_link_write_failure_raises_link_alarm() {
 /// Companion gate: a dfanout whose OUT links all write successfully must
 /// NOT raise a LINK alarm — SEVR stays NO_ALARM. Pins that the
 /// write-failure fold above only fires on a real `dbPutLink` failure.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dfanout_out_link_write_success_no_link_alarm() {
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
 
@@ -5711,7 +5710,7 @@ async fn test_dfanout_out_link_write_success_no_link_alarm() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_dol_lnk_dispatch() {
     use epics_base_rs::server::records::seq::SeqRecord;
     let db = PvDatabase::new();
@@ -5755,7 +5754,7 @@ async fn test_seq_dol_lnk_dispatch() {
 // then posts DOn on change. The Rust seq dispatch used DOLn only
 // transiently for the LNKn write and never wrote it back into DOn, so a
 // client reading/monitoring DOn saw a stale value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_writes_dol_readback_into_don() {
     use epics_base_rs::server::records::seq::SeqRecord;
     let db = PvDatabase::new();
@@ -5797,7 +5796,7 @@ async fn test_seq_writes_dol_readback_into_don() {
 // real link. A DOL-only group (real DOLn, empty LNKn) still reads back
 // DOn and posts it, even though nothing is driven. The Rust dispatch
 // skipped any group with an empty LNKn, so DOn never updated.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_dol_only_group_updates_don_with_empty_lnk() {
     use epics_base_rs::server::records::seq::SeqRecord;
     let db = PvDatabase::new();
@@ -5869,7 +5868,7 @@ impl Record for CountingTarget {
 // `parse_link_v2`/`parse_output_link_v2` default a modifier-less link
 // to NPP (`NoProcess`) like C `dbParseLink`, so the `MultiOut::Seq` arm
 // needs no per-call downgrade.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_bare_lnk_does_not_process_passive_target() {
     use epics_base_rs::server::records::seq::SeqRecord;
     let db = PvDatabase::new();
@@ -5953,7 +5952,7 @@ impl Record for WriteThenFlnkProducer {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_write_db_link_runs_before_flnk_target_reads_fresh() {
     let db = PvDatabase::new();
     // Target the producer writes 42.0 into.
@@ -6002,10 +6001,10 @@ async fn test_write_db_link_runs_before_flnk_target_reads_fresh() {
 async fn poll_atomic_reaches(label: &str, counter: &Arc<AtomicU32>, want: u32) {
     for _ in 0..400 {
         if counter.load(Ordering::SeqCst) >= want {
-            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(30)).await;
             return;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
     panic!(
         "{label}: counter reached {} (< {want}) before timeout",
@@ -6022,7 +6021,7 @@ async fn poll_pv_double(db: &PvDatabase, pv: &str, want: f64) {
                 return;
             }
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
     panic!(
         "{pv}: did not reach {want} before timeout (last {:?})",
@@ -6033,7 +6032,7 @@ async fn poll_pv_double(db: &PvDatabase, pv: &str, want: f64) {
 // BUG 1 regression — sseq `LNKn` is `DBF_OUTLINK` driven via `dbPutLink`
 // → `dbDbPutValue` (`dbDbLink.c:388`). A bare sseq LNKn is NPP and must
 // not process its target; an explicit-PP LNKn must.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sseq_bare_lnk_does_not_process_passive_target() {
     use epics_base_rs::server::records::sseq::SseqRecord;
     let db = PvDatabase::new();
@@ -6094,7 +6093,7 @@ async fn test_sseq_bare_lnk_does_not_process_passive_target() {
 // (`callbackRequestDelayed`), exactly as the base `seqRecord` does for
 // DLY0..DLYF. The async machine ports this with a per-step
 // `ReprocessAfter(DLYn)`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sseq_per_step_dly_delays_step_write() {
     use epics_base_rs::server::records::sseq::SseqRecord;
     let db = PvDatabase::new();
@@ -6133,7 +6132,7 @@ async fn test_sseq_per_step_dly_delays_step_write() {
 
     // Before DLY1 (0.3 s) elapses, step 1's value must NOT be written yet,
     // and step 2 must not fire before step 1.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(100)).await;
     assert_eq!(
         db.get_pv("SSEQ_DLY_TGT1").unwrap(),
         EpicsValue::Double(0.0),
@@ -6150,7 +6149,7 @@ async fn test_sseq_per_step_dly_delays_step_write() {
     poll_pv_double(&db, "SSEQ_DLY_TGT2", 22.0).await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sel_nvl_link() {
     use epics_base_rs::server::records::sel::SelRecord;
     let db = PvDatabase::new();
@@ -6183,7 +6182,7 @@ async fn test_sel_nvl_link() {
 // SELN is DBF_USHORT (selRecord.dbd.pod:295): an NVL link value in the
 // upper unsigned half (32768..65535) must reach SELN intact. The former
 // f64->i16 carrier saturated such a value to 32767, losing the high half.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sel_nvl_link_high_index_unsigned() {
     use epics_base_rs::server::records::sel::SelRecord;
     let db = PvDatabase::new();
@@ -6205,7 +6204,7 @@ async fn test_sel_nvl_link_high_index_unsigned() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dol_cp_link_registration() {
     let db = PvDatabase::new();
     db.add_record("MTR", Box::new(AoRecord::new(0.0)))
@@ -6222,7 +6221,7 @@ async fn test_dol_cp_link_registration() {
     assert!(!targets[0].passive_only, "CP link must not be passive_only");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_dol_cp_link_triggers_processing() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(10.0)))
@@ -6252,7 +6251,7 @@ async fn test_dol_cp_link_triggers_processing() {
 /// which — since the holder *writes* that target — is a processing loop that
 /// does not exist on a C IOC. The same text on an `INP` (`DBF_INLINK`) does
 /// register, which is the boundary this pins.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_out_link_cp_modifier_is_not_registered_as_a_cp_holder() {
     let db = PvDatabase::new();
     db.add_record("CPOUT_TGT", Box::new(AoRecord::new(0.0)))
@@ -6302,7 +6301,7 @@ async fn test_out_link_cp_modifier_is_not_registered_as_a_cp_holder() {
 
 /// A CPP link registers as `passive_only` (distinct from CP). Collapsing
 /// CPP into CP loses C's `precord->scan == 0` gate (`dbCa.c:994`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_cpp_link_registration_is_passive_only() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(0.0)))
@@ -6326,7 +6325,7 @@ async fn test_cpp_link_registration_is_passive_only() {
 /// processes the link-holder only when its SCAN is Passive. A non-Passive
 /// CPP target must NOT be processed by the dispatch — its own periodic scan
 /// owns it. Boundary: target SCAN != Passive.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_cpp_link_skips_nonpassive_target() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(10.0)))
@@ -6356,7 +6355,7 @@ async fn test_cpp_link_skips_nonpassive_target() {
 
 /// CPP gate, complementary boundary: a CPP link DOES process the link-holder
 /// when its SCAN is Passive (the default). Boundary: target SCAN == Passive.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_cpp_link_processes_passive_target() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(10.0)))
@@ -6385,7 +6384,7 @@ async fn test_cpp_link_processes_passive_target() {
 /// CP (not CPP) processes the link-holder regardless of its SCAN
 /// (`dbCa.c:993` adds CA_DBPROCESS unconditionally). A non-Passive CP target
 /// IS processed — the boundary that distinguishes CP from CPP.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_cp_link_processes_nonpassive_target() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(10.0)))
@@ -6416,7 +6415,7 @@ async fn test_cp_link_processes_nonpassive_target() {
 /// When the same source→target edge is registered from both a CP and a CPP
 /// link, CP dominates: the merged edge is NOT passive_only — an
 /// unconditional CP CA_DBPROCESS overrides the CPP scan gate (`dbCa.c:993`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_cp_overrides_cpp_for_same_edge() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(0.0)))
@@ -6444,7 +6443,7 @@ async fn test_cp_overrides_cpp_for_same_edge() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_dol_cp_link_registration() {
     use epics_base_rs::server::records::seq::SeqRecord;
     let db = PvDatabase::new();
@@ -6461,7 +6460,7 @@ async fn test_seq_dol_cp_link_registration() {
     assert!(!targets[0].passive_only, "CP link must not be passive_only");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sel_nvl_cp_link_registration() {
     use epics_base_rs::server::records::sel::SelRecord;
     let db = PvDatabase::new();
@@ -6478,7 +6477,7 @@ async fn test_sel_nvl_cp_link_registration() {
     assert!(!targets[0].passive_only, "CP link must not be passive_only");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sdis_cp_link_registration() {
     let db = PvDatabase::new();
     db.add_record("DISABLE_SRC", Box::new(AoRecord::new(0.0)))
@@ -6508,7 +6507,7 @@ async fn test_sdis_cp_link_registration() {
 /// "device-provided with BestTime fallback" and gated the call on
 /// UNIX_EPOCH. A stale device write of any non-epoch SystemTime
 /// suppressed every subsequent BestTime refresh.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_tse_minus1_always_overwrites_via_best_time() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -6535,7 +6534,7 @@ async fn test_tse_minus1_always_overwrites_via_best_time() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_tse_minus2_keeps_time_unchanged() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -6556,7 +6555,7 @@ async fn test_tse_minus2_keeps_time_unchanged() {
     assert_eq!(inst.common.time, fixed_time);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_putf_read_only_from_ca() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -6568,7 +6567,7 @@ async fn test_putf_read_only_from_ca() {
     assert!(result.is_err());
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_rpro_causes_reprocessing() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AoRecord::new(10.0)))
@@ -6607,7 +6606,7 @@ async fn test_rpro_causes_reprocessing() {
     assert!(inst.common.rpro == 0);
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_tsel_cp_link_registration() {
     let db = PvDatabase::new();
     db.add_record("TSE_SRC", Box::new(AoRecord::new(0.0)))
@@ -6634,7 +6633,7 @@ async fn test_tsel_cp_link_registration() {
 /// both through `dbGetTimeStampTag(plink, &prec->time, &prec->utag)`.
 /// Pre-fix only `common.time` was copied and the source's `utag` was
 /// dropped.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_tsel_time_link_copies_source_time_and_utag() {
     let db = PvDatabase::new();
     db.add_record("TSE_SRC", Box::new(AoRecord::new(0.0)))
@@ -6685,7 +6684,7 @@ async fn test_tsel_time_link_copies_source_time_and_utag() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_tsel_ca_time_link_copies_source_time() {
     // C `TSEL_modified` (dbLink.c:80-86) sets DBLINK_FLAG_TSELisTIME for
     // ANY PV_LINK TSEL whose pvname contains `.TIME`, set before the
@@ -6753,7 +6752,7 @@ async fn test_tsel_ca_time_link_copies_source_time() {
     assert_eq!(inst.common.tse, -2, "adopting link time marks TSE=-2");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_tsel_nonlocal_db_time_link_copies_remote_time() {
     // A bare TSEL `.TIME` link (no `ca://`, no CP/CPP/CA modifier) whose
     // target record is NOT local. C `dbInitLink` (dbLink.c:115-130) sets
@@ -6825,7 +6824,7 @@ async fn test_tsel_nonlocal_db_time_link_copies_remote_time() {
     assert_eq!(inst.common.tse, -2, "adopting link time marks TSE=-2");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_new_common_fields_get_put() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -6913,7 +6912,7 @@ async fn test_new_common_fields_get_put() {
 /// answers `10`; the recGbl simulation helpers bail on `*psscn == USHRT_MAX`
 /// (recGbl.c) and on nothing else, so 12 is an ordinary illegal index, not
 /// "unset".
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_sscn_serves_menu_index_and_65535_sentinel() {
     let db = PvDatabase::new();
     db.add_record("REC", Box::new(AoRecord::new(0.0)))
@@ -6975,7 +6974,7 @@ async fn test_sscn_serves_menu_index_and_65535_sentinel() {
 /// `notify_from_snapshot`. This test pins that contract for all four
 /// `ArrayKind` variants by subscribing to NORD, processing once, and
 /// verifying the delivered MonitorEvent timestamp is fresh.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_array_records_nord_monitor_uses_post_process_timestamp() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::waveform::{ArrayKind, WaveformRecord};
@@ -7075,7 +7074,7 @@ async fn test_array_records_nord_monitor_uses_post_process_timestamp() {
 ///
 /// This test pins the post-fix behaviour for both halves of the gate:
 /// (a) unchanged → no event; (b) changed → event flows through.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_complete_async_record_gates_subscribed_field_on_change() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::DbFieldType;
@@ -7165,7 +7164,7 @@ async fn test_complete_async_record_gates_subscribed_field_on_change() {
 /// This test pins the behaviour for waveform; the same code path
 /// applies to aai/aao/subArray since they share the WaveformRecord
 /// implementation.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_pv_and_post_propagates_nord_side_effect_on_waveform() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::waveform::{ArrayKind, WaveformRecord};
@@ -7261,7 +7260,7 @@ async fn test_put_pv_and_post_propagates_nord_side_effect_on_waveform() {
 /// downstream subscriber path (DST is an ai whose process()
 /// recomputes VAL from RVAL, washing out the put_pv side-effect)
 /// — the timestamp invariant is the load-bearing assertion here.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_output_link_cascade_uses_post_process_source_timestamp() {
     use std::time::SystemTime;
 
@@ -7348,7 +7347,7 @@ async fn test_output_link_cascade_uses_post_process_source_timestamp() {
 /// carry a timestamp ≥ the post-sleep wall-clock instant — proving
 /// the snapshot was timestamped at completion, not at process
 /// start.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_complete_async_record_updates_timestamp_at_completion() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::{DbFieldType, WallTime};
@@ -7379,7 +7378,7 @@ async fn test_complete_async_record_updates_timestamp_at_completion() {
 
     // Sleep a measurable interval so the completion timestamp is
     // distinguishable from the process-start timestamp.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
     let post_sleep = WallTime::now();
 
     // Second half: completion fires snapshot/notify with a fresh
@@ -7413,7 +7412,7 @@ async fn test_complete_async_record_updates_timestamp_at_completion() {
 /// OOPT=1 must drive write_db_link_value (observed via the target
 /// record's `common.time` advancing past baseline), and a second
 /// no-op process cycle must not.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_longout_oopt_on_change_first_cycle_emits_then_suppresses() {
     use epics_base_rs::server::records::longout::LongoutRecord;
     use std::time::SystemTime;
@@ -7471,7 +7470,7 @@ async fn test_longout_oopt_on_change_first_cycle_emits_then_suppresses() {
     // off. Capture DST's time before to detect any unwanted
     // re-process.
     let dst_time_before_second = dst_time_after_first;
-    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     let mut visited = HashSet::new();
     db.process_record_with_links("LO_SRC", &mut visited, 0)
         .await
@@ -7509,7 +7508,7 @@ async fn test_longout_oopt_on_change_first_cycle_emits_then_suppresses() {
 /// process exactly once per `process_record_with_links` call and the
 /// call must complete promptly (we use a 1s timeout to fail fast on
 /// infinite recursion regressions).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_self_link_out_does_not_loop() {
     use epics_base_rs::server::records::longout::LongoutRecord;
     use std::time::Duration;
@@ -7532,7 +7531,7 @@ async fn test_self_link_out_does_not_loop() {
     // process call would never return (infinite recursion via
     // write_db_link_value → process_record_with_links → ...).
     let mut visited = HashSet::new();
-    let result = tokio::time::timeout(
+    let result = epics_base_rs::runtime::task::timeout(
         Duration::from_secs(1),
         db.process_record_with_links("SELF_LO", &mut visited, 0),
     )
@@ -7553,7 +7552,7 @@ async fn test_self_link_out_does_not_loop() {
     // been left set on the record, otherwise the record would
     // reprocess in a loop after every external put.
     let mut visited2 = HashSet::new();
-    let result2 = tokio::time::timeout(
+    let result2 = epics_base_rs::runtime::task::timeout(
         Duration::from_secs(1),
         db.process_record_with_links("SELF_LO", &mut visited2, 0),
     )
@@ -7590,7 +7589,7 @@ async fn test_self_link_out_does_not_loop() {
 /// `process_record_with_links_inner`, whose snapshot path includes
 /// VAL via the always-on `include_val` branch for non-deadband
 /// records, so the VAL subscriber sees the post-reset empty array.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_compress_res_write_posts_val_monitor() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::compress::CompressRecord;
@@ -7674,7 +7673,7 @@ async fn test_compress_res_write_posts_val_monitor() {
 ///
 /// Pre-fix the port reset only on RES, so a BALG FIFO→LIFO switch re-read the
 /// stale ring in the new order and an N put corrupted the next emitted sample.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_compress_every_spc_reset_field_resets_the_buffer() {
     use epics_base_rs::server::records::compress::CompressRecord;
 
@@ -7747,7 +7746,7 @@ async fn test_compress_every_spc_reset_field_resets_the_buffer() {
 /// while the same put under BALG=FIFO succeeds. The port expressed NOMOD only
 /// as the static `FieldDesc::read_only`, which cannot depend on record state,
 /// so a LIFO compress accepted VAL puts.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_compress_val_no_mod_under_lifo_balg() {
     use epics_base_rs::server::records::compress::CompressRecord;
 
@@ -7806,7 +7805,7 @@ async fn test_compress_val_no_mod_under_lifo_balg() {
 ///
 /// Pre-fix the port accepted the put on every route, so a caput silently
 /// stopped a live acquisition.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_histogram_csta_is_no_mod() {
     use epics_base_rs::server::records::histogram::HistogramRecord;
 
@@ -7866,7 +7865,7 @@ async fn test_histogram_csta_is_no_mod() {
 /// dbpf LO2.VAL 70000.9 -> 70000     dbpf LO2.VAL -3.9 -> -3   (port agrees:
 ///                                   in range, no policy in play)
 /// ```
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_double_to_int_narrowing_saturates_per_cbug_e2() {
     use epics_base_rs::server::records::longout::LongoutRecord;
     use epics_base_rs::server::records::waveform::WaveformRecord;
@@ -7943,7 +7942,7 @@ async fn test_double_to_int_narrowing_saturates_per_cbug_e2() {
 /// MDEL can hold every process-time post back indefinitely (`monitor()` posts
 /// only when `mcnt > mdel`), so without the watchdog a slow accumulation never
 /// reaches a display. Pre-fix an SDEL put stored the number and nothing else.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_histogram_sdel_watchdog_posts_val() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::histogram::HistogramRecord;
@@ -7974,10 +7973,11 @@ async fn test_histogram_sdel_watchdog_posts_val() {
         .unwrap();
 
     // The tick must post VAL and zero MCNT.
-    let event = tokio::time::timeout(std::time::Duration::from_secs(2), val_rx.recv())
-        .await
-        .expect("SDEL watchdog must post VAL within one period")
-        .expect("subscription alive");
+    let event =
+        epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(2), val_rx.recv())
+            .await
+            .expect("SDEL watchdog must post VAL within one period")
+            .expect("subscription alive");
     match &event.snapshot.value {
         EpicsValue::ULongArray(v) => assert_eq!(
             v,
@@ -7996,10 +7996,11 @@ async fn test_histogram_sdel_watchdog_posts_val() {
     db.put_record_field_from_ca("HI_WDOG", "SGNL", EpicsValue::Double(6.0))
         .await
         .unwrap();
-    let event = tokio::time::timeout(std::time::Duration::from_secs(2), val_rx.recv())
-        .await
-        .expect("the watchdog re-arms itself (C: callbackRequestDelayed at the tail)")
-        .expect("subscription alive");
+    let event =
+        epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(2), val_rx.recv())
+            .await
+            .expect("the watchdog re-arms itself (C: callbackRequestDelayed at the tail)")
+            .expect("subscription alive");
     match &event.snapshot.value {
         EpicsValue::ULongArray(v) => assert_eq!(v, &vec![1, 1]),
         other => panic!("VAL must be ULongArray (C DBF_ULONG), got {other:?}"),
@@ -8024,7 +8025,7 @@ async fn test_histogram_sdel_watchdog_posts_val() {
 /// ```
 ///
 /// Both fields were absent from the port, so a caget on either failed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_compress_ouse_and_inpn_fields() {
     use epics_base_rs::server::records::compress::CompressRecord;
 
@@ -8111,7 +8112,7 @@ async fn test_compress_ouse_and_inpn_fields() {
 /// `common.udf`. We exercise the bits-set / undefined branch
 /// directly via the trait method since the full IocBuilder pipeline
 /// pulls in many unrelated pieces.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_mbbo_direct_initialises_val_from_bits_when_undef() {
     use epics_base_rs::server::record::Record;
     use epics_base_rs::server::records::mbbo_direct::MbboDirectRecord;
@@ -8155,7 +8156,7 @@ async fn test_mbbo_direct_initialises_val_from_bits_when_undef() {
 /// fetching each input PV and binding A..L slots, and timestamp
 /// passthrough from the chosen input is available via
 /// `evaluate_calc_link_with_time`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_lnk_calc_parses_evaluates_and_passes_timestamp() {
     use epics_base_rs::server::record::{CalcLink, ParsedLink, parse_link_v2};
     use epics_base_rs::server::records::ai::AiRecord;
@@ -8239,7 +8240,7 @@ async fn test_lnk_calc_parses_evaluates_and_passes_timestamp() {
 /// whole evaluation return `None` and the time fell back to the
 /// consumer's own. Sibling of the non-local Db read / OUT-write / TSEL
 /// `.TIME` fixes — same `dbInitLink` locality cause, the lnkCalc inputs.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_lnk_calc_nonlocal_input_resolves_externally() {
     use epics_base_rs::server::database::LinkSet;
     use epics_base_rs::server::record::CalcLink;
@@ -8316,7 +8317,7 @@ async fn test_lnk_calc_nonlocal_input_resolves_externally() {
 ///
 /// With `shft = 4` and no state table, `convert()` yields
 /// `RVAL = VAL << 4`. A CA put of VAL=3 must produce RVAL=ORAW=48.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ca_put_mbbo_val_recomputes_rval() {
     use epics_base_rs::server::records::mbbo::MbboRecord;
 
@@ -8360,7 +8361,7 @@ async fn test_ca_put_mbbo_val_recomputes_rval() {
 /// C `mbboDirectRecord.c::process` (line 198) calls `convert(prec)`
 /// unconditionally. With `shft = 4`, `convert()` yields
 /// `RVAL = VAL << 4`. A CA put of VAL=5 must produce RVAL=ORAW=80.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ca_put_mbbo_direct_val_recomputes_rval() {
     use epics_base_rs::server::records::mbbo_direct::MbboDirectRecord;
 
@@ -8394,7 +8395,7 @@ async fn test_ca_put_mbbo_direct_val_recomputes_rval() {
 /// (`aiRecord.c:168`). The pre-fix Rust port returned early from
 /// `check_simulation_mode`, so FLNK / CP / RPRO were skipped — every
 /// link chain downstream of a SIMM-mode record silently broke.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_simulation_mode_still_fires_forward_link() {
     let db = PvDatabase::new();
     db.add_record("SIM:SRC", Box::new(AoRecord::new(11.0)))
@@ -8437,7 +8438,7 @@ async fn test_simulation_mode_still_fires_forward_link() {
 /// `dbGetLink(&prec->siol, DBR_ULONG, &prec->sval)`. Pre-fix the Rust
 /// `is_input` set omitted `mbbi`, so a simulated mbbi fell into the
 /// OUTPUT branch and wrote its own VAL out to the SIOL target.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_simulated_mbbi_reads_siol_not_writes_it() {
     use epics_base_rs::server::records::mbbi::MbbiRecord;
 
@@ -8484,7 +8485,7 @@ async fn test_simulated_mbbi_reads_siol_not_writes_it() {
 /// synchronous `process_record_with_links_inner`). An FLNK chain that
 /// loops back (A -> FLNK -> B -> FLNK -> A) must terminate, not
 /// re-enter A unbounded.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_async_completion_flnk_cycle_terminates() {
     let db = PvDatabase::new();
     db.add_record("ACYC:A", Box::new(AoRecord::new(0.0)))
@@ -8518,7 +8519,7 @@ async fn test_async_completion_flnk_cycle_terminates() {
 /// of every `process()`. Pre-fix `dispatch_multi_output` read SELN
 /// directly from the field and never followed SELL, so a SELL link
 /// pointing at another record never updated the selection.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fanout_resolves_sell_link_into_seln() {
     use epics_base_rs::server::records::fanout::FanoutRecord;
 
@@ -8578,7 +8579,7 @@ async fn test_fanout_resolves_sell_link_into_seln() {
 /// for all three unconditionally, so an All-mode seq spuriously updated SELN
 /// (and would post a SELN monitor) from a live SELL link. Boundary test: All
 /// freezes SELN, Specified refreshes it, with the same live SELL link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_seq_skips_sell_in_all_mode_reads_in_specified() {
     use epics_base_rs::server::records::seq::SeqRecord;
 
@@ -8644,7 +8645,7 @@ async fn test_seq_skips_sell_in_all_mode_reads_in_specified() {
 /// hand-coded 0. Observable in SELM=Specified/Mask when the .db omits SELN
 /// (All ignores SELN). dfanout's Specified output is `seln - 1`, so 0 would
 /// drive nothing where C drives OUTA.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_fanout_dfanout_seq_seln_default_is_one() {
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
     use epics_base_rs::server::records::fanout::FanoutRecord;
@@ -8679,7 +8680,7 @@ async fn test_fanout_dfanout_seq_seln_default_is_one() {
 /// fields — softIoc refuses `caput N1.ACKS 2` with "Write access denied".
 /// The handlers moved to `RecordInstance::put_acks` / `put_ackt`; the
 /// semantics asserted here are unchanged.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_acks_put_compares_against_acks_and_ackt_lowers() {
     // putAcks: acks must be cleared when the written severity is >=
     // the STORED acks, even after sevr has dropped below it.
@@ -8738,7 +8739,7 @@ async fn test_acks_put_compares_against_acks_and_ackt_lowers() {
 /// value is written to the target but the target is NOT processed.
 /// C `dbDbPutValue` (dbDbLink.c:386-389) calls `processTarget` only
 /// when the link carries an explicit `PP` flag (or writes `.PROC`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_bare_out_link_does_not_process_target() {
     let db = PvDatabase::new();
     db.add_record("SRC_OUT", Box::new(AoRecord::new(33.0)))
@@ -8777,7 +8778,7 @@ async fn test_bare_out_link_does_not_process_target() {
 /// BUG 2 regression (positive case) — an OUT link with an explicit
 /// `PP` token DOES process a Passive target, mirroring C
 /// `dbDbPutValue` `pvlOptPP` branch.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_pp_out_link_processes_passive_target() {
     let db = PvDatabase::new();
     db.add_record("SRC_PP", Box::new(AoRecord::new(44.0)))
@@ -8824,7 +8825,7 @@ async fn mr_r5_foreign_process_blocks_on_held_epoch() {
     let db2 = db.clone();
     let processed = Arc::new(AtomicU32::new(0));
     let processed2 = processed.clone();
-    let h = tokio::spawn(async move {
+    let h = epics_base_rs::runtime::task::spawn(async move {
         // Foreign full-processing entry — must block on the gate the
         // epoch holds.
         let mut visited = HashSet::new();
@@ -8835,7 +8836,7 @@ async fn mr_r5_foreign_process_blocks_on_held_epoch() {
     });
 
     // Give the spawned task time to reach (and block on) the gate.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(
         processed.load(Ordering::SeqCst),
         0,
@@ -8896,7 +8897,7 @@ async fn mr_r5_already_locked_process_does_not_self_deadlock() {
 /// in between. Verified to fail when the tail is deferred out of the window
 /// (`tokio::spawn`ing the `update_scan_index` call makes this and the PHAS
 /// test below fail while the epoch test still passes).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scan_move_is_committed_when_put_pv_returns() {
     let db = PvDatabase::new();
     db.add_record("SIW_SCAN", Box::new(AoRecord::new(0.0)))
@@ -8932,7 +8933,7 @@ async fn scan_move_is_committed_when_put_pv_returns() {
 /// Boundary: `CommonFieldPutResult::PhasChanged`. A PHAS put reorders the
 /// bucket rather than moving the record between buckets, and that reorder
 /// is likewise complete when `put_pv` returns.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn phas_reorder_is_committed_when_put_pv_returns() {
     let db = PvDatabase::new();
     for name in ["SIW_PHAS_A", "SIW_PHAS_B"] {
@@ -8987,14 +8988,14 @@ async fn scan_move_cannot_land_inside_a_held_epoch() {
     let db2 = db.clone();
     let done = Arc::new(AtomicU32::new(0));
     let done2 = done.clone();
-    let h = tokio::spawn(async move {
+    let h = epics_base_rs::runtime::task::spawn(async move {
         db2.put_pv("SIW_EPOCH.SCAN", EpicsValue::String("1 second".into()))
             .await
             .unwrap();
         done2.store(1, Ordering::SeqCst);
     });
 
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(
         done.load(Ordering::SeqCst),
         0,
@@ -9026,7 +9027,7 @@ async fn scan_move_cannot_land_inside_a_held_epoch() {
 /// * MS   → max severity, STAT = LINK_ALARM (remote stat NOT preserved)
 /// * MSI  → propagate only when remote sevr == INVALID
 /// * MSS  → max severity AND remote STAT preserved (the cited gap)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn br_fr3_ca_link_applies_maximize_switch_at_processing() {
     use epics_base_rs::server::database::LinkSet;
     use epics_base_rs::server::recgbl::alarm_status;
@@ -9149,7 +9150,7 @@ async fn br_fr3_ca_link_applies_maximize_switch_at_processing() {
 // (lsiRecord.c:217-220). This test drives an unchanged cycle through
 // the link-processing path and asserts the VALUE event fires only when
 // MPST is Always.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_lsi_mpst_always_posts_value_on_unchanged_cycle() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::lsi::LsiRecord;
@@ -9208,7 +9209,7 @@ async fn test_lsi_mpst_always_posts_value_on_unchanged_cycle() {
 /// every `process()`. Before the fix the main engine called
 /// `record.process()` (a no-op for `sub`) without invoking the framework's
 /// `SubroutineFn`, so VAL never updated when the record was scanned.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sub_record_subroutine_runs_on_main_engine_path() {
     use epics_base_rs::server::records::sub_record::SubRecord;
 
@@ -9260,7 +9261,7 @@ async fn sub_record_subroutine_runs_on_main_engine_path() {
 /// is the standard analog limit check; the Rust port previously gave `sub`
 /// no limit fields and skipped the analog-alarm owner entirely, so a `sub`
 /// whose subroutine drove VAL past HIHI never alarmed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sub_record_hihi_alarm_fires_via_shared_owner() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::records::sub_record::SubRecord;
@@ -9340,7 +9341,7 @@ async fn sub_record_hihi_alarm_fires_via_shared_owner() {
 /// previously carried no MDEL/MLST, so the deadband owner saw
 /// `mdel=0` and posted on every change. MLST tracks the last posted value,
 /// so it is the observable witness of the deadband decision.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sub_record_mdel_gates_val_monitor() {
     use epics_base_rs::server::records::sub_record::SubRecord;
 
@@ -9391,7 +9392,7 @@ async fn sub_record_mdel_gates_val_monitor() {
 /// recGblSetSevr(SOFT_ALARM, prec->brsv)`). The earlier `SubroutineFn`
 /// returned `CaResult<()>`, so a subroutine could not signal an error and
 /// no SOFT_ALARM was ever raised.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sub_record_negative_status_raises_soft_alarm_at_brsv() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::records::sub_record::SubRecord;
@@ -9452,7 +9453,7 @@ async fn sub_record_negative_status_raises_soft_alarm_at_brsv() {
 /// An `aSub` publishes the subroutine's return status as VAL (C
 /// `aSubRecord.c:223` `prec->val = status`), overwriting whatever the
 /// closure wrote to VAL, and a negative status raises SOFT_ALARM at BRSV.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_record_val_is_return_status_and_negative_soft_alarms() {
     use epics_base_rs::server::recgbl::alarm_status;
     use epics_base_rs::server::records::asub_record::ASubRecord;
@@ -9529,7 +9530,7 @@ async fn asub_record_val_is_return_status_and_negative_soft_alarms() {
 /// `aSubRecord.c::monitor`): NEVER suppresses it, ON CHANGE (default) posts on
 /// change, ALWAYS posts every process even when unchanged. Exercised through
 /// the real foreign-process monitor path (`process_record` -> `process_local`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_eflg_gates_valx_output_monitor_posting() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::asub_record::ASubRecord;
@@ -9606,7 +9607,7 @@ async fn asub_eflg_gates_valx_output_monitor_posting() {
 /// process and re-resolves the function from the registry when it changed
 /// (C `aSubRecord.c::fetch_values`). A name not in the registry is C
 /// `S_db_BadSub`: the subroutine is not run (VAL frozen), ONAM kept for retry.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_lflg_read_reresolves_subroutine_from_subl_link() {
     use epics_base_rs::server::records::asub_record::ASubRecord;
     use epics_base_rs::server::records::stringout::StringoutRecord;
@@ -9721,7 +9722,7 @@ async fn asub_lflg_read_reresolves_subroutine_from_subl_link() {
 /// aSub `LFLG=IGNORE` (the default) resolves its subroutine from SNAM once at
 /// init via the function registry (C `aSubRecord.c::init_record` ->
 /// `registryFunctionFind`), wired by `wire_subroutines` on the `.db` path.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_lflg_ignore_subroutine_wired_by_snam_at_init() {
     use epics_base_rs::server::ioc_builder::IocBuilder;
     use std::collections::HashMap;
@@ -9757,7 +9758,7 @@ record(aSub, "ASUB_S") {
 /// `sub` and `aSub` INAM init routine: resolved through the function registry
 /// and invoked exactly once at init, before SNAM resolution, return discarded
 /// (C `subRecord.c` / `aSubRecord.c::init_record`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn inam_init_routine_runs_once_at_init_for_sub_and_asub() {
     use epics_base_rs::server::ioc_builder::IocBuilder;
     use std::collections::HashMap;
@@ -9838,7 +9839,7 @@ record(aSub, "ASUB_INIT") {
 /// The public direct-process API `process_record` re-resolves aSub LFLG=READ:
 /// it delegates to the canonical engine path, so a direct process re-reads the
 /// SUBL link, swaps the subroutine, and skips a bad sub like any other process.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_lflg_read_reresolves_on_foreign_process_path() {
     use epics_base_rs::server::records::asub_record::ASubRecord;
     use epics_base_rs::server::records::stringout::StringoutRecord;
@@ -9915,7 +9916,7 @@ async fn asub_lflg_read_reresolves_on_foreign_process_path() {
 /// `*pvalue += prec->val`, discarding any client caput to VAL during a
 /// DOL-driven cycle. The Rust port previously incremented from the current
 /// VAL, so a caput between cycles shifted every subsequent increment.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_ao_incremental_dol_increments_from_pval_not_val() {
     let db = PvDatabase::new();
 
@@ -9979,7 +9980,7 @@ async fn test_ao_incremental_dol_increments_from_pval_not_val() {
 /// re-applied every cycle. Before the fix, both the framework
 /// (`read_link_value` resolving a constant) and `ao::process` re-stamped the
 /// constant each cycle, clobbering the caput. Record-level-removal path (ao).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ao_constant_dol_seeded_at_init_not_reapplied_at_process() {
     let db = PvDatabase::new();
     let mut ao = AoRecord::new(0.0);
@@ -10031,7 +10032,7 @@ async fn ao_constant_dol_seeded_at_init_not_reapplied_at_process() {
 /// `else { value = prec->val; }` branch, so the OIF mode is irrelevant. The
 /// value tracks VAL (init constant, or a later caput) and never accumulates
 /// the constant each cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ao_constant_dol_incremental_does_not_increment() {
     let db = PvDatabase::new();
     let mut ao = AoRecord::new(0.0);
@@ -10061,7 +10062,7 @@ async fn ao_constant_dol_incremental_does_not_increment() {
 /// `longout::init_record` seeds the constant once; the gate keeps it out of
 /// process. Before the fix, the framework re-applied the constant every
 /// cycle, clobbering a caput.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn longout_constant_dol_seeded_at_init_not_reapplied_at_process() {
     use epics_base_rs::server::records::longout::LongoutRecord;
     let db = PvDatabase::new();
@@ -10104,7 +10105,7 @@ async fn longout_constant_dol_seeded_at_init_not_reapplied_at_process() {
 /// (`dbParseLink`, dbStaticLib.c:2346-2349). A quoted `"hi"` is not: softIoc
 /// makes `field(DOL,"\"hi\"")` a `CA_LINK "hi" NPP NMS` and leaves VAL empty /
 /// UDF=1, so this test used to encode a link type C does not have.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stringout_constant_dol_seeded_at_init_not_reapplied_at_process() {
     use epics_base_rs::server::records::stringout::StringoutRecord;
     let db = PvDatabase::new();
@@ -10142,7 +10143,7 @@ async fn stringout_constant_dol_seeded_at_init_not_reapplied_at_process() {
 /// gained an `init_record`/`post_init` seed. One assertion per record's
 /// value-type boundary (f64 / i64 / long-string / state-index→RVAL /
 /// bit-field decomposition).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn init_applies_constant_dol_across_record_types() {
     use epics_base_rs::server::records::dfanout::DfanoutRecord;
     use epics_base_rs::server::records::int64out::Int64outRecord;
@@ -10262,7 +10263,7 @@ async fn init_applies_constant_dol_across_record_types() {
 /// NOT process on the delaying cycle; it processes exactly once on the
 /// delayed cycle. Before the fix the delaying cycle ran the full Complete
 /// snapshot + FLNK tail, firing the forward link twice (delaying + delayed).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn calcout_odly_defers_forward_link_to_delayed_cycle() {
     use epics_base_rs::server::records::calc::CalcRecord;
     use epics_base_rs::server::records::calcout::CalcoutRecord;
@@ -10330,7 +10331,7 @@ async fn calcout_odly_defers_forward_link_to_delayed_cycle() {
 // only INP[SELN] is read; the other input links are never fetched, so
 // their PP sources are never processed. A non-selected PP source that
 // computes 42-on-process must therefore stay at its default 0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sel_specified_mode_fetches_only_the_selected_input() {
     use epics_base_rs::server::records::calc::CalcRecord;
     use epics_base_rs::server::records::sel::SelRecord;
@@ -10392,7 +10393,7 @@ async fn sel_specified_mode_fetches_only_the_selected_input() {
 
 // Control for the above: in High mode (SELM==1) C fetch_values reads
 // EVERY input to compare them, so all PP sources are processed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sel_high_mode_fetches_all_inputs() {
     use epics_base_rs::server::records::calc::CalcRecord;
     use epics_base_rs::server::records::sel::SelRecord;
@@ -10452,7 +10453,7 @@ async fn sel_high_mode_fetches_all_inputs() {
 // failure, so do_sel is skipped and VAL — set to 5.0 on a prior cycle —
 // freezes. Pre-fix do_sel ran over the NaN-initialised A field and VAL
 // became NaN.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sel_specified_mode_freezes_value_when_selected_link_fails() {
     use epics_base_rs::server::records::sel::SelRecord;
 
@@ -10484,7 +10485,7 @@ async fn sel_specified_mode_freezes_value_when_selected_link_fails() {
 // skipped. Here NVL points at a non-existent record while INPA holds a
 // valid source (3.0). Pre-fix Rust fell back to the stale SELN, fetched
 // INPA, and recomputed VAL=3.0; post-fix VAL freezes at 7.0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sel_specified_mode_freezes_value_when_nvl_link_fails() {
     use epics_base_rs::server::records::sel::SelRecord;
 
@@ -10521,7 +10522,7 @@ async fn sel_specified_mode_freezes_value_when_nvl_link_fails() {
 // and reads the NaN-initialised A field → VAL=NaN. This must NOT freeze
 // (contrast the broken-link case), proving the gate keys on
 // configured-but-unresolved, not merely unresolved.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sel_specified_mode_empty_selected_link_computes_nan_not_frozen() {
     use epics_base_rs::server::records::sel::SelRecord;
 
@@ -10559,7 +10560,7 @@ async fn sel_specified_mode_empty_selected_link_computes_nan_not_frozen() {
 ///   - `compress.NSAM`   — `promptgroup special(SPC_NOMOD)`: load resizes buffer.
 ///   - `subArray.MALM`   — `special(SPC_NOMOD)`: load sets, runtime rejects.
 ///   - `subArray.INDX`   — `pp(TRUE)`: load AND runtime set.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn promptgroup_config_fields_load_settable_runtime_immutable() {
     use epics_base_rs::server::db_loader::{apply_fields, create_record};
 
@@ -10658,7 +10659,7 @@ async fn promptgroup_config_fields_load_settable_runtime_immutable() {
 ///   - subArray NELM: `pp(TRUE)` -> runtime-writable; subArray FTVL: SPC_NOMOD.
 /// Load (apply_fields) stays settable for all of them (SPC_NOMOD blocks only
 /// runtime dbPutField).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn waveform_nelm_ftvl_runtime_immutable_subarray_nelm_writable() {
     use epics_base_rs::server::db_loader::{apply_fields, create_record};
 
@@ -10757,7 +10758,7 @@ fn asub_ftype_menu_fields_load_by_label() {
 /// subscriber must therefore receive no change update even though
 /// `process()` updates both trackers every cycle — while VAL and WFLG must
 /// still post on change.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_permissive_oval_oflg_not_monitor_posted() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::permissive::PermissiveRecord;
@@ -10822,7 +10823,7 @@ async fn test_permissive_oval_oflg_not_monitor_posted() {
 /// from the generic subscribed-field change loop via `event_posted_fields()`,
 /// so a `.OVAL` subscriber receives no change update even though `process()`
 /// copies VAL into OVAL on change — while VAL must still post on change.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_state_oval_not_monitor_posted() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::server::records::state::StateRecord;
@@ -10878,7 +10879,7 @@ async fn test_state_oval_not_monitor_posted() {
 /// value against the pre-put one, found it "changed", and published a SECOND
 /// event that C never sends. `SVAL` (ai simulation value) is the sample: a
 /// plain, non-`pp(TRUE)`, non-metadata auxiliary field.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn test_put_time_post_is_the_only_post_for_that_put() {
     use epics_base_rs::server::recgbl::EventMask;
     use epics_base_rs::types::DbFieldType;

--- a/crates/epics-base-rs/tests/db_json_link_escapes.rs
+++ b/crates/epics-base-rs/tests/db_json_link_escapes.rs
@@ -21,8 +21,6 @@
 //!     dbgf J2.VAL -> "x\\ny"    stored: x, BACKSLASH, n, y
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -38,7 +36,7 @@ async fn val(db: &epics_base_rs::server::database::PvDatabase, rec: &str) -> Str
 }
 
 /// The two records softIoc was measured on, byte for byte.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_const_json_link_string_reaches_the_record_decoded() {
     let db_text = concat!(
         r#"record(stringin,"J1") { field(DTYP,"Soft Channel") field(INP,{const:"a\tb"}) }"#,
@@ -66,7 +64,7 @@ async fn a_const_json_link_string_reaches_the_record_decoded() {
 }
 
 /// The escape set, one case per yajl production — the boundary, not a story.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn every_yajl_escape_is_translated_in_a_const_seed() {
     let cases: [(&str, &str, &[u8]); 6] = [
         ("E1", r#"{const:"a\nb"}"#, b"a\nb"),
@@ -103,7 +101,7 @@ async fn every_yajl_escape_is_translated_in_a_const_seed() {
 /// A QUOTED (non-brace) value keeps its own translator — C runs
 /// `dbTranslateEscape` on it (R18-91), not yajl. The two regimes must both
 /// hold; fixing one must not disturb the other.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_quoted_value_still_uses_the_db_translator() {
     let (db, _) = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/db_loader_link_context.rs
+++ b/crates/epics-base-rs/tests/db_loader_link_context.rs
@@ -17,8 +17,6 @@
 //! a record type that does not declare the field, so a record driving its own
 //! link is not driven twice per cycle).
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -86,7 +84,7 @@ const OUT_LINK: &str = "#C0 S0 @scaler1";
 /// The db file's `OUT` value must reach the dynamic device-support factory.
 /// Before the fix `ctx.out` was `""` and a factory keying on the link (C
 /// `scaler_init_record`) could not tell two boards apart.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn record_owned_out_link_reaches_device_support_context() {
     let seen: Arc<Mutex<Vec<(String, String, String)>>> = Arc::new(Mutex::new(Vec::new()));
     let captured = Arc::clone(&seen);
@@ -142,7 +140,7 @@ record(ownsOut, "SCALER:1") {{
 /// `parsed_out` were populated here, a record driving its own link (`acalcout`
 /// and `scalcout` via `multi_output_links`, `motorRecord`/`scalerRecord` via
 /// device support) would write that link twice per process cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn record_owned_out_link_does_not_arm_framework_dispatch() {
     let db = r#"
 record(ownsOut, "SCALER:2") {

--- a/crates/epics-base-rs/tests/db_string_is_a_byte_string.rs
+++ b/crates/epics-base-rs/tests/db_string_is_a_byte_string.rs
@@ -20,8 +20,6 @@
 //!     dbgf X1.VAL -> "h\xffz"     stored: h, 0xFF, z   (3 bytes)
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -37,7 +35,7 @@ async fn val_bytes(db: &epics_base_rs::server::database::PvDatabase, rec: &str) 
 }
 
 /// The record softIoc was measured on.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_high_hex_escape_in_a_db_value_is_one_byte() {
     let (db, _) = IocBuilder::new()
         .db_string(
@@ -57,7 +55,7 @@ async fn a_high_hex_escape_in_a_db_value_is_one_byte() {
 }
 
 /// The boundary: below 0x80 the two models agree, at and above it they did not.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_escape_boundary_at_0x80() {
     let (db, _) = IocBuilder::new()
         .db_string(
@@ -84,7 +82,7 @@ async fn the_escape_boundary_at_0x80() {
 }
 
 /// A common (dbCommon) DBF_STRING carries bytes too — DESC has the same budget.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_common_string_field_carries_bytes() {
     let (db, _) = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/db_token_string_positions.rs
+++ b/crates/epics-base-rs/tests/db_token_string_positions.rs
@@ -28,8 +28,6 @@
 //! C's two forms and rejected the other with a hard `DbParseError`. Tier 1: a
 //! `.db` C loads must load.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::db_loader::parse_db;
@@ -43,7 +41,7 @@ record(ai, QT2) { field(VAL, "6") alias(QT2ALIAS) }
 alias("QT2", QT2B)
 "#;
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_file_softioc_loads_loads() {
     let (db, _) = IocBuilder::new()
         .db_string(C_MEASURED_DB, &HashMap::new())

--- a/crates/epics-base-rs/tests/dbd_initial_is_the_default.rs
+++ b/crates/epics-base-rs/tests/dbd_initial_is_the_default.rs
@@ -31,8 +31,6 @@
 //! non-calc initial, to show the rule is the loader's and not a calc special
 //! case.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -78,7 +76,7 @@ const NO_ALARM: i64 = 0;
 const INVALID: i64 = 3;
 
 /// The finding, at the record: a plain `record(calc)` must compute, not alarm.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_default_calc_record_computes_instead_of_alarming() {
     let db = build(r#"record(calc, "D:CALC") {}"#).await;
 
@@ -101,7 +99,7 @@ async fn a_default_calc_record_computes_instead_of_alarming() {
 /// calcout carries the initial on BOTH of its expressions
 /// (`calcoutRecord.dbd:62` CALC, `:382` OCAL) — an empty OCAL alarms exactly
 /// like an empty CALC, so missing either one is the same defect.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_default_calcout_record_has_both_expressions() {
     let db = build(r#"record(calcout, "D:OUT") {}"#).await;
 
@@ -115,7 +113,7 @@ async fn a_default_calcout_record_has_both_expressions() {
 /// swait is the synApps record that DOES declare the initial
 /// (`swaitRecord.dbd:424`) — and it compiles with base's `postfix()`, so the
 /// empty expression was fatal there too.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_default_swait_record_computes_instead_of_alarming() {
     let db = build(r#"record(swait, "D:WAIT") {}"#).await;
 
@@ -130,7 +128,7 @@ async fn a_default_swait_record_computes_instead_of_alarming() {
 /// `sCalcPostfix("")`/`aCalcPostfix("")` accept it (status 0) and the perform
 /// then fails every cycle (measured: `perform=-1`). The fix must not invent an
 /// initial C does not have.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_and_acalcout_keep_the_empty_calc_their_dbd_declares() {
     let db = build(
         r#"
@@ -154,7 +152,7 @@ record(acalcout, "D:ACALC") {}
 
 /// The prototype is what the `.db` OVERWRITES — the initial must not win over an
 /// explicit field line, and must not be re-applied after it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_db_field_line_overrides_the_dbd_initial() {
     let db = build(
         r#"
@@ -175,7 +173,7 @@ record(calc, "D:EXPL") {
 /// initial gets it. `ai` declares `ASLO initial("1")` and `SDLY initial("-1.0")`
 /// (`aiRecord.dbd`), and a slope of 0 would zero every raw-to-engineering
 /// conversion.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_initial_is_applied_to_every_record_type_not_just_the_calc_family() {
     let db = build(r#"record(ai, "D:AI") {}"#).await;
 

--- a/crates/epics-base-rs/tests/dbput_nomod_gate.rs
+++ b/crates/epics-base-rs/tests/dbput_nomod_gate.rs
@@ -22,8 +22,6 @@
 //! Pre-fix the port enforced `read_only` only on the CA route, so the OUT link
 //! truncated NELM (and the data with it) and the writer stayed NO_ALARM.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::error::CaError;
@@ -55,7 +53,7 @@ async fn build() -> PvDatabase {
 /// The OUT link is the route C gates in `dbPut` and the port did not: a record
 /// writing `WF.NELM` must be refused, the waveform must keep its NELM *and its
 /// data*, and the WRITER must go LINK/INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn out_link_write_to_a_nomod_field_is_refused_and_alarms_the_writer() {
     let db = build().await;
 
@@ -90,7 +88,7 @@ async fn out_link_write_to_a_nomod_field_is_refused_and_alarms_the_writer() {
 
 /// The gate is in the shared `dbPut` owner, so the internal `put_pv` /
 /// `put_pv_and_post` routes are refused too — not only the CA route.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn every_put_route_is_refused_on_a_nomod_field() {
     let db = build().await;
 
@@ -122,7 +120,7 @@ async fn every_put_route_is_refused_on_a_nomod_field() {
 /// The gate is a *runtime* gate: `dbLoadRecords` sets NELM through
 /// `dbStaticLib`'s `dbPutString`, which never crosses `dbPut`. The load path
 /// (`Record::put_field`) must therefore still size the array.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_load_path_still_sets_nelm() {
     let db = PvDatabase::new();
     let mut wf = WaveformRecord::new(1, DbFieldType::Double);
@@ -153,7 +151,7 @@ async fn the_load_path_still_sets_nelm() {
 /// dbpf N1.NAMSG hi-> ""           dbpf N1.LCNT 3   -> 0
 /// caput N1.SEVR 2 -> ERROR from put operation: Write access denied
 /// ```
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn every_dbcommon_nomod_field_is_refused_on_every_route() {
     let db = PvDatabase::new();
     db.add_record("AO2", Box::new(AoRecord::new(0.0)))
@@ -227,7 +225,7 @@ async fn every_dbcommon_nomod_field_is_refused_on_every_route() {
 /// caget N1.SEVR                 -> MAJOR         (the alarm itself stays)
 /// caput N1.ACKS 2               -> ERROR: Write access denied
 /// ```
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn alarm_acknowledge_travels_the_dbr_type_route_not_the_field() {
     use epics_base_rs::server::record::AlarmAck;
 

--- a/crates/epics-base-rs/tests/dbput_pass0_special_all_bodies.rs
+++ b/crates/epics-base-rs/tests/dbput_pass0_special_all_bodies.rs
@@ -12,8 +12,6 @@
 //! bodies: `put_pv` (`dbPutLink` route, via `put_pv_already_locked`)
 //! and `put_pv_and_post` (gateway/sequencer route).
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -80,7 +78,7 @@ fn tracking_record() -> (Pass0TrackingRecord, Arc<AtomicU32>, Arc<AtomicU32>) {
 /// (`write_db_link_value` → `put_pv_already_locked` → `put_pv_inner`):
 /// pass-0 must run before the write, pass-1 after, exactly like the
 /// external-put body.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_pv_runs_pass0_special() {
     let db = PvDatabase::new();
     let (rec, pass0, pass1) = tracking_record();
@@ -94,7 +92,7 @@ async fn put_pv_runs_pass0_special() {
 
 /// `put_pv_and_post` is the third `dbPut` body (gateway / sequencer
 /// route) and must match the other two.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_pv_and_post_runs_pass0_special() {
     let db = PvDatabase::new();
     let (rec, pass0, pass1) = tracking_record();

--- a/crates/epics-base-rs/tests/dbstate_device.rs
+++ b/crates/epics-base-rs/tests/dbstate_device.rs
@@ -9,8 +9,6 @@
 //! merely that processing leaves the records un-alarmed — a no-alarm-only test
 //! would pass even if the device never ran.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::{HashMap, HashSet};
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -19,7 +17,7 @@ use epics_base_rs::types::EpicsValue;
 
 /// bo sets the named bit, bi reads it back — both set (1) and clear (0)
 /// round-trip through the shared `dbState` registry.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn db_state_bo_write_propagates_to_bi_read() {
     let (db, _) = IocBuilder::new()
         .db_string(
@@ -97,7 +95,7 @@ record(bi, "DBST_BI") {
 /// gate Errs in `init()`, so `wire_device_to_record` flags the record INVALID
 /// at build time — proving the device attached and gated rather than being
 /// silently accepted as a soft channel.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn db_state_wrong_record_type_is_invalid() {
     let (db, _) = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/device_link_type_is_enforced.rs
+++ b/crates/epics-base-rs/tests/device_link_type_is_enforced.rs
@@ -44,8 +44,6 @@
 //! runs the IOC anyway, leaving the record with a link that never reads or
 //! writes. The port refuses the load — the dead link is the illegal state.
 
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -68,7 +66,7 @@ async fn loads(body: &str) -> Result<(), String> {
 /// `.db` text parses to). One case per cell C rejects — the four ways to give an
 /// `INST_IO` device something that is not `@…`, and the one way to give a
 /// `CONSTANT` device an `@…`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_link_the_bound_device_cannot_take_is_refused_exactly_where_c_refuses_it() {
     // "Soft Timestamp" is `device(ai, INST_IO, ...)`; "Soft Channel" is
     // `device(ai, CONSTANT, ...)` — aiRecord's own `.dbd`, not a guess.
@@ -94,7 +92,7 @@ async fn a_link_the_bound_device_cannot_take_is_refused_exactly_where_c_refuses_
 /// The accepting side of the same boundary: an exact match, and the
 /// `{CONSTANT, PV_LINK, JSON_LINK}` set C treats as interchangeable
 /// (`dbStaticLib.c:2408-2416`) — a soft device takes any of the three.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_links_c_accepts_still_load() {
     let accepted = [
         ("Soft Timestamp", "@instio parm"), // INST_IO on INST_IO
@@ -115,7 +113,7 @@ async fn the_links_c_accepts_still_load() {
 /// and so is expected to be `CONSTANT`, whatever the record's DTYP is. C refuses
 /// `field(SDIS,"@instio parm")` and `field(FLNK,"@instio parm")` for that reason
 /// — measured, not reasoned.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_non_device_link_field_is_held_to_constant_whatever_the_dtyp_is() {
     for field in ["SDIS", "FLNK"] {
         let body =
@@ -134,7 +132,7 @@ async fn a_non_device_link_field_is_held_to_constant_whatever_the_dtyp_is() {
 /// never spells DTYP is still bound to the FIRST device its `.dbd` declares
 /// (`ai` → "Soft Channel", CONSTANT). C rejects a hardware `INP` there, and so
 /// must the port: "no DTYP" is not "no device".
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_unspelled_dtyp_still_binds_the_first_declared_device() {
     let err = loads("    field(INP, \"@instio parm\")")
         .await
@@ -146,7 +144,7 @@ async fn an_unspelled_dtyp_still_binds_the_first_declared_device() {
 /// checked (`if (!plink->text) continue;`, `dbStaticLib.c:2213`). An `INST_IO`
 /// DTYP with no `INP` line at all loads, in C and here — the check is on the
 /// text the `.db` supplied, not on the record's declaration.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_link_the_db_never_assigns_is_not_checked() {
     loads("    field(DTYP, \"Soft Timestamp\")")
         .await
@@ -164,7 +162,7 @@ async fn a_link_the_db_never_assigns_is_not_checked() {
 /// dbpf T:RT.INP "5"
 /// DBF_STRING:  "@instio parm"     <- the put is refused, the link is unchanged
 /// ```
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_runtime_put_of_a_link_the_device_cannot_take_is_refused_too() {
     use epics_base_rs::types::EpicsValue;
 
@@ -197,7 +195,7 @@ async fn a_runtime_put_of_a_link_the_device_cannot_take_is_refused_too() {
 /// verdict depend on the order the `.db` happened to use. MEASURED: C loads
 /// `record(ai,"T:ORD"){ field(INP,"@instio parm") field(DTYP,"Soft Timestamp") }`
 /// with no error.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_verdict_does_not_depend_on_the_order_the_db_spells_the_fields() {
     loads("    field(INP, \"@instio parm\")\n    field(DTYP, \"Soft Timestamp\")")
         .await
@@ -213,7 +211,7 @@ async fn the_verdict_does_not_depend_on_the_order_the_db_spells_the_fields() {
 /// (`asynInt32` on an `ai`) appears in no vendored `device()` line, so the port
 /// has no `link_type` for it and invents none — it must not reject the `.db` on
 /// a rule it cannot state.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_dtyp_no_vendored_dbd_declares_carries_no_rule() {
     loads("    field(DTYP, \"asynInt32\")\n    field(INP, \"@asyn(PORT,0)VALUE\")")
         .await

--- a/crates/epics-base-rs/tests/dfanout_ivoa_owner.rs
+++ b/crates/epics-base-rs/tests/dfanout_ivoa_owner.rs
@@ -31,8 +31,6 @@
 //! single owner in `process_record_with_links_inner`, and every output path
 //! (OUT, SIOL, the generic multi-output pairs, dfanout's push) consumes it.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -75,7 +73,7 @@ async fn add_dfanout(db: &PvDatabase, ivoa: i16, invalid: bool, outa: &str) {
 
 /// Boundary 1 — INVALID cycle, IVOA=Set_output_to_IVOV: the targets get IVOV,
 /// the record's own VAL becomes IVOV, and the VAL monitor fires with it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_65_ivoa_ivov_overwrites_val_and_posts_it() {
     let db = PvDatabase::new();
     db.add_record("DF_TGT", Box::new(AiRecord::new(0.0)))
@@ -120,7 +118,7 @@ async fn r15_65_ivoa_ivov_overwrites_val_and_posts_it() {
 /// alarm of its own; the only INVALID in the cycle is the one the FAILED OUTA
 /// put raises from inside the push. C evaluated the IVOA switch before that put
 /// and never returns to it, so VAL keeps its computed value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_65_a_failed_push_does_not_retro_trigger_the_ivov_arm() {
     let db = PvDatabase::new();
     add_dfanout(&db, 2, false, "NO_SUCH_TARGET").await;
@@ -143,7 +141,7 @@ async fn r15_65_a_failed_push_does_not_retro_trigger_the_ivov_arm() {
 
 /// Boundary 3 — IVOA=Continue_normally on an INVALID cycle: VAL is untouched
 /// and pushed as-is (dfanoutRecord.c:132-134).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_65_ivoa_continue_pushes_val_unchanged() {
     let db = PvDatabase::new();
     db.add_record("DF_TGT", Box::new(AiRecord::new(0.0)))
@@ -167,7 +165,7 @@ async fn r15_65_ivoa_continue_pushes_val_unchanged() {
 
 /// Boundary 4 — IVOA=Don't_drive_outputs on an INVALID cycle: no push at all
 /// (dfanoutRecord.c:139), VAL untouched.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_65_ivoa_dont_drive_suppresses_the_push() {
     let db = PvDatabase::new();
     db.add_record("DF_TGT", Box::new(AiRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/enum_string_put.rs
+++ b/crates/epics-base-rs/tests/enum_string_put.rs
@@ -43,8 +43,6 @@
 //! The cases below are the CONVERTER's boundaries, one per boundary, driven
 //! through the same `dbPut` entry the CA server uses.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::bo::BoRecord;
@@ -84,7 +82,7 @@ async fn put(db: &PvDatabase, name: &str, value: &str) -> Result<(), String> {
 
 // --- Boundary: the name IS a defined state --------------------------------
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn state_name_resolves_to_its_index() {
     let db = db_with("M", mbbo_three_states()).await;
 
@@ -97,7 +95,7 @@ async fn state_name_resolves_to_its_index() {
 
 // --- Boundary: the name is NOT a defined state ----------------------------
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unmatched_name_fails_the_put_and_stores_nothing() {
     let db = db_with("M", mbbo_three_states()).await;
     put(&db, "M", "Two").await.unwrap();
@@ -113,7 +111,7 @@ async fn unmatched_name_fails_the_put_and_stores_nothing() {
 
 /// C's `strncmp` is case-SENSITIVE. (The `busy` record's put arm matched
 /// case-insensitively AND coerced any unmatched name to state 0.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn wrong_case_is_not_a_state_name() {
     let db = db_with("M", mbbo_three_states()).await;
 
@@ -123,7 +121,7 @@ async fn wrong_case_is_not_a_state_name() {
 
 // --- Boundary: the numeric fallback, either side of `no_str` --------------
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn numeric_string_below_no_str_is_accepted() {
     let db = db_with("M", mbbo_three_states()).await;
 
@@ -131,7 +129,7 @@ async fn numeric_string_below_no_str_is_accepted() {
     assert_eq!(val_of(&db, "M").await, EpicsValue::Enum(2));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn numeric_string_at_or_above_no_str_is_badchoice() {
     let db = db_with("M", mbbo_three_states()).await;
     put(&db, "M", "1").await.unwrap();
@@ -144,7 +142,7 @@ async fn numeric_string_at_or_above_no_str_is_badchoice() {
 /// The `no_str` bound is the record's OWN table, not a fixed 2 or 16: a `bo`
 /// with a ZNAM and an empty ONAM advertises one state (`boRecord.c:342-352`),
 /// so index 1 is out of range.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn binary_no_str_trim_bounds_the_numeric_fallback() {
     let mut rec = BoRecord::new(0);
     rec.put_field("ZNAM", EpicsValue::String("Closed".into()))
@@ -164,7 +162,7 @@ async fn binary_no_str_trim_bounds_the_numeric_fallback() {
 /// `mbbiDirect`/`mbboDirect` leave the slot NULL (`mbboDirectRecord.c:58`
 /// `#define put_enum_str NULL`) — their `VAL` is `DBF_LONG`, so a string put
 /// takes C's numeric converter and a state NAME is never resolvable.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_direct_has_no_enum_state_table() {
     let rec = MbboDirectRecord::default();
     assert!(

--- a/crates/epics-base-rs/tests/event_val_monitor_mask.rs
+++ b/crates/epics-base-rs/tests/event_val_monitor_mask.rs
@@ -18,8 +18,6 @@
 //! The port gave VAL the framework default `DBE_VALUE | DBE_LOG`, so a
 //! `DBE_LOG`-only archiver was sent the event name on every process.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -48,7 +46,7 @@ async fn process(db: &PvDatabase, rec: &str) {
 
 /// The post carries `DBE_VALUE` and nothing else: no alarm moved, and event has
 /// no ADEL to put `DBE_LOG` into the mask.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_77_event_val_posts_dbe_value_without_dbe_log() {
     let db = PvDatabase::new();
     db.add_record("EV", Box::new(EventRecord::new("shutter")))
@@ -78,7 +76,7 @@ async fn r9_77_event_val_posts_dbe_value_without_dbe_log() {
 
 /// C posts VAL unguarded on every `monitor()` call, so a second cycle with an
 /// unchanged event name posts again — and again without `DBE_LOG`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_77_event_val_reposts_each_cycle_still_without_log() {
     let db = PvDatabase::new();
     db.add_record("EV", Box::new(EventRecord::new("shutter")))
@@ -104,7 +102,7 @@ async fn r9_77_event_val_reposts_each_cycle_still_without_log() {
 
 /// A `DBE_LOG`-only subscriber — an archiver — receives event VAL on no cycle
 /// at all. This is the observable the forced LOG bit broke.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_77_dbe_log_only_subscriber_receives_nothing() {
     let db = PvDatabase::new();
     db.add_record("EV", Box::new(EventRecord::new("shutter")))
@@ -143,7 +141,7 @@ async fn r9_77_dbe_log_only_subscriber_receives_nothing() {
 /// The rule is per-record, not a framework-wide change: calc's VAL still takes
 /// `DBE_LOG` from its own ADEL deadband (`calcRecord.c:411`, the standard
 /// `if (monitor_mask) db_post_events(&prec->val, monitor_mask)`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_77_calc_val_still_logs_on_adel_crossing() {
     let db = PvDatabase::new();
     // `CalcRecord::new` compiles RPCL at construction; a bare `put_field`

--- a/crates/epics-base-rs/tests/external_cp_access_alarm.rs
+++ b/crates/epics-base-rs/tests/external_cp_access_alarm.rs
@@ -20,8 +20,6 @@
 //! stays `true` throughout (C's lset `isConnected`, `dbCa.c:633-641`, does
 //! not consult access rights) and only the value read fails.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 
 use epics_base_rs::server::database::{LinkSet, PvDatabase};
@@ -105,7 +103,7 @@ async fn holder_db(lset: Arc<ReadGateLset>) -> PvDatabase {
 /// (`dbCa.c:1094-1099`) and that calink did not: without it the holder is
 /// Passive, is never processed again, and reports its last good value
 /// with SEVR=0 for as long as the server denies reads.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_dispatch_on_a_read_denied_link_commits_link_invalid() {
     use epics_base_rs::server::recgbl::alarm_status::LINK_ALARM;
 
@@ -150,7 +148,7 @@ async fn a_dispatch_on_a_read_denied_link_commits_link_invalid() {
 /// Recovery: C dispatches NOTHING on a full rights regain
 /// (`dbCa.c:1091` `goto done`), so the alarm clears on the next monitor
 /// event — modelled here as the next dispatch after the gate reopens.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_link_alarm_clears_on_the_next_event_after_read_access_returns() {
     let lset = ReadGateLset::new(7.25);
     let db = holder_db(lset.clone()).await;

--- a/crates/epics-base-rs/tests/external_cp_disconnect_alarm.rs
+++ b/crates/epics-base-rs/tests/external_cp_disconnect_alarm.rs
@@ -17,8 +17,6 @@
 //! downstream records held their last good value with `SEVR=0 STAT=0` for
 //! the whole 65 s upstream outage.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 
 use epics_base_rs::server::database::{LinkSet, PvDatabase};
@@ -96,7 +94,7 @@ async fn holder_db(lset: Arc<SwitchableLset>) -> PvDatabase {
 /// The gate itself: with the circuit up, a dispatch pulls the upstream
 /// value in with no alarm; with the circuit down, the very same dispatch
 /// commits LINK/INVALID and leaves VAL where it was.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_dispatch_on_a_dropped_link_commits_link_invalid() {
     use epics_base_rs::server::recgbl::alarm_status::LINK_ALARM;
 
@@ -138,7 +136,7 @@ async fn a_dispatch_on_a_dropped_link_commits_link_invalid() {
 
 /// Recovery, the other half of criterion 4: the alarm must clear on the
 /// next event after the circuit comes back, with no restart of the IOC.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_link_alarm_clears_on_the_next_event_after_recovery() {
     let lset = SwitchableLset::new(7.25);
     let db = holder_db(lset.clone()).await;

--- a/crates/epics-base-rs/tests/external_link_get_cached.rs
+++ b/crates/epics-base-rs/tests/external_link_get_cached.rs
@@ -16,8 +16,6 @@
 //! differs by one scan cycle, which C also spends in LINK/INVALID whenever the
 //! link has not connected yet.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -115,7 +113,7 @@ async fn val_of(db: &PvDatabase, name: &str) -> Option<f64> {
 /// thread: it stages the open on the link work owner and returns nothing this
 /// cycle, which is C returning -1 for a link that is not connected
 /// (`dbCa.c:459-464`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_cache_miss_stages_the_open_instead_of_opening_inline() {
     let opens = Arc::new(AtomicUsize::new(0));
     let reads = Arc::new(AtomicUsize::new(0));
@@ -156,7 +154,7 @@ async fn a_cache_miss_stages_the_open_instead_of_opening_inline() {
 /// Boundary — cache hit. Once the work owner has opened the link and the
 /// monitor has published a value, the read serves it with no further opens
 /// and still no network read.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_warm_cache_is_read_without_opening_or_network() {
     let opens = Arc::new(AtomicUsize::new(0));
     let reads = Arc::new(AtomicUsize::new(0));
@@ -197,7 +195,7 @@ async fn a_warm_cache_is_read_without_opening_or_network() {
 /// link (`dbCaAddLink`, `dbCa.c:735-800`) and libca owns every retry from
 /// then on. So a record scanning against a dead remote must produce one
 /// connect attempt, not one per scan.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_permanently_cold_link_is_opened_once_not_once_per_scan() {
     let opens = Arc::new(AtomicUsize::new(0));
     let reads = Arc::new(AtomicUsize::new(0));
@@ -222,7 +220,7 @@ async fn a_permanently_cold_link_is_opened_once_not_once_per_scan() {
 
 /// Boundary — distinct links each get their own open. The once-only rule is
 /// per link, not global; a second link must not be starved by the first.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn distinct_links_are_each_opened_once() {
     let opens = Arc::new(AtomicUsize::new(0));
     let reads = Arc::new(AtomicUsize::new(0));

--- a/crates/epics-base-rs/tests/external_link_init_open.rs
+++ b/crates/epics-base-rs/tests/external_link_init_open.rs
@@ -15,8 +15,6 @@
 //! `stage_external_link_open_by_name`, i.e. the same `LinkPutQueue` owner
 //! that consumes `connect_link`. Nothing here opens a channel inline.
 
-// RTEMS-EXEC-MODEL-ALLOW(15): checked - these run and pass in the feature-ON suite.
-
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -122,7 +120,7 @@ async fn val_of(db: &PvDatabase, name: &str) -> Option<f64> {
 /// link is opened at init like any other. The port must therefore stage it
 /// in the iocInit pass, NOT on the first scan's cache miss: the observable
 /// consequence is that scan 1 already reads a warm cache.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn non_cp_external_inp_link_is_opened_at_init_not_on_first_scan() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -161,7 +159,7 @@ async fn non_cp_external_inp_link_is_opened_at_init_not_on_first_scan() {
 /// `dbInitLink` above the `dbfType` switch (`dbLink.c:118-130`), so C opens
 /// `DBF_OUTLINK` channels at init too; only the `pvlOptInpNative` /
 /// `pvlOptFWD` flags below it are direction-specific.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn out_only_external_link_is_opened_at_init() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -184,7 +182,7 @@ async fn out_only_external_link_is_opened_at_init() {
 /// same `record_link_fields` enumeration, so an external `INPA` is opened
 /// at init exactly like `INP`. This is the property that would break if the
 /// pass grew its own field list instead of reusing the CP pass's owner.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn record_specific_input_link_fields_are_opened_at_init() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -218,7 +216,7 @@ async fn record_specific_input_link_fields_are_opened_at_init() {
 /// `dbDbInitLink` and returns before `dbCaAddLink` (`dbLink.c:118-124`);
 /// a `CONSTANT` link returns even earlier (`dbLink.c:101-104`). Neither may
 /// consume the link queue's one-shot open.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn local_and_constant_links_stage_nothing() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -249,7 +247,7 @@ async fn local_and_constant_links_stage_nothing() {
 /// `dbCaAddLinkCallbackOpt` (`dbLink.c:129`) and the link IS a CA link from
 /// then on. So both halves must hold: the holder's parse cache is rewritten to
 /// `Ca`, and the channel is opened at init like any other external link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn plain_non_local_db_link_converts_and_opens_at_init() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -295,7 +293,7 @@ async fn plain_non_local_db_link_converts_and_opens_at_init() {
 /// `plink->value.pv_link.pvname` verbatim (`dbLink.c:129`), i.e. the same
 /// `record.FIELD` string `dbChannelCreate` just failed on — not the bare
 /// record name.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn plain_non_local_db_link_keeps_its_field_in_the_channel_name() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -314,7 +312,7 @@ async fn plain_non_local_db_link_keeps_its_field_in_the_channel_name() {
 /// `dbInitLink` the moment `dbDbInitLink` succeeds (`dbLink.c:118-120`), never
 /// reaching `dbCaAddLink`: the link keeps `dbDb_lset`, its lock-set merge, its
 /// `PP` target processing and its `MS` severity inheritance.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn local_db_link_is_not_converted() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -351,7 +349,7 @@ async fn local_db_link_is_not_converted() {
 /// external CP trigger; moving the rewrite to the `dbInitLink` pass must keep
 /// BOTH halves, because C reaches the identical `dbCaAddLink` call for a
 /// CP link — it just skips `dbDbInitLink` on the way (`dbLink.c:117`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn non_local_cp_link_keeps_its_conversion_and_its_external_trigger() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -386,7 +384,7 @@ async fn non_local_cp_link_keeps_its_conversion_and_its_external_trigger() {
 /// that appears in the IOC *after* iocInit does NOT pull an already-converted
 /// link back to a local DB link. Our commit into the parse cache has the same
 /// shape: nothing re-derives it from locality afterwards.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_record_added_after_init_does_not_un_convert_the_link() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -415,7 +413,7 @@ async fn a_record_added_after_init_does_not_un_convert_the_link() {
 /// locality test: `dbInitLink` returns at `dbConstInitLink`
 /// (`dbLink.c:101-104`). A numeric `INP` must not be turned into a CA channel
 /// named `3.5`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_link_is_not_converted() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -438,7 +436,7 @@ async fn constant_link_is_not_converted() {
 /// (`processing.rs::dispatch_external_forward_link`), so the channel must be
 /// connecting before the first forward trigger rather than being staged by
 /// that trigger's own refusal.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn external_forward_link_is_opened_at_init() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -470,7 +468,7 @@ async fn external_forward_link_is_opened_at_init() {
 /// forward trigger is the local `dbScanPassive` path, not a link set. Widening
 /// `record_link_fields` to carry `FLNK` must not turn every fanout chain in a
 /// database into an external open attempt.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn local_forward_link_stages_nothing() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -505,7 +503,7 @@ async fn local_forward_link_stages_nothing() {
 /// set to `pvlOptCA` alone (`dbStaticLib.c:2390`), which is what
 /// `LinkFieldType::Fwd` reproduces: `FLNK="OTHER CP"` parses as a plain NPP
 /// forward link, never a CP holder edge.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn forward_link_never_registers_a_cp_holder() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -538,7 +536,7 @@ async fn forward_link_never_registers_a_cp_holder() {
 /// is once-per-key and terminal (`link_put_queue.rs:346-369`), so the link
 /// is connected exactly once: C stages one `CA_CONNECT` per link and libca
 /// owns every retry from then on.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn external_cp_link_already_warmed_is_not_staged_again() {
     let reads = Arc::new(AtomicUsize::new(0));
     let lset = CountingLset::new(&reads);
@@ -574,7 +572,7 @@ async fn external_cp_link_already_warmed_is_not_staged_again() {
 /// installers run before this pass, but a test or a late installer may not
 /// have) would then never be asked to open it. The gate keeps the link
 /// stageable.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn no_link_set_registered_stages_nothing_and_leaves_the_link_openable() {
     let db = PvDatabase::new();
     add_ai(&db, "AI_NOLSET", "ca://REMOTE:IN").await;

--- a/crates/epics-base-rs/tests/external_link_put_enqueue.rs
+++ b/crates/epics-base-rs/tests/external_link_put_enqueue.rs
@@ -22,8 +22,6 @@
 //!
 //! Each test below is one boundary of that queue, not one narrative.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
@@ -182,7 +180,7 @@ async fn alarm_of(db: &PvDatabase, name: &str) -> (u16, AlarmSeverity) {
 ///
 /// This is the property the whole change exists for: the last network
 /// suspension inside the record's advisory write gate is gone.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn plain_put_returns_before_the_wire_write_completes() {
     let completed = Arc::new(Mutex::new(Vec::new()));
     let (entered, mut entered_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -231,7 +229,7 @@ async fn plain_put_returns_before_the_wire_write_completes() {
 /// (`dbCa.c:558-561`: `if (!pca->isConnected || !pca->hasWriteAccess) return
 /// -1`), so `put_value` must never run and the writing record must alarm in
 /// this cycle (`dbLink.c:434-448` `setLinkAlarm`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn disconnected_link_stages_nothing_and_alarms() {
     let writes = Arc::new(Mutex::new(Vec::new()));
     let db = PvDatabase::new();
@@ -273,7 +271,7 @@ async fn disconnected_link_stages_nothing_and_alarms() {
 /// Here: put 1.0 goes in flight (gated), 2.0 is staged behind it, 3.0
 /// overwrites 2.0. Exactly two writes reach the wire, in order, and the
 /// middle value is dropped — which is `nNoWrite == 1`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn pending_put_is_overwritten_latest_wins() {
     let completed = Arc::new(Mutex::new(Vec::new()));
     let (entered, mut entered_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -325,7 +323,7 @@ async fn pending_put_is_overwritten_latest_wins() {
 /// C guarantees this by having a single `dbCaTask` service `workList` FIFO
 /// (`dbCa.c:1180-1197`); ours by keeping at most one write in flight per link
 /// and re-queueing a restaged value at its tail (`link_put_queue::finish`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn per_link_put_ordering_is_preserved() {
     let writes = Arc::new(Mutex::new(Vec::new()));
     let db = PvDatabase::new();
@@ -363,7 +361,7 @@ async fn per_link_put_ordering_is_preserved() {
 /// source record's `NotifyWaitSet` must stay unsettled until the completion
 /// resolves. On the pre-H6 shape `process()` awaited the completion, so this
 /// test would deadlock on the gate rather than fail an assertion.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn async_put_completion_is_reported_through_the_notify_chain() {
     let completed = Arc::new(Mutex::new(Vec::new()));
     let (entered, mut entered_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -429,7 +427,7 @@ async fn async_put_completion_is_reported_through_the_notify_chain() {
 /// If the queue owner ever dropped a completion instead of resolving it, this
 /// test would hang rather than fail — which is why `PutCompletion` resolves on
 /// `Drop` as well as on the success path.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn async_put_wire_failure_settles_the_chain_without_alarming() {
     let writes = Arc::new(Mutex::new(Vec::new()));
     let db = PvDatabase::new();
@@ -468,7 +466,7 @@ async fn async_put_wire_failure_settles_the_chain_without_alarming() {
 /// writes to every other link. C gets this free (`ca_array_put` only queues
 /// into libca's send buffer); ours needs the owner to keep one in-flight write
 /// PER LINK rather than one globally.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_blocked_link_does_not_stall_other_links() {
     let completed = Arc::new(Mutex::new(Vec::new()));
     let (entered, mut entered_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -504,7 +502,7 @@ async fn a_blocked_link_does_not_stall_other_links() {
         if completed.lock().unwrap().contains(&2.0) {
             break;
         }
-        tokio::task::yield_now().await;
+        epics_base_rs::runtime::task::yield_now().await;
     }
     let mid = completed.lock().unwrap().clone();
     assert_eq!(

--- a/crates/epics-base-rs/tests/fanout_seq_val_long_put_stores.rs
+++ b/crates/epics-base-rs/tests/fanout_seq_val_long_put_stores.rs
@@ -15,8 +15,6 @@
 //! `c_parse::put_string` Long row, which stores the value and range-checks it
 //! exactly as C's `epicsParseInt32` does.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::{AlarmSeverity, Record};
 use epics_base_rs::server::records::fanout::FanoutRecord;
@@ -80,13 +78,13 @@ async fn assert_val_put_stores(db: &PvDatabase) {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn fanout_val_long_put_stores() {
     let db = db_with(Box::new(FanoutRecord::new())).await;
     assert_val_put_stores(&db).await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn seq_val_long_put_stores() {
     let db = db_with(Box::new(SeqRecord::new())).await;
     assert_val_put_stores(&db).await;

--- a/crates/epics-base-rs/tests/fanout_seq_val_no_per_put_monitor.rs
+++ b/crates/epics-base-rs/tests/fanout_seq_val_no_per_put_monitor.rs
@@ -30,8 +30,6 @@
 //! (the in-process subscribe seam emits no connect snapshot, so every event
 //! here would be an over-post) while VAL still stores the last put.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::EventMask;
 use epics_base_rs::server::record::Record;
@@ -93,7 +91,7 @@ async fn db_with(record: Box<dyn Record>) -> PvDatabase {
     db
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn fanout_val_posts_no_per_put_monitor() {
     let db = db_with(Box::new(FanoutRecord::new())).await;
     assert_eq!(
@@ -103,7 +101,7 @@ async fn fanout_val_posts_no_per_put_monitor() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn seq_val_posts_no_per_put_monitor() {
     let db = db_with(Box::new(SeqRecord::new())).await;
     assert_eq!(

--- a/crates/epics-base-rs/tests/force_block_process_notify.rs
+++ b/crates/epics-base-rs/tests/force_block_process_notify.rs
@@ -11,8 +11,6 @@
 //! chain went async. A fully synchronous chain drains the wait-set inside
 //! processing and returns `Ok(None)`.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::ai::AiRecord;
@@ -23,7 +21,7 @@ use epics_base_rs::types::EpicsValue;
 /// processing call: the wait-set drains before `process_record_with_notify`
 /// returns, so it yields `Ok(None)` (no receiver to await) — and it processed
 /// UNCONDITIONALLY (Force = C `dbProcess`), driving the OUT link synchronously.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn force_block_sync_record_returns_none_and_processes() {
     let db = PvDatabase::new();
     db.add_record("TGT0", Box::new(AiRecord::new(0.0)))
@@ -69,7 +67,7 @@ async fn force_block_sync_record_returns_none_and_processes() {
 /// a bug that ignored block would have returned before the async work, either
 /// `Ok(None)` or with the OUT already fired. The 100 s timer cannot fire in the
 /// test, so the OUT stays deferred (DLYA=1, TGT unchanged).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn force_block_async_record_withholds_completion_until_processing_done() {
     let db = PvDatabase::new();
     db.add_record("TGT1", Box::new(AiRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/get_pv_blocking_contexts.rs
+++ b/crates/epics-base-rs/tests/get_pv_blocking_contexts.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(3): blocking-context tests that hand-build specific tokio runtimes on purpose; run and pass in the feature-ON suite.
 //! `PvDatabase::get_pv_blocking` across caller contexts.
 //!
 //! It USED to be a sync bridge over an async `get_pv`, and whether blocking was
@@ -11,8 +12,6 @@
 //! context-dependent soundness question either — every context below must
 //! simply return the value. The three cases are kept as BOUNDARIES: if a future
 //! change re-introduces a blocking bridge, the current-thread case fails again.
-
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 
 use std::time::Duration;
 
@@ -79,10 +78,11 @@ fn get_pv_blocking_from_multi_thread_runtime_succeeds() {
     let db = rt.block_on(db_with_pv());
 
     rt.block_on(async move {
-        let value = tokio::task::spawn_blocking(move || db.get_pv_blocking("BLOCKING:PV"))
-            .await
-            .unwrap()
-            .expect("multi-thread runtime must keep working");
+        let value =
+            epics_base_rs::runtime::task::spawn_blocking(move || db.get_pv_blocking("BLOCKING:PV"))
+                .await
+                .unwrap()
+                .expect("multi-thread runtime must keep working");
         assert_eq!(value, EpicsValue::Long(7));
     });
 }

--- a/crates/epics-base-rs/tests/getenv_device.rs
+++ b/crates/epics-base-rs/tests/getenv_device.rs
@@ -19,8 +19,6 @@
 //! `std::env::set_var` is race-free here: nextest runs each `#[test]` in its own
 //! process, so the variable set below is private to this test's process.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::{HashMap, HashSet};
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -32,7 +30,7 @@ use epics_base_rs::types::EpicsValue;
 /// environment variable into `VAL` — proving the static builtin factory wired
 /// the device and its read ran end-to-end (the pre-wiring default `VAL` is an
 /// empty string, so a non-empty match proves the device ran).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn getenv_stringin_reads_env_var_through_iocbuilder() {
     // SAFETY: nextest isolates each test in its own process (see module doc),
     // so this set_var cannot race another test.
@@ -78,7 +76,7 @@ record(stringin, "GETENV_SI") {
 /// record-type gate Errs in `init()`, so `wire_device_to_record` flags an
 /// `ai` with `DTYP="getenv"` INVALID at build time — proving the device
 /// attached and gated rather than being silently accepted.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn getenv_wrong_record_type_is_invalid() {
     let (db, _) = IocBuilder::new()
         .db_string(
@@ -109,7 +107,7 @@ record(ai, "GETENV_AI") {
 /// :114-118). base-rs surfaces the SAME UDF_ALARM via the device `last_alarm()`
 /// channel — not READ_ALARM (which the earlier soft-Err path produced) and with
 /// no per-cycle stderr spam.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn getenv_unset_var_raises_udf_alarm_not_read_alarm() {
     // SAFETY: nextest isolates each test in its own process (see module doc), so
     // removing this variable cannot race another test.
@@ -164,7 +162,7 @@ record(stringin, "GETENV_UNSET") {
 /// reason `set_process_context` exists: drop the `ctx.udfs` capture and the
 /// severity reverts to the INVALID default, failing this assertion (the
 /// default-UDFS test above would still pass, so it cannot catch that regression).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn getenv_unset_var_honors_user_lowered_udfs() {
     // SAFETY: nextest isolates each test in its own process (see module doc), so
     // removing this variable cannot race another test.

--- a/crates/epics-base-rs/tests/h6_gate_released_across_async.rs
+++ b/crates/epics-base-rs/tests/h6_gate_released_across_async.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(4): multi-thread-flavored tokio tests (the gate contention needs real parallel workers); run and pass in the feature-ON suite.
 //! H6 boundaries: the L1 record gate is NOT held across an asynchronous wait.
 //!
 //! C `dbProcess` never blocks under `dbScanLock`. On async device support it
@@ -18,8 +19,6 @@
 //!    the gate is free while the delay runs;
 //! 3. the completion re-entry RE-TAKES the gate, so it serialises against a
 //!    concurrent holder rather than racing it.
-
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -114,9 +113,9 @@ async fn async_pending_record_does_not_hold_the_gate() {
 /// owned, which is the assertion these tests make.
 async fn probe_gate_is_free(db: &PvDatabase, record: &'static str) -> Result<(), &'static str> {
     let db = db.clone();
-    tokio::time::timeout(
+    epics_base_rs::runtime::task::timeout(
         Duration::from_secs(5),
-        tokio::task::spawn_blocking(move || drop(db.lock_record(record))),
+        epics_base_rs::runtime::task::spawn_blocking(move || drop(db.lock_record(record))),
     )
     .await
     .map_err(|_| "gate still held")?
@@ -142,7 +141,7 @@ async fn a_put_during_the_async_window_is_not_gate_blocked() {
 
     // The plain `dbPutField` analogue (no put-notify wait-set — C builds one
     // only in `dbPutNotify`).
-    tokio::time::timeout(
+    epics_base_rs::runtime::task::timeout(
         Duration::from_secs(5),
         db.put_record_field_from_ca_no_notify("H6:ASYNC2", "VAL", EpicsValue::Double(3.0)),
     )
@@ -238,7 +237,7 @@ async fn seq_delay_runs_outside_the_gate_and_fires_after_release() {
         {
             break;
         }
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
     }
     assert_eq!(
         db.get_record("H6:SEQTGT")
@@ -254,7 +253,7 @@ async fn seq_delay_runs_outside_the_gate_and_fires_after_release() {
         if !db.get_record("H6:SEQ").unwrap().read().is_processing() {
             break;
         }
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
     }
     assert!(
         !db.get_record("H6:SEQ").unwrap().read().is_processing(),
@@ -299,12 +298,12 @@ async fn the_async_completion_waits_for_the_gate() {
     let db2 = db.clone();
     let completed = Arc::new(AtomicU32::new(0));
     let completed2 = completed.clone();
-    let h = tokio::spawn(async move {
+    let h = epics_base_rs::runtime::task::spawn(async move {
         db2.complete_async_record("H6:CMPL").await.unwrap();
         completed2.store(1, Ordering::SeqCst);
     });
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(100)).await;
     assert_eq!(
         completed.load(Ordering::SeqCst),
         0,
@@ -313,7 +312,7 @@ async fn the_async_completion_waits_for_the_gate() {
 
     drop(release_tx);
     holder.join().expect("epoch holder thread");
-    tokio::time::timeout(Duration::from_secs(5), h)
+    epics_base_rs::runtime::task::timeout(Duration::from_secs(5), h)
         .await
         .expect("the completion must run once the gate is released")
         .unwrap();

--- a/crates/epics-base-rs/tests/histogram_cmd_over_max_stores_raw.rs
+++ b/crates/epics-base-rs/tests/histogram_cmd_over_max_stores_raw.rs
@@ -27,8 +27,6 @@
 //! catch-all `_ => clear_histogram(); cmd = 0`, so an over-max CMD read back as
 //! 0/"Read" — the divergence this test pins.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::records::histogram::HistogramRecord;
 use epics_base_rs::types::EpicsValue;
@@ -59,7 +57,7 @@ async fn db_with(record: HistogramRecord) -> PvDatabase {
 /// The reported case: a bare `record(histogram,"X"){}` then `caput X.CMD 4`. The
 /// over-max ordinal is stored verbatim; the command switch has no matching case,
 /// so counting state and buckets are untouched.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn cmd_over_max_ordinal_stores_raw() {
     let db = db_with(HistogramRecord::default()).await;
     caput_cmd(&db, 4).await.unwrap();
@@ -79,7 +77,7 @@ async fn cmd_over_max_ordinal_stores_raw() {
 
 /// The in-range commands are NOT regressed: each valid ordinal executes its arm
 /// and C resets `cmd` back to 0 afterwards.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn cmd_in_range_commands_execute_and_reset_to_zero() {
     let db = db_with(HistogramRecord::new(2, 0.0, 10.0)).await;
 

--- a/crates/epics-base-rs/tests/histogram_invalid_limits_alarm.rs
+++ b/crates/epics-base-rs/tests/histogram_invalid_limits_alarm.rs
@@ -23,8 +23,6 @@
 //! process path, where C erases the alarm; recorded as a CBUG-F12 allowlist
 //! row.)
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::alarm_status;
 use epics_base_rs::server::record::AlarmSeverity;
@@ -45,7 +43,7 @@ async fn alarm(db: &PvDatabase, name: &str) -> (AlarmSeverity, u16) {
 /// The process path raises the misconfiguration alarm through `nsta`/`nsev`, so
 /// `recGblResetAlarms` COMMITS it (rather than erasing a direct write) —
 /// SOFT/INVALID. C erases it here (NO_ALARM); the port refuses that dead code.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn inverted_limits_alarm_is_raised_on_the_process_cycle() {
     let db = PvDatabase::new();
     // LLIM=10, ULIM=5 — the compiled-C proof case.
@@ -65,7 +63,7 @@ async fn inverted_limits_alarm_is_raised_on_the_process_cycle() {
 
 /// Inverted limits alarm SOFT/INVALID every process cycle; fixing the limits to
 /// valid clears the alarm on the next cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn process_path_alarms_while_inverted_clears_when_valid() {
     let db = PvDatabase::new();
     db.add_record("H2", Box::new(HistogramRecord::new(16, 10.0, 5.0)))
@@ -93,7 +91,7 @@ async fn process_path_alarms_while_inverted_clears_when_valid() {
 
 /// Equal limits are inverted limits (C's test is `>=`); they too raise
 /// SOFT/INVALID on the process path.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn equal_limits_alarm_on_process_too() {
     let db = PvDatabase::new();
     db.add_record("H3", Box::new(HistogramRecord::new(16, 5.0, 5.0)))
@@ -112,7 +110,7 @@ async fn equal_limits_alarm_on_process_too() {
 /// The SGNL SPC_MOD special path runs `check_alarms` then commits it via
 /// `recGblResetAlarms`, so the SOFT/INVALID is observable — same as the process
 /// path, and same value C's sticky direct write happens to leave here.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sgnl_special_path_raises_the_soft_alarm() {
     let db = PvDatabase::new();
     db.add_record("H5", Box::new(HistogramRecord::new(16, 10.0, 5.0)))
@@ -133,7 +131,7 @@ async fn sgnl_special_path_raises_the_soft_alarm() {
 /// The negative control: valid limits raise nothing on either path. (A histogram
 /// never clears UDF and has no UDF alarm, so a well-formed one publishes
 /// NO_ALARM even though UDF stays 1 — `udf_clear_is_per_record_type` pins that.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn valid_limits_raise_no_alarm() {
     let db = PvDatabase::new();
     db.add_record("H4", Box::new(HistogramRecord::new(16, 0.0, 10.0)))

--- a/crates/epics-base-rs/tests/histogram_mdel_count_deadband.rs
+++ b/crates/epics-base-rs/tests/histogram_mdel_count_deadband.rs
@@ -31,8 +31,6 @@
 //! MCNT:      0   2   0   2      <- zeroed by the post on cycle 4
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -73,7 +71,7 @@ async fn mcnt(db: &PvDatabase, rec: &str) -> f64 {
 
 /// The softIoc transcript, value for value: MCNT counts up to MDEL+1, the post
 /// zeroes it, and it counts up again.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mcnt_is_counts_since_the_last_posted_val() {
     let db = build().await;
 
@@ -99,7 +97,7 @@ async fn mcnt_is_counts_since_the_last_posted_val() {
 /// The traffic half: MDEL is the histogram's only VAL-monitor rate limiter.
 /// Six processes with MDEL=3 produce exactly ONE VAL event (on the 4th); the
 /// port produced six.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mdel_rate_limits_the_val_monitor() {
     let db = build().await;
     let rec = db.get_record("HG").unwrap();
@@ -131,7 +129,7 @@ async fn mdel_rate_limits_the_val_monitor() {
 /// MDEL=0 (the dbd default) posts every cycle: the first count already makes
 /// `mcnt (1) > mdel (0)`. The gate must not suppress a default-configured
 /// histogram.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_default_mdel_of_zero_posts_every_process() {
     let db = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/histogram_sdel_full_double_range.rs
+++ b/crates/epics-base-rs/tests/histogram_sdel_full_double_range.rs
@@ -15,8 +15,6 @@
 //! arms, behaviourally identical to C's never-firing callback), so the store
 //! itself is accepted across the whole double range.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::histogram::HistogramRecord;
@@ -45,7 +43,7 @@ async fn db_with(record: Box<dyn Record>) -> PvDatabase {
 
 /// `1e308` (near double max), `1e39` (over float max), `inf` — all SUCCEED. The
 /// store must be accepted and arming the watchdog must not panic.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn histogram_sdel_accepts_large_and_infinite_double() {
     let db = db_with(Box::new(HistogramRecord::default())).await;
     for text in ["1e308", "1e39", "inf"] {
@@ -62,7 +60,7 @@ async fn histogram_sdel_accepts_large_and_infinite_double() {
 
 /// A finite value that fits still arms a real watchdog interval — the fix must
 /// not have turned every SDEL into a no-arm.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn histogram_sdel_finite_positive_still_stored() {
     let db = db_with(Box::new(HistogramRecord::default())).await;
     caput(&db, "SDEL", "2.5").await.unwrap();

--- a/crates/epics-base-rs/tests/histogram_svl_input_link.rs
+++ b/crates/epics-base-rs/tests/histogram_svl_input_link.rs
@@ -25,8 +25,6 @@
 //! records over CA. Its loader rejects the INP form with
 //! `ERROR: histogram record 'H:INP' doesn't have a field 'INP'`.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::error::CaError;
@@ -80,7 +78,7 @@ async fn bins(db: &epics_base_rs::server::database::PvDatabase, rec: &str) -> Ve
 /// SVL seeds SGNL at init and clears UDF — and does NOT bin anything (add_count
 /// runs only from `process()` / the SGNL `special()`). softIoc: `SGNL = 2.5`,
 /// `UDF = 0`, `VAL = 0 0 0 0`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_svl_seeds_sgnl_at_init_without_counting() {
     let db = build().await;
 
@@ -99,7 +97,7 @@ async fn constant_svl_seeds_sgnl_at_init_without_counting() {
 /// Each process bins the seeded SGNL once. softIoc, NELM=4 LLIM=0 ULIM=4
 /// (WDTH=1), SGNL=2.5 → bucket 2: `0 0 1 0` after one process, `0 0 2 0` after
 /// two.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_svl_bins_once_per_process() {
     let db = build().await;
 
@@ -117,7 +115,7 @@ async fn constant_svl_bins_once_per_process() {
 /// directly and never runs `special()`, so the SPC_MOD `add_count` that a SGNL
 /// *caput* triggers must not fire on the link delivery — otherwise every linked
 /// sample would be counted twice.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn real_svl_link_is_read_into_sgnl_and_binned_once_per_process() {
     let db = build().await;
 
@@ -140,7 +138,7 @@ async fn real_svl_link_is_read_into_sgnl_and_binned_once_per_process() {
 /// itself (`histogramRecord.c:334`, SPC_MOD → `add_count`) and SGNL is not
 /// `pp(TRUE)`, so no process runs and the sample is counted exactly once.
 /// softIoc: `caput H:LINK.SGNL 0.5` → `VAL` bucket 0 += 1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sgnl_caput_still_counts_through_special() {
     let db = build().await;
 
@@ -154,7 +152,7 @@ async fn sgnl_caput_still_counts_through_special() {
 /// `ERROR: histogram record 'H:INP' doesn't have a field 'INP'` and the record
 /// is inert. The port must refuse it at the same gate rather than driving the
 /// record from a field the C record type does not have.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn field_inp_is_refused_on_a_histogram() {
     let db = IocBuilder::new()
         .db_string(
@@ -202,7 +200,7 @@ record(histogram, "H:INP") {
 /// The port refused `field(INP,...)` at load and at `dbPut`, but `.INP` still
 /// resolved as a readable (empty) channel. Both routes now consult the same
 /// `declares_inp_link()` declaration.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn histogram_inp_does_not_resolve_as_a_channel() {
     let db = IocBuilder::new()
         .db_string(

--- a/crates/epics-base-rs/tests/init_parks_pact.rs
+++ b/crates/epics-base-rs/tests/init_parks_pact.rs
@@ -25,8 +25,6 @@
 //! (`RecordInstance::run_init_passes`) off the record's `init_record_parks_pact`,
 //! not by a record reaching into common state.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::sub_record::SubRecord;
@@ -38,7 +36,7 @@ async fn pact_of(db: &PvDatabase, name: &str) -> EpicsValue {
     inst.client_field_value("PACT").expect("PACT resolves")
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r21_a_sub_with_no_snam_is_parked_active() {
     let db = PvDatabase::new();
     db.add_record("SUB_BARE", Box::new(SubRecord::default()))
@@ -51,7 +49,7 @@ async fn r21_a_sub_with_no_snam_is_parked_active() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r21_a_sub_with_an_snam_is_not_parked() {
     let db = PvDatabase::new();
     let mut rec = SubRecord::default();
@@ -67,7 +65,7 @@ async fn r21_a_sub_with_an_snam_is_not_parked() {
 
 /// The park is not a one-shot flag a later process clears: C never releases it,
 /// so every scan from then on hits the PACT-active branch and VAL never moves.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r21_a_parked_sub_never_runs_record_support() {
     let db = PvDatabase::new();
     db.add_record("SUB_DEAD", Box::new(SubRecord::default()))

--- a/crates/epics-base-rs/tests/initial_udf_severity.rs
+++ b/crates/epics-base-rs/tests/initial_udf_severity.rs
@@ -1,4 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(1): IocShell::new takes a tokio Handle, so one test needs an ambient tokio runtime; runs and passes in the feature-ON suite.
 //! R16-82: the initial UDF severity — a record that has never processed is
 //! INVALID, not NO_ALARM.
 //!
@@ -165,11 +164,7 @@ async fn a_db_val_defines_the_record_so_the_seed_does_not_fire() {
 /// The same rule on the runtime `dbLoadRecords` path — the second `.db` loader.
 /// The seed is evaluated by the creation sink, which both loaders now hand
 /// their complete field set to, so neither can init a half-loaded record.
-///
-/// `#[tokio::test]`, not `#[epics_test]`: `IocShell::new` takes a
-/// `tokio::runtime::Handle`, so this body needs an ambient tokio runtime on
-/// both backends (the census marker accounts for it).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_runtime_db_loader_applies_the_val_udf_rule_too() {
     use epics_base_rs::server::iocsh::IocShell;
 
@@ -185,10 +180,11 @@ async fn the_runtime_db_loader_applies_the_val_udf_rule_too() {
     let db = std::sync::Arc::new(PvDatabase::new());
     {
         // iocsh commands block on the runtime, so they run off the async thread.
-        let (db, handle) = (db.clone(), tokio::runtime::Handle::current());
+        let db = db.clone();
+        let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
         let line = format!("dbLoadRecords(\"{}\")", db_file.display());
         std::thread::spawn(move || {
-            IocShell::new(db, handle).execute_line(&line).unwrap();
+            IocShell::new(db, bridge).execute_line(&line).unwrap();
         })
         .join()
         .unwrap();

--- a/crates/epics-base-rs/tests/initial_udf_severity.rs
+++ b/crates/epics-base-rs/tests/initial_udf_severity.rs
@@ -1,3 +1,4 @@
+// RTEMS-EXEC-MODEL-ALLOW(1): IocShell::new takes a tokio Handle, so one test needs an ambient tokio runtime; runs and passes in the feature-ON suite.
 //! R16-82: the initial UDF severity — a record that has never processed is
 //! INVALID, not NO_ALARM.
 //!
@@ -27,8 +28,6 @@
 //! consumer inherited NOTHING from a not-yet-processed source — the IOC-startup
 //! ordering case MS exists for.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -48,7 +47,7 @@ async fn build(db_text: &str) -> std::sync::Arc<PvDatabase> {
 }
 
 /// Every record type: born UDF, so `iocInit` publishes STAT=UDF SEVR=INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_never_processed_record_is_udf_invalid_after_init() {
     let db = build(
         r#"
@@ -80,7 +79,7 @@ async fn a_never_processed_record_is_udf_invalid_after_init() {
 /// The case the finding is about: an `MS` consumer of a not-yet-processed
 /// source inherits INVALID and reports LINK — the IOC-startup ordering the MS
 /// modifier exists for. softIoc: CON.STAT=LINK, CON.SEVR=INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ms_inherits_the_initial_udf_severity_from_an_unprocessed_source() {
     let db = build(
         r#"
@@ -124,7 +123,7 @@ async fn ms_inherits_the_initial_udf_severity_from_an_unprocessed_source() {
 /// ```
 ///
 /// STAT stays UDF in both: `iocInit` lowers nothing, it only raises SEVR.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_db_val_defines_the_record_so_the_seed_does_not_fire() {
     let db = build(
         r#"
@@ -166,6 +165,10 @@ async fn a_db_val_defines_the_record_so_the_seed_does_not_fire() {
 /// The same rule on the runtime `dbLoadRecords` path — the second `.db` loader.
 /// The seed is evaluated by the creation sink, which both loaders now hand
 /// their complete field set to, so neither can init a half-loaded record.
+///
+/// `#[tokio::test]`, not `#[epics_test]`: `IocShell::new` takes a
+/// `tokio::runtime::Handle`, so this body needs an ambient tokio runtime on
+/// both backends (the census marker accounts for it).
 #[tokio::test]
 async fn the_runtime_db_loader_applies_the_val_udf_rule_too() {
     use epics_base_rs::server::iocsh::IocShell;
@@ -209,7 +212,7 @@ async fn the_runtime_db_loader_applies_the_val_udf_rule_too() {
 
 /// UDFS is the severity the rule uses — a record that declares
 /// `field(UDFS,"MINOR")` starts MINOR, not INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_initial_severity_comes_from_udfs() {
     let db = build(r#"record(ai, "A2") { field(UDFS, "MINOR") }"#).await;
     let rec = db.get_record("A2").unwrap();
@@ -221,7 +224,7 @@ async fn the_initial_severity_comes_from_udfs() {
 /// A record whose value is defined at init (a constant INP loaded by the
 /// init-seed owner) clears UDF on its first process and the initial severity
 /// goes away — the alarm is not sticky.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_initial_severity_clears_on_the_first_successful_process() {
     let db = build(r#"record(calc, "C2") { field(INPA, "5") field(CALC, "A+1") }"#).await;
 

--- a/crates/epics-base-rs/tests/input_link_severity_inheritance.rs
+++ b/crates/epics-base-rs/tests/input_link_severity_inheritance.rs
@@ -28,8 +28,6 @@
 //! folded a record's OWN committed severity back into its pending alarm, which
 //! `recGblResetAlarms` then re-committed: a self-sustaining latch.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -61,7 +59,7 @@ async fn alarm(db: &PvDatabase, rec: &str) -> (u16, AlarmSeverity) {
 }
 
 /// R16-61: the ReadDbLink reader (compress INP) inherits MS from a healthy read.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_read_db_link_input_inherits_ms_severity() {
     let db = build(
         r#"
@@ -88,7 +86,7 @@ async fn a_read_db_link_input_inherits_ms_severity() {
 }
 
 /// NMS (the default) still inherits nothing — the MS class is what selects it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_read_db_link_input_without_ms_inherits_nothing() {
     let db = build(
         r#"
@@ -111,7 +109,7 @@ async fn a_read_db_link_input_without_ms_inherits_nothing() {
 /// committed severity back in — C's `precord != dbChannelRecord(chan)` guard.
 /// Without it the alarm latches: reset_alarms commits it, next cycle inherits
 /// it again, forever.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_self_referencing_ms_link_does_not_latch_the_record_alarm() {
     let db = build(
         r#"record(calc, "SELF") { field(INPA, "SELF.VAL MS") field(CALC, "A")

--- a/crates/epics-base-rs/tests/int64_field_put_is_integer_parsed.rs
+++ b/crates/epics-base-rs/tests/int64_field_put_is_integer_parsed.rs
@@ -15,8 +15,6 @@
 //! same trailing-text tolerance the dbCommon parse gate keeps. Only an
 //! out-of-integer-range magnitude is refused.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::records::asub_record::ASubRecord;
 use epics_base_rs::server::records::int64in::Int64inRecord;
@@ -49,7 +47,7 @@ async fn db_with(record: Box<dyn epics_base_rs::server::record::Record>) -> PvDa
 /// `9223372036854775808` is `2^63`, one past `i64::MAX`. A `DBF_DOUBLE` parse
 /// accepts it (`9.22e18`); `epicsParseInt64` refuses it — so the put must be
 /// REFUSED and the field must keep its prior value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn int64out_hopr_over_i64_max_is_refused() {
     let db = db_with(Box::new(Int64outRecord::new(0))).await;
     assert!(
@@ -65,7 +63,7 @@ async fn int64out_hopr_over_i64_max_is_refused() {
 
 /// The same magnitude a double would silently accept is fine once it fits: the
 /// top of the i64 band lands, stored as `Int64`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn int64out_drive_and_display_fields_accept_the_i64_band() {
     let db = db_with(Box::new(Int64outRecord::new(0))).await;
     for field in [
@@ -88,7 +86,7 @@ async fn int64out_drive_and_display_fields_accept_the_i64_band() {
 /// Trailing-text tolerance is preserved (C `strtol`): `5volts` -> `5`, and a
 /// fractional string truncates rather than being rejected — RANGE is the gate,
 /// not fractionality.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn int64out_trailing_text_and_fraction_truncate_not_reject() {
     let db = db_with(Box::new(Int64outRecord::new(0))).await;
     caput(&db, "HOPR", "5volts").await.unwrap();
@@ -99,7 +97,7 @@ async fn int64out_trailing_text_and_fraction_truncate_not_reject() {
 
 // --- int64in: DBF_INT64 fields via the derive macro ---------------------------
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn int64in_over_i64_max_is_refused_in_range_accepted() {
     let db = db_with(Box::new(Int64inRecord::new(0))).await;
     for field in ["HOPR", "LOPR", "HYST", "ADEL", "MDEL"] {
@@ -120,7 +118,7 @@ async fn int64in_over_i64_max_is_refused_in_range_accepted() {
 
 /// aSub `VAL` is `DBF_LONG`, i.e. `epicsInt32`. `2147483648` is `2^31`, one past
 /// `i32::MAX`; a double parse accepts it, `epicsParseLong` refuses it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_val_over_i32_max_is_refused() {
     let db = db_with(Box::new(ASubRecord::default())).await;
     assert!(
@@ -135,7 +133,7 @@ async fn asub_val_over_i32_max_is_refused() {
     assert_eq!(stored(&db, "VAL").await, EpicsValue::Long(0));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_val_in_range_accepted_as_i32() {
     let db = db_with(Box::new(ASubRecord::default())).await;
     caput(&db, "VAL", "42").await.unwrap();
@@ -152,7 +150,7 @@ async fn asub_val_in_range_accepted_as_i32() {
 /// The stored variant now integer, the CA wire type is unchanged: `Int64`
 /// promotes to `DBR_DOUBLE` (the record serves int64 as double, as C does),
 /// `Long` stays `DBR_LONG`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn integer_fields_keep_their_ca_wire_type() {
     assert_eq!(
         EpicsValue::Int64(1).dbr_type(),

--- a/crates/epics-base-rs/tests/link_read_inherits_ms_everywhere.rs
+++ b/crates/epics-base-rs/tests/link_read_inherits_ms_everywhere.rs
@@ -26,8 +26,6 @@
 //! record(ai,"R4"){field(SIML,"SRC0")}    (no MS)                  -> NO_ALARM
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -66,7 +64,7 @@ async fn alarm(db: &PvDatabase, name: &str) -> (u16, AlarmSeverity) {
 
 /// The closed-loop DOL read: `dbGetLink(&prec->dol, ...)` in `fetch_values`
 /// runs the same tail as an INP read.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn closed_loop_dol_inherits_ms() {
     let db = db_with_major_source().await;
 
@@ -107,7 +105,7 @@ async fn closed_loop_dol_inherits_ms() {
 
 /// SIML (`recGblGetSimm` → `dbTryGetLink`) and SIOL (`readValue` →
 /// `dbGetLink`) both run the tail.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn siml_and_siol_inherit_ms() {
     let db = db_with_major_source().await;
     // SIMM must stay out of simulation for the SIML case, so the source's
@@ -172,7 +170,7 @@ async fn siml_and_siol_inherit_ms() {
 
 /// SDIS (`dbAccess.c:566`) and TSEL (`recGbl.c:315`) are `dbGetLink` reads too,
 /// so they inherit as well — the rule is the read, not the field.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sdis_and_tsel_inherit_ms() {
     let db = db_with_major_source().await;
 

--- a/crates/epics-base-rs/tests/link_status_waits_for_db_load.rs
+++ b/crates/epics-base-rs/tests/link_status_waits_for_db_load.rs
@@ -27,8 +27,6 @@
 //! DBF_STRING:         "Local PV"
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -61,7 +59,7 @@ async fn add_calcout(db: &PvDatabase, name: &str, inpa: &str) {
 /// The load phase spans every load, not one: `CO` is created by the first load
 /// and its target by a SECOND one, exactly as an `st.cmd` with two
 /// `dbLoadRecords` lines does. C says Local PV; so must the port.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn forward_reference_across_two_loads_is_local() {
     let db = Arc::new(PvDatabase::new());
 
@@ -72,7 +70,7 @@ async fn forward_reference_across_two_loads_is_local() {
     // Between the two loads the pre-fix code had already closed its load group
     // and classified `CO` against a database without `LATER` in it. Give any
     // such task every chance to run.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
 
     // Second `dbLoadRecords`.
     db.begin_load().unwrap();
@@ -91,7 +89,7 @@ async fn forward_reference_across_two_loads_is_local() {
 /// The classification is FINAL when `iocInit` returns — no sleep, no re-poll.
 /// The pre-fix spawn left `INAV` at its struct default (`Constant`) for a
 /// caller that read it straight after the load.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn link_status_is_final_when_ioc_init_returns() {
     let db = Arc::new(PvDatabase::new());
     db.begin_load().unwrap();
@@ -109,13 +107,13 @@ async fn link_status_is_final_when_ioc_init_returns() {
 }
 
 /// A forward reference inside ONE load — the case R17-69 closed — stays closed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn forward_referenced_local_link_classifies_as_local() {
     let db = Arc::new(PvDatabase::new());
     db.begin_load().unwrap();
 
     add_calcout(&db, "CO", "TARGET.VAL").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     db.add_record("TARGET", Box::new(AiRecord::new(1.0)))
         .await
         .unwrap();
@@ -127,7 +125,7 @@ async fn forward_referenced_local_link_classifies_as_local() {
 /// The barrier does not paper over a genuinely absent target: a DB-syntax link
 /// to a record that no load ever creates stays Ext PV NC (C `init_record`'s
 /// else branch, `dbNameToAddr` failing).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unresolvable_link_still_classifies_as_ext_nc() {
     let db = Arc::new(PvDatabase::new());
     db.begin_load().unwrap();
@@ -144,21 +142,21 @@ async fn unresolvable_link_still_classifies_as_ext_nc() {
 /// A record created on a COMPLETE database (no load phase) classifies at once —
 /// the runtime `dbCreateRecord` / `special()` re-point path, which must not wait
 /// for an `iocInit` that already happened.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn no_load_in_progress_classifies_immediately() {
     let db = Arc::new(PvDatabase::new());
     db.add_record("TARGET", Box::new(AiRecord::new(1.0)))
         .await
         .unwrap();
     add_calcout(&db, "CO", "TARGET.VAL").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
 
     assert_eq!(inav(&db, "CO").await, LINK_LOC);
 }
 
 /// Records added AFTER the barrier classify immediately as well — `ioc_init`
 /// leaves the database complete, it does not park later work.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn record_added_after_ioc_init_classifies_immediately() {
     let db = Arc::new(PvDatabase::new());
     db.begin_load().unwrap();
@@ -168,7 +166,7 @@ async fn record_added_after_ioc_init_classifies_immediately() {
     db.ioc_init().await;
 
     add_calcout(&db, "CO", "TARGET.VAL").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
 
     assert_eq!(inav(&db, "CO").await, LINK_LOC);
 }
@@ -181,7 +179,7 @@ async fn record_added_after_ioc_init_classifies_immediately() {
 /// Measured on the port before the fix: `iocInit; dbLoadRecords(b.db); dbpf
 /// CO.INPA "9.5"` left `CO.INAV` at 0, where a plain `iocInit; dbpf CO.INPA
 /// "9.5"` gives 3 (Constant).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn begin_load_after_ioc_init_does_not_re_open_the_load_phase() {
     let db = Arc::new(PvDatabase::new());
     db.begin_load().unwrap();
@@ -198,7 +196,7 @@ async fn begin_load_after_ioc_init_does_not_re_open_the_load_phase() {
     // Anything classified from here on must still run: the phase is terminal, so
     // this is a spawn, not a push into a queue nothing drains.
     add_calcout(&db, "CO", "TARGET.VAL").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
 
     assert_eq!(
         inav(&db, "CO").await,
@@ -211,7 +209,7 @@ async fn begin_load_after_ioc_init_does_not_re_open_the_load_phase() {
 /// runtime `special()` link re-point (`calcout.rs`, `sseq.rs`, `swait.rs`,
 /// std-rs `throttle.rs`). A put to `INPA` re-classifies the link; after a
 /// post-iocInit `begin_load` it was stranded, freezing `INAV` at its old value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn runtime_link_re_point_still_classifies_after_a_post_init_load() {
     let db = Arc::new(PvDatabase::new());
     db.begin_load().unwrap();
@@ -228,7 +226,7 @@ async fn runtime_link_re_point_still_classifies_after_a_post_init_load() {
     db.put_pv("CO.INPA", EpicsValue::String("9.5".into()))
         .await
         .unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
 
     assert_eq!(
         inav(&db, "CO").await,
@@ -240,7 +238,7 @@ async fn runtime_link_re_point_still_classifies_after_a_post_init_load() {
 /// The `.db` path: `CO`'s `INPA` names `TARGET`, defined AFTER it in the same
 /// file. `IocBuilder::build` runs the barrier, so the status is Local — and
 /// final the moment `build` returns.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn db_file_forward_reference_is_local() {
     const DB: &str = r#"
 record(calcout, "CO") {

--- a/crates/epics-base-rs/tests/long_string_constant_link_load.rs
+++ b/crates/epics-base-rs/tests/long_string_constant_link_load.rs
@@ -31,8 +31,6 @@
 //! record(lsi,"L4"){field(INP,"5")}                 VAL ""          LEN 1  UDF 0
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -68,7 +66,7 @@ async fn state(db: &PvDatabase, rec: &str) -> (String, u32, bool) {
     (val, len, inst.common.udf != 0)
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_numeric_constant_link_defines_the_record_without_text() {
     let db = build(
         r#"
@@ -91,7 +89,7 @@ async fn a_numeric_constant_link_defines_the_record_without_text() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_json_const_string_is_the_only_text_form() {
     let db = build(
         r#"
@@ -115,7 +113,7 @@ async fn a_json_const_string_is_the_only_text_form() {
 
 /// SIZV bounds the copy (`strncpy(pbuffer, pstr, --size)`, lnkConst.c:446-448),
 /// so the text is truncated to `SIZV-1` and LEN counts the NUL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_json_const_string_is_clamped_at_sizv() {
     let db = build(
         r#"
@@ -132,7 +130,7 @@ async fn a_json_const_string_is_clamped_at_sizv() {
 }
 
 /// A PV link has no init-time `loadLS` at all, so the record stays undefined.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_pv_link_loads_nothing_and_leaves_the_record_undefined() {
     let db = build(
         r#"

--- a/crates/epics-base-rs/tests/longin_longout_deadband_is_dbf_long.rs
+++ b/crates/epics-base-rs/tests/longin_longout_deadband_is_dbf_long.rs
@@ -15,8 +15,6 @@
 //! boundary is RANGE, not fractionality — `strtol` trailing-text tolerance keeps
 //! `"5volts"` -> `5`. Mirrors the int64in/int64out Cause B fix (commit 224d5ad5).
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::longin::LonginRecord;
@@ -47,7 +45,7 @@ async fn db_with(record: Box<dyn Record>) -> PvDatabase {
 /// `2147483648` is `2^31`, one past `i32::MAX`; `-2147483649` is one past
 /// `i32::MIN`. `epicsParseInt32` refuses both — so the put must be REFUSED and
 /// the field must keep its prior value (0).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn longin_adel_mdel_over_i32_are_refused() {
     let db = db_with(Box::new(LonginRecord::new(0))).await;
     for field in ["ADEL", "MDEL"] {
@@ -67,7 +65,7 @@ async fn longin_adel_mdel_over_i32_are_refused() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn longout_adel_mdel_over_i32_are_refused() {
     let db = db_with(Box::new(LongoutRecord::new(0))).await;
     for field in ["ADEL", "MDEL"] {
@@ -90,7 +88,7 @@ async fn longout_adel_mdel_over_i32_are_refused() {
 /// The band edge (`i32::MAX` / `i32::MIN`) still lands, served as `Long` — the
 /// gate is RANGE, not fractionality (`strtol` trailing-text tolerance keeps
 /// `"5volts"` -> `5`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn longin_longout_adel_accept_the_i32_band_and_trailing_text() {
     for db in [
         db_with(Box::new(LonginRecord::new(0))).await,

--- a/crates/epics-base-rs/tests/mbbi_direct_bit_put_parity.rs
+++ b/crates/epics-base-rs/tests/mbbi_direct_bit_put_parity.rs
@@ -16,8 +16,6 @@
 //! accepted put — exactly what C does (oracle c_side: value 0, NO_ALARM,
 //! put_accepted=true). The fix only flips put_accepted false→true.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -60,7 +58,7 @@ async fn alarm(db: &PvDatabase, name: &str) -> (AlarmSeverity, u16) {
 /// `caput -c TMAX.B0 255` is ACCEPTED. The `pp(TRUE)` put processes the record,
 /// which re-derives the bit from the unchanged VAL=0 → B0 reads back 0. Live C
 /// (oracle): `put_accepted=true, B0=0, STAT=NO_ALARM, SEVR=NO_ALARM`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn type_max_bit_put_is_accepted() {
     let db = ioc().await;
 

--- a/crates/epics-base-rs/tests/mbbo_direct_bit_put_parity.rs
+++ b/crates/epics-base-rs/tests/mbbo_direct_bit_put_parity.rs
@@ -19,8 +19,6 @@
 //! Ground truth captured live from softIoc 7.0.10.1-DEV on this host
 //! (`caput -c`, one fresh `record(mbboDirect,"X"){}` per case).
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -65,7 +63,7 @@ async fn alarm(db: &PvDatabase, name: &str) -> (AlarmSeverity, u16, bool) {
 
 /// Cause 1: `caput -c TMAX.B0 255` is accepted; the bit stores 1 and folds into
 /// VAL. Live C: `TMAX.B0=1 VAL=1 STAT=NO_ALARM UDF=0`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn type_max_bit_put_is_accepted_and_stores_one() {
     let db = ioc().await;
 
@@ -97,7 +95,7 @@ async fn type_max_bit_put_is_accepted_and_stores_one() {
 /// Cause 2 (over-max): `caput -c OMAX.B0 256` is REFUSED, but the after-put
 /// special still clears UDF and the record processes → NO_ALARM. Live C:
 /// `put FAILED, B0=0 STAT=NO_ALARM SEVR=NO_ALARM UDF=0`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rejected_over_max_bit_put_clears_udf_reads_no_alarm() {
     let db = ioc().await;
 
@@ -120,7 +118,7 @@ async fn rejected_over_max_bit_put_clears_udf_reads_no_alarm() {
 }
 
 /// Cause 2 (non-numeric): `caput -c NONNUM.B0 notanumber` — same as over-max.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rejected_non_numeric_bit_put_clears_udf_reads_no_alarm() {
     let db = ioc().await;
 
@@ -140,7 +138,7 @@ async fn rejected_non_numeric_bit_put_clears_udf_reads_no_alarm() {
 /// VAL put must KEEP UDF/INVALID — VAL's UDF clear is `isValueField`, which runs
 /// AFTER the status check, so a rejected conversion never reaches it. Live C:
 /// `caput -c VALREJ.VAL notanumber` → `STAT=UDF SEVR=INVALID UDF=1`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rejected_val_put_keeps_udf_invalid() {
     let db = ioc().await;
 

--- a/crates/epics-base-rs/tests/mbbo_rval_undefined_put_stores.rs
+++ b/crates/epics-base-rs/tests/mbbo_rval_undefined_put_stores.rs
@@ -24,8 +24,6 @@
 //! unconditionally and clobbered RVAL to 0; opting mbbo into the framework's
 //! undefined-skip mirrors C's `goto CONTINUE`.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::mbbo::MbboRecord;
@@ -54,7 +52,7 @@ async fn db_with(record: Box<dyn Record>) -> PvDatabase {
 
 /// On a bare mbbo (UDF=1) a `caput RVAL v` stores `v`. `4294967295` is
 /// `u32::MAX`; `-1` reaches the unsigned field as `u32::MAX` too (C `strtoul`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_rval_put_stores_on_undefined_record() {
     let db = db_with(Box::new(MbboRecord::new(0))).await;
     caput(&db, "RVAL", "1").await.unwrap();
@@ -74,7 +72,7 @@ async fn mbbo_rval_put_stores_on_undefined_record() {
 /// The convert-skip is gated on UDF, exactly as C's `goto CONTINUE` is: once a
 /// VAL put clears UDF, the next process cycle DOES run `convert()` and RVAL is
 /// recomputed from VAL. Guards the fix against becoming an unconditional skip.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_rval_is_overwritten_by_convert_once_val_is_defined() {
     let db = db_with(Box::new(MbboRecord::new(0))).await;
     // Define VAL (clears UDF). VAL=0 on a bare mbbo -> convert() sets RVAL=0.

--- a/crates/epics-base-rs/tests/mbbo_udf_sync_timestamp.rs
+++ b/crates/epics-base-rs/tests/mbbo_udf_sync_timestamp.rs
@@ -27,8 +27,6 @@
 //! epoch. ao/bo/longout stamp UNCONDITIONALLY in their `if (!pact)` block, so
 //! they are NOT in this family and must keep stamping while undefined.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::runtime::general_time::epics_epoch;
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
@@ -55,7 +53,7 @@ async fn udf_of(db: &PvDatabase, name: &str) -> u8 {
 /// A soft UDF mbbo, processed synchronously, keeps TIME at the epoch — C's
 /// `goto CONTINUE` skips the pre-output stamp and the only other stamp is
 /// `if (pact)`-guarded (never taken on a soft record).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sync_udf_mbbo_keeps_epoch_time() {
     let db = PvDatabase::new();
     add(&db, "M", Box::new(MbboRecord::new(0))).await;
@@ -79,7 +77,7 @@ async fn sync_udf_mbbo_keeps_epoch_time() {
 
 /// Same for mbboDirect: bit-derived VAL, but it shares the `goto CONTINUE`
 /// timestamp-skip while undefined.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sync_udf_mbbo_direct_keeps_epoch_time() {
     let db = PvDatabase::new();
     add(&db, "MD", Box::new(MbboDirectRecord::default())).await;
@@ -104,7 +102,7 @@ async fn sync_udf_mbbo_direct_keeps_epoch_time() {
 /// the skip is gated on UDF exactly as C's `goto CONTINUE` is, so defined
 /// updates keep stamping. Guards the fix against becoming an unconditional
 /// skip.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn defined_mbbo_stamps_wall_clock_time() {
     let db = PvDatabase::new();
     add(&db, "M2", Box::new(MbboRecord::new(0))).await;
@@ -122,7 +120,7 @@ async fn defined_mbbo_stamps_wall_clock_time() {
 }
 
 /// mbboDirect too: a VAL put clears UDF and the sync process stamps.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn defined_mbbo_direct_stamps_wall_clock_time() {
     let db = PvDatabase::new();
     add(&db, "MD2", Box::new(MbboDirectRecord::default())).await;

--- a/crates/epics-base-rs/tests/menu_common_field_scan_pini.rs
+++ b/crates/epics-base-rs/tests/menu_common_field_scan_pini.rs
@@ -20,8 +20,6 @@
 //! `field(SSCN,"65535")` — menuScan's out-of-range "use SCAN" sentinel — load
 //! from a `.db` while `caput REC.SSCN 65535` is refused at runtime.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::error::CaError;
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::{RecordInstance, ScanType, SimModeScan};
@@ -44,7 +42,7 @@ async fn scan_of(db: &PvDatabase) -> ScanType {
 
 /// menuScan's periodic choices are spelled `".5 second"` — with no leading
 /// zero. The `"0.5 second"` alias is not a menuScan choice in any C release.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn invented_scan_aliases_are_rejected() {
     let db = ai_db().await;
 
@@ -61,7 +59,7 @@ async fn invented_scan_aliases_are_rejected() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn canonical_scan_labels_and_indices_still_resolve() {
     let db = ai_db().await;
 
@@ -88,7 +86,7 @@ async fn canonical_scan_labels_and_indices_still_resolve() {
 
 /// The case that used to end in `Passive` instead of an error: `from_u16`
 /// clamps, so every out-of-menu index silently became a Passive record.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn out_of_menu_scan_index_is_bad_choice_not_passive() {
     let db = ai_db().await;
     db.put_record_field_from_ca("REC", "SCAN", EpicsValue::String("1 second".into()))
@@ -110,7 +108,7 @@ async fn out_of_menu_scan_index_is_bad_choice_not_passive() {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn pini_uses_the_menu_converter() {
     let db = ai_db().await;
     let rec = db.get_record("REC").unwrap();
@@ -136,7 +134,7 @@ async fn pini_uses_the_menu_converter() {
 /// The two C converters differ at exactly one place that matters in practice:
 /// SSCN's `65535` sentinel. The loader (`dbPutStringNum`) takes it; a runtime
 /// `dbPut` (`putStringMenu`, bound `val < nChoice`) does not.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sscn_sentinel_loads_from_db_but_is_refused_at_runtime() {
     let mut inst = RecordInstance::new("SIM".to_string(), AiRecord::default());
     inst.put_common_field_db_load("SSCN", EpicsValue::String("65535".into()))

--- a/crates/epics-base-rs/tests/menu_field_put_bad_choice.rs
+++ b/crates/epics-base-rs/tests/menu_field_put_bad_choice.rs
@@ -20,8 +20,6 @@
 //! string became `to_f64().unwrap_or(0.0) as u16`, i.e. **menu index 0**. So
 //! `caput FAN.SELM Bogus` silently selected `All`.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::error::CaError;
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::records::fanout::FanoutRecord;
@@ -46,7 +44,7 @@ async fn selm(db: &PvDatabase) -> i16 {
 }
 
 /// `menu(fanoutSELM)` = All(0) / Specified(1) / Mask(2) — `nChoice` is 3.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn out_of_menu_index_is_bad_choice_and_stores_nothing() {
     let db = fanout_db().await;
     db.put_record_field_from_ca("FAN", "SELM", EpicsValue::String("Mask".into()))
@@ -69,7 +67,7 @@ async fn out_of_menu_index_is_bad_choice_and_stores_nothing() {
 /// The pre-fix fallback's real damage: an unrecognised string was coerced by
 /// the field-blind `convert_to`, landing as index 0 (`All`) with a SUCCESS
 /// status. C stores nothing and fails the put.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unknown_label_fails_instead_of_collapsing_to_index_zero() {
     let db = fanout_db().await;
     db.put_record_field_from_ca("FAN", "SELM", EpicsValue::String("Mask".into()))
@@ -85,7 +83,7 @@ async fn unknown_label_fails_instead_of_collapsing_to_index_zero() {
 }
 
 /// C matches with `strcmp`: no trimming, no case folding.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn label_match_is_exact_strcmp() {
     let db = fanout_db().await;
 
@@ -110,7 +108,7 @@ async fn label_match_is_exact_strcmp() {
 /// `epicsParseUInt16(pbuffer, &val, dbConvertBase, NULL)` — `dbConvertBase` is
 /// 0 (`epicsConvert.c:37`), so `strtoul` base 0 applies: whitespace around the
 /// digits is fine, `0x`/leading-`0` change the radix.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn in_range_index_is_parsed_the_way_epics_parse_uint16_parses_it() {
     let db = fanout_db().await;
 
@@ -133,7 +131,7 @@ async fn in_range_index_is_parsed_the_way_epics_parse_uint16_parses_it() {
 /// `menu(menuPriority)` (LOW/MEDIUM/HIGH), reached through
 /// `RecordInstance::put_common_field`, which used to hand a miss to
 /// `EpicsValue::parse` and drop it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn shared_menu_common_field_uses_the_same_converter() {
     let db = fanout_db().await;
 

--- a/crates/epics-base-rs/tests/ms_out_link_pending_alarm.rs
+++ b/crates/epics-base-rs/tests/ms_out_link_pending_alarm.rs
@@ -24,8 +24,6 @@
 //! the `dispatch_multi_output` path (dfanout OUTx), the recovery cycle, and
 //! NMS (no propagation at all).
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -71,7 +69,7 @@ async fn add_target(db: &PvDatabase, name: &str) {
 /// Boundary 1 + 4 — the `WriteDbLink` action path (transform `OUTx`).
 /// `OUTA` is MS, `OUTB` is bare (NMS). One process of TR must leave the MS
 /// target INVALID and the NMS target clean.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_61_write_db_link_out_inherits_this_cycles_pending_severity() {
     let db = PvDatabase::new();
     add_source(&db).await;
@@ -112,7 +110,7 @@ async fn r15_61_write_db_link_out_inherits_this_cycles_pending_severity() {
 /// Boundary 2 — the recovery cycle. The source clears, and the MS target must
 /// clear in the SAME cycle. Reading the committed alarm would hand the target
 /// the previous cycle's INVALID one cycle after the source recovered.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_61_ms_out_target_clears_in_the_cycle_the_source_clears() {
     let db = PvDatabase::new();
     add_source(&db).await;
@@ -154,7 +152,7 @@ async fn r15_61_ms_out_target_clears_in_the_cycle_the_source_clears() {
 /// Boundary 3 — the `dispatch_multi_output` path (dfanout `OUTx`). Same
 /// snapshot, a different writer: dfanout's own HIHI/HHSV puts it INVALID this
 /// cycle, and its MS `OUTA` must carry that INVALID out with the value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_61_dfanout_ms_out_inherits_this_cycles_pending_severity() {
     let db = PvDatabase::new();
     add_target(&db, "DF_TGT").await;

--- a/crates/epics-base-rs/tests/out_link_failure_alarm.rs
+++ b/crates/epics-base-rs/tests/out_link_failure_alarm.rs
@@ -16,8 +16,6 @@
 //! boundary of the put owner: local DB target, external `ca://` target, SIOL
 //! simulated output, and the recovery cycle.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
@@ -90,7 +88,7 @@ async fn alarm_of(db: &PvDatabase, name: &str) -> (u16, AlarmSeverity) {
 
 /// Boundary 1 — the OUT link names no local record and no external link set is
 /// registered, so the put fails. One process must leave LINK/INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_62_failing_local_out_put_raises_link_invalid_same_cycle() {
     let db = PvDatabase::new();
     add_ao_with_out(&db, "AO_BADOUT", "NO_SUCH_TARGET").await;
@@ -111,7 +109,7 @@ async fn r14_62_failing_local_out_put_raises_link_invalid_same_cycle() {
 /// Boundary 2 — an external `ca://` OUT link whose put fails takes the same
 /// raise: C routes DB and CA links through the identical `dbPutLink` gate, the
 /// alarm comes from `dbPutLink` itself, not from the lset.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_62_failing_external_out_put_raises_link_invalid() {
     let db = PvDatabase::new();
     db.register_link_set("ca", Arc::new(FailingLset)).await;
@@ -135,7 +133,7 @@ async fn r14_62_failing_external_out_put_raises_link_invalid() {
 /// 384-406) puts the simulated value through `dbPutLink(&prec->siol, …)`, the
 /// same gate, so a failing SIOL raises LINK/INVALID exactly as a failing OUT
 /// does. The port's `write_sim_siol_value` used to drop its error entirely.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_62_failing_siol_sim_write_raises_link_invalid() {
     let db = PvDatabase::new();
     db.add_record("SIM_ON", Box::new(AoRecord::new(1.0)))
@@ -163,7 +161,7 @@ async fn r14_62_failing_siol_sim_write_raises_link_invalid() {
 /// the put that fails; once the put succeeds, the next `recGblResetAlarms`
 /// commits NO_ALARM (recGbl.c:186-220: `nsta`/`nsev` are re-initialised to 0
 /// at the end of every commit). A latched alarm would stay INVALID forever.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_62_successful_put_next_cycle_clears_the_link_alarm() {
     let puts = Arc::new(Mutex::new(Vec::new()));
     let db = PvDatabase::new();
@@ -215,7 +213,7 @@ async fn r14_62_successful_put_next_cycle_clears_the_link_alarm() {
 
 /// Companion gate — a working OUT link must NOT raise any alarm. Pins that the
 /// raise fires on a real put failure only.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_62_successful_local_out_put_raises_no_alarm() {
     let db = PvDatabase::new();
     db.add_record("AO_GOOD_DEST", Box::new(AoRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/pact_async_primitive.rs
+++ b/crates/epics-base-rs/tests/pact_async_primitive.rs
@@ -8,8 +8,6 @@
 //! `modules/database/src/ioc/db/callback.c` (delayed re-entry) and
 //! `dbNotify.c` (put-notify wait-set / completion).
 
-// RTEMS-EXEC-MODEL-ALLOW(11): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -86,7 +84,7 @@ async fn db_with_record(name: &str) -> (PvDatabase, Arc<AtomicU32>) {
 
 /// (1) A fresh `AsyncToken` drives a process re-entry: firing it runs the
 /// record's `process()` once (C `callbackRequestDelayed` → `(*process)`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn async_token_fire_drives_process_reentry() {
     let (db, count) = db_with_record("T1").await;
     let baseline = count.load(Ordering::Relaxed);
@@ -108,7 +106,7 @@ async fn async_token_fire_drives_process_reentry() {
 /// (2) Cancel via the generation gate makes a stale re-entry a structural
 /// no-op: after `cancel_async_reentry`, the outstanding token is no longer
 /// current and `fire` re-enters nothing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn async_token_stale_after_cancel_is_noop() {
     let (db, count) = db_with_record("T2").await;
 
@@ -144,7 +142,7 @@ async fn async_token_stale_after_cancel_is_noop() {
 /// (2b) Minting a newer token supersedes the prior one (C
 /// `callbackRequestDelayed` replacing an outstanding delayed callback):
 /// the older token's `fire` is a no-op, the newer one's fires.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn newer_mint_supersedes_prior_token() {
     let (db, count) = db_with_record("T2B").await;
 
@@ -171,7 +169,7 @@ async fn newer_mint_supersedes_prior_token() {
 /// (3) `post_fields` applies an async-side field update and posts a monitor
 /// event for it (C `db_post_events(precord, &prec->field, DBE_VALUE|DBE_LOG)`),
 /// without running a process cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn post_fields_applies_and_posts_async_update() {
     let (db, count) = db_with_record("T3").await;
     let baseline = count.load(Ordering::Relaxed);
@@ -220,7 +218,7 @@ async fn post_fields_applies_and_posts_async_update() {
 /// (4a) A put-notify wait-set resolves its completion oneshot when the
 /// downstream operation completes (C `dbNotifyCompletion` draining the
 /// waitList to zero).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_notify_oneshot_resolves_on_downstream_completion() {
     let (notify, rx) = PvDatabase::new_put_notify();
     assert!(
@@ -239,7 +237,7 @@ async fn put_notify_oneshot_resolves_on_downstream_completion() {
 /// (4b) `reprocess_on_notify` wires a put-notify completion to an
 /// `AsyncToken`: when the downstream completes, the waiting record's
 /// `process()` is re-entered (SSEQ `WAITn` shape).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn reprocess_on_notify_reenters_waiter_on_completion() {
     let (db, count) = db_with_record("T4").await;
     let baseline = count.load(Ordering::Relaxed);
@@ -264,7 +262,7 @@ async fn reprocess_on_notify_reenters_waiter_on_completion() {
 /// A cancelled token wired through `reprocess_on_notify` re-enters nothing
 /// even when the downstream completes — the wiring inherits the structural
 /// no-op from `AsyncToken::fire`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn reprocess_on_notify_with_cancelled_token_is_noop() {
     let (db, count) = db_with_record("T5").await;
     let baseline = count.load(Ordering::Relaxed);
@@ -301,7 +299,7 @@ async fn poll_until<F: Fn() -> bool>(label: &str, pred: F) {
         if pred() {
             return;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(1)).await;
     }
     panic!("timed out waiting for: {label}");
 }
@@ -432,7 +430,7 @@ impl Record for AbortSourceRecord {
 /// out-of-band `post_fields`, and because the handle is a `Weak` reference,
 /// dropping the only strong `PvDatabase` reports the handle dead (no
 /// ownership-cycle leak) and makes further posts a no-op.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn set_async_context_delivers_working_cycle_free_handle() {
     let sink: Arc<Mutex<Option<AsyncDbHandle>>> = Arc::new(Mutex::new(None));
     let db = PvDatabase::new();
@@ -492,7 +490,7 @@ async fn set_async_context_delivers_working_cycle_free_handle() {
 /// (S2) The `WriteDbLinkNotify` ProcessAction arm writes the downstream OUT
 /// link (DST.VAL) through a put-notify wait-set and re-enters the *source*
 /// when the downstream completes — the in-band `sseq` `WAITn` step.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn write_db_link_notify_action_drives_downstream_and_reenters_source() {
     let db = PvDatabase::new();
     let src_count = Arc::new(AtomicU32::new(0));
@@ -587,7 +585,7 @@ impl Record for PendingNotifyWriteSource {
 /// pass (motorRecord.cc:1495), so dropping the action on the pending cycle
 /// would lose one of the target's process cycles. Pre-fix the
 /// `AsyncPendingNotify` branch dropped `outcome.actions` entirely.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn async_pending_notify_runs_write_db_link_on_pending_cycle() {
     let db = PvDatabase::new();
 
@@ -632,7 +630,7 @@ async fn async_pending_notify_runs_write_db_link_on_pending_cycle() {
 /// re-entry generation, so an outstanding token (a pending DLYn/WAITn
 /// re-entry) becomes a structural no-op — the `sseq` `ABORT` path, with no
 /// runtime is-aborted check on the re-entry.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn cancel_reprocess_action_supersedes_outstanding_token() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicU32::new(0));

--- a/crates/epics-base-rs/tests/parity_multi_output_event.rs
+++ b/crates/epics-base-rs/tests/parity_multi_output_event.rs
@@ -3,8 +3,6 @@
 //! event-record routing, and UDF-on-NaN.
 #![allow(clippy::all)]
 
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -38,7 +36,7 @@ fn fanout_has_lnk0_field() {
 
 /// `SELM=All` fans out through `LNK0`; the primary first
 /// slot is no longer silently dropped.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn fanout_selm_all_processes_lnk0_target() {
     let db = Arc::new(PvDatabase::new());
     db.add_record("DOWNSTREAM", Box::new(AiRecord::new(0.0)))
@@ -65,7 +63,7 @@ async fn fanout_selm_all_processes_lnk0_target() {
 
 /// dfanout `SELM=Specified` is 1-based: `SELN=1`
 /// drives OUTA, `SELN=0` drives nothing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn dfanout_specified_is_one_based() {
     let db = Arc::new(PvDatabase::new());
     db.add_record("OUT_A", Box::new(AiRecord::new(0.0)))
@@ -108,7 +106,7 @@ async fn dfanout_specified_is_one_based() {
 
 /// An out-of-range `SELN` on a dfanout raises
 /// SOFT_ALARM / INVALID_ALARM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn dfanout_specified_out_of_range_raises_invalid() {
     use epics_base_rs::server::record::AlarmSeverity;
     let db = Arc::new(PvDatabase::new());
@@ -153,7 +151,7 @@ fn event_record_val_is_string() {
 
 /// `post_event_named` routes by event number:
 /// a record with `EVNT=5` fires only on event 5, not event 7.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn event_scan_routes_by_event_number() {
     use epics_base_rs::server::record::ScanType;
 
@@ -199,7 +197,7 @@ async fn event_scan_routes_by_event_number() {
 
 /// UDF stays true when the processed value is NaN, so the
 /// record raises UDF_ALARM instead of reporting a garbage value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn udf_stays_true_on_nan_value() {
     use epics_base_rs::server::record::AlarmSeverity;
 
@@ -227,7 +225,7 @@ async fn udf_stays_true_on_nan_value() {
 
 /// UDF IS cleared when the processed value is a defined
 /// (non-NaN) number — the fix must not over-suppress UDF clearing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn udf_cleared_on_defined_value() {
     let db = Arc::new(PvDatabase::new());
     db.add_record("OK_REC", Box::new(AiRecord::new(3.14)))
@@ -247,7 +245,7 @@ async fn udf_cleared_on_defined_value() {
 /// `dbScanFwdLink` → `dbScanPassive` (`dbDbLink.c:425-432`), which
 /// returns early when `pto->scan != 0`. The Rust fanout path
 /// previously called `process_record_with_links` unconditionally.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn fanout_lnk_skips_non_passive_target() {
     use epics_base_rs::server::record::ScanType;
 
@@ -316,10 +314,10 @@ async fn poll_until(label: &str, cond: impl Fn() -> bool) {
     for _ in 0..400 {
         if cond() {
             // settle window — a spurious second dispatch would land here.
-            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(30)).await;
             return;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
     panic!("{label}: sseq sequence did not complete within timeout");
 }
@@ -365,7 +363,7 @@ impl Record for CountingTarget {
 /// One `process` of an sseq record writes each selected `LNKn` value
 /// exactly once — never twice. Regression for the two-owner
 /// double-dispatch defect.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_lnkn_dispatched_exactly_once_per_cycle() {
     let db = PvDatabase::new();
 
@@ -439,7 +437,7 @@ async fn sseq_lnkn_dispatched_exactly_once_per_cycle() {
 
 /// `SELM=Specified` selects a single sseq step — only that step's
 /// `LNKn` is dispatched (and only once), the others are not written.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_selm_specified_writes_only_selected_step_once() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/process_target_passive_gate.rs
+++ b/crates/epics-base-rs/tests/process_target_passive_gate.rs
@@ -26,8 +26,6 @@
 //! epics> dbgf ASY.PUTF      DBF_UCHAR: 0
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -70,7 +68,7 @@ async fn flags(db: &PvDatabase, rec: &str) -> (bool, bool) {
 /// R18-93: an FLNK to a BUSY, non-Passive target must not be touched at all.
 /// `dbScanPassive` returns above `processTarget`, so no PUTF, no RPRO — and so
 /// no extra unscheduled cycle when the target's async completes.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn flnk_to_busy_non_passive_target_sets_no_rpro() {
     let db = build("1 second").await;
 
@@ -90,7 +88,7 @@ async fn flnk_to_busy_non_passive_target_sets_no_rpro() {
 
 /// The Passive half of the same gate still works: a busy PASSIVE target does
 /// get `RPRO = 1` (C `processTarget`'s `else if (psrc->putf && claim_dst)`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn flnk_to_busy_passive_target_still_sets_rpro() {
     let db = build("Passive").await;
 
@@ -116,7 +114,7 @@ async fn flnk_to_busy_passive_target_still_sets_rpro() {
 /// epics> dbpf SRCO.PROC 1
 /// epics> dbgf TGT.VAL      DBF_DOUBLE: 2
 /// ```
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn db_link_to_proc_field_processes_a_non_passive_target() {
     const DB: &str = r#"
 record(calcout, "SRCO") {
@@ -162,7 +160,7 @@ record(calc, "TGT") {
 /// The `.PROC` gate is the only one that ignores SCAN: an ordinary `PP` OUT
 /// link to the same non-Passive target still does NOT process it
 /// (dbDbLink.c:388 — `pvlOptPP && pdest->scan == 0`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn pp_link_to_a_non_passive_target_still_does_not_process_it() {
     const DB: &str = r#"
 record(calcout, "SRCV") {

--- a/crates/epics-base-rs/tests/put_common_field_is_parsed_not_coerced.rs
+++ b/crates/epics-base-rs/tests/put_common_field_is_parsed_not_coerced.rs
@@ -28,8 +28,6 @@
 //! (`dbAccess.c:1263-1264`) processes only when `dbPut` returned 0, so the
 //! fire-and-forget path does NOT process a rejected put. The port mirrors both.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -122,7 +120,7 @@ async fn read_proc(db: &PvDatabase) -> EpicsValue {
 /// C refuses the put (`ECA_PUTFAIL`) but `putCallback` still returns `didPut=1`,
 /// so the record STILL processes (UDF cleared → NO_ALARM). Refuse the put AND
 /// force-process, matching C.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn proc_overflow_via_notify_is_refused_but_still_processes() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -144,7 +142,7 @@ async fn proc_overflow_via_notify_is_refused_but_still_processes() {
 }
 
 /// Same for non-numeric text (`S_stdlib_noConversion`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn proc_non_numeric_via_notify_is_refused_but_still_processes() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -164,7 +162,7 @@ async fn proc_non_numeric_via_notify_is_refused_but_still_processes() {
 /// The fire-and-forget path differs: plain `dbPutField` returns before
 /// `dbProcess` on a non-zero conversion status, so a rejected PROC put drives NO
 /// cycle. Measured: `caput REC.PROC 256` leaves STAT=UDF.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn proc_overflow_fire_and_forget_is_refused_and_does_not_process() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -183,7 +181,7 @@ async fn proc_overflow_fire_and_forget_is_refused_and_does_not_process() {
 
 /// A VALID PROC put still does BOTH on either path: stores the byte AND
 /// force-processes.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn proc_valid_stores_the_byte_and_processes() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -208,7 +206,7 @@ async fn proc_valid_stores_the_byte_and_processes() {
 /// `caput REC.PROC -1`: `epicsParseUInt8` accepts a negative and truncates it to
 /// 255 (`strtoul("-1") == ULONG_MAX`, outside the reject band). It is NOT a naive
 /// `[0, 255]` rejection.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn proc_negative_wraps_to_255_and_is_accepted() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -227,7 +225,7 @@ async fn proc_negative_wraps_to_255_and_is_accepted() {
 /// The whole in-range band lands: 255 is the last accepted value, and 128 —
 /// which a *signed* Char parse would wrongly refuse — is accepted because the
 /// field is C-declared DBF_UCHAR.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn proc_full_uchar_band_is_accepted() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -248,7 +246,7 @@ async fn proc_full_uchar_band_is_accepted() {
 /// The gate is shared: `caput REC.DISP notanumber` / `256` are refused too — DISP
 /// takes the same DBF_UCHAR conversion as PROC. (DISP is not pp(TRUE), so it
 /// drives no process; the assertion is the refusal and that a valid put lands.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn disp_non_numeric_and_overflow_are_refused() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;

--- a/crates/epics-base-rs/tests/put_notify_defers_on_pact.rs
+++ b/crates/epics-base-rs/tests/put_notify_defers_on_pact.rs
@@ -40,8 +40,6 @@
 //! the others stranded the put forever AND bricked the record for every later
 //! put-notify.
 
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -169,7 +167,7 @@ async fn rpro(db: &PvDatabase) -> bool {
 
 /// The deferral itself: while the record is PACT the put-notify writes NOTHING
 /// — no value, no RPRO — and its callback has not fired.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_notify_on_a_pact_record_writes_nothing() {
     let f = busy_record().await;
 
@@ -202,7 +200,7 @@ async fn put_notify_on_a_pact_record_writes_nothing() {
 
 /// The restart: when the record's async work completes, `dbNotifyCompletion`
 /// replays the whole put — value, process, and only then the callback.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn deferred_put_is_replayed_and_completes_after_it() {
     let f = busy_record().await;
 
@@ -216,7 +214,7 @@ async fn deferred_put_is_replayed_and_completes_after_it() {
     // The device round-trip finishes: C `dbNotifyCompletion` runs here.
     f.db.complete_async_record("ASY").await.unwrap();
 
-    tokio::time::timeout(std::time::Duration::from_secs(5), rx)
+    epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(5), rx)
         .await
         .expect("the put-notify callback must fire after the restarted put")
         .expect("the completion sender must not be dropped");
@@ -245,7 +243,7 @@ async fn deferred_put_is_replayed_and_completes_after_it() {
 /// C `dbNotify.c:213-217`: a record already owning a put-notify restart refuses
 /// the next one (`S_db_Blocked` → ECA_PUTCBINPROG), rather than silently
 /// dropping the first caller's sender.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_second_put_notify_onto_a_deferred_record_is_refused() {
     let f = busy_record().await;
 
@@ -268,7 +266,7 @@ async fn a_second_put_notify_onto_a_deferred_record_is_refused() {
 
 /// Await a deferred put's callback, failing the test rather than hanging.
 async fn expect_callback(rx: epics_base_rs::runtime::sync::oneshot::Receiver<()>, site: &str) {
-    tokio::time::timeout(std::time::Duration::from_secs(5), rx)
+    epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(5), rx)
         .await
         .unwrap_or_else(|_| panic!("the put parked on the PACT window {site} released was never replayed — its callback never fired"))
         .expect("the completion sender must not be dropped");
@@ -339,7 +337,7 @@ impl Record for OdlyRecord {
 /// PRESENT. The measured defect — `caput -c ASY.A 7` into a `calcout ODLY=20`
 /// window left A=5, the callback never fired, and every later put-callback on
 /// that record was refused.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn deferred_put_is_replayed_when_the_odly_continuation_releases_pact() {
     let db = PvDatabase::new();
     db.add_record(
@@ -424,7 +422,7 @@ async fn await_replayed_value(db: &PvDatabase, name: &str, want: f64) {
         {
             return;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(10)).await;
     }
     panic!("{name}: the deferred put was never replayed — VAL never reached {want}");
 }
@@ -436,7 +434,7 @@ async fn await_replayed_value(db: &PvDatabase, name: &str, want: f64) {
 /// continuation, not this one. That is the deferral being closed under its own
 /// restart, and it is exactly what the strand looked nothing like: before the
 /// fix VAL stayed at its pre-put value forever.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn deferred_put_is_replayed_when_the_sdly_input_continuation_releases_pact() {
     let db = sdly_input_record().await;
 
@@ -478,7 +476,7 @@ async fn deferred_put_is_replayed_when_the_sdly_input_continuation_releases_pact
 
 /// Boundary: PACT released by the SIM/SDLY OUTPUT continuation (the
 /// `RedirectOutputToSiol` arm), deferral PRESENT.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn deferred_put_is_replayed_when_the_sdly_output_continuation_releases_pact() {
     let db = PvDatabase::new();
     db.add_record("SW", Box::new(AoRecord::new(1.0)))
@@ -529,7 +527,7 @@ async fn deferred_put_is_replayed_when_the_sdly_output_continuation_releases_pac
 /// `switch (prec->simm) default:` — `recGblSetSevr(SOFT_ALARM, INVALID)`, no
 /// SIOL round-trip), deferral PRESENT. The cycle ends in an alarm, but the put
 /// parked on the window it just released must still be replayed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn deferred_put_is_replayed_when_the_illegal_simm_continuation_releases_pact() {
     let db = sdly_input_record().await;
 
@@ -578,7 +576,7 @@ async fn deferred_put_is_replayed_when_the_illegal_simm_continuation_releases_pa
 /// The fire-and-forget route is NOT deferred: C `dbPutField` on a PACT record
 /// writes the value and raises RPRO (dbAccess.c:1263-1277). Only `dbPutNotify`
 /// waits — the gate must not swallow the ordinary put.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_fire_and_forget_put_on_a_pact_record_still_writes_and_sets_rpro() {
     let f = busy_record().await;
 

--- a/crates/epics-base-rs/tests/put_notify_rejected_still_processes.rs
+++ b/crates/epics-base-rs/tests/put_notify_rejected_still_processes.rs
@@ -15,8 +15,6 @@
 //! keep the current behavior: return `Err` and process NOTHING, matching C
 //! `dbPutField` (dbAccess.c:1263 processes only when `dbPut` status==0).
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -94,7 +92,7 @@ const BAD: fn() -> EpicsValue = || EpicsValue::String("notanumber".into());
 
 /// Notify path: the rejected conversion still drives exactly one process cycle,
 /// and the client still receives the failure.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rejected_notify_put_still_processes() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -119,7 +117,7 @@ async fn rejected_notify_put_still_processes() {
 
 /// Plain `ca_put` path: the rejected conversion returns Err and processes
 /// NOTHING — the notify-only fix must not touch the fire-and-forget path.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rejected_plain_put_does_not_process() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -138,7 +136,7 @@ async fn rejected_plain_put_does_not_process() {
 
 /// Sanity: an ACCEPTED put on the notify path processes exactly once and writes
 /// the value — the fix only adds a cycle on the FAILING path.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn accepted_notify_put_processes_and_writes() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;

--- a/crates/epics-base-rs/tests/put_pv_posts_like_dbput.rs
+++ b/crates/epics-base-rs/tests/put_pv_posts_like_dbput.rs
@@ -32,8 +32,6 @@
 //! a caller that needs a monitor there uses `put_record_field_from_ca*` or
 //! `put_pv_and_post`.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::event_queue::EventReader;
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -78,7 +76,7 @@ fn udf(db: &PvDatabase, rec: &str) -> bool {
 /// Row 1 — a value field that is NOT `pp(TRUE)` (calc VAL): the `dbPut` post
 /// is the only one there is, and the value-field put clears UDF. This is the
 /// case C's comment in `dbPut` exists for — no reprocess will ever re-post it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_to_a_non_pp_value_field_posts_and_clears_udf() {
     let db = build().await;
     assert!(
@@ -104,7 +102,7 @@ async fn a_put_to_a_non_pp_value_field_posts_and_clears_udf() {
 /// post (the process cycle a `dbPutField` drives is the poster), but the UDF
 /// clear is unconditional on a value-field put. Both halves on one write, so
 /// the two predicates cannot be merged back into one.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_to_a_pp_value_field_is_suppressed_but_clears_udf() {
     let db = build().await;
     assert!(
@@ -134,7 +132,7 @@ async fn a_put_to_a_pp_value_field_is_suppressed_but_clears_udf() {
 /// Row 3 — `pp(TRUE)` but NOT the value field (ai HIHI): suppression requires
 /// BOTH predicates, so this posts. A rule keyed on pp alone would go silent
 /// here; a rule keyed on value-field alone would double-post row 2.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_to_a_pp_non_value_field_still_posts() {
     let db = build().await;
     let mut rx = subscribe(&db, "AI1", "HIHI", DbFieldType::Double);
@@ -157,7 +155,7 @@ async fn a_put_to_a_pp_non_value_field_still_posts() {
 }
 
 /// Row 4 — neither predicate (ai EGU): posts, and UDF stands.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_to_a_plain_field_posts_and_leaves_udf() {
     let db = build().await;
     let mut rx = subscribe(&db, "AI1", "EGU", DbFieldType::String);

--- a/crates/epics-base-rs/tests/put_string_is_parsed_not_coerced.rs
+++ b/crates/epics-base-rs/tests/put_string_is_parsed_not_coerced.rs
@@ -46,8 +46,6 @@
 //! The cases are the invariant BOUNDARIES of the row — at-limit, just-over,
 //! just-under, unparseable, empty — not a narrative.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -104,7 +102,7 @@ async fn stored(db: &PvDatabase, rec: &str, field: &str, text: &str, want: Epics
     assert_eq!(read(db, &pv).await, want, "{pv} = {text:?}");
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn short_field_at_limit_stores_and_one_past_it_is_refused() {
     let db = build().await;
     stored(&db, "C", "PREC", "32767", EpicsValue::Short(32767)).await;
@@ -113,7 +111,7 @@ async fn short_field_at_limit_stores_and_one_past_it_is_refused() {
     refused(&db, "C", "PREC", "-32769", EpicsValue::Short(-32768)).await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn long_field_at_limit_stores_and_one_past_it_is_refused() {
     let db = build().await;
     stored(
@@ -136,7 +134,7 @@ async fn long_field_at_limit_stores_and_one_past_it_is_refused() {
     stored(&db, "LO", "DRVH", "-1", EpicsValue::Long(-1)).await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unparseable_text_is_refused_not_stored_as_zero() {
     let db = build().await;
     refused(&db, "C", "PREC", "notanumber", EpicsValue::Short(3)).await;
@@ -145,7 +143,7 @@ async fn unparseable_text_is_refused_not_stored_as_zero() {
     refused(&db, "C", "VAL", "", EpicsValue::Double(7.0)).await;
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn double_overflow_is_refused_but_nan_and_infinity_are_values() {
     let db = build().await;
     refused(&db, "C", "VAL", "1e400", EpicsValue::Double(7.0)).await;
@@ -173,7 +171,7 @@ async fn double_overflow_is_refused_but_nan_and_infinity_are_values() {
 
 /// `strtol` with `dbConvertBase == 0` stops at the first character it cannot
 /// use, and the trailing text is the field's `units` — never an error.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_numeric_prefix_is_taken_and_the_rest_is_units() {
     let db = build().await;
     stored(&db, "C", "PREC", "1.7", EpicsValue::Short(1)).await;
@@ -184,7 +182,7 @@ async fn the_numeric_prefix_is_taken_and_the_rest_is_units() {
 
 /// Base 0: `0x` is hex, a leading `0` is octal. The range check then applies to
 /// the parsed VALUE, so `0x8000` overflows a short even though the text is short.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn integers_parse_base_zero() {
     let db = build().await;
     stored(&db, "C", "PREC", "0x10", EpicsValue::Short(16)).await;
@@ -197,7 +195,7 @@ async fn integers_parse_base_zero() {
 /// a string as its bytes. Guards the exemption in `coerce_put_value` — without
 /// it, the parse would reject `"hi"` as unparseable text and the char-waveform
 /// carry would be dead.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_string_into_a_char_array_is_still_its_bytes() {
     let db = build().await;
     db.put_pv("W.VAL", EpicsValue::String("hi".into()))

--- a/crates/epics-base-rs/tests/put_udf_drives_processing.rs
+++ b/crates/epics-base-rs/tests/put_udf_drives_processing.rs
@@ -12,8 +12,6 @@
 //! UDF/INVALID because the process-decision gate special-cased PROC and omitted
 //! UDF, so a UDF put stored the field but drove no process cycle.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -88,7 +86,7 @@ async fn record_with(count: Arc<AtomicU32>) -> Arc<PvDatabase> {
 
 /// A put to `UDF` on a Passive record drives exactly one process cycle — the
 /// `dbCommon` `pp(TRUE)` field that the gate previously omitted.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_to_udf_drives_processing() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -106,7 +104,7 @@ async fn put_to_udf_drives_processing() {
 
 /// The `-c` (callback / put-notify) route drives the same cycle — the gate is
 /// shared between the plain and notify paths.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_notify_to_udf_drives_processing() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;
@@ -124,7 +122,7 @@ async fn put_notify_to_udf_drives_processing() {
 
 /// Boundary: the fix adds UDF specifically, not a blanket "every dbCommon put
 /// processes". A put to a non-`pp` common field (DESC) drives NO cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn put_to_a_non_pp_common_field_does_not_process() {
     let count = Arc::new(AtomicU32::new(0));
     let db = record_with(count.clone()).await;

--- a/crates/epics-base-rs/tests/put_udf_survives_when_nothing_sourced.rs
+++ b/crates/epics-base-rs/tests/put_udf_survives_when_nothing_sourced.rs
@@ -20,8 +20,6 @@
 //! record type, so a UDF-put-driven cycle on stringin/lsi/aSub clobbered the
 //! client's `UDF=1` back to 0.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -42,7 +40,7 @@ async fn udf(db: &PvDatabase, name: &str) -> bool {
 
 /// A UDF put drives processing; because the cycle sources nothing, the put
 /// value survives — both `UDF=1` and `UDF=0` stand.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stringin_udf_put_survives_both_directions() {
     let db = PvDatabase::new();
     db.add_record("SI", Box::new(StringinRecord::new("hi")))
@@ -68,7 +66,7 @@ async fn stringin_udf_put_survives_both_directions() {
 
 /// lsi: same shape — a constant/empty INP sources nothing at process, so the
 /// UDF put is not clobbered.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn lsi_udf_put_survives() {
     let db = PvDatabase::new();
     db.add_record("LSI", Box::new(LsiRecord::new("hi")))
@@ -86,7 +84,7 @@ async fn lsi_udf_put_survives() {
 
 /// aSub with NO subroutine runs no `do_sub`, so it sources nothing and the UDF
 /// put stands.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_udf_put_survives_without_subroutine() {
     let db = PvDatabase::new();
     db.add_record("ASUB", Box::new(ASubRecord::default()))
@@ -105,7 +103,7 @@ async fn asub_udf_put_survives_without_subroutine() {
 /// aSub WITH a subroutine that runs and returns `>= 0` DOES clear UDF — C
 /// `aSubRecord.c::do_sub` (`else prec->udf = FALSE`). This is aSub's own UDF
 /// clear, the compensating source-clear for opting out of the blanket re-derive.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn asub_clears_udf_when_subroutine_runs() {
     let db = PvDatabase::new();
 
@@ -156,7 +154,7 @@ async fn asub_clears_udf_when_subroutine_runs() {
 /// Control: a record whose C `process()` re-derives UDF UNCONDITIONALLY
 /// (`longinRecord.c:148` `if(status==0) prec->udf = FALSE`) is UNTOUCHED by the
 /// opt-out — a UDF-put-driven cycle re-derives to 0, matching C.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn longin_still_re_derives_udf_on_process() {
     let db = PvDatabase::new();
     db.add_record("LI", Box::new(LonginRecord::new(3)))

--- a/crates/epics-base-rs/tests/raw_soft_channel.rs
+++ b/crates/epics-base-rs/tests/raw_soft_channel.rs
@@ -16,8 +16,6 @@
 //!   - record type with NO SoftRaw dset in C (longin/longout): the DTYP must
 //!     fall back to the VAL-direct soft path, not drop the value.
 
-// RTEMS-EXEC-MODEL-ALLOW(11): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -133,7 +131,7 @@ async fn put_val(db: &PvDatabase, name: &str, value: EpicsValue) {
 /// `devAiSoftRaw.c::read_ai` (52): `dbGetLink(pinp, DBR_LONG, &prec->rval)` — no
 /// mask — then `aiRecord.c:158` runs `convert()`. With the default
 /// LINR=NO CONVERSION / ASLO=1 / AOFF=0 that gives VAL == RVAL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ai_raw_soft_channel_link_lands_in_rval_and_converts() {
     let db = ioc().await;
     process(&db, "RAI").await;
@@ -150,7 +148,7 @@ async fn ai_raw_soft_channel_link_lands_in_rval_and_converts() {
 /// softIoc 7.0.10.1-DEV oracle, `field(INP,"12")` + `DTYP="Raw Soft Channel"`:
 /// at init RVAL=12 VAL=0 UDF=1 STAT=UDF; after `caput RAI:CONST.PROC 1`
 /// RVAL=12 VAL=12 UDF=0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ai_raw_soft_channel_constant_inp_seeds_rval_not_val_at_init() {
     let db = ioc().await;
 
@@ -171,7 +169,7 @@ async fn ai_raw_soft_channel_constant_inp_seeds_rval_not_val_at_init() {
 /// its `init_record` (60-64) defaulted to `0xffffffff` (NOBT==0) and shifted by
 /// SHFT. `mbbiRecord.c` then matches RVAL against the state values: ONVL=37 with
 /// RVAL=37 selects state 1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbi_raw_soft_channel_nobt_zero_masks_all_bits_then_matches_state() {
     let db = ioc().await;
     process(&db, "RMBI").await;
@@ -182,7 +180,7 @@ async fn mbbi_raw_soft_channel_nobt_zero_masks_all_bits_then_matches_state() {
 
 /// SHFT boundary: NOBT=4/SHFT=4 makes the dset mask `0xf << 4 == 0xf0`, so bits
 /// outside the field are dropped. Source 293 == 0x125; 0x125 & 0xf0 == 0x20.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbi_raw_soft_channel_shft_masks_out_of_field_bits() {
     let db = ioc().await;
     process(&db, "RMBI:SHFT").await;
@@ -196,7 +194,7 @@ async fn mbbi_raw_soft_channel_shft_masks_out_of_field_bits() {
 /// `devMbbiDirectSoftRaw.c::read_mbbi` (57-58): same mask rule; `mbbiDirect`
 /// then spreads `RVAL >> SHFT` across B0..BF. 293 == 0x125, NOBT==0 so nothing
 /// is masked out, and the low bits 0/2/5/8 are set.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbi_direct_raw_soft_channel_masks_then_spreads_bits() {
     let db = ioc().await;
     process(&db, "RMBID").await;
@@ -214,7 +212,7 @@ async fn mbbi_direct_raw_soft_channel_masks_then_spreads_bits() {
 /// `devAoSoftRaw.c::write_ao` (44): `dbPutLink(&prec->out, DBR_LONG,
 /// &prec->rval, 1)`. The ao's `convert()` puts VAL into RVAL (default linear
 /// conversion), and RVAL is what reaches the target.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ao_raw_soft_channel_writes_rval_to_out_link() {
     let db = ioc().await;
     put_val(&db, "RAO", EpicsValue::Double(37.0)).await;
@@ -225,7 +223,7 @@ async fn ao_raw_soft_channel_writes_rval_to_out_link() {
 
 /// `devBoSoftRaw.c::write_bo` (65): the OUT link carries RVAL. `boRecord.c`
 /// converts VAL=1 -> RVAL=1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_raw_soft_channel_writes_rval_to_out_link() {
     let db = ioc().await;
     put_val(&db, "RBO", EpicsValue::Enum(1)).await;
@@ -236,7 +234,7 @@ async fn bo_raw_soft_channel_writes_rval_to_out_link() {
 /// `devMbboSoftRaw.c::write_mbbo` (71-75): `data = prec->rval & prec->mask`.
 /// ONVL=37 and VAL=1 give RVAL=37; NOBT==0 makes the dset mask all-ones, so the
 /// target sees 37 — NOT the 1 the plain Soft Channel dset would have sent.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_raw_soft_channel_writes_masked_rval_to_out_link() {
     let db = ioc().await;
     put_val(&db, "RMBO", EpicsValue::Enum(1)).await;
@@ -249,7 +247,7 @@ async fn mbbo_raw_soft_channel_writes_masked_rval_to_out_link() {
 /// NOBT=4/SHFT=4 makes the dset mask `0xf << 4 == 0xf0`. ONVL=499 (0x1f3) with
 /// VAL=1 gives RVAL = 0x1f3 << 4 == 0x1f30 (`mbboRecord.c::convert` 428-433,
 /// which does NOT mask), so the OUT link must carry 0x1f30 & 0xf0 == 0x30.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_raw_soft_channel_dset_mask_trims_rval_before_out_link() {
     let db = ioc().await;
     put_val(&db, "RMBO:SHFT", EpicsValue::Enum(1)).await;
@@ -268,7 +266,7 @@ async fn mbbo_raw_soft_channel_dset_mask_trims_rval_before_out_link() {
 /// NOBT==0 rule (`mask = 0xffffffff`): nothing is trimmed, so the whole raw word
 /// reaches the target — the VAL-direct dset would have sent the same number
 /// here, which is exactly why the mbbo case above is the discriminating one.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_direct_raw_soft_channel_nobt_zero_passes_whole_raw_word() {
     let db = ioc().await;
     put_val(&db, "RMBOD", EpicsValue::ULong(0x125)).await;
@@ -288,7 +286,7 @@ async fn mbbo_direct_raw_soft_channel_nobt_zero_passes_whole_raw_word() {
 /// keeps the plain VAL-direct soft path instead of routing the value into an
 /// RVAL that does not exist. (C rejects that DTYP at init; the port reads soft
 /// DTYPs leniently, and leniency must not turn the write into a silent no-op.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn record_without_a_softraw_dset_falls_back_to_val_direct() {
     let db = ioc().await;
     process(&db, "RLI").await;

--- a/crates/epics-base-rs/tests/raw_soft_source_type.rs
+++ b/crates/epics-base-rs/tests/raw_soft_source_type.rs
@@ -22,8 +22,6 @@
 //! source x {signed, unsigned} RVAL, plus the in-range control that cannot tell
 //! the two rules apart.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -71,7 +69,7 @@ async fn rval(db: &PvDatabase, rec: &str) -> EpicsValue {
 /// `epicsInt32`; C's integer conversion keeps the bits, so RVAL is the negative
 /// word with the same pattern. The float rule would have saturated it to
 /// `INT32_MAX` and thrown the bits away.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_integer_source_wraps_into_a_signed_rval() {
     let db = ioc().await;
     assert_eq!(rval(&db, "AI:INT").await, EpicsValue::Long(-559038737));
@@ -82,7 +80,7 @@ async fn an_integer_source_wraps_into_a_signed_rval() {
 /// (6.3.1.3p2). This is the case the old float rule destroyed outright: `-1.0`
 /// through a saturating `f64 -> u32` is `0`, i.e. every bit of an all-ones source
 /// lost, and mbbiDirect's whole bit field with it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_integer_source_wraps_into_an_unsigned_rval() {
     let db = ioc().await;
     for rec in ["BI:INT", "MBI:INT", "MBD:INT"] {
@@ -98,7 +96,7 @@ async fn an_integer_source_wraps_into_an_unsigned_rval() {
 /// range and which this port saturates (CBUG-E2) rather than reproducing x86-64's
 /// `INT32_MIN`. The two rules must not be collapsed into one — this is why the
 /// conversion is the coercion owner's to make and not a `to_f64()` away.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_float_source_saturates_into_a_signed_rval() {
     let db = ioc().await;
     assert_eq!(rval(&db, "AI:DBL").await, EpicsValue::Long(i32::MAX));
@@ -106,7 +104,7 @@ async fn a_float_source_saturates_into_a_signed_rval() {
 
 /// The control: in range, both rules agree, so no test above proves anything
 /// unless this one passes too.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_in_range_source_is_unaffected_by_which_rule_runs() {
     let db = ioc().await;
     db.put_pv("SRC:BIG", EpicsValue::Long(37)).await.unwrap();

--- a/crates/epics-base-rs/tests/record_load_order.rs
+++ b/crates/epics-base-rs/tests/record_load_order.rs
@@ -15,8 +15,6 @@
 //! two different orders — one boot succeeding, the next failing with "opcuaItem
 //! record ... is not loaded yet".
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -63,7 +61,7 @@ fn load_ordered_names() -> Vec<String> {
 /// `wire_device_support_binds_in_database_load_order`). Pinned here so the two
 /// paths cannot silently diverge — an IOC must wire the same way whether its
 /// database came from the builder or from iocsh `dbLoadRecords`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn builder_wires_device_support_in_database_load_order() {
     let names = load_ordered_names();
 
@@ -105,7 +103,7 @@ async fn builder_wires_device_support_in_database_load_order() {
 /// The ordering owner itself: every whole-database walk goes through
 /// `all_record_names`, so pinning it pins `wire_device_support`,
 /// `setup_io_intr`, `setup_cp_links`, `dbl`, and the rest.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn all_record_names_returns_load_order() {
     let db = Arc::new(PvDatabase::new());
     let names = load_ordered_names();
@@ -125,7 +123,7 @@ async fn all_record_names_returns_load_order() {
 /// PINI processing is a whole-database walk too: C `initialProcess` iterates
 /// with `dbFirstRecord`/`dbNextRecord`, so a PINI record that depends on an
 /// earlier PINI record's output processes after it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn pini_records_returns_load_order() {
     let db = Arc::new(PvDatabase::new());
     let names = load_ordered_names();

--- a/crates/epics-base-rs/tests/scalc_sval_token.rs
+++ b/crates/epics-base-rs/tests/scalc_sval_token.rs
@@ -24,8 +24,6 @@
 //! which takes no `psresult`, and the numeric `postfix()` element table has no
 //! SVAL token — so neither C nor the port has an SVAL in swait.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::calc::{
@@ -170,7 +168,7 @@ fn engines_reject_each_others_tokens_at_compile_time() {
 /// discriminator: the string engine compiles it, produces `Str("42")`, and the
 /// coercion lands **42.0** in VAL — a value C's swait can never produce, since
 /// its compiler cannot lex a string literal at all.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_calc_uses_the_numeric_engine_and_rejects_a_string_expression() {
     use epics_base_rs::server::records::swait::SwaitRecord;
 
@@ -215,7 +213,7 @@ async fn swait_calc_uses_the_numeric_engine_and_rejects_a_string_expression() {
 /// scalcout CALC: SVAL is the record's previous SVAL, so a self-referential
 /// `SVAL+'x'` accumulates across process cycles (C `:357-359` passes
 /// `pcalc->sval` as `psresult`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_calc_sval_reads_the_previous_sval() {
     let db = PvDatabase::new();
 
@@ -244,7 +242,7 @@ async fn scalcout_calc_sval_reads_the_previous_sval() {
 /// scalcout OCAL (DOPT=Use_OVAL): C passes `pcalc->osv` as `psresult`
 /// (`:768-770`), so SVAL inside OCAL is the previous **OSV** — not the SVAL
 /// that CALC produced this very cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_ocal_sval_reads_the_previous_osv_not_the_current_sval() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/scalcout_analog_alarm_surface.rs
+++ b/crates/epics-base-rs/tests/scalcout_analog_alarm_surface.rs
@@ -15,8 +15,6 @@
 //! hysteresis band on the way back down (which is what LALM is for); and the
 //! IVOA gate the C ordering exists to feed.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -76,7 +74,7 @@ async fn severity_at(db: &PvDatabase, a: f64) -> (AlarmSeverity, u16) {
 
 /// The ten fields exist and take a put — the surface itself. `caput
 /// scalc.HIHI 5` used to be `FieldNotFound`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_alarm_fields_exist_and_are_writable() {
     let db = build().await;
 
@@ -95,7 +93,7 @@ async fn the_alarm_fields_exist_and_are_writable() {
 
 /// The C ladder, level by level (`sCalcoutRecord.c:727-748`): HIHI/LOLO are
 /// checked before HIGH/LOW, and a zero severity disables its level.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_ladder_raises_each_level() {
     let db = build().await;
     use epics_base_rs::server::recgbl::alarm_status;
@@ -131,7 +129,7 @@ async fn the_ladder_raises_each_level() {
 /// `(lalm == hihi) && (val >= hihi - hyst)`. Coming down from 12 to 9, the HIHI
 /// alarm HOLDS (9 >= 10 - 2) because LALM latched at 10; at 7.5 it releases to
 /// the HIGH level.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn hysteresis_holds_the_level_through_lalm() {
     let db = build().await;
     use epics_base_rs::server::recgbl::alarm_status;
@@ -164,7 +162,7 @@ async fn hysteresis_holds_the_level_through_lalm() {
 /// otherwise takes the IVOA branch — so an INVALID limit excursion must reach
 /// the gate and leave the OUT target untouched. A record with no alarm surface
 /// at all can never raise that severity, which is what made this unreachable.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_invalid_limit_excursion_reaches_the_ivoa_gate() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/scalcout_ivoa_dont_drive_invalid.rs
+++ b/crates/epics-base-rs/tests/scalcout_ivoa_dont_drive_invalid.rs
@@ -12,8 +12,6 @@
 //! `skip_out` path already enforced, closing the family for all INVALID
 //! sources (and for both `scalcout` and `acalcout`).
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -24,7 +22,7 @@ use epics_base_rs::types::EpicsValue;
 
 /// Non-calc-fail INVALID (NaN VAL → UDF) + IVOA=Don't_drive + output due:
 /// the OUT link must NOT be written.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_dont_drive_suppresses_out_on_noncalc_invalid() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/scalcout_ivov_output_gate.rs
+++ b/crates/epics-base-rs/tests/scalcout_ivov_output_gate.rs
@@ -11,8 +11,6 @@
 //! (record_instance.rs:1653) raises CALC_ALARM/INVALID from the CALC_ALARM
 //! field, so `sevr == INVALID` and `apply_invalid_output_value` runs.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -21,7 +19,7 @@ use epics_base_rs::server::records::scalcout::ScalcoutRecord;
 use epics_base_rs::types::EpicsValue;
 
 /// calc-fail + IVOA=Set_to_IVOV + output due: OVAL = IVOV, VAL = -1 (sentinel).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_ivov_drives_oval_not_val_on_calc_fail() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/scalcout_menu_target_buffer.rs
+++ b/crates/epics-base-rs/tests/scalcout_menu_target_buffer.rs
@@ -18,8 +18,6 @@
 //! and `DTYP` fell through to the numeric arm and received OVAL. The class is
 //! now settled at target resolution (`OutTarget::puts_as_string`).
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -55,7 +53,7 @@ async fn process(db: &PvDatabase, name: &str) {
 /// Boundary 1 — `DBF_MENU` target: `TGT.PRIO` is `menu(menuPriority)`
 /// (LOW/MEDIUM/HIGH). C puts the OSV string, so the label resolves to index 2.
 /// The pre-fix port took the numeric arm and sent OVAL — 0.0 here, i.e. `LOW`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_64_menu_target_receives_the_osv_label() {
     let db = PvDatabase::new();
     db.add_record("TGT", Box::new(AiRecord::new(0.0)))
@@ -75,7 +73,7 @@ async fn r15_64_menu_target_receives_the_osv_label() {
 
 /// Boundary 2 — the numeric target is unchanged: C's `default:` arm puts
 /// `DBR_DOUBLE` from OVAL (`devsCalcoutSoft.c:140`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_64_numeric_target_still_receives_oval() {
     let db = PvDatabase::new();
     db.add_record("TGT", Box::new(AiRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/scalcout_odly_holds_pact.rs
+++ b/crates/epics-base-rs/tests/scalcout_odly_holds_pact.rs
@@ -15,8 +15,6 @@
 //! generalization of the swait PACT fix; motor's notify carries no
 //! `ReprocessAfter` and so is untouched.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -25,7 +23,7 @@ use epics_base_rs::server::records::ai::AiRecord;
 use epics_base_rs::server::records::scalcout::ScalcoutRecord;
 use epics_base_rs::types::EpicsValue;
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_odly_holds_pact_foreign_process_does_not_fire_early() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/scalcout_odly_mslink_dont_drive.rs
+++ b/crates/epics-base-rs/tests/scalcout_odly_mslink_dont_drive.rs
@@ -18,8 +18,6 @@
 //! severity is NOT lost, and neutralizing the gate drives the target to OVAL,
 //! proving the suppression is the gate's doing.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -28,7 +26,7 @@ use epics_base_rs::server::records::ai::AiRecord;
 use epics_base_rs::server::records::scalcout::ScalcoutRecord;
 use epics_base_rs::types::EpicsValue;
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_odly_mslink_invalid_dont_drive_suppresses_out() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/scalcout_oopt_never.rs
+++ b/crates/epics-base-rs/tests/scalcout_oopt_never.rs
@@ -13,8 +13,6 @@
 //! Boundaries: Never vs Every Time (the OUT target moves / does not move), and
 //! the unnamed-index catch-all.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -60,7 +58,7 @@ async fn process(db: &PvDatabase, name: &str) {
 }
 
 /// `OOPT="Never"`, `CALC="7"`: C writes nothing to OUT. The port wrote 7.0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_never_writes_nothing_to_out() {
     let db = build().await;
 
@@ -82,7 +80,7 @@ async fn scalcout_never_writes_nothing_to_out() {
 
 /// The owner path: `Every Time` still drives OUT, so the fix is a polarity
 /// correction on index 6, not a disabled output stage.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalcout_every_time_still_drives_out() {
     let db = build().await;
 
@@ -96,7 +94,7 @@ async fn scalcout_every_time_still_drives_out() {
 }
 
 /// acalcout's `Never` (same menu index, same C rule).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn acalcout_never_writes_nothing_to_out() {
     let db = build().await;
 
@@ -114,7 +112,7 @@ async fn acalcout_never_writes_nothing_to_out() {
 /// The catch-all: an OOPT index the switch does not name is C's untouched
 /// `doOutput = 0` — no output. Driven through the record's own field put, which
 /// is the only way an out-of-menu index can arise.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_unnamed_oopt_index_drives_no_output() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/scalcout_out_target_type.rs
+++ b/crates/epics-base-rs/tests/scalcout_out_target_type.rs
@@ -19,8 +19,6 @@
 //! tests in `records::scalcout`. This file proves the framework owner feeds it
 //! the real target metadata end to end.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -50,7 +48,7 @@ fn scalcout_with_out(out: &str) -> ScalcoutRecord {
     sc
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_61_string_target_receives_osv_not_oval() {
     let db = PvDatabase::new();
     db.add_record("SO_TGT", Box::new(StringoutRecord::new("seed")))
@@ -72,7 +70,7 @@ async fn r14_61_string_target_receives_osv_not_oval() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_61_char_array_target_receives_sval_bytes() {
     let db = PvDatabase::new();
     db.add_record(
@@ -101,7 +99,7 @@ async fn r14_61_char_array_target_receives_sval_bytes() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r14_61_numeric_target_still_receives_oval() {
     let db = PvDatabase::new();
     db.add_record("AI_TGT", Box::new(AiRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/scalcout_previous_value_pair.rs
+++ b/crates/epics-base-rs/tests/scalcout_previous_value_pair.rs
@@ -15,8 +15,6 @@
 //! the previous cycle's result only when nothing wrote VAL in between — and a
 //! `prev_sval` that nothing read.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -74,7 +72,7 @@ async fn on_change_db(mdel: f64) -> PvDatabase {
 
 /// PVAL is C's `pval`: the VAL from the END of the previous cycle. It is
 /// readable, and it is what the OOPT comparison uses.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_66_pval_holds_the_previous_cycles_val() {
     let db = on_change_db(0.0).await;
 
@@ -101,7 +99,7 @@ async fn r10_66_pval_holds_the_previous_cycles_val() {
 /// moved the port's previous-value cell. C's `pval` is untouched by a `dbPut` to
 /// VAL, so the next On-Change test still compares against the last COMPUTED
 /// value — here 5, so a recompute back to 5 must NOT drive OUT.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_66_a_val_put_between_cycles_does_not_move_pval() {
     let db = on_change_db(0.0).await;
 
@@ -140,7 +138,7 @@ async fn r10_66_a_val_put_between_cycles_does_not_move_pval() {
 /// PVAL is a plain DBF_DOUBLE in C — writable. An operator aims the next OOPT
 /// decision with it: set PVAL away from VAL and the next cycle sees a change
 /// even though the computed value did not move.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_66_pval_is_writable_and_aims_the_next_output() {
     let db = on_change_db(0.0).await;
 
@@ -163,7 +161,7 @@ async fn r10_66_pval_is_writable_and_aims_the_next_output() {
 
 /// Negative control on the deadband: the On-Change test is `fabs(pval - val) >
 /// mdel`, so a move inside MDEL drives nothing even though PVAL differs.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_66_pval_change_inside_mdel_drives_no_output() {
     let db = on_change_db(2.0).await;
 
@@ -184,7 +182,7 @@ async fn r10_66_pval_change_inside_mdel_drives_no_output() {
 
 /// PSVL is the SVAL C last posted (`monitor()`, :842-846), so after a completed
 /// cycle it equals SVAL.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_66_psvl_tracks_the_posted_sval() {
     let db = PvDatabase::new();
     let mut c = scalcout("'ab'+'cd'");
@@ -211,7 +209,7 @@ async fn r10_66_psvl_tracks_the_posted_sval() {
 }
 
 /// PSVL is `special(SPC_NOMOD)` — C refuses a client put outright.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_66_psvl_is_read_only() {
     let db = PvDatabase::new();
     db.add_record("SC", Box::new(scalcout("0"))).await.unwrap();

--- a/crates/epics-base-rs/tests/scalcout_string_input_links.rs
+++ b/crates/epics-base-rs/tests/scalcout_string_input_links.rs
@@ -10,8 +10,6 @@
 //! The port had no INAA..INLL fields and never ran that loop, so AA..LL could
 //! only ever hold what a client put into them.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -45,7 +43,7 @@ fn scalcout(calc: &str) -> ScalcoutRecord {
 
 /// The base case the record could not do at all: INAA points at a string PV,
 /// and the CALC reads it as AA.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_65_string_input_link_is_fetched_into_aa() {
     let db = PvDatabase::new();
     db.add_record("SSRC", Box::new(StringinRecord::new("hello")))
@@ -75,7 +73,7 @@ async fn r10_65_string_input_link_is_fetched_into_aa() {
 /// link that does not resolve leaves the record computing (C returns 0 from the
 /// string loop) and replaces the value field with the diagnostic text
 /// (sCalcoutRecord.c:939-940).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_65_failed_string_link_writes_the_diagnostic_and_does_not_gate_the_calc() {
     let db = PvDatabase::new();
     db.add_record("NSRC", Box::new(AiRecord::new(7.0)))
@@ -109,7 +107,7 @@ async fn r10_65_failed_string_link_writes_the_diagnostic_and_does_not_gate_the_c
 /// Negative control for the gate: the SAME failure on a NUMERIC link does gate
 /// the calc (`InputFetchPolicy::AbortOnFirstFailure`), so VAL freezes. The two
 /// loops must not share a policy.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_65_failed_numeric_link_still_gates_the_calc() {
     let db = PvDatabase::new();
 
@@ -130,7 +128,7 @@ async fn r10_65_failed_numeric_link_still_gates_the_calc() {
 
 /// An unset INAA link is neither CA_LINK nor DB_LINK in C, so neither
 /// `dbGetLink` branch runs, status stays 0, and AA keeps what was put to it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_65_unset_string_link_leaves_the_field_alone() {
     let db = PvDatabase::new();
 
@@ -152,7 +150,7 @@ async fn r10_65_unset_string_link_leaves_the_field_alone() {
 /// element is the one type NOT read as DBR_STRING — C reads the array as text
 /// and escapes it (`epicsStrSnPrintEscaped`). A DBR_STRING read of a char
 /// waveform would have rendered element 0 as a number instead.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_65_char_waveform_source_is_read_as_escaped_text() {
     let db = PvDatabase::new();
     let mut wf = WaveformRecord::new(64, DbFieldType::Char);
@@ -180,7 +178,7 @@ async fn r10_65_char_waveform_source_is_read_as_escaped_text() {
 
 /// C caps the string fields at STRING_SIZE-1 = 39 bytes (the `epicsSnprintf` /
 /// `epicsStrSnPrintEscaped` size argument, and the DBR_STRING buffer itself).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_65_fetched_string_is_capped_at_the_c_field_width() {
     let db = PvDatabase::new();
     let long = "x".repeat(50);

--- a/crates/epics-base-rs/tests/scan_illegal_index_is_carried.rs
+++ b/crates/epics-base-rs/tests/scan_illegal_index_is_carried.rs
@@ -35,8 +35,6 @@
 //! in `menu_common_field_scan_pini.rs`. `caput` sends a numeric put for an enum
 //! channel whose text matches no choice, which is the row measured above.)
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::ScanType;
 use epics_base_rs::types::EpicsValue;
@@ -85,7 +83,7 @@ async fn scanned_anywhere(db: &PvDatabase, name: &str) -> bool {
 }
 
 /// The menu boundary: 9 is the last choice, 10 is the first illegal index.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_last_menu_choice_scans_and_the_first_illegal_index_does_not() {
     let db = db_with_scanned_ai().await;
 
@@ -107,7 +105,7 @@ async fn the_last_menu_choice_scans_and_the_first_illegal_index_does_not() {
 
 /// `-1` reaches the field as the `epicsEnum16` 65535 — still stored, still
 /// scanned by nothing, and still not `Passive`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_top_of_the_enum_is_stored_and_is_not_passive() {
     let db = db_with_scanned_ai().await;
 
@@ -128,7 +126,7 @@ async fn the_top_of_the_enum_is_stored_and_is_not_passive() {
 
 /// A legal index put back after an illegal one re-joins its list — the illegal
 /// state is carried, not sticky.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_illegal_index_is_left_behind_when_a_legal_one_is_written() {
     let db = db_with_scanned_ai().await;
 
@@ -147,7 +145,7 @@ async fn an_illegal_index_is_left_behind_when_a_legal_one_is_written() {
 
 /// SSCN is the same menu, so it carries an illegal index too — and 10 is NOT
 /// the 65535 "unset" sentinel that `recGblCheckSimm` bails on.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sscn_carries_an_illegal_index_and_only_65535_is_the_sentinel() {
     let db = db_with_scanned_ai().await;
 

--- a/crates/epics-base-rs/tests/sdly_async_simulation.rs
+++ b/crates/epics-base-rs/tests/sdly_async_simulation.rs
@@ -18,8 +18,6 @@
 //! as the swait/scalcout ODLY tests do) so the assertions are deterministic and
 //! do not race the real timer (`SDLY = 100s` makes it unfireable here).
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -38,7 +36,7 @@ async fn is_processing(db: &PvDatabase, name: &str) -> bool {
 /// the continuation while holding PACT. On the fresh cycle VAL is untouched and
 /// no alarm is raised; the continuation reads SIOL into VAL, raises SIMM_ALARM,
 /// and clears PACT.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sdly_async_defers_input_sim_read_to_continuation() {
     let db = PvDatabase::new();
     // SIML source reads 1 -> SIMM=YES; SIOL source carries the simulated value.
@@ -108,7 +106,7 @@ async fn sdly_async_defers_input_sim_read_to_continuation() {
 /// Regression guard: the default `SDLY = -1.0` reads synchronously on the single
 /// cycle (`pact || sdly < 0` takes the sync branch) — the async defer is gated
 /// strictly on `sdly >= 0`, so VAL is set immediately and PACT is never held.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sdly_negative_reads_input_synchronously() {
     let db = PvDatabase::new();
     db.add_record("SDLYN_SW", Box::new(AoRecord::new(1.0)))
@@ -151,7 +149,7 @@ async fn sdly_negative_reads_input_synchronously() {
 /// gating the SIML read on `!is_continuation`; without that gate the
 /// continuation would re-read SIML, switch to `NotSimulated`, and read the real
 /// (here empty) device — a value-source divergence.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sdly_continuation_keeps_simm_latched_from_fresh_cycle() {
     let db = PvDatabase::new();
     db.add_record("SDLYL_SW", Box::new(AoRecord::new(1.0)))
@@ -225,7 +223,7 @@ async fn sdly_continuation_keeps_simm_latched_from_fresh_cycle() {
 /// re-resolve SIMM=YES, matching C. (Twin of
 /// `sdly_continuation_keeps_simm_latched_from_fresh_cycle`, which pins the other
 /// boundary: a PACT-held continuation must NOT re-resolve.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn pact_false_retrigger_reresolves_simm_from_siml() {
     use epics_base_rs::server::records::bo::BoRecord;
 
@@ -284,7 +282,7 @@ async fn pact_false_retrigger_reresolves_simm_from_siml() {
 /// shares the same async branch as the input read). On the fresh cycle the
 /// SIOL target keeps its value and PACT is held; the continuation writes VAL to
 /// the target and clears PACT.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sdly_async_defers_output_sim_write_to_continuation() {
     let db = PvDatabase::new();
     db.add_record("SDLYO_SW", Box::new(AoRecord::new(1.0)))

--- a/crates/epics-base-rs/tests/seq_link_alarm_same_cycle.rs
+++ b/crates/epics-base-rs/tests/seq_link_alarm_same_cycle.rs
@@ -15,8 +15,6 @@
 //! `LNK0..LNKF` are `DBF_FWDLINK` (`dbScanFwdLink`), driving no value and
 //! raising no put alarm.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -42,7 +40,7 @@ async fn alarm_of(db: &PvDatabase, name: &str) -> (u16, AlarmSeverity) {
 /// of the seq must leave LINK/INVALID committed: this is the whole point of
 /// the finding, and it is what a one-shot passive seq (processed once by a
 /// client put, never scanned again) can observe.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_62_failed_seq_lnk_put_alarms_in_the_same_cycle() {
     let db = PvDatabase::new();
     db.add_record("SEQ_SRC", Box::new(AoRecord::new(7.0)))
@@ -68,7 +66,7 @@ async fn r15_62_failed_seq_lnk_put_alarms_in_the_same_cycle() {
 /// Boundary 2 — the recovery cycle: every LNKn put succeeds, so the seq must
 /// commit NO_ALARM and the target must hold the driven value. Guards against
 /// a fix that simply pins the alarm on.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_62_successful_seq_lnk_put_leaves_no_alarm() {
     let db = PvDatabase::new();
     db.add_record("SEQ_SRC", Box::new(AoRecord::new(7.0)))
@@ -102,7 +100,7 @@ async fn r15_62_successful_seq_lnk_put_leaves_no_alarm() {
 /// with `dbScanFwdLink` (fanoutRecord.c:110). A link naming a record that does
 /// not exist scans nothing and raises NOTHING — there is no put and so no
 /// `setLinkAlarm`. It must not be dragged into the value-put phase.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_62_fanout_forward_links_still_raise_no_put_alarm() {
     let db = PvDatabase::new();
     db.add_record("FO_DST", Box::new(AoRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/sim_aai_device_read.rs
+++ b/crates/epics-base-rs/tests/sim_aai_device_read.rs
@@ -14,8 +14,6 @@
 //! took the OUTPUT redirect and wrote its VAL array OUT to its DBF_INLINK SIOL
 //! (direction inverted). Classifying it as an input pins the correct SIOL read.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -28,7 +26,7 @@ use epics_base_rs::types::{DbFieldType, EpicsValue};
 /// `dbGetLink(&siol)` when SIMM=YES), raises SIMM_ALARM at the SIMS severity,
 /// and leaves the SIOL source untouched. Under the pre-fix output
 /// misclassification the record instead wrote VAL OUT to the SIOL target.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_aai_reads_siol_array_into_val_and_raises_simm_alarm() {
     const SIMM_ALARM: i16 = 19;
     const MINOR: i16 = 1;

--- a/crates/epics-base-rs/tests/sim_input_classification.rs
+++ b/crates/epics-base-rs/tests/sim_input_classification.rs
@@ -7,8 +7,6 @@
 //! wrote VAL OUT to SIOL (direction inverted, simulation defeated). These tests
 //! pin the corrected input direction.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -22,7 +20,7 @@ use epics_base_rs::types::{DbFieldType, EpicsValue};
 /// `dbGetLink(&siol, ftvl, bptr)`), and leaves the SIOL source untouched. Under
 /// the pre-fix output misclassification the record instead ran its body and
 /// wrote VAL OUT to the SIOL target — so VAL would NOT carry the source array.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_waveform_reads_siol_array_into_val() {
     let db = PvDatabase::new();
     db.add_record("WFIN_SW", Box::new(AoRecord::new(1.0)))
@@ -66,7 +64,7 @@ async fn sim_waveform_reads_siol_array_into_val() {
 /// SIOL = 42.0 with LLIM=0, ULIM=100, NELM=4 → WDTH=25, and C's
 /// `for (i = 1; i <= nelm; i++) if (temp <= i*wdth) break;` picks i=2, so
 /// `bptr[1]` is incremented: VAL = [0, 1, 0, 0].
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_histogram_lands_siol_in_sgnl_and_bins_it() {
     let db = PvDatabase::new();
     db.add_record("HGIN_SW", Box::new(AoRecord::new(1.0)))
@@ -112,7 +110,7 @@ async fn sim_histogram_lands_siol_in_sgnl_and_bins_it() {
 /// A FAILED SIOL read leaves C's `status != 0`, so `readValue` never runs
 /// `prec->sgnl = prec->sval` (`:385`, gated on `status == 0`) and `process`
 /// never runs `add_count` (`:218-219`, the same gate). No bin moves.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_histogram_with_a_failed_siol_read_bins_nothing() {
     let db = PvDatabase::new();
     db.add_record("HGF_SW", Box::new(AoRecord::new(1.0)))

--- a/crates/epics-base-rs/tests/sim_output_body_runs.rs
+++ b/crates/epics-base-rs/tests/sim_output_body_runs.rs
@@ -18,8 +18,6 @@
 //!   * `bo` HIGH: the momentary reset arms and (on the timer reprocess) drives
 //!     the simulated output back to 0.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -33,7 +31,7 @@ use epics_base_rs::types::EpicsValue;
 /// body computes OVAL=1, so the SIOL target receives 1 — NOT the un-limited
 /// VAL=10. The pre-fix short-circuit skipped `convert()`, leaving OVAL=0 and
 /// writing VAL=10 straight through, so this assertion pins the body running.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_output_runs_ao_oroc_body_writes_limited_oval_to_siol() {
     let db = PvDatabase::new();
     // SIML reads 1 -> SIMM=YES; SIOL target starts at a sentinel.
@@ -87,7 +85,7 @@ async fn sim_output_runs_ao_oroc_body_writes_limited_oval_to_siol() {
 /// runs the body again, sees the pending reset, sets VAL=0, and writes 0 to
 /// SIOL. The pre-fix short-circuit never ran the body, so the reset never armed
 /// and the simulated output stayed latched at 1.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_output_runs_bo_high_momentary_reset_in_sim_mode() {
     let db = PvDatabase::new();
     db.add_record("BOHI_SW", Box::new(AoRecord::new(1.0)))
@@ -145,7 +143,7 @@ async fn sim_output_runs_bo_high_momentary_reset_in_sim_mode() {
 /// in-range VAL (`nsev < INVALID` at the gate) takes the normal `writeValue`
 /// branch and DOES write OVAL to SIOL, even though SIMS=INVALID makes the
 /// final SEVR=INVALID. The IVOA Don't_drive veto is never consulted.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_output_sims_invalid_does_not_veto_siol_write() {
     let db = PvDatabase::new();
     db.add_record("AOIV_SW", Box::new(AoRecord::new(1.0)))
@@ -188,7 +186,7 @@ async fn sim_output_sims_invalid_does_not_veto_siol_write() {
 /// C skips `writeValue` — no SIOL write, and (because `writeValue` is skipped)
 /// SIMM_ALARM is never raised, so STAT stays STATE_ALARM. This guards that the
 /// switch to the pre-SIMM `real_sev` did not disable the genuine veto.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_output_real_invalid_alarm_ivoa_dont_drive_suppresses() {
     use epics_base_rs::server::records::bo::BoRecord;
 
@@ -246,7 +244,7 @@ async fn sim_output_real_invalid_alarm_ivoa_dont_drive_suppresses() {
 /// `OSV=MINOR`, `VAL=1`, `SIMS=MINOR` must report STAT=STATE_ALARM, not
 /// STAT=SIMM_ALARM. (Pre-fix the SIMM raise preceded `checkAlarms`, so SIMM won
 /// the tie and STAT was wrongly SIMM_ALARM.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sim_output_simm_alarm_loses_stat_on_severity_tie() {
     use epics_base_rs::server::records::bo::BoRecord;
 

--- a/crates/epics-base-rs/tests/sim_simm_contract.rs
+++ b/crates/epics-base-rs/tests/sim_simm_contract.rs
@@ -25,8 +25,6 @@
 //! `NotSimulated` before SIMM was even read whenever SIML and SIOL were both
 //! empty, so the idiom was a complete no-op on every record type.
 
-// RTEMS-EXEC-MODEL-ALLOW(15): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -38,7 +36,7 @@ use epics_base_rs::types::EpicsValue;
 /// NO SIML and NO SIOL: C reads SIMM (YES), raises SIMM_ALARM at SIMS, reads
 /// the (constant, unset) SIOL — status 0, SVAL untouched — and publishes
 /// `VAL = SVAL = 42` with UDF cleared.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn simm_yes_with_unset_siml_and_siol_simulates_from_sval() {
     let db = PvDatabase::new();
     let mut li = LonginRecord::new(7); // VAL = 7 (the pre-simulation value)
@@ -84,7 +82,7 @@ async fn simm_yes_with_unset_siml_and_siol_simulates_from_sval() {
 
 /// The same record with SIMM back at NO must NOT simulate: the SVAL is ignored
 /// and the real (soft, empty INP) device path runs, leaving VAL alone.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn simm_no_with_unset_links_does_not_simulate() {
     let db = PvDatabase::new();
     let mut li = LonginRecord::new(7);
@@ -146,7 +144,7 @@ const SCAN_PASSIVE: u16 = 0;
 /// periodic scan, and SSCN comes back holding the scan the record just left.
 /// Leaving simulation swaps them back. Both directions are a swap, not an
 /// assignment.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn simm_transition_swaps_scan_with_sscn() {
     let db = PvDatabase::new();
     db.add_record("SWAP", Box::new(LonginRecord::new(1)))
@@ -202,7 +200,7 @@ async fn simm_transition_swaps_scan_with_sscn() {
 /// `*psscn == USHRT_MAX` (the dbd default, `initial("65535")`) — C returns
 /// immediately from BOTH recGblSaveSimm and recGblCheckSimm, so SCAN is
 /// untouched and OLDSIMM is never even latched.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unset_sscn_leaves_scan_alone_on_a_simm_transition() {
     let db = PvDatabase::new();
     db.add_record("NOSSCN", Box::new(LonginRecord::new(1)))
@@ -235,7 +233,7 @@ async fn unset_sscn_leaves_scan_alone_on_a_simm_transition() {
 /// OLDSIMM, and `busyRecord.c` calls neither recGblSaveSimm nor
 /// recGblCheckSimm — it has no `special()` at all. So a SIMM transition on a
 /// busy record must NOT move its SCAN, even with SSCN set. Same for `swait`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn busy_has_no_sscn_so_a_simm_transition_never_swaps_its_scan() {
     let db = PvDatabase::new();
     db.add_record("BUSY", Box::new(BusyRecord::new()))
@@ -289,7 +287,7 @@ async fn busy_has_no_sscn_so_a_simm_transition_never_swaps_its_scan() {
 use epics_base_rs::server::recgbl::alarm_status;
 
 /// The 21 recGblGetSimm records: STAT=LINK_ALARM, SEVR untouched.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn failed_siml_read_sets_nsta_link_alarm_without_touching_sevr() {
     let db = PvDatabase::new();
     let mut li = LonginRecord::new(5);
@@ -321,7 +319,7 @@ async fn failed_siml_read_sets_nsta_link_alarm_without_touching_sevr() {
 
 /// `busy` reads SIML with a plain `dbGetLink`, so its failure is a full
 /// `setLinkAlarm` — LINK_ALARM at INVALID severity.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn busy_failed_siml_read_raises_link_alarm_at_invalid_severity() {
     let db = PvDatabase::new();
     let mut b = BusyRecord::new();
@@ -371,7 +369,7 @@ async fn busy_failed_siml_read_raises_link_alarm_at_invalid_severity() {
 
 /// The headline: with the DEFAULT `SIMS = NO_ALARM`, a broken SIOL is reported
 /// as LINK_ALARM/INVALID with AMSG "field SIOL". The port reported NO_ALARM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn failed_siol_read_raises_link_alarm_at_default_sims() {
     let db = PvDatabase::new();
     let mut li = LonginRecord::new(5);
@@ -407,7 +405,7 @@ async fn failed_siol_read_raises_link_alarm_at_default_sims() {
 /// base record raised SIMM FIRST — so the strict-greater `recGblSetSevr` leaves
 /// SIMM_ALARM in STAT and the LINK_ALARM loses the tie. (AMSG is empty: the
 /// SIMM raise went through message-less `recGblSetSevr`, which CLEARS namsg.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn failed_siol_read_loses_the_tie_to_simm_alarm_at_sims_invalid() {
     let db = PvDatabase::new();
     let mut li = LonginRecord::new(5);
@@ -465,7 +463,7 @@ use epics_base_rs::server::records::longout::LongoutRecord;
 
 /// A menuYesNo INPUT record with SIMM=2: SOFT_ALARM/INVALID, and SVAL is NOT
 /// copied into VAL (C never reaches the SIOL read on this arm).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn simm_raw_on_a_menu_yesno_input_is_soft_alarm_and_no_substitution() {
     let db = PvDatabase::new();
     let mut li = LonginRecord::new(7);
@@ -497,7 +495,7 @@ async fn simm_raw_on_a_menu_yesno_input_is_soft_alarm_and_no_substitution() {
 /// A menuYesNo OUTPUT record with SIMM=2: SOFT_ALARM/INVALID, and NOTHING is
 /// written — not the device/OUT link, not SIOL. C `writeValue` returns -1 from
 /// the default arm, before either write.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn simm_raw_on_a_menu_yesno_output_writes_nothing() {
     let db = PvDatabase::new();
     db.add_record("SINK", Box::new(LonginRecord::new(0)))
@@ -529,7 +527,7 @@ async fn simm_raw_on_a_menu_yesno_output_writes_nothing() {
 
 /// `busy` is menuYesNo too (`busyRecord.c:409-413` is the `else` of its YES
 /// test): SIMM=2 raises SOFT_ALARM/INVALID and writes nothing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn busy_simm_raw_is_soft_alarm_and_writes_nothing() {
     let db = PvDatabase::new();
     db.add_record("BSINK", Box::new(LonginRecord::new(0)))
@@ -556,7 +554,7 @@ async fn busy_simm_raw_is_soft_alarm_and_writes_nothing() {
 /// The guard on the other side: `ai` IS `menu(menuSimm)`, so SIMM=2 is the
 /// legal RAW arm — it must still simulate (SIOL -> SVAL -> RVAL -> conversion),
 /// with SIMM_ALARM and no SOFT_ALARM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn simm_raw_on_a_menu_simm_record_still_simulates() {
     use epics_base_rs::server::records::ai::AiRecord;
 
@@ -606,7 +604,7 @@ async fn simm_raw_on_a_menu_simm_record_still_simulates() {
 
 /// A broken SIML on a `busy` with a local OUT link: C returns from
 /// `writeValue` before the write, so the OUT target must not be driven.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_e5_busy_failed_siml_read_performs_no_output_write() {
     let db = PvDatabase::new();
     db.add_record("E5TGT", Box::new(LonginRecord::new(0)))
@@ -646,7 +644,7 @@ async fn w10_e5_busy_failed_siml_read_performs_no_output_write() {
 
 /// The same busy in SIMM=YES: the abort precedes the SIOL redirect too, so a
 /// failed SIML read means NO write of any kind — not even the simulated one.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_e5_busy_failed_siml_read_suppresses_the_siol_redirect_as_well() {
     let db = PvDatabase::new();
     db.add_record("E5STGT", Box::new(LonginRecord::new(0)))

--- a/crates/epics-base-rs/tests/siol_put_owner.rs
+++ b/crates/epics-base-rs/tests/siol_put_owner.rs
@@ -13,8 +13,6 @@
 //! `write_out_link_value`'s single-raise invariant. SIOL now goes through the
 //! put owner like every other OUT link.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -54,7 +52,7 @@ async fn add_simulated_ao(db: &PvDatabase, name: &str, siol: &str, val: f64) {
 /// `dbDbPutValue` (dbDbLink.c:387-389) processes the target. The old bare
 /// field write never did, so a simulated ao driving a `PP` SIOL left the
 /// downstream record unprocessed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_63_siol_pp_processes_the_passive_target() {
     let db = PvDatabase::new();
     // Target: an ai whose own OUT-less process copies VAL through; the FLNK
@@ -92,7 +90,7 @@ async fn r15_63_siol_pp_processes_the_passive_target() {
 /// Boundary 2 — `SIOL` with `MS`: the writing record's severity folds into the
 /// target, exactly as an MS OUT link's does (`recGblInheritSevrMsg`,
 /// dbDbLink.c:382-383). The bare field write propagated nothing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_63_siol_ms_inherits_the_writers_severity() {
     let db = PvDatabase::new();
     db.add_record("SIOL_TGT", Box::new(AiRecord::new(0.0)))
@@ -127,7 +125,7 @@ async fn r15_63_siol_ms_inherits_the_writers_severity() {
 
 /// Boundary 3 — the failure path still alarms, and now the OWNER raises it
 /// (R14-62 must keep passing with the caller's raise removed).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r15_63_failed_siol_put_is_alarmed_by_the_put_owner() {
     let db = PvDatabase::new();
     add_simulated_ao(&db, "AO_SIM", "NO_SUCH_SIOL", 5.0).await;

--- a/crates/epics-base-rs/tests/snl_process_put_origin.rs
+++ b/crates/epics-base-rs/tests/snl_process_put_origin.rs
@@ -11,8 +11,6 @@
 //! (clamp → rollback → clamp ping-pong, measured on the mini-beamline
 //! example 2026-07-24).
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::database::db_access::{DbChannel, DbSubscription};
 use epics_base_rs::server::records::ao::AoRecord;
@@ -29,7 +27,7 @@ async fn setup() -> PvDatabase {
 
 /// The writer's own filtered subscription must NOT see its `put_f64_process`:
 /// the process-cycle VAL post carries the channel's origin.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn process_put_is_invisible_to_its_own_origin() {
     let db = setup().await;
     let mut own = DbSubscription::subscribe_filtered(&db, "SP.VAL", WRITER)
@@ -48,7 +46,7 @@ async fn process_put_is_invisible_to_its_own_origin() {
 
 /// The same put MUST stay visible to everyone else: a subscription with a
 /// different (or no) filter origin receives the process-cycle post.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn process_put_is_visible_to_other_origins() {
     let db = setup().await;
     let mut other = DbSubscription::subscribe_filtered(&db, "SP.VAL", WRITER + 1)
@@ -72,7 +70,7 @@ async fn process_put_is_visible_to_other_origins() {
 }
 
 /// An origin-less channel keeps today's behavior: origin 0 is never filtered.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn originless_process_put_reaches_a_filtered_subscription() {
     let db = setup().await;
     let mut sub = DbSubscription::subscribe_filtered(&db, "SP.VAL", WRITER)

--- a/crates/epics-base-rs/tests/soft_timestamp_device.rs
+++ b/crates/epics-base-rs/tests/soft_timestamp_device.rs
@@ -6,8 +6,6 @@
 //! before `is_soft_dtyp` stopped classifying "Soft Timestamp" as a soft
 //! channel).
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::{HashMap, HashSet};
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -24,7 +22,7 @@ async fn read_val(db: &epics_base_rs::server::database::PvDatabase, name: &str) 
 /// `TSE=0` (wall clock) writes `VAL = secPastEpoch + frac`. In 2026 that is
 /// well over 1e9 seconds past the 1990 EPICS epoch, so a `VAL > 1.0e9`
 /// proves the device ran (the pre-fix silent no-op left `VAL == 0.0`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn soft_timestamp_ai_writes_current_seconds_past_epoch() {
     let db_content = r#"
 record(ai, "TS_AI") {
@@ -58,7 +56,7 @@ record(ai, "TS_AI") {
 /// into VAL. With `INP="@%Y"` (wall clock, TSE=0) that is the current
 /// four-digit year — proving the instio `INP` format string reached the
 /// device (a missing INP would format an empty string).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn soft_timestamp_stringin_formats_current_year() {
     let db_content = r#"
 record(stringin, "TS_SI") {

--- a/crates/epics-base-rs/tests/sseq_async_machine.rs
+++ b/crates/epics-base-rs/tests/sseq_async_machine.rs
@@ -26,8 +26,6 @@
 //! drains the in-flight set before finishing.
 #![allow(clippy::all)]
 
-// RTEMS-EXEC-MODEL-ALLOW(14): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -226,7 +224,7 @@ async fn poll_short(db: &PvDatabase, pv: &str, want: i16, label: &str) {
                 return;
             }
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!(
         "{label}: {pv} did not reach Short({want}) before timeout (last {:?})",
@@ -245,7 +243,7 @@ async fn poll_i16(db: &PvDatabase, pv: &str, want: i16, label: &str) {
                 return;
             }
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!(
         "{label}: {pv} did not reach {want} before timeout (last {:?})",
@@ -270,7 +268,7 @@ async fn poll_double(db: &PvDatabase, pv: &str, want: f64, label: &str) {
                 return;
             }
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!(
         "{label}: {pv} did not reach {want} before timeout (last {:?})",
@@ -291,7 +289,7 @@ fn read_short(db_value: Option<EpicsValue>) -> i16 {
 /// While blocked: `BUSY == 1`, `WTG1 == 1`, and the next step has not
 /// fired. When the downstream completes, the sequence advances, runs the
 /// last step, and clears `BUSY` (C `asyncFinish`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_waitn_blocks_until_downstream_completes() {
     let db = PvDatabase::new();
     // Step-1 target: a CA link whose put-callback the lset holds open until
@@ -332,7 +330,7 @@ async fn sseq_waitn_blocks_until_downstream_completes() {
     );
 
     // Settle: confirm the block is stable, not just not-yet-arrived.
-    tokio::time::sleep(Duration::from_millis(60)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(60)).await;
     assert_eq!(
         db.get_pv("SSEQ_W_TGT2").unwrap(),
         EpicsValue::Double(0.0),
@@ -372,7 +370,7 @@ async fn sseq_waitn_blocks_until_downstream_completes() {
 /// favour of the per-step machine; this proves the retirement neither
 /// dropped a step nor left a duplicate dispatch. Also pins last-step
 /// `BUSY` clearing.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_each_lnkn_dispatched_exactly_once_and_clears_busy() {
     let db = PvDatabase::new();
     let c1 = Arc::new(AtomicU32::new(0));
@@ -422,7 +420,7 @@ async fn sseq_each_lnkn_dispatched_exactly_once_and_clears_busy() {
     // Wait for the last step's target, then settle so any erroneous extra
     // dispatch (a leftover all-at-once path) would also have landed.
     poll_short(&db, "SSEQ_ONCE.BUSY", 0, "sequence finishes").await;
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(40)).await;
 
     assert_eq!(
         c1.load(Ordering::SeqCst),
@@ -452,7 +450,7 @@ async fn sseq_each_lnkn_dispatched_exactly_once_and_clears_busy() {
 /// never fires, `BUSY`/`ABORT`/`ABORTING` reset, and the superseded delay
 /// re-entry is a structural no-op (the `AsyncToken` generation gate) — no
 /// stale double-dispatch.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_abort_during_delay_finishes_without_dispatch() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicU32::new(0));
@@ -503,7 +501,7 @@ async fn sseq_abort_during_delay_finishes_without_dispatch() {
         "ABORTING cleared by asyncFinish"
     );
     // Settle: the aborted step's write must never land.
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(40)).await;
     assert_eq!(
         count.load(Ordering::SeqCst),
         0,
@@ -517,7 +515,7 @@ async fn sseq_abort_during_delay_finishes_without_dispatch() {
 /// re-entry from phase `Wait`); the second abort clears the `waiting`
 /// flags, drops the remaining steps, and forces the finish
 /// (C `sseqRecord.c` second-abort branch).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_second_abort_escapes_hung_wait_callback() {
     let db = PvDatabase::new();
     // CA target whose put-callback is never completed — the WAIT step parks
@@ -541,7 +539,7 @@ async fn sseq_second_abort_escapes_hung_wait_callback() {
         .await
         .unwrap();
     poll_short(&db, "SSEQ_HUNG.ABORTING", 1, "first abort sets ABORTING").await;
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(40)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_HUNG.BUSY").ok()),
         1,
@@ -578,7 +576,7 @@ async fn sseq_second_abort_escapes_hung_wait_callback() {
 /// raise the same alarm AND dispatch no `LNKn` — the regression the old
 /// `MultiOut::Sseq` dispatch covered via `apply_selm_alarm` and the
 /// per-step machine dropped (it finished silently).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_seln_out_of_range_raises_invalid_alarm_and_no_dispatch() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicU32::new(0));
@@ -618,7 +616,7 @@ async fn sseq_seln_out_of_range_raises_invalid_alarm_and_no_dispatch() {
     drop(inst);
 
     // Settle so any erroneous step dispatch would also have landed.
-    tokio::time::sleep(Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(40)).await;
     assert_eq!(
         count.load(Ordering::SeqCst),
         0,
@@ -636,7 +634,7 @@ async fn sseq_seln_out_of_range_raises_invalid_alarm_and_no_dispatch() {
 /// `init_record` 202-250). A LOCAL DB link → `LOC` (2) + the resolved
 /// target field type; an empty (constant) link → `CON` (3) + the unknown
 /// (-1) field type. The refresh runs at record init (`set_async_context`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_link_status_loc_vs_con() {
     let db = PvDatabase::new();
     // A local target (ao VAL is DBF_DOUBLE = 10 in C dbStatic numbering,
@@ -699,7 +697,7 @@ async fn sseq_link_status_loc_vs_con() {
 /// the runtime re-point refresh (local link → `LOC`). The monotonic
 /// generation gate makes the later classification win regardless of which
 /// spawned task posts last, so `DOL1V` settles at `LOC` and stays there.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_link_status_reclassifies_on_special() {
     let db = PvDatabase::new();
     db.add_record("SSEQ_SP_TGT", Box::new(AoRecord::new(0.0)))
@@ -722,7 +720,7 @@ async fn sseq_link_status_reclassifies_on_special() {
 
     // And it must stay LOC — a stale CON post arriving late cannot clobber it.
     for _ in 0..20 {
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
         assert_eq!(
             read_i16(&db, "SSEQ_SP.DOL1V").await,
             2,
@@ -740,7 +738,7 @@ async fn sseq_link_status_reclassifies_on_special() {
 ///
 /// The pre-fix port had this inverted: it raised `WERRn` on the constant and
 /// never on the local DB link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_werr_raised_on_local_db_wait_cleared_on_ca_and_constant() {
     let db = PvDatabase::new();
     let _hold = ca_hold(&db).await;
@@ -799,7 +797,7 @@ async fn sseq_werr_raised_on_local_db_wait_cleared_on_ca_and_constant() {
 /// hung forever on `WTG1`. Under C's rule the step takes the plain put, does
 /// not wait, and the sequence runs straight to the end — while `WERR1` tells
 /// the user the wait they asked for was dropped.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_waitn_on_local_db_link_does_not_wait() {
     let db = PvDatabase::new();
     // Local target that never finishes its own processing.
@@ -856,7 +854,7 @@ async fn sseq_waitn_on_local_db_link_does_not_wait() {
 /// `usePutCallback == sseqWAIT_Wait` returns immediately, blocking every
 /// later step until that callback completes. Both steps are `Wait` into
 /// async holds; only `WTG1` is high until `HOLD1` completes, then `WTG2`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_wait_full_barrier_serialises_steps() {
     let db = PvDatabase::new();
     let hold = ca_hold(&db).await;
@@ -879,7 +877,7 @@ async fn sseq_wait_full_barrier_serialises_steps() {
 
     // Step 1 in flight; step 2 blocked by the full barrier → NOT dispatched.
     poll_short(&db, "SSEQ_FB.WTG1", 1, "step 1 Wait parks").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_FB.WTG2").ok()),
         0,
@@ -921,7 +919,7 @@ async fn sseq_wait_full_barrier_serialises_steps() {
 /// arithmetic — `After3` gates index `>= 3` — so the overlap+barrier shape
 /// it describes is pinned with `After2`, the value that actually gates
 /// index 2.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_after_n_overlaps_then_barriers() {
     let db = PvDatabase::new();
     let hold = ca_hold(&db).await;
@@ -953,7 +951,7 @@ async fn sseq_after_n_overlaps_then_barriers() {
         1,
         "step 1 is still in flight while step 2 is also in flight (overlap)"
     );
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_OV.WTG3").ok()),
         0,
@@ -963,7 +961,7 @@ async fn sseq_after_n_overlaps_then_barriers() {
     // Complete only step 1 → step 3 STILL blocked (step 2's After2 holds it).
     hold.release("SSEQ_OV_HOLD1");
     poll_short(&db, "SSEQ_OV.WTG1", 0, "step 1 cleared").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_OV.WTG3").ok()),
         0,
@@ -998,7 +996,7 @@ async fn sseq_after_n_overlaps_then_barriers() {
 /// only when none remain. Two `After2` steps (no later step, so no barrier
 /// between them) both dispatch and the sequence drains: completing one keeps
 /// `BUSY` high; completing the second finishes.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_end_drain_waits_for_all_in_flight() {
     let db = PvDatabase::new();
     let hold = ca_hold(&db).await;
@@ -1031,7 +1029,7 @@ async fn sseq_end_drain_waits_for_all_in_flight() {
     // Complete ONE → drain is not done; BUSY must stay high.
     hold.release("SSEQ_DR_HOLD1");
     poll_short(&db, "SSEQ_DR.WTG1", 0, "step 1 drained").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_DR.BUSY").ok()),
         1,
@@ -1056,7 +1054,7 @@ async fn sseq_end_drain_waits_for_all_in_flight() {
 /// (`asyncFinish` runs once they return). Two overlapping `After2` steps are
 /// in flight; the abort holds `ABORTING`/`BUSY` high until BOTH complete,
 /// then finishes cleanly.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_abort_drains_in_flight_before_finish() {
     let db = PvDatabase::new();
     let hold = ca_hold(&db).await;
@@ -1082,7 +1080,7 @@ async fn sseq_abort_drains_in_flight_before_finish() {
         .await
         .unwrap();
     poll_short(&db, "SSEQ_ABD.ABORTING", 1, "abort accepted, draining").await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_ABD.BUSY").ok()),
         1,
@@ -1098,7 +1096,7 @@ async fn sseq_abort_drains_in_flight_before_finish() {
         "first in-flight drained under abort",
     )
     .await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
     assert_eq!(
         read_short(db.get_pv("SSEQ_ABD.BUSY").ok()),
         1,
@@ -1135,7 +1133,7 @@ async fn sseq_abort_drains_in_flight_before_finish() {
 /// gates index `>= 2`) into an async hold that stays in flight; step 2
 /// (index 1, `< 2`) is `NoWait` into a sync target and must fire immediately,
 /// landing its value while step 1's callback is still outstanding.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_after_n_does_not_block_lower_index_step() {
     let db = PvDatabase::new();
     let hold = ca_hold(&db).await;

--- a/crates/epics-base-rs/tests/sseq_dly_quantization.rs
+++ b/crates/epics-base-rs/tests/sseq_dly_quantization.rs
@@ -25,8 +25,6 @@
 //! `epicsThreadSleepQuantum()` is `1/sysconf(_SC_CLK_TCK)` = 0.01 s on Linux
 //! and macOS, and `NINT(f) = (long)(f > 0 ? f+0.5 : f-0.5)` (sseqRecord.c:67).
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::runtime::time::thread_sleep_quantum;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::sseq::SseqRecord;
@@ -45,7 +43,7 @@ fn expect_quantized(seconds: f64) -> f64 {
     q * (ticks + 0.5).trunc()
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_70_init_rounds_every_dly_to_a_clock_tick() {
     let mut rec = SseqRecord::default();
     // Raw db-file values: put_field alone stores them verbatim (C `dbPut` at
@@ -95,7 +93,7 @@ async fn r9_70_init_rounds_every_dly_to_a_clock_tick() {
 
 /// A put to DLY1 quantizes DLY1 — the one index where C's `special` quirk and
 /// the obvious reading agree.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_70_put_to_dly1_quantizes_dly1() {
     let mut rec = SseqRecord::default();
     rec.put_field("DLY1", EpicsValue::Double(0.037)).unwrap();
@@ -109,7 +107,7 @@ async fn r9_70_put_to_dly1_quantizes_dly1() {
 }
 
 /// C's `special` quirk, pinned: a put to DLYA rounds DLY1 and leaves DLYA raw.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_70_put_to_dlya_quantizes_dly1_and_leaves_dlya_raw() {
     let mut rec = SseqRecord::default();
     // DLY1 left unrounded on purpose, so the quirk is observable.
@@ -136,7 +134,7 @@ async fn r9_70_put_to_dlya_quantizes_dly1_and_leaves_dlya_raw() {
 /// casts `0.0` to the integer `0`, so every served/monitored `DLYn` is `+0.0`
 /// — it renders `"0"`. An `f64::trunc` port produced `-0.0` (`(-0.0 -
 /// 0.5).trunc()` = `-0.0`), which renders `"-0"`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_70_default_dly_serves_positive_zero_not_negative_zero() {
     let mut rec = SseqRecord::default();
     rec.init_record(0).unwrap();
@@ -154,7 +152,7 @@ async fn r9_70_default_dly_serves_positive_zero_not_negative_zero() {
 /// Oracle symptom (put): a huge `caput DLY1` overflows C's `(long)` cast to
 /// i64::MIN, so the served value is `quantum * i64::MIN` ≈ -9.22e16 — finite
 /// and negative. An `f64::trunc` port kept `inf`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_70_huge_put_to_dly1_overflows_to_c_long_min() {
     let q = thread_sleep_quantum();
     let expect_overflow = q * (i64::MIN as f64);
@@ -183,7 +181,7 @@ async fn r9_70_huge_put_to_dly1_overflows_to_c_long_min() {
 
 /// The framework put path (`special` after the store) must show the same
 /// thing end to end: DLYA raw, DLY1 rounded.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_70_framework_put_path_matches_c() {
     use epics_base_rs::server::database::PvDatabase;
 

--- a/crates/epics-base-rs/tests/sseq_dol_source_typed.rs
+++ b/crates/epics-base-rs/tests/sseq_dol_source_typed.rs
@@ -17,8 +17,6 @@
 //! One test per boundary of that switch, plus the failed-store path the read
 //! owner used to discard silently.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -53,7 +51,7 @@ async fn run_step(db: &PvDatabase, sseq: &str, dst: &str, label: &str) {
                 return;
             }
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!("{label}: {dst}.VAL never received the step's forwarded value");
 }
@@ -70,7 +68,7 @@ async fn field(db: &PvDatabase, record: &str, name: &str) -> EpicsValue {
 /// `DBF_ENUM` source (mbbi): C reads it with `DBR_STRING`, so `STRn` gets the
 /// state LABEL and `DOn` gets `atof(label)`. Pre-fix the port stored the index
 /// (`DO1 = 2`, `STR1 = "2"`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_enum_dol_delivers_state_label_not_index() {
     let db = PvDatabase::new();
 
@@ -117,7 +115,7 @@ async fn sseq_enum_dol_delivers_state_label_not_index() {
 
 /// `DBF_MENU` source (a menu-index field — here the mbbi's `SIMM`): the same
 /// `DBR_STRING` arm, resolved through the field's `menu()` choices.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_menu_dol_delivers_choice_label() {
     let db = PvDatabase::new();
 
@@ -148,7 +146,7 @@ async fn sseq_menu_dol_delivers_choice_label() {
 /// `DBF_CHAR` array source (the long-string idiom): C reads up to 40 bytes into
 /// `s` and sets `dov = atof(s)`. Pre-fix the native `CharArray` reached `DOn`,
 /// `to_f64()` failed, and the error was discarded — `DO1`/`STR1` stayed stale.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_char_array_dol_delivers_string_and_atof() {
     let db = PvDatabase::new();
 
@@ -192,7 +190,7 @@ async fn sseq_char_array_dol_delivers_string_and_atof() {
 
 /// A numeric source keeps the `DBR_DOUBLE` arm: `DOn` is the value and `STRn`
 /// is re-rendered at the record's PREC.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_numeric_dol_keeps_double_arm() {
     let db = PvDatabase::new();
 
@@ -225,7 +223,7 @@ async fn sseq_numeric_dol_keeps_double_arm() {
 /// A CONSTANT `DOLn` is C's `default:` arm at process time: seeded ONCE at
 /// init (the link TEXT into `s`, `dov = atof(s)`), never re-read. A client put
 /// to `DO1` therefore survives the next cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_constant_dol_seeds_at_init_and_is_never_re_read() {
     let db = PvDatabase::new();
 
@@ -341,7 +339,7 @@ impl Record for PickyReader {
     }
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn rejected_link_store_raises_link_invalid() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/sseq_dol_string.rs
+++ b/crates/epics-base-rs/tests/sseq_dol_string.rs
@@ -10,8 +10,6 @@
 //! ReadDbLink`, which delivers the link target's NATIVE `EpicsValue`; `sseq`
 //! preserves a string in `STRn` (byte-exact) instead of coercing to `DOn`.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -39,7 +37,7 @@ async fn poll_field(db: &PvDatabase, record: &str, field: &str, label: &str) -> 
                 }
             }
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!("{label}: {record}.{field} did not receive the forwarded value before timeout");
 }
@@ -48,7 +46,7 @@ async fn poll_field(db: &PvDatabase, record: &str, field: &str, label: &str) -> 
 /// `LNKn` target byte-exact — no numeric coercion, no `as_str_lossy` on the
 /// value path. Pre-fix the read funnelled through `DOn` (Double), so the
 /// bytes were lost.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_string_dol_forwards_string_byte_exact() {
     let db = PvDatabase::new();
 
@@ -100,7 +98,7 @@ async fn sseq_string_dol_forwards_string_byte_exact() {
 
 /// A numeric `DOLn` source still forwards a `Double` to `LNKn` — the
 /// pre-existing behavior must be unchanged.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_numeric_dol_forwards_double_unchanged() {
     let db = PvDatabase::new();
 
@@ -136,7 +134,7 @@ async fn sseq_numeric_dol_forwards_double_unchanged() {
 /// `cvtDoubleToString(dov, str, prec)` and posts it (sseqRecord.c:676-679). A
 /// client GET of `STRn` must return the record-PREC rendering of the numeric
 /// value, not the stale string left over from before the read.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_numeric_dol_refreshes_strn_with_prec() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/sseq_lnk_destination_typed.rs
+++ b/crates/epics-base-rs/tests/sseq_lnk_destination_typed.rs
@@ -18,8 +18,6 @@
 //!
 //! One test per boundary of that switch.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -129,21 +127,21 @@ async fn poll_put(cell: &Arc<Mutex<Option<EpicsValue>>>, label: &str) -> EpicsVa
         if let Some(v) = cell.lock().unwrap().clone() {
             return v;
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!("{label}: LNK1 was never written");
 }
 
 /// Settle long enough that a write, had one been issued, would have landed.
 async fn settle() {
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    epics_base_rs::runtime::task::sleep(Duration::from_millis(120)).await;
 }
 
 /// Boundary — NUMERIC source, STRING-class destination: C puts `DBR_STRING`
 /// from `s`, which the numeric arm rendered with `cvtDoubleToString(dov,
 /// s, pR->prec)`. With PREC=2 the wire value is "1.23", NOT the full-
 /// precision double the source delivered.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn numeric_source_string_destination_puts_the_prec_rendered_string() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -181,7 +179,7 @@ async fn numeric_source_string_destination_puts_the_prec_rendered_string() {
 /// Boundary — STRING source, NUMERIC destination: C puts `DBR_DOUBLE` from
 /// `dov`, which the string arm set to `atof(s)`. A non-numeric string is
 /// 0.0 on the wire — the put still happens (and processes the target).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn string_source_numeric_destination_puts_atof_of_the_string() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -217,7 +215,7 @@ async fn string_source_numeric_destination_puts_atof_of_the_string() {
 /// Boundary — CHAR destination with `n_elements > 1` (the long-string
 /// idiom): C puts `min(n_elements, 40)` bytes of the 40-byte `s` as a char
 /// array, NUL-padded — not the double.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn char_array_destination_puts_the_string_bytes() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -256,7 +254,7 @@ async fn char_array_destination_puts_the_string_bytes() {
 
 /// Boundary — a CHAR destination with `n_elements == 1` is a scalar, and C's
 /// CHAR arm falls back to `DBR_DOUBLE` from `dov` (sseqRecord.c:786-789).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn scalar_char_destination_puts_the_double() {
     let db = PvDatabase::new();
     let last = Arc::new(Mutex::new(None));
@@ -293,7 +291,7 @@ async fn scalar_char_destination_puts_the_double() {
 /// Boundary — an UNRESOLVABLE destination (C `dbGetLinkDBFtype` → -1, i.e.
 /// a disconnected CA link) hits `default: break`: NO put is issued at all.
 /// The port previously wrote the source-typed value regardless.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unresolved_destination_is_not_written_at_all() {
     let db = PvDatabase::new();
     let last_put = Arc::new(Mutex::new(None));
@@ -341,7 +339,7 @@ async fn unresolved_destination_is_not_written_at_all() {
 /// Boundary — a RESOLVED external destination is written, typed by the
 /// remote field's class (C `dbCaGetLinkDBFtype`): a remote string channel
 /// takes the STRn view.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn resolved_external_string_destination_takes_the_string_view() {
     let db = PvDatabase::new();
     let last_put = Arc::new(Mutex::new(None));

--- a/crates/epics-base-rs/tests/sseq_unresolved_lnk_no_wait.rs
+++ b/crates/epics-base-rs/tests/sseq_unresolved_lnk_no_wait.rs
@@ -28,8 +28,6 @@
 //! any path where that completion is not delivered, a step waiting forever on a
 //! put that was never made.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -54,7 +52,7 @@ async fn poll_short(db: &PvDatabase, pv: &str, want: i16, label: &str) {
         {
             return;
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
     panic!(
         "{label}: {pv} did not reach Short({want}) (last {:?})",
@@ -66,7 +64,7 @@ async fn poll_short(db: &PvDatabase, pv: &str, want: i16, label: &str) {
 /// set is registered, so the target has no DBF class — C's disconnected
 /// `CA_LINK`). C's `default:` arm makes no put and raises no `waiting`, so no
 /// `WTG1` event is ever emitted and the sequence runs straight through step 2.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r17_3_a_wait_step_with_an_unresolvable_lnk_never_raises_wtg() {
     let db = PvDatabase::new();
     db.add_record("SS_NR_TGT2", Box::new(AoRecord::new(0.0)))
@@ -124,7 +122,7 @@ async fn r17_3_a_wait_step_with_an_unresolvable_lnk_never_raises_wtg() {
 /// a `WAITn` on a link that DOES resolve still parks the sequence. (The full
 /// wait/complete cycle is `sseq_async_machine.rs`; this pins that the put-class
 /// gate did not swallow the waiting path.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r17_3_a_wait_step_with_a_resolvable_local_lnk_still_puts() {
     let db = PvDatabase::new();
     db.add_record("SS_NR2_TGT", Box::new(AoRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/sseq_val_per_process_monitor.rs
+++ b/crates/epics-base-rs/tests/sseq_val_per_process_monitor.rs
@@ -19,8 +19,6 @@
 //! and `monitor_always_post = (true, false)`, encoding "value class always,
 //! archive class never".
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::EventMask;
 use epics_base_rs::server::records::sseq::SseqRecord;
@@ -43,7 +41,7 @@ async fn bare_sseq() -> PvDatabase {
 
 /// `caput VAL 1;2;2;3` posts four `DBE_VALUE` events — the repeated `2` posts a
 /// second time, because C posts VAL every process regardless of value change.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_val_posts_every_process_including_the_unchanged_repeat() {
     let db = bare_sseq().await;
     let inst = db.get_record("SQV").unwrap();

--- a/crates/epics-base-rs/tests/sseq_val_timestamp_lags_restamp.rs
+++ b/crates/epics-base-rs/tests/sseq_val_timestamp_lags_restamp.rs
@@ -22,8 +22,6 @@
 //! "now" instead of the pre-update time the differential oracle observed from
 //! C's QSRV2 monitor.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::EventMask;
 use epics_base_rs::server::records::sseq::SseqRecord;
@@ -48,7 +46,7 @@ async fn bare_sseq() -> PvDatabase {
 /// the second cycle's VAL carries the timestamp the FIRST cycle restamped to —
 /// the one-completion lag C's `asyncFinish` produces (VAL at `:474` before
 /// `recGblGetTimeStamp` at `:501`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn sseq_val_timestamp_is_pre_restamp_and_lags_one_cycle() {
     let db = bare_sseq().await;
     let inst = db.get_record("SQV").unwrap();

--- a/crates/epics-base-rs/tests/sseq_value_pair_monitor.rs
+++ b/crates/epics-base-rs/tests/sseq_value_pair_monitor.rs
@@ -25,8 +25,6 @@
 //! with `DBE_VALUE|DBE_LOG`, unconditionally — an archiver on `STR1` logged a
 //! sample on every `caput DO1` that changed nothing.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -60,7 +58,7 @@ async fn sseq_with_prec2() -> PvDatabase {
 
 /// `caput VP.DO1 3.7` (PREC=2): the put path posts DO1 (C `dbPut`), and
 /// `special()` posts the re-rendered STR1="3.70" with a bare `DBE_VALUE`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r17_4_a_do_put_posts_the_derived_string_with_a_bare_value_mask() {
     let db = sseq_with_prec2().await;
     let inst = db.get_record("VP").unwrap();
@@ -105,7 +103,7 @@ async fn r17_4_a_do_put_posts_the_derived_string_with_a_bare_value_mask() {
 
 /// The change test C makes and a static field list cannot: re-putting the SAME
 /// DO1 leaves `strcmp(str, plinkGroup->s) == 0`, so STR1 posts NOTHING.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r17_4_a_do_put_that_moves_no_string_posts_no_string_event() {
     let db = sseq_with_prec2().await;
     let inst = db.get_record("VP").unwrap();
@@ -139,7 +137,7 @@ async fn r17_4_a_do_put_that_moves_no_string_posts_no_string_event() {
 
 /// The mirror site: a `STRn` put derives `DOn = atof(s)` and posts it with a
 /// bare `DBE_VALUE`, only when it moved (sseqRecord.c:1136-1140).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r17_4_a_str_put_posts_the_derived_double_with_a_bare_value_mask() {
     let db = sseq_with_prec2().await;
     let inst = db.get_record("VP").unwrap();
@@ -174,7 +172,7 @@ async fn r17_4_a_str_put_posts_the_derived_double_with_a_bare_value_mask() {
 /// The process path (`processCallback`, numeric DOL arm): NO put posts the
 /// field, so the record owes BOTH events — the view READ carries
 /// `DBE_VALUE|DBE_LOG`, the view DERIVED from it a bare `DBE_VALUE`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r17_4_a_dol_read_posts_the_read_view_with_log_and_the_derived_view_without() {
     let db = PvDatabase::new();
     db.add_record("VPP_SRC", Box::new(AoRecord::new(7.25)))
@@ -220,7 +218,7 @@ async fn r17_4_a_dol_read_posts_the_read_view_with_log_and_the_derived_view_with
         {
             break;
         }
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(5)).await;
     }
 
     let e = do_rx.try_recv().expect("the DOL read moved DO1 0 -> 7.25");

--- a/crates/epics-base-rs/tests/stdio_device.rs
+++ b/crates/epics-base-rs/tests/stdio_device.rs
@@ -14,8 +14,6 @@
 //! `can_device_write()`, so a "not INVALID" assertion alone would pass even
 //! when nothing is printed.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::sync::{Arc, Mutex};
@@ -55,7 +53,7 @@ impl<'a> MakeWriter<'a> for CaptureBuf {
 }
 
 /// Install a thread-local subscriber capturing the `errlog` `tracing` sink for
-/// the lifetime of the returned guard. `#[tokio::test]` runs the body and every
+/// the lifetime of the returned guard. `#[epics_macros_rs::epics_test]` runs the body and every
 /// `.await` on a single (current-thread) runtime, so the thread-local default
 /// stays active across `process_record_with_links`, where the `stdio` device's
 /// `errlog_printf` is emitted inline.
@@ -93,7 +91,7 @@ async fn build_and_process(db_content: &str, record: &str) -> AlarmSeverity {
 
 /// `stringout` carries a String VAL; processing must route it to the stdio
 /// device and print VAL to the `errlog` stream, leaving the record un-alarmed.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stdio_stringout_prints_val_to_errlog() {
     let (_guard, buf) = capture_errlog();
     let sevr = build_and_process(
@@ -121,7 +119,7 @@ async fn stdio_stringout_prints_val_to_errlog() {
 /// `lso` carries a `CharArray` VAL (not a String). A String-only `write()`
 /// would print nothing for it; this test fails on that regression because the
 /// VAL never reaches the `errlog` sink.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stdio_lso_prints_char_array_val_to_errlog() {
     let (_guard, buf) = capture_errlog();
     let (db, _) = IocBuilder::new()
@@ -170,7 +168,7 @@ async fn stdio_lso_prints_char_array_val_to_errlog() {
 /// output mechanism (`printfRecord.c:388` calls `write_string` unconditionally).
 /// This fails on the regression where `printf` is absent from
 /// `can_device_write()` and so never reaches `dev.write()`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stdio_printf_routes_to_dev_write_and_prints_to_errlog() {
     let (_guard, buf) = capture_errlog();
     let sevr = build_and_process(
@@ -200,7 +198,7 @@ async fn stdio_printf_routes_to_dev_write_and_prints_to_errlog() {
 /// gate Errs in `init()`, so `wire_device_to_record` flags the record INVALID
 /// at build time — proving the stdio device attached and gated, rather than
 /// being silently accepted as a soft channel.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stdio_wrong_record_type_is_invalid() {
     let db_content = r#"
 record(stringin, "SI_STDIO") {

--- a/crates/epics-base-rs/tests/string_array_put_is_element_wise.rs
+++ b/crates/epics-base-rs/tests/string_array_put_is_element_wise.rs
@@ -37,8 +37,6 @@
 //! caput -a WD 3 1.5 2.5 3.5 -> WD = 1.5 2.5 3.5 NORD = 3
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::{DbFieldType, EpicsValue, PvString};
@@ -67,7 +65,7 @@ async fn nord(db: &PvDatabase, rec: &str) -> f64 {
 }
 
 /// The finding's exact case: `caput -a WV 3 7 8 9` on a `FTVL=LONG` waveform.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ca_string_array_put_writes_every_element() {
     let db = build().await;
 
@@ -84,7 +82,7 @@ async fn ca_string_array_put_writes_every_element() {
 }
 
 /// A `DOUBLE` waveform takes the same path with the float parse.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ca_string_array_put_to_a_double_waveform() {
     let db = build().await;
 
@@ -102,7 +100,7 @@ async fn ca_string_array_put_to_a_double_waveform() {
 /// Per-element semantics are the SCALAR string semantics, applied N times:
 /// truncation toward zero into an integer target, and `dbConvertBase = 0`
 /// hex. softIoc: `7.5 -3.9` → `7 -3`; `0x10 12` → `16 12`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn per_element_conversion_matches_the_scalar_string_rules() {
     let db = build().await;
 
@@ -127,7 +125,7 @@ async fn per_element_conversion_matches_the_scalar_string_rules() {
 
 /// The fix lives in the one coercion owner (`EpicsValue::convert_to`), so every
 /// numeric array target gets it — not just the waveform put route.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn convert_to_is_element_wise_for_every_numeric_target() {
     let src = strings(&["1", "2", "3"]);
 

--- a/crates/epics-base-rs/tests/string_record_monitor_gate.rs
+++ b/crates/epics-base-rs/tests/string_record_monitor_gate.rs
@@ -39,8 +39,6 @@
 //! C compares strings, never a `to_f64()` deadband. The port emitted one VAL
 //! event per subscriber per cycle for all three.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::EventMask;
 use epics_base_rs::server::record::Record;
@@ -186,7 +184,7 @@ async fn cycles_posted(mpst: i16, name: &str) -> usize {
 
 /// The whole finding, as the client sees it: six process cycles on an
 /// unchanging stringin deliver ZERO VAL monitor events.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn unchanging_stringin_posts_no_val_events_across_scan_cycles() {
     // The first cycle is a real change (OVAL starts empty, as in C, where
     // init_record leaves oval NUL and the first process posts once).
@@ -199,7 +197,7 @@ async fn unchanging_stringin_posts_no_val_events_across_scan_cycles() {
 }
 
 /// And MPST=Always is not a dead field: it posts every cycle, as `T:SIA` does.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mpst_always_stringin_posts_every_cycle() {
     let events = cycles_posted(ALWAYS, "SI:ALWAYS").await;
     assert_eq!(

--- a/crates/epics-base-rs/tests/sub_fetch_values_gate.rs
+++ b/crates/epics-base-rs/tests/sub_fetch_values_gate.rs
@@ -27,8 +27,6 @@
 //!
 //! `aSubRecord.c` (fetch 277-289, process 216-218) has the identical shape.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -86,7 +84,7 @@ async fn sub_db(inpb: &str) -> PvDatabase {
     db
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_69_failed_inpn_read_skips_the_subroutine_and_freezes_val() {
     // INPB names a PV that does not exist: C's `dbGetLink` fails here and
     // `fetch_values` returns -1 before ever reaching INPC.
@@ -121,7 +119,7 @@ async fn r9_69_failed_inpn_read_skips_the_subroutine_and_freezes_val() {
 /// An *unset* INPB is a CONSTANT link, not a failure — C `dbGetLink` returns
 /// success for it, so the subroutine still runs. Guards the gate against
 /// arming on "no link configured".
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_69_unset_link_is_not_a_fetch_failure() {
     let db = sub_db("").await;
 
@@ -142,7 +140,7 @@ async fn r9_69_unset_link_is_not_a_fetch_failure() {
 /// aSub is the same C shape (`aSubRecord.c::fetch_values` 277-289 returns on
 /// the first failure; `process` 216-218 gates `do_sub`). Its VAL is the
 /// subroutine's return status, so a skipped run leaves VAL untouched.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_69_asub_failed_inpn_read_skips_the_subroutine() {
     let db = PvDatabase::new();
     db.add_record("SRCA", Box::new(AiRecord::new(10.0)))

--- a/crates/epics-base-rs/tests/sub_link_put_notify_on_parked_pact.rs
+++ b/crates/epics-base-rs/tests/sub_link_put_notify_on_parked_pact.rs
@@ -41,8 +41,6 @@
 //! `TSEL`/`SDIS`/`FLNK` — while a real DB link and an empty link still
 //! round-trip verbatim.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
@@ -92,7 +90,7 @@ const INP_FIELDS: &[&str] = &[
 /// The finding's own probe on every link field of a parked `sub`: the constant
 /// string "0" is written and read back, with the callback completing
 /// synchronously (not parked on the never-firing PACT exit).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_string_lands_on_every_parked_sub_link_field() {
     let db = build().await;
     assert!(
@@ -124,7 +122,7 @@ async fn constant_string_lands_on_every_parked_sub_link_field() {
 /// Preservation: a real DB link string on a parked `sub` link field still
 /// round-trips verbatim — the fix only removes the erroneous PACT-park, it does
 /// not touch the write itself.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn real_db_link_string_round_trips_on_parked_sub() {
     let db = build().await;
     assert!(is_parked(&db, "W:SUB").await);
@@ -138,7 +136,7 @@ async fn real_db_link_string_round_trips_on_parked_sub() {
 
 /// Preservation: an empty link string still round-trips as empty (a cleared
 /// link), not spuriously kept from a prior value.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn empty_link_string_round_trips_on_parked_sub() {
     let db = build().await;
     assert!(is_parked(&db, "W:SUB").await);

--- a/crates/epics-base-rs/tests/subarray_pp_put_processing.rs
+++ b/crates/epics-base-rs/tests/subarray_pp_put_processing.rs
@@ -11,8 +11,6 @@
 //! (`/home/stevek/work/epics-base/bin/linux-x86_64/softIoc`) driving these exact
 //! records over CA.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
 
@@ -52,7 +50,7 @@ async fn field(
 
 /// C, `caput SA:CONST.NELM 2` on `INP="[1,2,3,4]" MALM=8 INDX=0`:
 /// `VAL = 1 2`, `NORD = 2`. The port emptied VAL (`NORD = 0`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nelm_put_narrows_the_slice_it_does_not_empty_val() {
     let db = build().await;
 
@@ -78,7 +76,7 @@ async fn nelm_put_narrows_the_slice_it_does_not_empty_val() {
 /// C `readValue` (310-311) clamps NELM to MALM at process, so a NELM put above
 /// MALM lands as MALM. softIoc: `caput SA:CONST.NELM 9` → `NELM = 8`, and the
 /// slice is the whole 4-element constant (`NORD = 4`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn nelm_put_above_malm_clamps_at_process() {
     let db = build().await;
 
@@ -102,7 +100,7 @@ async fn nelm_put_above_malm_clamps_at_process() {
 
 /// C: `caput SA:CONST.INDX 1` → the window moves to `2 3 4` (the constant is
 /// re-loaded whole, then shifted). The port stored INDX and left a stale window.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn indx_put_moves_the_window() {
     let db = build().await;
 
@@ -124,7 +122,7 @@ async fn indx_put_moves_the_window() {
 /// `NORD = 0`, and `readValue`'s `nord <= 0 → status = -1` makes the record UDF
 /// (softIoc: `SEVR INVALID`). MALM=8 keeps INDX=5 un-clamped, so this is the
 /// genuine "past the source" path, not the MALM clamp.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn indx_put_past_the_data_empties_the_slice_and_alarms() {
     let db = build().await;
 
@@ -146,7 +144,7 @@ async fn indx_put_past_the_data_empties_the_slice_and_alarms() {
 /// back already sliced. softIoc, `SA:EMPTY` (INDX=1 NELM=3 MALM=8) after
 /// `caput -a SA:EMPTY 5 10 20 30 40 50`: `VAL = 20 30 40`, `NORD = 3`. A
 /// following `caput SA:EMPTY.NELM 2` re-subsets the buffer in place: `30 40`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn empty_inp_val_put_processes_and_nelm_put_re_subsets() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/subarray_process_reloads_inp.rs
+++ b/crates/epics-base-rs/tests/subarray_process_reloads_inp.rs
@@ -26,8 +26,6 @@
 //! (`/home/stevek/work/epics-base/bin/linux-x86_64/softIoc`) driving the same
 //! record definitions over CA.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::ioc_builder::IocBuilder;
@@ -88,7 +86,7 @@ async fn udf(db: &epics_base_rs::server::database::PvDatabase, rec: &str) -> boo
 /// C: `dbLoadLinkArray` + `subset` in `devSASoft.c::init_record` (58-73) — the
 /// INDX window of the constant is in VAL before any process. softIoc:
 /// `SA:CONST` reads `1 2 3`, NORD=3, UDF=0.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_inp_slice_is_loaded_at_init() {
     let db = build().await;
 
@@ -106,7 +104,7 @@ async fn constant_inp_slice_is_loaded_at_init() {
 ///
 /// This is the R15-78 rule INVERTED for this one record type, so the aai/wf
 /// half of that rule is pinned alongside it (they must still NOT re-load).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_inp_is_re_loaded_and_re_sliced_at_process() {
     let db = build().await;
 
@@ -129,7 +127,7 @@ async fn constant_inp_is_re_loaded_and_re_sliced_at_process() {
 /// C: the INDX window moves with INDX because the constant is re-loaded whole
 /// (`nRequest = min(INDX+NELM, MALM)`) before the shift. softIoc: `caput
 /// SA:CONST.INDX 1` → VAL `2 3 4`, NORD=3.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn constant_inp_indx_selects_the_window() {
     let db = build().await;
 
@@ -167,7 +165,7 @@ async fn constant_inp_indx_selects_the_window() {
 /// | +1    | `30 40`    | 2    |
 /// | +2    | `40`       | 1    |
 /// | +3    | (empty)    | 0    | → UDF/INVALID
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn empty_inp_re_slices_the_client_written_val() {
     let db = build().await;
 
@@ -214,7 +212,7 @@ async fn empty_inp_re_slices_the_client_written_val() {
 /// The DB-link path is unchanged: `read_sa`'s `else` arm reads INDX+NELM
 /// elements from the source and subsets them, and the source is re-read every
 /// cycle (so no in-place eating).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn db_link_inp_re_reads_the_source_every_cycle() {
     let db = build().await;
 

--- a/crates/epics-base-rs/tests/swait_clcv_and_calc_alarm.rs
+++ b/crates/epics-base-rs/tests/swait_clcv_and_calc_alarm.rs
@@ -22,8 +22,6 @@
 //! per-cycle fact cannot outlive its cycle: a gated or simulated cycle, which
 //! runs no `calcPerform`, raises nothing.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -59,7 +57,7 @@ async fn field(db: &PvDatabase, rec: &str, f: &str) -> EpicsValue {
 /// CLCV carries `postfix()`'s status: 0 for a CALC that compiled, -1 for one
 /// that did not. Base `postfix("")` is `CALC_ERR_NULL_ARG` → -1, so swait's
 /// empty CALC is INVALID (unlike sCalcPostfix/aCalcPostfix, which accept it).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_clcv_carries_the_postfix_status() {
     for (calc, want) in [("A+1", 0), ("", -1), ("1+", -1), ("@#$", -1)] {
         let mut w = SwaitRecord::default();
@@ -72,7 +70,7 @@ async fn r10_67_clcv_carries_the_postfix_status() {
 
 /// The put SUCCEEDS and CLCV reports the verdict — C's `special(SPC_CALC)`
 /// returns 0 (`swaitRecord.c:560-567`), unlike calcRecord's `S_db_badField`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_a_broken_calc_put_succeeds_and_lands_in_clcv() {
     let db = PvDatabase::new();
     let mut w = SwaitRecord::default();
@@ -95,7 +93,7 @@ async fn r10_67_a_broken_calc_put_succeeds_and_lands_in_clcv() {
 
 /// C posts CLCV `DBE_VALUE` from `special()` (`swaitRecord.c:566`) — CLCV is not
 /// `pp(TRUE)`, so nothing else would post it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_a_calc_put_posts_clcv() {
     let db = PvDatabase::new();
     let mut w = SwaitRecord::default();
@@ -119,7 +117,7 @@ async fn r10_67_a_calc_put_posts_clcv() {
 
 /// The alarm. A broken CALC fails `calcPerform` every cycle, and C raises
 /// CALC_ALARM/INVALID every cycle. Pre-fix the port reported NO_ALARM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_a_broken_calc_raises_calc_alarm_every_cycle() {
     let db = PvDatabase::new();
     let mut w = SwaitRecord::default();
@@ -157,7 +155,7 @@ async fn r10_67_a_broken_calc_raises_calc_alarm_every_cycle() {
 /// fact. A cycle that runs no `calcPerform` — here because the input fetch
 /// failed (C `swaitRecord.c:407`) — must not re-raise the previous cycle's
 /// failure. C raises READ_ALARM instead, and nothing else.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_a_gated_cycle_does_not_inherit_the_previous_calc_alarm() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(1.0)))
@@ -191,7 +189,7 @@ async fn r10_67_a_gated_cycle_does_not_inherit_the_previous_calc_alarm() {
 /// the sticky flag. C `calcRecord.c:120` runs no `calcPerform` on a failed fetch
 /// and — unlike swait — raises nothing at all, so the record must report
 /// NO_ALARM. Pre-fix the stale flag re-raised CALC_ALARM on every gated cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_calc_gated_cycle_clears_the_calc_alarm() {
     let db = PvDatabase::new();
     db.add_record("CSRC", Box::new(AiRecord::new(1.0)))
@@ -224,7 +222,7 @@ async fn r10_67_calc_gated_cycle_clears_the_calc_alarm() {
 /// first one wins the tie. The framework used to raise CALC_ALARM after
 /// `rec_gbl_check_udf`, reporting UDF_ALARM for a broken CALC on an undefined
 /// record.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r10_67_calc_alarm_wins_the_stat_over_udf_alarm() {
     let db = PvDatabase::new();
 

--- a/crates/epics-base-rs/tests/swait_dol_output_time_fetch.rs
+++ b/crates/epics-base-rs/tests/swait_dol_output_time_fetch.rs
@@ -24,8 +24,6 @@
 //! on a cycle whose output fires (ODLY delay-end included), so a non-firing
 //! cycle neither refreshes DOLD nor posts it.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -72,7 +70,7 @@ async fn field(db: &PvDatabase, rec: &str, f: &str) -> Option<f64> {
     g.record.get_field(f).and_then(|v| v.to_f64())
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_65_use_dol_drives_out_from_the_live_dol_link() {
     let db = swait_db(1, "W_SRC", 0, 0.0).await;
 
@@ -105,7 +103,7 @@ async fn r9_65_use_dol_drives_out_from_the_live_dol_link() {
 
 /// DOPT="Use VAL" never reads DOL — C guards the `recDynLinkGet` with
 /// `if (pwait->dopt)`. DOLD keeps its client-put value and VAL goes out.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_65_use_val_never_reads_the_dol_link() {
     let db = swait_db(0, "W_SRC", 0, 0.0).await;
 
@@ -126,7 +124,7 @@ async fn r9_65_use_val_never_reads_the_dol_link() {
 
 /// DOPT="Use DOL" with DOLN unset is C's `dolv == NO_PV`: the get is skipped
 /// and the current DOLD — whatever a client put there — is what goes out.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_65_use_dol_without_a_link_writes_the_client_put_dold() {
     let db = swait_db(1, "", 0, 0.0).await;
 
@@ -143,7 +141,7 @@ async fn r9_65_use_dol_without_a_link_writes_the_client_put_dold() {
 /// A cycle whose output does not fire (OOPT="Never") must not read DOL at all
 /// — C reaches the `recDynLinkGet` only from inside `execOutput`, which
 /// `process` calls only when the OOPT test passes.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_65_non_firing_cycle_does_not_refresh_dold() {
     let db = swait_db(1, "W_SRC", 6, 0.0).await; // OOPT=6 = "Never"
 
@@ -165,7 +163,7 @@ async fn r9_65_non_firing_cycle_does_not_refresh_dold() {
 
 /// ODLY>0: C schedules `execOutput` on the watchdog, so the DOL fetch happens
 /// at delay END. A source that moves during the delay window is picked up.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_65_odly_fetches_dol_at_delay_end_not_delay_start() {
     let db = swait_db(1, "W_SRC", 0, 100.0).await;
 

--- a/crates/epics-base-rs/tests/swait_input_monitor_mask.rs
+++ b/crates/epics-base-rs/tests/swait_input_monitor_mask.rs
@@ -22,8 +22,6 @@
 //! a field posts that field `DBE_VALUE | DBE_LOG` on its own, which is a
 //! different post from `monitor()`'s.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -84,7 +82,7 @@ async fn prime_then_move(db: &PvDatabase, rec: &str, rx: &mut EventReader, to: f
 /// VAL's ADEL is wide enough that the archive deadband does not cross, so
 /// `monitor_mask` carries no `DBE_LOG` and the changed input A posts
 /// `DBE_VALUE` alone.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_72_changed_input_posts_dbe_value_without_dbe_log() {
     let db = swait_db(0.0, 1000.0).await;
     let mut rx = subscribe_a(&db, "W").await;
@@ -106,7 +104,7 @@ async fn r9_72_changed_input_posts_dbe_value_without_dbe_log() {
 /// ADEL=0: VAL's archive deadband crosses, so `monitor_mask` itself carries
 /// `DBE_LOG` and C's `monitor_mask | DBE_VALUE` includes it. The LOG bit is not
 /// forbidden — it is derived from VAL's mask.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_72_input_post_carries_log_when_vals_adel_crossed() {
     let db = swait_db(0.0, 0.0).await;
     let mut rx = subscribe_a(&db, "W").await;
@@ -126,7 +124,7 @@ async fn r9_72_input_post_carries_log_when_vals_adel_crossed() {
 
 /// The other side of the same rule: `calcRecord.c:420` DOES force
 /// `DBE_VALUE | DBE_LOG` on a changed input, so calc's mask must not move.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_72_calc_input_post_still_forces_dbe_log() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(7.0)))

--- a/crates/epics-base-rs/tests/swait_odly_output_delay.rs
+++ b/crates/epics-base-rs/tests/swait_odly_output_delay.rs
@@ -19,8 +19,6 @@
 //! scalcout ODLY test does) so the assertion is deterministic and does not race
 //! the real timer (ODLY=100s makes the timer unfireable here).
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -74,7 +72,7 @@ async fn add_event_sibling(db: &PvDatabase, name: &str, evnt: &str, counter: Arc
 
 /// ODLY>0: the delaying cycle defers, the continuation drives OUT to OVAL and
 /// posts OEVT exactly once.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_odly_defers_out_write_and_oevt_to_continuation() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -109,7 +107,7 @@ async fn swait_odly_defers_out_write_and_oevt_to_continuation() {
         .await
         .unwrap();
     // Give any erroneous spawned OEVT post time to land before asserting none.
-    tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(60)).await;
     assert_eq!(
         db.get_pv("W_TGT").unwrap().to_f64(),
         Some(0.0),
@@ -131,9 +129,9 @@ async fn swait_odly_defers_out_write_and_oevt_to_continuation() {
         if count.load(Ordering::SeqCst) >= 1 {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(20)).await;
     assert_eq!(
         db.get_pv("W_TGT").unwrap().to_f64(),
         Some(42.0),
@@ -153,7 +151,7 @@ async fn swait_odly_defers_out_write_and_oevt_to_continuation() {
 /// `output_wait` continuation and firing the deferred OUT / OEVT early. Without
 /// the PACT hold the foreign process drives the target to OVAL before the delay
 /// elapses.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_odly_holds_pact_foreign_process_does_not_fire_early() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -194,7 +192,7 @@ async fn swait_odly_holds_pact_foreign_process_does_not_fire_early() {
     db.process_record_with_links("W3_ODLY", &mut v2, 0)
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(40)).await;
     assert_eq!(
         db.get_pv("W3_TGT").unwrap().to_f64(),
         Some(0.0),
@@ -216,9 +214,9 @@ async fn swait_odly_holds_pact_foreign_process_does_not_fire_early() {
         if count.load(Ordering::SeqCst) >= 1 {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(20)).await;
     assert_eq!(
         db.get_pv("W3_TGT").unwrap().to_f64(),
         Some(42.0),
@@ -240,7 +238,7 @@ async fn swait_odly_holds_pact_foreign_process_does_not_fire_early() {
 /// `monitor()` and so post VAL at delay-end.) This is the regression guard for
 /// the gross divergence the bare-`AsyncPending` port had: VAL arriving ODLY
 /// seconds late.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_odly_posts_val_at_delay_start_not_delay_end() {
     use epics_base_rs::server::database::db_access::DbSubscription;
 
@@ -280,9 +278,12 @@ async fn swait_odly_posts_val_at_delay_start_not_delay_end() {
     // Decisive: VAL=42 must reach the monitor on the delaying cycle. The buggy
     // bare-`AsyncPending` port posted nothing here (VAL only at the continuation),
     // so this recv would time out.
-    let posted = tokio::time::timeout(std::time::Duration::from_millis(500), sub.recv_f64())
-        .await
-        .expect("VAL must be posted at delay-START (not deferred to the watchdog)");
+    let posted = epics_base_rs::runtime::task::timeout(
+        std::time::Duration::from_millis(500),
+        sub.recv_f64(),
+    )
+    .await
+    .expect("VAL must be posted at delay-START (not deferred to the watchdog)");
     assert_eq!(
         posted,
         Some(42.0),
@@ -308,7 +309,11 @@ async fn swait_odly_posts_val_at_delay_start_not_delay_end() {
         Some(42.0),
         "continuation drives OUT to OVAL=42 after the delay"
     );
-    let re_post = tokio::time::timeout(std::time::Duration::from_millis(150), sub.recv_f64()).await;
+    let re_post = epics_base_rs::runtime::task::timeout(
+        std::time::Duration::from_millis(150),
+        sub.recv_f64(),
+    )
+    .await;
     assert!(
         re_post.is_err(),
         "continuation must NOT re-post VAL — it was already posted at delay-start \
@@ -325,7 +330,7 @@ async fn swait_odly_posts_val_at_delay_start_not_delay_end() {
 /// alongside the OUT write and OEVT. (Regression guard for the
 /// `run_forward_link_tail` skip in the defer branch: without it the new
 /// Complete-epilogue path would fire FLNK at delay-start.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_odly_defers_forward_link_to_continuation() {
     let db = PvDatabase::new();
     let fcount = Arc::new(AtomicUsize::new(0));
@@ -359,7 +364,7 @@ async fn swait_odly_defers_forward_link_to_continuation() {
     db.process_record_with_links("W5_ODLY", &mut v1, 0)
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(40)).await;
     assert_eq!(
         fcount.load(Ordering::SeqCst),
         0,
@@ -372,7 +377,7 @@ async fn swait_odly_defers_forward_link_to_continuation() {
     db.process_record_continuation("W5_ODLY", &mut v2, 0)
         .await
         .unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(40)).await;
     assert_eq!(
         fcount.load(Ordering::SeqCst),
         1,
@@ -382,7 +387,7 @@ async fn swait_odly_defers_forward_link_to_continuation() {
 
 /// ODLY=0: OUT write and OEVT both fire synchronously on the single cycle —
 /// the regression guard that the defer is gated strictly on `odly > 0`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn swait_no_odly_writes_out_and_posts_oevt_synchronously() {
     let db = PvDatabase::new();
     let count = Arc::new(AtomicUsize::new(0));
@@ -414,9 +419,9 @@ async fn swait_no_odly_writes_out_and_posts_oevt_synchronously() {
         if count.load(Ordering::SeqCst) >= 1 {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
     }
-    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(20)).await;
     assert_eq!(
         db.get_pv("W2_TGT").unwrap().to_f64(),
         Some(7.0),

--- a/crates/epics-base-rs/tests/swait_prev_input_fields.rs
+++ b/crates/epics-base-rs/tests/swait_prev_input_fields.rs
@@ -17,8 +17,6 @@
 //! LA, both with `monitor_mask | DBE_VALUE` — the mask R9-72 gave A. The port
 //! had no LA..LL fields at all.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -63,7 +61,7 @@ async fn subscribe(db: &PvDatabase, field: &str) -> EventReader {
 }
 
 /// LA tracks A: after a cycle that fetched A=7 through INAN, LA reads 7.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_75_la_holds_previous_input_value() {
     let db = swait_db().await;
     process(&db).await;
@@ -84,7 +82,7 @@ async fn r9_75_la_holds_previous_input_value() {
 
 /// The advanced LA is posted with the same mask as A: `monitor_mask |
 /// DBE_VALUE`, with no forced DBE_LOG (ADEL=1000 is not crossed by 7 -> 8).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_75_la_posts_with_the_inputs_monitor_mask() {
     let db = swait_db().await;
     let mut rx_a = subscribe(&db, "A").await;
@@ -119,7 +117,7 @@ async fn r9_75_la_posts_with_the_inputs_monitor_mask() {
 
 /// An unchanged input posts nothing — C's `if (*pnew != *pprev)` guard covers
 /// both `db_post_events` calls, so LA is silent on a no-change cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_75_la_is_silent_when_the_input_did_not_change() {
     let db = swait_db().await;
     let mut rx_la = subscribe(&db, "LA").await;

--- a/crates/epics-base-rs/tests/swait_pv_link_status.rs
+++ b/crates/epics-base-rs/tests/swait_pv_link_status.rs
@@ -15,8 +15,6 @@
 //! on DOLV; see `r9_76_dol_fetch_does_not_wait_for_the_classification_task` for
 //! why gating on it would be wrong.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -77,7 +75,7 @@ async fn settle_until(db: &PvDatabase, rec: &str, f: &str, want: u16) {
 
 /// A resolvable name is PV_OK, an unresolvable one is PV_NC, a blank one is
 /// NO_PV — C's three states, one per link.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_76_pv_status_classifies_each_link() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(7.0)))
@@ -124,7 +122,7 @@ async fn r9_76_pv_status_classifies_each_link() {
 /// A runtime re-point re-runs the search: C `special()` (swaitRecord.c:507-553)
 /// re-issues `recDynLinkAddInput` for the new name and clears to NO_PV when the
 /// name is emptied.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_76_put_to_a_pv_name_reclassifies_it() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(7.0)))
@@ -170,7 +168,7 @@ async fn r9_76_put_to_a_pv_name_reclassifies_it() {
 /// and that stale DOLD is what C writes to OUT. The port reaches the same
 /// observable state through the failed read (the framework writes DOLD only on
 /// a successful fetch), so DOLV reports the bad status without gating on it.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_76_unresolvable_dol_keeps_dold_and_still_writes_it() {
     let db = PvDatabase::new();
     db.add_record("SINK", Box::new(AiRecord::new(0.0)))
@@ -214,7 +212,7 @@ async fn r9_76_unresolvable_dol_keeps_dold_and_still_writes_it() {
 
 /// The other side: a DOL that DOES connect is fetched, and the fetched value is
 /// what reaches OUT.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_76_connected_dol_is_fetched_at_output_time() {
     let db = PvDatabase::new();
     db.add_record("DOLSRC", Box::new(AiRecord::new(5.0)))
@@ -263,7 +261,7 @@ async fn r9_76_connected_dol_is_fetched_at_output_time() {
 /// are not a gate: a cycle that runs BEFORE that task lands (no `settle()`
 /// here, DOLV still reads NO_PV) must still fetch a DOL that resolves. Gating
 /// the fetch on `DOLV == PV_OK` made this cycle skip a get C performs.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_76_dol_fetch_does_not_wait_for_the_classification_task() {
     let db = PvDatabase::new();
     db.add_record("DOLSRC", Box::new(AiRecord::new(7.0)))

--- a/crates/epics-base-rs/tests/swait_simulation_mode.rs
+++ b/crates/epics-base-rs/tests/swait_simulation_mode.rs
@@ -31,8 +31,6 @@
 //! redirect. The port omitted the fields there too, so `check_simulation_mode`
 //! saw an unconfigured record and a simulated busy drove its real output.
 
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -114,7 +112,7 @@ async fn amsg(db: &PvDatabase) -> String {
 
 /// SIMM = YES: VAL comes from SIOL through SVAL, the calc does not run, and the
 /// cycle carries SIMM_ALARM at SIMS.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_62_simm_yes_reads_siol_into_sval_and_val() {
     let db = sim_db("", 1, 2 /* MAJOR */, "SIM").await;
 
@@ -146,7 +144,7 @@ async fn r11_62_simm_yes_reads_siol_into_sval_and_val() {
 /// switch and `execOutput` still run, so the simulated VAL is written out
 /// through OUT. (A whole-cycle `readValue` simulation — ai/bi — would have
 /// skipped the body and left DEST alone.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_62_a_simulated_cycle_still_drives_the_output_link() {
     let db = sim_db("", 1, 0, "SIM").await;
 
@@ -162,7 +160,7 @@ async fn r11_62_a_simulated_cycle_still_drives_the_output_link() {
 
 /// SIML resolves SIMM on every process (C `:402`), so the mode can be driven
 /// from another PV — and driving it back to NO restores the real calc.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_62_siml_refreshes_simm_every_cycle() {
     let db = sim_db("MODE", 0, 0, "SIM").await;
 
@@ -210,7 +208,7 @@ async fn r11_62_siml_refreshes_simm_every_cycle() {
 /// ```
 ///
 /// The port used to raise ONLY the SIMM_ALARM here, publishing MINOR/SIMM.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_e4_a_failed_siol_read_raises_link_alarm() {
     let db = sim_db("MODE", 0, 1 /* MINOR */, "NOSUCHREC").await;
 
@@ -247,7 +245,7 @@ async fn w10_e4_a_failed_siol_read_raises_link_alarm() {
 /// strict-greater `recGblSetSevr` leaves LINK in place. (A base record reverses
 /// this: `longinRecord.c:414` raises SIMM BEFORE its read, so SIMM wins there.
 /// Same two alarms, opposite winner, decided purely by C's call order.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn w10_e4_swait_link_alarm_wins_the_tie_at_sims_invalid() {
     let db = sim_db("MODE", 0, 3 /* INVALID */, "NOSUCHREC").await;
 
@@ -266,7 +264,7 @@ async fn w10_e4_swait_link_alarm_wins_the_tie_at_sims_invalid() {
 /// Negative control: with SIMM = NO the record is untouched — the inputs are
 /// fetched, the calc runs, and no SIMM alarm is raised. The failing-input gate
 /// (READ_ALARM, C `:413`) belongs to the real branch...
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_62_simm_no_runs_the_real_calc_and_its_read_gate() {
     let db = sim_db("MODE", 0, 1, "SIM").await;
 
@@ -300,7 +298,7 @@ async fn r11_62_simm_no_runs_the_real_calc_and_its_read_gate() {
 /// omission; its shape is the OUTPUT redirect the framework already owns, so
 /// declaring the fields is the whole fix: SIMM=YES sends VAL to SIOL instead of
 /// OUT, and the cycle carries SIMM_ALARM at SIMS.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_62_busy_simm_yes_redirects_the_output_to_siol() {
     let db = PvDatabase::new();
     db.add_record("B_OUT", Box::new(AiRecord::new(0.0)))
@@ -352,7 +350,7 @@ async fn r11_62_busy_simm_yes_redirects_the_output_to_siol() {
 
 /// Negative control for the widened site: SIMM = NO drives the real OUT link and
 /// raises no SIMM alarm.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_62_busy_simm_no_drives_the_real_output() {
     let db = PvDatabase::new();
     db.add_record("B2_OUT", Box::new(AiRecord::new(0.0)))

--- a/crates/epics-base-rs/tests/swait_udf_discipline.rs
+++ b/crates/epics-base-rs/tests/swait_udf_discipline.rs
@@ -26,8 +26,6 @@
 //!     cleared it on the first cycle merely because VAL (still its initial 0)
 //!     was not NaN.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::{AlarmSeverity, Record};
 use epics_base_rs::server::records::swait::SwaitRecord;
@@ -53,7 +51,7 @@ async fn alarm(db: &PvDatabase, name: &str) -> (AlarmSeverity, u16) {
 
 /// A NaN result is a calcPerform SUCCESS in base C — UDF is cleared and no
 /// alarm is raised. The port used to report UDF_ALARM/INVALID here.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c13_a_nan_result_clears_udf_and_raises_no_alarm() {
     let db = PvDatabase::new();
     let mut w = SwaitRecord::default();
@@ -82,7 +80,7 @@ async fn r11_c13_a_nan_result_clears_udf_and_raises_no_alarm() {
 
 /// A calc that FAILS never clears UDF: C only clears it in the `else` arm.
 /// The port cleared it anyway (VAL, still 0.0, is not NaN).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c13_a_failing_calc_leaves_udf_set() {
     let db = PvDatabase::new();
     let mut w = SwaitRecord::default();
@@ -114,7 +112,7 @@ async fn r11_c13_a_failing_calc_leaves_udf_set() {
 /// The fetch gate: C runs no calcPerform, so UDF freezes at whatever it was
 /// (here: still set — no calc has ever succeeded), and READ_ALARM is the only
 /// alarm.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c13_a_gated_cycle_does_not_touch_udf() {
     const READ_ALARM: u16 = 1;
     let db = PvDatabase::new();

--- a/crates/epics-base-rs/tests/transform_conditional_calc.rs
+++ b/crates/epics-base-rs/tests/transform_conditional_calc.rs
@@ -21,8 +21,6 @@
 //!
 //! One case per boundary of the gate.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::Record;
 use epics_base_rs::server::records::transform::TransformRecord;
@@ -71,7 +69,7 @@ fn s(v: &str) -> EpicsValue {
 /// number. `field(INPA,"2")` seeds A=2 and leaves the channel UNLINKED, so
 /// Conditional mode evaluates CLCA every cycle. (The port used to read the
 /// text's emptiness: A sat at 2 forever.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_constant_valued_inp_link_is_no_inlink_so_the_channel_still_calcs() {
     let db = transform_db(&[("INPA", s("2")), ("CLCA", s("A+1"))]).await;
     assert_eq!(field(&db, "T", "A").await, 2.0, "the init seed");
@@ -87,7 +85,7 @@ async fn a_constant_valued_inp_link_is_no_inlink_so_the_channel_still_calcs() {
 /// `transformRecord.dbd:409-414`, so `dbPutField` processes the record) leaves
 /// the value alone. `:600` clears the map, so the NEXT cycle calculates again:
 /// the put survives exactly one cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_put_to_the_value_field_suppresses_one_cycle_then_calc_resumes() {
     let db = transform_db(&[("CLCA", s("A+1"))]).await;
 
@@ -107,7 +105,7 @@ async fn a_put_to_the_value_field_suppresses_one_cycle_then_calc_resumes() {
 /// (A != LA) that makes the channel new and stops CLCA from overwriting the
 /// value the operator just seeded. This is the case the port's `map`-only gate
 /// got wrong: it recalculated immediately and the re-seed was invisible.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_constant_inp_reseed_is_new_by_the_same_test_not_by_the_map_bit() {
     let db = transform_db(&[("INPA", s("2")), ("CLCA", s("A+1"))]).await;
 
@@ -131,7 +129,7 @@ async fn a_constant_inp_reseed_is_new_by_the_same_test_not_by_the_map_bit() {
 /// compare would call the channel new. C's first clause overrides exactly that:
 /// two zeroes of any sign are the same, so the channel is NOT new and CLCA runs
 /// on the very next cycle.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_reseed_of_negative_zero_is_same_as_positive_zero_so_calc_is_not_suppressed() {
     let db = transform_db(&[("CLCA", s("A+1"))]).await;
     assert_eq!(field(&db, "T", "A").await, 0.0);
@@ -148,7 +146,7 @@ async fn a_reseed_of_negative_zero_is_same_as_positive_zero_so_calc_is_not_suppr
 
 /// `no_inlink` false — a channel driven by a real PV link is never calculated in
 /// Conditional mode, whatever its value did.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_pv_linked_channel_is_not_calculated_in_conditional_mode() {
     let db = transform_db(&[("INPA", s("SRC")), ("CLCA", s("A+1"))]).await;
     let mut src = TransformRecord::default();
@@ -162,7 +160,7 @@ async fn a_pv_linked_channel_is_not_calculated_in_conditional_mode() {
 /// `copt == ALWAYS` — the other arm of the gate. It overrides BOTH `no_inlink`
 /// and `new_value`: a linked channel, and a channel that was just put, are
 /// calculated anyway.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn copt_always_calculates_a_linked_channel_and_a_freshly_put_one() {
     let db = transform_db(&[
         ("COPT", EpicsValue::Short(1)),
@@ -185,7 +183,7 @@ async fn copt_always_calculates_a_linked_channel_and_a_freshly_put_one() {
 /// `postfix_ok` — an EMPTY CLCx is never evaluated (`*pclcbuf` is false), so an
 /// unlinked channel with no expression keeps its value forever. It is the
 /// passthrough shape: INPx -> A -> OUTx with no calc at all.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_empty_clc_is_never_evaluated() {
     let db = transform_db(&[("INPA", s("2"))]).await;
 

--- a/crates/epics-base-rs/tests/transform_input_read_failure_zeroes.rs
+++ b/crates/epics-base-rs/tests/transform_input_read_failure_zeroes.rs
@@ -14,8 +14,6 @@
 //! disconnected INPx source re-drove its OUTx with the last good value where C
 //! drives 0.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -24,7 +22,7 @@ use epics_base_rs::server::records::ai::AiRecord;
 use epics_base_rs::server::records::transform::TransformRecord;
 use epics_base_rs::types::EpicsValue;
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_64_failed_input_link_zeroes_its_channel_and_drives_zero_out() {
     let db = PvDatabase::new();
     // OUT target seeded 111 — must be driven to 0 by the zeroed channel.

--- a/crates/epics-base-rs/tests/transform_ivla_do_nothing.rs
+++ b/crates/epics-base-rs/tests/transform_ivla_do_nothing.rs
@@ -21,8 +21,6 @@
 //! Before the fix the port used IVLA only as a per-channel calc-error policy,
 //! so this cycle recomputed CLCB and drove OUTB.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -72,7 +70,7 @@ async fn tr_field(db: &PvDatabase, field: &str) -> Option<EpicsValue> {
     db.get_record("TR").unwrap().read().record.get_field(field)
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_61_ivla_do_nothing_skips_calc_and_every_output_link() {
     let db = PvDatabase::new();
     invalid_source(&db).await;
@@ -116,7 +114,7 @@ async fn r9_61_ivla_do_nothing_skips_calc_and_every_output_link() {
 /// Same wiring, IVLA="Ignore error" (0): the identical INVALID input must NOT
 /// freeze the record — proving the freeze above is IVLA's doing and not a
 /// side effect of the INVALID severity itself.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r9_61_ivla_ignore_error_still_calcs_and_drives_outputs() {
     let db = PvDatabase::new();
     invalid_source(&db).await;

--- a/crates/epics-base-rs/tests/transform_la_lp_readback.rs
+++ b/crates/epics-base-rs/tests/transform_la_lp_readback.rs
@@ -26,8 +26,6 @@
 //! window between cycles — which is exactly what a `caget .LA` is for. The port
 //! did not serve the fields at all: `caget TR.LA` failed.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -44,7 +42,7 @@ async fn process(db: &PvDatabase, rec: &str) {
 
 /// LA tracks A across the monitor commit, and lags it in the window C exposes:
 /// a value written to A but not yet published leaves LA at the last posted one.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r13_63_la_is_the_previous_posted_value_of_a() {
     let db = PvDatabase::new();
     let mut t = TransformRecord::new();
@@ -75,7 +73,7 @@ async fn r13_63_la_is_the_previous_posted_value_of_a() {
 }
 
 /// SPC_NOMOD: a client may not write LA (`transformRecord.dbd:507`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r13_63_la_is_read_only() {
     let db = PvDatabase::new();
     db.add_record("TR2", Box::new(TransformRecord::new()))

--- a/crates/epics-base-rs/tests/transform_monitor_mask.rs
+++ b/crates/epics-base-rs/tests/transform_monitor_mask.rs
@@ -25,8 +25,6 @@
 //! folded in by `dbGetLink`), so the same cycle both moves A and raises the
 //! severity.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -81,7 +79,7 @@ async fn transform_with_an_ms_input() -> PvDatabase {
 /// The finding: on the alarm-transition cycle, A posts with a literal
 /// `DBE_VALUE|DBE_LOG` — no alarm bit — while STAT (posted by
 /// `recGblResetAlarms` itself, not by `monitor()`) does carry `DBE_ALARM`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_64_transform_channels_post_without_the_cycles_alarm_bits() {
     let db = transform_with_an_ms_input().await;
     let inst = db.get_record("T").unwrap();
@@ -134,7 +132,7 @@ async fn r11_64_transform_channels_post_without_the_cycles_alarm_bits() {
 
 /// The subscriber-side statement of the same fact, across both alarm
 /// transitions.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_64_an_alarm_only_subscriber_on_a_transform_channel_never_fires() {
     let db = transform_with_an_ms_input().await;
     let inst = db.get_record("T").unwrap();

--- a/crates/epics-base-rs/tests/transform_non_finite_result_is_kept.rs
+++ b/crates/epics-base-rs/tests/transform_non_finite_result_is_kept.rs
@@ -33,8 +33,6 @@
 //! `1e308*10` → `st=-1 d=inf`; `ACOS(2)` → `st=-1 d=nan`; `1/0` → `st=-1 d=0`
 //! (nothing written).
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -76,7 +74,7 @@ async fn channel(db: &PvDatabase, field: &str) -> f64 {
 
 /// The boundary: overflow to `+inf`. C writes it into the channel and returns
 /// -1 — the record alarms AND keeps the infinity.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_overflowing_result_is_stored_in_the_channel_and_alarms() {
     let db = transform_db().await;
     put(&db, "CLCA", EpicsValue::String("1e308*10".into())).await;
@@ -101,7 +99,7 @@ async fn an_overflowing_result_is_stored_in_the_channel_and_alarms() {
 
 /// The same rule with a NaN — C's tail tests `isnan(*presult)` too, and the
 /// written cell is the NaN.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_nan_result_is_stored_in_the_channel_and_alarms() {
     let db = transform_db().await;
     put(&db, "CLCB", EpicsValue::String("ACOS(2)".into())).await;
@@ -120,7 +118,7 @@ async fn a_nan_result_is_stored_in_the_channel_and_alarms() {
 /// The value C wrote is a value like any other: the OUTx loop fans it out.
 /// This is what made the discard observable off-record — a downstream ao that
 /// C drives to `inf` saw nothing at all.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn the_non_finite_value_is_fanned_out_through_outa() {
     let db = transform_db().await;
     db.add_record("T_TGT", Box::new(AoRecord::new(0.0)))
@@ -146,7 +144,7 @@ async fn the_non_finite_value_is_fanned_out_through_outa() {
 /// REFUSES returns -1 from inside the loop, so C never reaches the epilogue and
 /// `*pval` keeps its old value. `1/0` (`sCalcPerform.c:1022-1030`) must NOT
 /// write the channel — the alarm is raised all the same.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn an_operator_refusal_leaves_the_channel_untouched() {
     let db = transform_db().await;
     // Seed the channel so "untouched" is distinguishable from "written 0".
@@ -171,7 +169,7 @@ async fn an_operator_refusal_leaves_the_channel_untouched() {
 }
 
 /// Control — a finite result is status 0: no alarm, no UDF, value stored.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn a_finite_result_stores_the_value_and_does_not_alarm() {
     let db = transform_db().await;
     put(&db, "CLCA", EpicsValue::String("1e308/10".into())).await;

--- a/crates/epics-base-rs/tests/transform_scalc_engine.rs
+++ b/crates/epics-base-rs/tests/transform_scalc_engine.rs
@@ -24,8 +24,6 @@
 //! post fires on any class, and the alarm bits alone are a class, so a
 //! transform that went INVALID was firing a `.VAL` monitor C never sends.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -57,7 +55,7 @@ async fn transform_db() -> PvDatabase {
 /// never assigns `*pval` — the channel keeps its previous value. (The other -1,
 /// the non-finite tail at `:2056`, writes the cell first; R16-4 and
 /// `transform_non_finite_result_is_kept.rs` cover that half.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c14_divide_by_zero_is_a_calc_failure() {
     let db = transform_db().await;
 
@@ -94,7 +92,7 @@ async fn r11_c14_divide_by_zero_is_a_calc_failure() {
 }
 
 /// The control: a finite result is not a failure. Same engine, no alarm.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c14_a_finite_result_raises_no_alarm() {
     let db = transform_db().await;
 
@@ -112,7 +110,7 @@ async fn r11_c14_a_finite_result_raises_no_alarm() {
 /// Second half: no process cycle of a transform posts `.VAL` — not the first
 /// one (which the deadband's never-posted sentinel would otherwise fire), and
 /// not the alarm cycle (whose alarm bits alone would otherwise fire it).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c14_no_process_cycle_posts_val() {
     let db = transform_db().await;
     let rec = db.get_record("T").unwrap();
@@ -164,7 +162,7 @@ async fn r11_c14_no_process_cycle_posts_val() {
 
 /// VAL is still a plain writable dummy: a client put stores it and posts it
 /// (C `dbPut`, dbAccess.c:1414). The closed set gates PROCESS posts, not puts.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn r11_c14_a_put_to_the_val_dummy_still_posts() {
     let db = transform_db().await;
     let rec = db.get_record("T").unwrap();

--- a/crates/epics-base-rs/tests/udf_clear_is_per_record_type.rs
+++ b/crates/epics-base-rs/tests/udf_clear_is_per_record_type.rs
@@ -32,8 +32,6 @@
 //! record(ai,"A1"){}   (a type that DOES clear)               UDF 0  NO_ALARM NO_ALARM
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashSet;
 
 use epics_base_rs::server::database::PvDatabase;
@@ -61,7 +59,7 @@ async fn state(db: &PvDatabase, name: &str) -> (bool, AlarmSeverity, u16) {
 
 /// A dfanout with no DOL is undefined FOREVER: it publishes INVALID/UDF on
 /// every process, and processing never clears the flag.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn dfanout_without_dol_stays_undefined_and_invalid() {
     let db = PvDatabase::new();
     db.add_record("DFN", Box::new(DfanoutRecord::new(0.0)))
@@ -81,7 +79,7 @@ async fn dfanout_without_dol_stays_undefined_and_invalid() {
 
 /// The closed-loop DOL branch is the ONE place dfanout writes UDF
 /// (`udf = isnan(val)`), so a dfanout fed by a DOL comes up defined.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn dfanout_with_closed_loop_dol_is_defined() {
     let db = PvDatabase::new();
     db.add_record("SRC", Box::new(AiRecord::new(7.0)))
@@ -121,7 +119,7 @@ async fn dfanout_with_closed_loop_dol_is_defined() {
 /// blanket UDF *alarm* invents an alarm C does not raise. (Histogram's limits are
 /// valid here, so its CBUG-F12 invalid-limits alarm stays silent — that alarm is
 /// about `LLIM >= ULIM`, not about UDF.)
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn histogram_and_event_keep_udf_without_alarming() {
     let db = PvDatabase::new();
     db.add_record("H1", Box::new(HistogramRecord::new(16, 0.0, 10.0)))
@@ -148,7 +146,7 @@ async fn histogram_and_event_keep_udf_without_alarming() {
 
 /// A record type that DOES clear UDF in its own `process()` is untouched by
 /// the opt-out.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn ai_and_ao_still_clear_udf_on_process() {
     let db = PvDatabase::new();
     db.add_record("A1", Box::new(AiRecord::new(1.0)))

--- a/crates/epics-base-rs/tests/udf_put_exact_one_no_alarm.rs
+++ b/crates/epics-base-rs/tests/udf_put_exact_one_no_alarm.rs
@@ -14,8 +14,6 @@
 //! `rec_gbl_check_udf` tested `udf != 0` (truthy) for every record. Verified
 //! against the C source (not the running oracle) per the panel's constraints.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::{AlarmSeverity, Record};
 use epics_base_rs::server::records::bo::BoRecord;
@@ -43,7 +41,7 @@ async fn state(db: &PvDatabase) -> (AlarmSeverity, u16, u8) {
     (g.common.sevr, g.common.stat, g.common.udf)
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_udf_put_type_max_raises_no_alarm() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     caput(&db, "UDF", "255").await;
@@ -56,7 +54,7 @@ async fn bo_udf_put_type_max_raises_no_alarm() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_udf_put_negative_raises_no_alarm() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     // `-1` into the signed-served DBF_UCHAR reaches the field as 255.
@@ -66,7 +64,7 @@ async fn bo_udf_put_negative_raises_no_alarm() {
     assert_eq!((sevr, stat), (AlarmSeverity::NoAlarm, NO_ALARM));
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stringout_udf_put_type_max_raises_no_alarm() {
     let db = db_with(Box::new(StringoutRecord::default())).await;
     caput(&db, "UDF", "255").await;
@@ -79,7 +77,7 @@ async fn stringout_udf_put_type_max_raises_no_alarm() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn stringout_udf_put_negative_raises_no_alarm() {
     let db = db_with(Box::new(StringoutRecord::default())).await;
     caput(&db, "UDF", "-1").await;
@@ -90,7 +88,7 @@ async fn stringout_udf_put_negative_raises_no_alarm() {
 
 /// The exact-one gate must NOT suppress the ordinary undefined alarm: a fresh
 /// record with `udf == 1` still raises UDF_ALARM/INVALID (C `1 == TRUE`).
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_udf_one_still_raises() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     // A UDF put of exactly 1 keeps the record undefined and must alarm.

--- a/crates/epics-base-rs/tests/udf_state_alarm_precedence.rs
+++ b/crates/epics-base-rs/tests/udf_state_alarm_precedence.rs
@@ -19,8 +19,6 @@
 //! after), so the equal-severity UDF could not displace STATE and STAT came out
 //! STATE. Verified against the C source, not the running oracle.
 
-// RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::record::{AlarmSeverity, Record};
 use epics_base_rs::server::records::bo::BoRecord;
@@ -62,7 +60,7 @@ async fn alarm(db: &PvDatabase) -> (AlarmSeverity, u16) {
 
 /// Fresh bo (VAL=0, UDF=1), `caput ZSV 3` (INVALID). STAT=UDF, SEVR=INVALID —
 /// the equal-severity STATE alarm does not overwrite the leading UDF.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_udf_beats_equal_severity_state() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     caput(&db, "ZSV", "3").await;
@@ -74,7 +72,7 @@ async fn bo_udf_beats_equal_severity_state() {
 }
 
 /// Fresh mbbo (VAL=0, UDF=1), `caput ZRSV 3` (INVALID). STAT=UDF, SEVR=INVALID.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_udf_beats_equal_severity_state() {
     let db = db_with(Box::new(MbboRecord::new(0))).await;
     caput(&db, "ZRSV", "3").await;
@@ -91,7 +89,7 @@ async fn mbbo_udf_beats_equal_severity_state() {
 /// displayed SEVR stays INVALID (`recGblResetAlarms` clamps). This is the
 /// regression the raw-ordinal compare fixes — clamping `zsv=4` to `Invalid(3)`
 /// before the compare would tie UDF and wrongly leave STAT=UDF.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_over_max_state_severity_overrides_udf() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     caput_raw(&db, "ZSV", 4).await;
@@ -104,7 +102,7 @@ async fn bo_over_max_state_severity_overrides_udf() {
 
 /// Negative STATE severity ordinal (`ZSV=-1` → `65535`) also overrides: the raw
 /// `DBF_MENU` field holds `65535`, numerically greater than UDFS's `3`.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_negative_state_severity_overrides_udf() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     caput_raw(&db, "ZSV", -1).await;
@@ -115,7 +113,7 @@ async fn bo_negative_state_severity_overrides_udf() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_over_max_state_severity_overrides_udf() {
     let db = db_with(Box::new(MbboRecord::new(0))).await;
     caput_raw(&db, "ZRSV", 4).await;
@@ -126,7 +124,7 @@ async fn mbbo_over_max_state_severity_overrides_udf() {
     );
 }
 
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn mbbo_negative_state_severity_overrides_udf() {
     let db = db_with(Box::new(MbboRecord::new(0))).await;
     caput_raw(&db, "ZRSV", -1).await;
@@ -142,7 +140,7 @@ async fn mbbo_negative_state_severity_overrides_udf() {
 /// put clears UDF (bo `clears_udf()==false`, but a VAL put defines it), and a
 /// following ZSV put then yields STATE, proving UDF is not suppressing STATE
 /// unconditionally.
-#[tokio::test]
+#[epics_macros_rs::epics_test]
 async fn bo_state_alarm_stands_when_defined() {
     let db = db_with(Box::new(BoRecord::new(0))).await;
     // Define VAL=0 (clears UDF).

--- a/crates/epics-bridge-rs/src/pvalink/iocsh.rs
+++ b/crates/epics-bridge-rs/src/pvalink/iocsh.rs
@@ -41,9 +41,9 @@ pub fn db_pvxr_command(resolver: PvaLinkResolver) -> CommandDef {
                 _ => return Err("pvxr: missing pv_name".into()),
             };
             let resolver = resolver.clone();
-            let handle = ctx.runtime_handle().clone();
+            let bridge = ctx.bridge().clone();
             let result = std::thread::spawn(move || {
-                handle.block_on(async move { resolver.open(&name).await })
+                bridge.block_on(async move { resolver.open(&name).await })
             })
             .join();
             match result {

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -3119,10 +3119,10 @@ mod tests {
         std::fs::write(&path, json).unwrap();
         {
             let db_t = db.clone();
-            let handle = tokio::runtime::Handle::current();
+            let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
             let line = format!("dbLoadGroup(\"{}\")", path.display());
             std::thread::spawn(move || {
-                let shell = IocShell::new(db_t, handle);
+                let shell = IocShell::new(db_t, bridge);
                 shell.register(db_load_group_startup_command());
                 shell.execute_line(&line).expect("dbLoadGroup must queue");
             })

--- a/crates/epics-ca-rs/Cargo.toml
+++ b/crates/epics-ca-rs/Cargo.toml
@@ -220,6 +220,9 @@ epics-rtems-boot = { workspace = true }
 # crate that declares the feature has the same hole, and three copies of a
 # 300-line audit is how three copies of a rule come to disagree.
 rtems-exec-gate = { path = "../../tools/rtems-exec-gate" }
+# Dev-only: `#[epics_test]` — the backend-selected test driver — for this
+# crate's own suite.
+epics-macros-rs = { workspace = true }
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 tempfile = "3"
 proptest = "1"

--- a/crates/epics-ca-rs/src/audit.rs
+++ b/crates/epics-ca-rs/src/audit.rs
@@ -22,8 +22,6 @@
 //! `caput`, `acf_deny`, `subscribe`, `unsubscribe`. Keep additions
 //! strictly additive — downstream log shippers parse the JSON.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -412,7 +410,7 @@ mod tests {
     /// Boundary sweep over the fields, and over both renderers, because the
     /// framing is applied at the sink and must therefore hold for whichever
     /// one is configured.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn no_wire_field_can_forge_a_second_audit_record() {
         const FORGE: &str = "x\n04/09/2026 09:00:00 ASUSER W root@localhost caput: SAFETY:ILK=0 ok";
 

--- a/crates/epics-ca-rs/src/calink/iocsh.rs
+++ b/crates/epics-ca-rs/src/calink/iocsh.rs
@@ -5,8 +5,9 @@
 //! record-link resolver reads cached monitor values without a blocking
 //! GET (`caxr`), and dump CA-link state for a record (`dbcaxr`).
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): the flavored test drives the CA client stack,
+// which needs a multi-thread tokio runtime. These run and pass in the
+// feature-ON suite on the tokio driver.
 use epics_base_rs::server::database::LinkSet;
 use epics_base_rs::server::iocsh::registry::{
     ArgDesc, ArgType, ArgValue, CommandContext, CommandDef, CommandOutcome,

--- a/crates/epics-ca-rs/src/calink/iocsh.rs
+++ b/crates/epics-ca-rs/src/calink/iocsh.rs
@@ -33,9 +33,9 @@ pub fn ca_caxr_command(resolver: CaLinkResolver) -> CommandDef {
                 _ => return Err("caxr: missing pv_name".into()),
             };
             let resolver = resolver.clone();
-            let handle = ctx.runtime_handle().clone();
+            let bridge = ctx.bridge().clone();
             let result = std::thread::spawn(move || {
-                handle.block_on(async move { resolver.open(&name).await })
+                bridge.block_on(async move { resolver.open(&name).await })
             })
             .join();
             match result {
@@ -100,12 +100,12 @@ pub fn db_dbcaxr_command(resolver: CaLinkResolver) -> CommandDef {
                             // for the one remaining blocking call.
                             let r = resolver.clone();
                             let n = name.clone();
-                            let h = ctx.runtime_handle().clone();
+                            let b = ctx.bridge().clone();
                             let connected = <CaLinkResolver as LinkSet>::is_connected(&r, &n);
                             let alarm = <CaLinkResolver as LinkSet>::alarm_severity(&r, &n);
                             let ts = <CaLinkResolver as LinkSet>::time_stamp(&r, &n);
                             let value = std::thread::spawn(move || {
-                                h.block_on(async move {
+                                b.block_on(async move {
                                     <CaLinkResolver as LinkSet>::get_value(&r, &n).await
                                 })
                             })

--- a/crates/epics-ca-rs/src/cli.rs
+++ b/crates/epics-ca-rs/src/cli.rs
@@ -1,8 +1,9 @@
 //! Helpers shared across the `caget` / `caput` / `cainfo` / `camonitor`
 //! command-line binaries.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): the test's subject is arming a *tokio* timer with
+// INDEFINITE_TIMEOUT; the tokio timer is the property under test. These run and pass in the
+// feature-ON suite on the tokio driver.
 use epics_base_rs::server::snapshot::Snapshot;
 use epics_base_rs::types::{DbFieldType, EpicsValue, PvString, WallTime};
 

--- a/crates/epics-ca-rs/src/client/beacon_monitor.rs
+++ b/crates/epics-ca-rs/src/client/beacon_monitor.rs
@@ -1,5 +1,6 @@
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(4): the four flavored tests drive tokio::net
+// UDP beacon traffic, which needs the reactor. These run and pass in the
+// feature-ON suite on the tokio driver.
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::time::{Duration, Instant};

--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(13): checked - these run and pass in the feature-ON suite.
-
 // The beacon monitor is a UDP listener on the CA beacon port, fed by the
 // repeater. `client-core` has no UDP client socket at all (the target's
 // search reaches servers over `EPICS_CA_NAME_SERVERS`, §4.1), so there are
@@ -18,6 +16,9 @@
 // `--features rtems-exec-model` build had `feature = "client"` on and panicked
 // on both of those sockets at `rtems-ca-ioc` boot, measured — two of the three
 // panics in `doc/calink-rtems-design.md` §10.10 item 2.
+// RTEMS-EXEC-MODEL-ALLOW(11): the flavored tests drive the full CA client over
+// tokio::net or pin a specific tokio runtime flavor. These run and pass in the
+// feature-ON suite on the tokio driver.
 #[cfg(ca_beacon_monitor)]
 mod beacon_monitor;
 mod circuit_breaker;
@@ -6090,7 +6091,7 @@ mod monitor_pause_tests {
     /// 1. pre-pause channel backlog is delivered even while paused (3a);
     /// 2. a value arriving during pause is held — `recv` blocks (2a);
     /// 3. `resume` releases the held latest, in order after the backlog.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pause_holds_value_resume_releases_after_backlog() {
         let (callback_tx, callback_rx) = mpsc::channel::<CaResult<Snapshot>>(4);
         let (coord_tx, _coord_rx) = mpsc::unbounded_channel();
@@ -6116,7 +6117,7 @@ mod monitor_pause_tests {
         ));
 
         // (3a) The pre-pause backlog is still delivered while paused.
-        let v1 = tokio::time::timeout(Duration::from_millis(200), handle.recv())
+        let v1 = epics_base_rs::runtime::task::timeout(Duration::from_millis(200), handle.recv())
             .await
             .expect("backlog should deliver promptly")
             .expect("Some")
@@ -6125,7 +6126,8 @@ mod monitor_pause_tests {
 
         // (2a) The held value (2) must NOT be delivered while paused —
         // recv blocks.
-        let blocked = tokio::time::timeout(Duration::from_millis(150), handle.recv()).await;
+        let blocked =
+            epics_base_rs::runtime::task::timeout(Duration::from_millis(150), handle.recv()).await;
         assert!(
             blocked.is_err(),
             "held value must stay withheld while paused (recv-side gate)"
@@ -6133,7 +6135,7 @@ mod monitor_pause_tests {
 
         // resume → the held latest is released.
         handle.resume();
-        let v2 = tokio::time::timeout(Duration::from_millis(200), handle.recv())
+        let v2 = epics_base_rs::runtime::task::timeout(Duration::from_millis(200), handle.recv())
             .await
             .expect("held value should deliver after resume")
             .expect("Some")
@@ -6163,7 +6165,7 @@ mod monitor_pause_tests {
     /// A′ error policy end-to-end: an error arriving during pause is
     /// delivered immediately (bypasses the gate), without waiting for
     /// resume.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pause_does_not_hide_errors() {
         let (callback_tx, callback_rx) = mpsc::channel::<CaResult<Snapshot>>(4);
         let (coord_tx, _coord_rx) = mpsc::unbounded_channel();
@@ -6184,7 +6186,7 @@ mod monitor_pause_tests {
             .try_send(Err(CaError::ServerError(192))) // ECA_DISCONN
             .expect("enqueue error");
 
-        let got = tokio::time::timeout(Duration::from_millis(200), handle.recv())
+        let got = epics_base_rs::runtime::task::timeout(Duration::from_millis(200), handle.recv())
             .await
             .expect("error must deliver while paused")
             .expect("Some");

--- a/crates/epics-ca-rs/src/client/search.rs
+++ b/crates/epics-ca-rs/src/client/search.rs
@@ -1,11 +1,8 @@
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these two run and pass in the feature-ON
-// suite. The rest of this file's async tests drive the UDP SEARCH transport,
-// which only exists on `tokio_backend`, so they carry that gate and the census
-// no longer vouches for them feature-ON.
-// The sixth tokio::test (stage_c1_name_servers_only_resolves_without_binding_udp)
-// is per-test #[cfg(not(feature = "rtems-exec-model"))] — its TCP name-server
-// resolution cannot run on the exec backend until Stage C2/C3 — so it is not one
-// of the five ungated sites this count covers.
+// The remaining #[tokio::test]s here are mod-gated to `tokio_backend`: they
+// drive the UDP SEARCH transport, which only exists there. The one per-test
+// #[cfg(not(feature = "rtems-exec-model"))] site
+// (stage_c1_name_servers_only_resolves_without_binding_udp) cannot run on the
+// exec backend until Stage C2/C3.
 
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -2211,7 +2208,7 @@ mod tests {
     /// `ns_try_send` drops the frame instead of blocking or queuing.
     /// This test exercises the helper directly: with a 2-slot channel
     /// and no consumer, the third send must drop.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn nameserver_queue_drops_when_full_no_leak() {
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(2);
         ns_try_send(&tx, vec![1, 2, 3]);
@@ -2228,7 +2225,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn nameserver_queue_handles_closed_receiver() {
         // Receiver dropped — ns_try_send must not panic.
         let (tx, rx) = mpsc::channel::<Vec<u8>>(2);
@@ -2283,7 +2280,7 @@ mod tests {
     /// sum type is that there is no way to hold UDP destinations without the
     /// socket that would transmit to them.
     #[cfg(all(feature = "client", tokio_backend))]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn add_then_remove_address_round_trip() {
         let mut state = SearchEngineState::new();
         let mut transport = SearchTransport::bind_udp(Vec::new()).expect("bind UDP transport");

--- a/crates/epics-ca-rs/src/client/transport.rs
+++ b/crates/epics-ca-rs/src/client/transport.rs
@@ -1,10 +1,12 @@
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
 // Was 18: the nine that left are the three virtual-time watchdog modules
 // (read_loop_tests, recv_watchdog_tests, write_loop_timeout_tests), now gated
 // off under the feature because the circuit path's deadlines moved onto the
 // runtime seam and `start_paused` cannot advance the seam's clock. Ratcheted
 // DOWN, never up, without running the survivors under the feature.
 
+// RTEMS-EXEC-MODEL-ALLOW(9): the flavored tests drive the TCP transport
+// over tokio::net, which needs the reactor. These run and pass in the
+// feature-ON suite on the tokio driver.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 #[cfg(feature = "experimental-rust-tls")]
@@ -3365,7 +3367,7 @@ mod server_connection_drop_tests {
     use std::time::Duration;
     use tokio::sync::mpsc;
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn drop_aborts_read_and_write_tasks() {
         // Long-running dummy tasks that never complete on their own.
         let read_task = tokio::spawn(async {

--- a/crates/epics-ca-rs/src/hostname.rs
+++ b/crates/epics-ca-rs/src/hostname.rs
@@ -24,8 +24,9 @@
 //!   paths (`cac::defaultExcep` → `tcpiiu::getHostName`) print exactly that:
 //!   the dotted IP until the engine has answered, the name afterwards.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): the flavored test asserts resolution inside a
+// multi-thread tokio runtime. These run and pass in the
+// feature-ON suite on the tokio driver.
 use std::net::SocketAddr;
 use std::sync::OnceLock;
 
@@ -252,7 +253,7 @@ mod tests {
 
     /// The non-blocking half answers immediately on a cold cache — with the
     /// dotted IP, as libca does before its engine replies.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn the_cache_answers_without_blocking_on_a_miss() {
         let a: SocketAddr = "192.0.2.2:5064".parse().unwrap();
         assert_eq!(cached_name(a), "192.0.2.2:5064");

--- a/crates/epics-ca-rs/src/replay.rs
+++ b/crates/epics-ca-rs/src/replay.rs
@@ -26,8 +26,6 @@
 //! {"ts":1714200002.000,"ev":"client_disconnect","peer":"10.0.0.6:54311"}
 //! ```
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
@@ -308,7 +306,7 @@ mod tests {
         assert!(RecordedEvent::from_json(line).is_none());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn record_then_replay_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rec.jsonl");

--- a/crates/epics-ca-rs/src/server/blocking.rs
+++ b/crates/epics-ca-rs/src/server/blocking.rs
@@ -126,8 +126,6 @@
 //! ARE handled (the loop waits for the rest). A future increment factors the
 //! shared sans-io frame parser both loops call.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, SocketAddrV4, TcpListener, TcpStream, ToSocketAddrs, UdpSocket};
@@ -1518,7 +1516,7 @@ mod tests {
     /// Only the bind direction is forceable on Linux; the `local_addr`
     /// direction cannot be provoked on this host, so its labelling is proven
     /// by inspection of the `map_err` and not by this test.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_bind_failure_is_not_reported_as_a_local_addr_failure() {
         use std::net::TcpListener as StdTcpListener;
 

--- a/crates/epics-ca-rs/src/server/ca_server.rs
+++ b/crates/epics-ca-rs/src/server/ca_server.rs
@@ -4,8 +4,9 @@
 //! [`epics_base_rs::server::ioc_builder::IocBuilder`] and adds only
 //! CA-specific configuration (port, access security).
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(2): both tests bind the server's tokio::net TCP
+// listener, which needs the reactor. These run and pass in the
+// feature-ON suite on the tokio driver.
 use std::sync::Arc;
 
 use epics_base_rs::error::{CaError, CaResult};

--- a/crates/epics-ca-rs/src/server/ca_server.rs
+++ b/crates/epics-ca-rs/src/server/ca_server.rs
@@ -786,7 +786,7 @@ impl CaServer {
         F: FnOnce(&iocsh::IocShell) + Send + 'static,
     {
         let db = self.db.clone();
-        let handle = tokio::runtime::Handle::current();
+        let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
 
         let autosave_cmds = self
             .autosave_manager
@@ -801,7 +801,7 @@ impl CaServer {
 
         let (tx, rx) = epics_base_rs::runtime::sync::oneshot::channel();
         std::thread::spawn(move || {
-            let shell = iocsh::IocShell::new(db, handle);
+            let shell = iocsh::IocShell::new(db, bridge);
             register_fn(&shell);
             if let Some(cmds) = autosave_cmds {
                 for cmd in cmds {

--- a/crates/epics-ca-rs/src/server/introspection.rs
+++ b/crates/epics-ca-rs/src/server/introspection.rs
@@ -20,8 +20,9 @@
 //! you've cleared the network policy explicitly. There is no auth —
 //! treat this like `/proc`.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): end_to_end_healthz binds a tokio::net TCP
+// listener for a real GET, which needs the reactor. These run and pass in the
+// feature-ON suite on the tokio driver.
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -462,7 +463,7 @@ mod tests {
         assert!(body.contains("\"version\":"));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn render_clients_handles_empty() {
         let s = IntrospectionState::new(5064);
         assert_eq!(render_clients(&s).await, "{\"clients\":[]}");

--- a/crates/epics-ca-rs/src/server/monitor.rs
+++ b/crates/epics-ca-rs/src/server/monitor.rs
@@ -1,5 +1,3 @@
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -229,7 +227,7 @@ mod tests {
     /// following message. A true abort-race is non-deterministic to
     /// schedule, so this asserts the structural property that makes the
     /// race impossible: exactly one queued frame, equal to the full frame.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn send_event_pushes_frame_in_single_push() {
         use epics_base_rs::server::pv::MonitorEvent;
         use epics_base_rs::server::snapshot::Snapshot;
@@ -333,9 +331,9 @@ mod tests {
         /// single-threaded test runtime so the spawned monitor task can
         /// run. Fails the test if it does not arrive within the timeout.
         async fn wait_for(counter: &std::sync::atomic::AtomicU64, want: u64) {
-            tokio::time::timeout(Duration::from_secs(5), async {
+            epics_base_rs::runtime::task::timeout(Duration::from_secs(5), async {
                 while counter.load(Ordering::Relaxed) < want {
-                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    epics_base_rs::runtime::task::sleep(Duration::from_millis(1)).await;
                 }
             })
             .await
@@ -352,7 +350,7 @@ mod tests {
         /// granted and the writer always succeeding — processed. Each
         /// post is drained before the next so coalescing never collapses
         /// two updates into one cycle, giving a deterministic count.
-        #[tokio::test]
+        #[epics_macros_rs::epics_test]
         async fn successful_delivery_advances_posted_and_processed() {
             let pv = Arc::new(ProcessVariable::new("c:pv".into(), EpicsValue::Double(0.0)));
             let reader = pv
@@ -398,7 +396,7 @@ mod tests {
         /// dropped before the wire — so PROCESSED never advances. This
         /// is the `serverPostRate` > `serverEventRate` divergence the
         /// gateway surfaces; both counters reading equal would hide it.
-        #[tokio::test]
+        #[epics_macros_rs::epics_test]
         async fn denied_delivery_counts_posted_not_processed() {
             let pv = Arc::new(ProcessVariable::new("c:pv".into(), EpicsValue::Double(0.0)));
             let reader = pv

--- a/crates/epics-ca-rs/src/server/outbox.rs
+++ b/crates/epics-ca-rs/src/server/outbox.rs
@@ -38,8 +38,6 @@
 //! contiguous `Vec<u8>` per message for the pre-existing abort-safety
 //! invariant, so this is the shape they already produce.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use epics_base_rs::runtime::sync::mpsc;
 
 /// Cloneable producer handle. Handed to every emit site (in-loop handlers
@@ -107,7 +105,7 @@ impl OutboxDrain {
 mod tests {
     use super::*;
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn push_then_drain_preserves_frame_order() {
         let (outbox, mut drain) = channel();
         outbox.push(vec![1, 2, 3]);
@@ -121,7 +119,7 @@ mod tests {
         assert_eq!(drain.try_next(), None);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn push_after_drain_dropped_is_silently_discarded() {
         let (outbox, drain) = channel();
         drop(drain);

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -1,5 +1,6 @@
-// RTEMS-EXEC-MODEL-ALLOW(45): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(35): the flavored tests drive the async CA TCP server
+// (tokio::net, tokio::spawn AbortHandle machinery), which needs the reactor. These run and pass in the
+// feature-ON suite on the tokio driver.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -7296,7 +7297,7 @@ mod pre_v49_peer_tests {
     /// extended form only when `CA_V49(minor)`. For a pre-V49 peer the
     /// echo is the plain 16-byte header — a 24-byte echo would de-sync a
     /// client with no annex parser.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pre_v49_error_echo_is_sixteen_bytes() {
         let (outbox, mut drain) = live_outbox();
         let mut original = CaHeader::new(CA_PROTO_READ_NOTIFY);
@@ -7332,7 +7333,7 @@ mod pre_v49_peer_tests {
     }
 
     /// The same error to a V49 peer keeps the 24-byte extended echo.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn v49_error_echo_is_twenty_four_bytes() {
         let (outbox, mut drain) = live_outbox();
         let mut original = CaHeader::new(CA_PROTO_READ_NOTIFY);
@@ -7364,7 +7365,7 @@ mod pre_v49_peer_tests {
     /// pre-V49 peer. C `read_reply` / `read_action` answer with
     /// `send_err(ECA_16KARRAYCLIENT)` (`camessage.c:~700`) rather than
     /// emitting an extended header the peer cannot parse.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn oversize_reply_to_pre_v49_peer_is_eca_16karrayclient() {
         use epics_base_rs::server::snapshot::Snapshot;
         use epics_base_rs::types::{DBR_LONG, EpicsValue};
@@ -8988,7 +8989,7 @@ mod single_write_all_framing_tests {
 
     /// `send_ca_error` builds response-header + echoed-request-header +
     /// diagnostic string. All three must leave in a single `write_all`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn send_ca_error_writes_single_frame() {
         let (outbox, mut drain) = live_outbox();
         let original = CaHeader::new(CA_PROTO_READ_NOTIFY);
@@ -9029,7 +9030,7 @@ mod single_write_all_framing_tests {
     /// ZEROED body. The pre-fix `send_cmd_error` shipped `count=0` + an
     /// empty body; this locks the corrected `send_no_read_access_event`
     /// shape the get-failure and no-snapshot paths now use.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn read_notify_get_failure_frame_keeps_count_and_zero_body() {
         let (outbox, mut drain) = live_outbox();
         let requested_count = 3u32;
@@ -9097,7 +9098,7 @@ mod single_write_all_framing_tests {
     /// Regression: when the original request used an extended
     /// 24-byte header, the outer CA_PROTO_ERROR reply must declare
     /// `m_postsize = 24 + diag_len`, not `16 + diag_len`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn send_ca_error_extended_original_declares_correct_payload_size() {
         let (outbox, mut drain) = live_outbox();
         // Build an extended original header: set_payload_size triggers
@@ -9145,7 +9146,7 @@ mod single_write_all_framing_tests {
 
     /// `send_monitor_snapshot` (the introspection EVENT_ADD reply) must
     /// emit header + padded payload as a single `write_all`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn send_monitor_snapshot_writes_single_frame() {
         use epics_base_rs::server::snapshot::Snapshot;
         use epics_base_rs::types::{DBR_LONG, EpicsValue};
@@ -9188,7 +9189,7 @@ mod single_write_all_framing_tests {
     /// shape the READ path and later monitor updates use. Pre-fix the
     /// initial frame was framed at `snapshot.value.count()`, so a
     /// client saw a count/size discontinuity inside one subscription.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r9_initial_snapshot_pads_over_requested_count() {
         use epics_base_rs::server::snapshot::Snapshot;
         use epics_base_rs::types::{DBR_LONG, DbFieldType, EpicsValue};
@@ -9253,7 +9254,7 @@ mod single_write_all_framing_tests {
     /// a request count SMALLER than the live element count
     /// still truncates — `send_monitor_snapshot` must own both
     /// directions of the count contract.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r9_initial_snapshot_truncates_under_requested_count() {
         use epics_base_rs::server::snapshot::Snapshot;
         use epics_base_rs::types::{DBR_LONG, EpicsValue};
@@ -9286,7 +9287,7 @@ mod single_write_all_framing_tests {
 
     /// `requested_count == 0` is autosize — the frame keeps the
     /// live element count, unchanged behaviour.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r9_autosize_keeps_live_count() {
         use epics_base_rs::server::snapshot::Snapshot;
         use epics_base_rs::types::{DBR_LONG, EpicsValue};

--- a/crates/epics-ca-rs/src/server/udp.rs
+++ b/crates/epics-ca-rs/src/server/udp.rs
@@ -1,11 +1,12 @@
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 // The bound-socket UDP responder stack (`socket2` shared-port setup, the
 // `tokio::net::UdpSocket` recv loops, the `epics_base_rs::net` RX-overflow
 // helpers) is the async host-only front-end. The RTEMS build answers SEARCH
 // through `server::blocking`'s `std::net` responder, reusing only the shared
 // decode/shape logic (`SearchReplyBatch`, `parse_search_datagram`,
 // `shape_search_reply_dg`) below. Those imports are gated out for RTEMS.
+// RTEMS-EXEC-MODEL-ALLOW(2): both sites hand-build a tokio runtime to drive the
+// tokio::net UDP name-server socket. These run and pass in the
+// feature-ON suite on the tokio driver.
 #[cfg(not(target_os = "rtems"))]
 use socket2::{Domain, Protocol, Socket, Type};
 use std::net::SocketAddr;

--- a/crates/epics-ca-rs/tests/acf_hot_reload.rs
+++ b/crates/epics-ca-rs/tests/acf_hot_reload.rs
@@ -1,8 +1,9 @@
 //! ACF hot reload test — server keeps running, ACF file is rewritten,
 //! reload_acf() picks up the change without restart.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): the flavored test runs a live CaServer over
+// tokio::net for the reload round-trip. These run and pass in the
+// feature-ON suite on the tokio driver.
 use epics_ca_rs::server::CaServer;
 use std::time::Duration;
 

--- a/crates/epics-ca-rs/tests/async_write_notify_rtems_exec.rs
+++ b/crates/epics-ca-rs/tests/async_write_notify_rtems_exec.rs
@@ -48,9 +48,11 @@
 //!
 //! The whole file is `#[cfg(feature = "rtems-exec-model")]`: with the feature
 //! off it compiles to nothing, so the hosted default test set is unchanged.
+// RTEMS-EXEC-MODEL-ALLOW(1): the flavored e2e drives a live
+// client/server pair over tokio::net; the exec-model behavior it proves is in
+// the server task it spawns. These run and pass in the
+// feature-ON suite on the tokio driver.
 #![cfg(feature = "rtems-exec-model")]
-
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - this file IS the feature-ON e2e; it runs and passes there.
 
 use std::collections::HashMap;
 use std::io::{Read, Write};

--- a/crates/epics-ca-rs/tests/calink_lset_contexts.rs
+++ b/crates/epics-ca-rs/tests/calink_lset_contexts.rs
@@ -1,7 +1,8 @@
 //! The `ca://` lset must answer link reads on any runtime flavor.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(2): both flavored tests run a live
+// CaServer over tokio::net. These run and pass in the
+// feature-ON suite on the tokio driver.
 use epics_base_rs::server::database::LinkSet;
 use epics_ca_rs::calink::CaLinkResolver;
 

--- a/crates/epics-libcom-rs/Cargo.toml
+++ b/crates/epics-libcom-rs/Cargo.toml
@@ -72,6 +72,10 @@ libc = "0.2"
 # crate that declares the feature has the same hole, and copies of a 300-line
 # audit is how copies of a rule come to disagree.
 rtems-exec-gate = { path = "../../tools/rtems-exec-gate" }
+# Dev-only: `#[epics_test]` for this crate's own suite. The macro resolves the
+# runtime path through `epics-libcom-rs` itself (its last fallback), so the
+# tests use the backend-selected driver without a cycle through epics-base-rs.
+epics-macros-rs = { workspace = true }
 tempfile = "3"
 serial_test = "3"
 # Test-only: `runtime::log`'s tests install a bare `tracing` registry to prove

--- a/crates/epics-libcom-rs/src/lib.rs
+++ b/crates/epics-libcom-rs/src/lib.rs
@@ -56,6 +56,12 @@ compile_error!(
      backend on Windows instead"
 );
 
+// Lets `#[epics_macros_rs::epics_test]` expansions — which name the runtime
+// crate by its external path — resolve inside this crate's own unit tests,
+// where proc-macro-crate reports `FoundCrate::Itself`. Same device as
+// `epics-base-rs`'s alias for the same macro.
+extern crate self as epics_libcom_rs;
+
 pub mod net;
 pub mod runtime;
 pub mod walltime;

--- a/crates/epics-libcom-rs/src/net/async_udp_v4.rs
+++ b/crates/epics-libcom-rs/src/net/async_udp_v4.rs
@@ -37,8 +37,9 @@
 //! socket-per-NIC mapping (e.g. for diagnostics or NS-driven response
 //! correlation).
 
-// RTEMS-EXEC-MODEL-ALLOW(14): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(14): every test binds tokio::net UDP sockets, which
+// need a reactor the exec backend does not start; under the feature these
+// still run on the tokio driver `#[tokio::test]` builds, and pass.
 use std::io;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;

--- a/crates/epics-libcom-rs/src/net/iface_map.rs
+++ b/crates/epics-libcom-rs/src/net/iface_map.rs
@@ -8,8 +8,6 @@
 //!
 //! Mirrors the data carried by pvxs `IfaceMap::Current` (src/iface.cpp).
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -409,12 +407,12 @@ mod tests {
     /// the snapshot's `last_refresh` advances at least once in the
     /// poll window. Mirrors pvxs `IfMapDaemon` 15 s behaviour at a
     /// short test cadence (50 ms × ~3 ticks ≈ 150 ms total).
-    #[tokio::test(flavor = "current_thread")]
+    #[epics_macros_rs::epics_test]
     async fn spawn_refresh_advances_last_refresh() {
         let map = IfaceMap::new();
         let initial = map.inner.lock().last_refresh;
         let handle = map.spawn_refresh(Duration::from_millis(50));
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        crate::runtime::task::sleep(Duration::from_millis(200)).await;
         let after = map.inner.lock().last_refresh;
         assert!(
             after > initial,

--- a/crates/epics-libcom-rs/src/net/loopback_mcast.rs
+++ b/crates/epics-libcom-rs/src/net/loopback_mcast.rs
@@ -19,8 +19,9 @@
 //! `udp_collector.cpp:561-567` (forward send), `evhelper.cpp:519-585`
 //! (mcast option setters).
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(3): every test binds tokio::net UDP sockets, which
+// need a reactor the exec backend does not start; under the feature these
+// still run on the tokio driver `#[tokio::test]` builds, and pass.
 use std::io;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 

--- a/crates/epics-libcom-rs/src/runtime/blocking_io.rs
+++ b/crates/epics-libcom-rs/src/runtime/blocking_io.rs
@@ -98,11 +98,11 @@
 //! a protocol crate for the reason the pumps are: `epics-ca-rs` and
 //! `epics-pva-rs` both dial and neither may depend on the other.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON
-// suite. Each drives an adapter, a real socket pump, or a `DialPool` worker;
-// those threads are std threads that reach `block_on_sync`/`connect` with no
-// runtime entered, which is the exec-backend path, so the tokio runtime here
-// only hosts the assertions.
+// RTEMS-EXEC-MODEL-ALLOW(1): `one_descriptor_serves_both_pumps` asserts both
+// pump directions concurrently from the async side, which needs the
+// multi-thread tokio flavor; it runs and passes in the feature-ON suite (the
+// pumps themselves are std threads, the tokio runtime only hosts the
+// assertions).
 
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
@@ -1182,7 +1182,7 @@ mod tests {
     ///   parked in `cur`/`pos`;
     /// * **pending** — no chunk has arrived at all, so the poll registered a
     ///   waker and returned `Pending`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn channel_reader_loses_no_bytes_when_a_select_race_is_lost() {
         let (tx, rx) = mpsc::channel::<Vec<u8>>(1);
         let mut reader = ChannelReader::new(rx);
@@ -1244,7 +1244,7 @@ mod tests {
     }
 
     /// A zero-length `poll_read` buffer must not eat a chunk.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_zero_length_read_consumes_nothing() {
         let (tx, rx) = mpsc::channel::<Vec<u8>>(1);
         let mut reader = ChannelReader::new(rx);
@@ -1260,7 +1260,7 @@ mod tests {
 
     /// The adapter must not be what keeps the frame channel open, or a pump
     /// would outlive the guard that is supposed to end it.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn channel_writer_does_not_keep_the_frame_channel_open() {
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(1);
         let room = Arc::new(WriteRoom::default());
@@ -1616,7 +1616,7 @@ mod tests {
     /// the very worker that must serve it next, so a pool that counted parked
     /// workers would see none available and create a second. That is why the
     /// assertion is inside the loop and not only after it.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn sequential_dials_reuse_one_worker() {
         static POOL: DialPool = DialPool::new("test-dial", ThreadPriority::Low);
         const DIALS: usize = 8;

--- a/crates/epics-libcom-rs/src/runtime/fs.rs
+++ b/crates/epics-libcom-rs/src/runtime/fs.rs
@@ -35,8 +35,6 @@
 //! interleave between the steps; the same sequence in one closure makes one
 //! hop and keeps the durability ordering where a reader can see it.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -96,7 +94,7 @@ pub async fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
 mod tests {
     use super::*;
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_round_trip_goes_through_the_seam() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("seam.txt");
@@ -107,14 +105,14 @@ mod tests {
     /// The error must be the filesystem's, not a wrapper's: callers switch on
     /// `ErrorKind::NotFound` (autosave treats a missing `.sav` as "no saved
     /// state" and anything else as corruption), so flattening must not lose it.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_missing_file_keeps_its_error_kind() {
         let dir = tempfile::tempdir().unwrap();
         let e = read_to_string(dir.path().join("absent")).await.unwrap_err();
         assert_eq!(e.kind(), io::ErrorKind::NotFound);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rename_and_copy_move_the_bytes() {
         let dir = tempfile::tempdir().unwrap();
         let a = dir.path().join("a");
@@ -127,7 +125,7 @@ mod tests {
         assert_eq!(read_to_string(&c).await.unwrap(), "payload");
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn canonicalize_resolves_to_an_absolute_path() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("real");
@@ -137,7 +135,7 @@ mod tests {
 
     /// A composite sequence is one hop, and its `io::Error` reaches the caller
     /// unchanged — this is the shape `write_save_file` uses.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_composite_closure_returns_its_own_error() {
         let e = blocking(|| std::fs::read_to_string("/definitely/not/here"))
             .await

--- a/crates/epics-libcom-rs/src/runtime/supervise.rs
+++ b/crates/epics-libcom-rs/src/runtime/supervise.rs
@@ -19,8 +19,6 @@
 //! backoff is a different policy with different semantics. This
 //! module is exclusively for the sliding-window pattern.
 
-// RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::time::{Duration, Instant};
 
 /// Policy: at most `max_restarts` attempts inside `window`,
@@ -257,7 +255,7 @@ mod tests {
         assert!(t.try_record(&policy).is_ok());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn supervise_immediate_success() {
         let policy = RestartPolicy {
             max_restarts: 3,
@@ -269,7 +267,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn supervise_eventual_success() {
         let count = Arc::new(AtomicU32::new(0));
         let policy = RestartPolicy {
@@ -294,7 +292,7 @@ mod tests {
         assert_eq!(count.load(Ordering::Relaxed), 3);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn supervise_too_many_restarts() {
         let policy = RestartPolicy {
             max_restarts: 2,
@@ -323,7 +321,7 @@ mod tests {
     /// check sits at the launch boundary, not after a failed launch. The
     /// pre-fix loop recorded on failure and admitted `max_restarts + 1`
     /// launches (one extra full gateway start vs C NRESTARTS).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn supervise_launch_count_equals_max_restarts() {
         for max in [1u32, 2, 3, 10] {
             let launches = Arc::new(AtomicU32::new(0));
@@ -358,7 +356,7 @@ mod tests {
     /// supervisor's contract is to run the task at least once, so it must
     /// launch exactly once and then honor the cap — never panic on the
     /// missing root-cause error.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn supervise_zero_max_runs_task_once() {
         let launches = Arc::new(AtomicU32::new(0));
         let policy = RestartPolicy {

--- a/crates/epics-libcom-rs/src/runtime/task.rs
+++ b/crates/epics-libcom-rs/src/runtime/task.rs
@@ -153,6 +153,96 @@ pub fn block_on_sync<F: Future>(fut: F) -> Result<F::Output, NotBlockable> {
     }
 }
 
+/// A capability, captured where the backend's executor is reachable, to run
+/// async work from a plain blocking thread (iocsh, a REPL, a script thread).
+///
+/// [`block_on_sync`] answers "may I block *here*, now?" per call and can only
+/// use whatever runtime is visible on the calling thread. This type answers
+/// the reachability question once, at [`capture`](Self::capture) time, and
+/// carries the answer to a thread the runtime is otherwise invisible from: a
+/// tokio handle is thread-local state, so a blocking thread spawned *before*
+/// it exists has no way to find it. The exec backend's executor is
+/// process-global, so there is nothing to carry and the bridge is a ZST —
+/// which is what makes an API taking a `BlockingBridge` compile and work on
+/// both backends, where one taking `tokio::runtime::Handle` pinned every
+/// caller to tokio.
+#[cfg(tokio_backend)]
+#[derive(Clone)]
+pub struct BlockingBridge {
+    handle: tokio::runtime::Handle,
+}
+
+/// See the `tokio_backend` definition. The executor here is the
+/// process-global background executor, reachable from any thread, so there is
+/// no state to capture.
+#[cfg(exec_backend)]
+#[derive(Clone)]
+pub struct BlockingBridge;
+
+#[cfg(tokio_backend)]
+impl BlockingBridge {
+    /// Capture the current tokio runtime.
+    ///
+    /// # Panics
+    /// Panics when no runtime is entered on this thread — call it on the
+    /// async setup path (where the runtime is known), not on the blocking
+    /// thread the bridge is being made for.
+    pub fn capture() -> Self {
+        Self {
+            handle: tokio::runtime::Handle::current(),
+        }
+    }
+
+    /// Drive `fut` to completion on this thread, with the captured runtime
+    /// entered so the future may spawn and use the reactor.
+    ///
+    /// # Panics
+    /// Panics on a runtime worker thread: blocking one parks tasks that may
+    /// include the future's own wakers (the same refusal `block_on_sync`
+    /// reports as a value).
+    pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
+        assert!(
+            RuntimeHandle::try_current().is_err(),
+            "BlockingBridge::block_on must not be called from a runtime thread"
+        );
+        self.handle.block_on(fut)
+    }
+
+    /// Spawn `future` onto the captured runtime — [`spawn`] for a thread the
+    /// runtime is not entered on.
+    pub fn spawn<F>(&self, future: F) -> TaskHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.handle.spawn(future)
+    }
+}
+
+#[cfg(exec_backend)]
+impl BlockingBridge {
+    /// The exec backend's executor is process-global; capturing is a no-op
+    /// and never panics.
+    pub fn capture() -> Self {
+        Self
+    }
+
+    /// Drive `fut` on this thread via [`park_on`]; whatever it spawns or
+    /// sleeps on lands on the background executor.
+    pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
+        park_on(fut)
+    }
+
+    /// [`spawn`] — the global executor needs no captured state.
+    pub fn spawn<F>(&self, future: F) -> TaskHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        spawn(future)
+    }
+}
+
 /// Drive an async test body to completion — the driver behind
 /// `#[epics_test]` (`epics-macros-rs`).
 ///

--- a/crates/epics-libcom-rs/src/runtime/task.rs
+++ b/crates/epics-libcom-rs/src/runtime/task.rs
@@ -1,4 +1,7 @@
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(2): the two multi-thread-flavored tests prove a
+// dedicated thread carries the ambient tokio runtime / requested stack; the
+// tokio flavor is the property under test. Both run and pass in the
+// feature-ON suite.
 
 use std::future::Future;
 use std::sync::Arc;
@@ -1880,13 +1883,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn test_spawn() {
         let handle = spawn(async { 42 });
         assert_eq!(handle.await.unwrap(), 42);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn test_spawn_blocking() {
         let handle = spawn_blocking(|| 123);
         assert_eq!(handle.await.unwrap(), 123);
@@ -1944,7 +1947,7 @@ mod tests {
     /// The assertion is on `block_on_sync` succeeding, not on the absence of a
     /// handle, because being able to block is the property the thread is spawned
     /// for; how that is arranged is this function's business.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_dedicated_thread_can_block_under_a_current_thread_ambient() {
         let (tx, rx) = std::sync::mpsc::channel();
         let joined = spawn_dedicated_thread(
@@ -2107,7 +2110,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn test_sleep() {
         let start = std::time::Instant::now();
         sleep(Duration::from_millis(10)).await;
@@ -2118,13 +2121,13 @@ mod tests {
     // tokio delegation, and that is the point: they are what a later backend
     // swap has to keep true, on a seam whose whole purpose is to be
     // reimplemented.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn timeout_yields_the_value_when_the_future_finishes_first() {
         let r = timeout(Duration::from_secs(30), async { 42 }).await;
         assert_eq!(r.unwrap(), 42);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn timeout_elapses_on_a_future_that_never_finishes() {
         let r = timeout(Duration::from_millis(10), std::future::pending::<()>()).await;
         assert!(r.is_err());
@@ -2789,7 +2792,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn spawn_blocking_with_priority_runs_closure() {
         let handle = spawn_blocking_with_priority(ThreadPriority::CaServerHigh, || 7);
         assert_eq!(handle.await.unwrap(), 7);

--- a/crates/epics-libcom-rs/src/runtime/task.rs
+++ b/crates/epics-libcom-rs/src/runtime/task.rs
@@ -153,6 +153,38 @@ pub fn block_on_sync<F: Future>(fut: F) -> Result<F::Output, NotBlockable> {
     }
 }
 
+/// Drive an async test body to completion — the driver behind
+/// `#[epics_test]` (`epics-macros-rs`).
+///
+/// The point of the indirection is that the *backend* picks the driver, not
+/// the test. On `tokio_backend` this builds exactly what `#[tokio::test]`
+/// builds: a fresh current-thread runtime with IO and time enabled. On
+/// `exec_backend` (the RTEMS target, or a host run with
+/// `--features rtems-exec-model`) no tokio runtime exists to build, so the
+/// test thread itself drives the future via [`park_on`], and everything the
+/// body spawns or sleeps on lands on the process-global background executor
+/// (lazily initialised on first use) — the same seam the RTEMS boot path
+/// exercises. A test written with `#[epics_test]` therefore needs no
+/// per-backend gating and no `RTEMS-EXEC-MODEL-ALLOW` census entry.
+#[cfg(tokio_backend)]
+pub fn test_block_on<F: Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio test runtime")
+        .block_on(fut)
+}
+
+/// `exec_backend` twin of [`test_block_on`]: see the `tokio_backend` copy for
+/// the contract. The body's awaits must reach only runtime-agnostic
+/// primitives (`park_on`'s rule) — a body that touches `tokio::net` or
+/// `tokio::time` directly belongs under `#[tokio::test]` with a backend gate
+/// instead.
+#[cfg(exec_backend)]
+pub fn test_block_on<F: Future>(fut: F) -> F::Output {
+    park_on(fut)
+}
+
 // ---------------------------------------------------------------------------
 // Platform-selected task handle types (decision A2 / B)
 //
@@ -265,6 +297,36 @@ where
         DEFAULT_SPAWN_PRIORITY,
         future,
     )
+}
+
+/// Yield the current task once — the seam replacement for
+/// `tokio::task::yield_now`, so no call site names `tokio::task` directly.
+#[cfg(tokio_backend)]
+pub async fn yield_now() {
+    tokio::task::yield_now().await;
+}
+
+/// Exec-backend yield: return `Pending` once with the waker already woken.
+/// On the cooperative background executor that re-enqueues the task behind
+/// whatever else is runnable; under a `park_on` driver the wake sets the
+/// park token, so the driver re-polls immediately — both give one fair
+/// scheduling point, which is all `yield_now` promises.
+#[cfg(exec_backend)]
+pub async fn yield_now() {
+    struct YieldNow(bool);
+    impl Future for YieldNow {
+        type Output = ();
+        fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+    YieldNow(false).await;
 }
 
 #[cfg(tokio_backend)]

--- a/crates/epics-macros-rs/src/lib.rs
+++ b/crates/epics-macros-rs/src/lib.rs
@@ -8,7 +8,12 @@ use syn::{Data, DeriveInput, Fields, ItemFn, Lit, parse_macro_input};
 fn epics_base_path() -> proc_macro2::TokenStream {
     if let Ok(found) = crate_name("epics-base-rs") {
         match found {
-            FoundCrate::Itself => quote!(crate),
+            // `crate` would be wrong everywhere except the library target
+            // itself (an integration test or bin under the same package sees
+            // `crate` as *its own* crate root), so refer to the library by
+            // name; `epics-base-rs`'s `extern crate self as epics_base_rs;`
+            // makes that name resolve inside the library target too.
+            FoundCrate::Itself => quote!(::epics_base_rs),
             FoundCrate::Name(name) => {
                 let ident = proc_macro2::Ident::new(&name, proc_macro2::Span::call_site());
                 quote!(::#ident)
@@ -97,10 +102,19 @@ pub fn epics_main(attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Marks an async function as an EPICS test.
+/// Marks an async function as an EPICS test, driven by whichever backend the
+/// build selected.
 ///
-/// Builds a current-thread tokio runtime (via `epics_base_rs::__tokio`),
-/// matching the default behavior of `#[tokio::test]`.
+/// Expands to a plain `#[test]` whose body runs through
+/// `epics_base_rs::runtime::task::test_block_on`: on the tokio backend that
+/// is a fresh current-thread runtime (exactly what `#[tokio::test]` builds);
+/// on the exec backend (`--features rtems-exec-model` / the RTEMS target) the
+/// test thread drives the future itself and spawns/sleeps land on the
+/// background executor. Use this instead of `#[tokio::test]` for any test
+/// whose body sticks to the `runtime::` abstractions — such a test needs no
+/// backend gating and no `RTEMS-EXEC-MODEL-ALLOW` census entry. A body that
+/// touches `tokio::net`/`tokio::time` directly still needs `#[tokio::test]`
+/// plus a backend gate.
 ///
 /// # Restrictions
 /// - Must be applied to an `async fn` with no arguments and no generics.
@@ -166,11 +180,7 @@ pub fn epics_test(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[test]
         #(#attrs)*
         #vis fn #name() #ret {
-            #base::__tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("failed to build tokio runtime")
-                .block_on(async move #body)
+            #base::runtime::task::test_block_on(async move #body)
         }
     }
     .into()

--- a/crates/epics-macros-rs/src/lib.rs
+++ b/crates/epics-macros-rs/src/lib.rs
@@ -27,6 +27,20 @@ fn epics_base_path() -> proc_macro2::TokenStream {
                 quote!(::#ident::base)
             }
         }
+    } else if let Ok(found) = crate_name("epics-libcom-rs") {
+        // `epics_base_rs::runtime` is a re-export of `epics_libcom_rs::runtime`,
+        // so for a consumer that only has the libcom layer — including
+        // `epics-libcom-rs`'s own test suite, which cannot depend on
+        // `epics-base-rs` without a cycle — the same expansions resolve
+        // through the libcom path. Probed last so a crate with both deps
+        // keeps the canonical `epics_base_rs` spelling.
+        match found {
+            FoundCrate::Itself => quote!(::epics_libcom_rs),
+            FoundCrate::Name(name) => {
+                let ident = proc_macro2::Ident::new(&name, proc_macro2::Span::call_site());
+                quote!(::#ident)
+            }
+        }
     } else {
         quote!(::epics_base_rs)
     }

--- a/crates/epics-pva-rs/src/client_native/channel.rs
+++ b/crates/epics-pva-rs/src/client_native/channel.rs
@@ -19,9 +19,9 @@
 //! [`crate::client_native::ops_v2::op_monitor_handle`] for the loop that
 //! re-issues INIT/START on each new server conn.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 // (1 search-timeout test gated out feature-ON below; §4.2 UDP search, stage 3.)
 
+// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/crates/epics-pva-rs/src/client_native/context.rs
+++ b/crates/epics-pva-rs/src/client_native/context.rs
@@ -17,7 +17,6 @@
 
 // (1 search-timeout test gated out feature-ON below; §4.2 UDP search, stage 3.)
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -3280,7 +3279,7 @@ mod tests {
         assert_eq!(removed.len(), 2);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn periodic_cache_cleaner_sweeps_only_unreferenced_channels() {
         // Drive the same loop the client arms on its first cached channel.
         // `tokio`'s "full" feature excludes "test-util", so paused time is
@@ -3288,7 +3287,10 @@ mod tests {
         // test deterministic without depending on one sleep landing on a tick.
         let client = PvaClient::builder().build();
         let period = Duration::from_millis(25);
-        tokio::spawn(cache_clean_loop(Arc::downgrade(&client.inner), period));
+        epics_base_rs::runtime::task::spawn(cache_clean_loop(
+            Arc::downgrade(&client.inner),
+            period,
+        ));
 
         // (a) a cached channel with no external Arc is swept within a few ticks.
         client
@@ -3302,7 +3304,7 @@ mod tests {
                 swept = true;
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(10)).await;
         }
         assert!(
             swept,
@@ -3316,7 +3318,7 @@ mod tests {
             .channels
             .write()
             .insert("held".into(), Arc::clone(&held));
-        tokio::time::sleep(period * 5).await;
+        epics_base_rs::runtime::task::sleep(period * 5).await;
         assert!(
             client.inner.channels.read().contains_key("held"),
             "cleaner preserves a channel that still has a live external reference"
@@ -3330,7 +3332,7 @@ mod tests {
                 swept = true;
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(10)).await;
         }
         assert!(
             swept,
@@ -3338,11 +3340,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn periodic_cache_cleaner_exits_when_client_dropped() {
         let client = PvaClient::builder().build();
         let weak = Arc::downgrade(&client.inner);
-        let handle = tokio::spawn(cache_clean_loop(weak.clone(), Duration::from_millis(25)));
+        let handle = epics_base_rs::runtime::task::spawn(cache_clean_loop(
+            weak.clone(),
+            Duration::from_millis(25),
+        ));
 
         // Dropping the only PvaClient clone releases the last strong ref; the
         // cleaner's next `Weak::upgrade` fails and the task returns.
@@ -3354,7 +3359,7 @@ mod tests {
                 finished = true;
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(10)).await;
         }
         assert!(
             finished,
@@ -3507,7 +3512,7 @@ mod tests {
     /// channel Idle, so no `on_connect` can race in — the only callback
     /// expected is the initial `on_disconnect`, and it must arrive with
     /// no other operation issued on the client.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_rs_48_connect_fires_initial_on_disconnect_without_other_op() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::time::Duration;
@@ -3531,12 +3536,12 @@ mod tests {
 
         // No pvget/pvput/monitor is issued. The initial on_disconnect
         // must still fire promptly. Pre-fix `fired` stayed 0 forever.
-        tokio::time::timeout(Duration::from_secs(2), async {
+        epics_base_rs::runtime::task::timeout(Duration::from_secs(2), async {
             loop {
                 if fired.load(Ordering::SeqCst) >= 1 {
                     break;
                 }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                epics_base_rs::runtime::task::sleep(Duration::from_millis(10)).await;
             }
         })
         .await
@@ -3550,7 +3555,7 @@ mod tests {
     /// server: async mode detaches (the task observes the cancel token and
     /// runs to completion), sync mode aborts (the task is cancelled before
     /// its pending work finishes).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_rs_49_drop_async_detaches_sync_aborts() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use tokio_util::sync::CancellationToken;
@@ -3566,7 +3571,7 @@ mod tests {
                 let c = cancel.clone();
                 async move {
                     c.cancelled().await;
-                    tokio::task::yield_now().await;
+                    epics_base_rs::runtime::task::yield_now().await;
                     flag.store(true, Ordering::SeqCst);
                 }
             })),
@@ -3579,7 +3584,7 @@ mod tests {
                 detached_finished = true;
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(2)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(2)).await;
         }
         assert!(
             detached_finished,
@@ -3595,14 +3600,14 @@ mod tests {
             task: Some(epics_base_rs::runtime::task::spawn({
                 let flag = did_complete.clone();
                 async move {
-                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    epics_base_rs::runtime::task::sleep(Duration::from_secs(5)).await;
                     flag.store(true, Ordering::SeqCst);
                 }
             })),
             sync_cancel: true,
         };
         drop(handle2);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
         assert!(
             !did_complete.load(Ordering::SeqCst),
             "sync sync_cancel(true) Drop must abort the task before its pending work completes"
@@ -3615,7 +3620,7 @@ mod tests {
     /// with the watcher parked mid-work, dropping a default
     /// (`sync_cancel(true)`) handle returns WITHOUT the parked work having
     /// finished, while `wait()` awaits full task termination.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn connect_handle_only_wait_bounds_callback_completion() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use tokio_util::sync::CancellationToken;
@@ -3647,7 +3652,7 @@ mod tests {
             if started.load(Ordering::SeqCst) {
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(2)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(2)).await;
         }
         assert!(
             started.load(Ordering::SeqCst),
@@ -3675,7 +3680,7 @@ mod tests {
             })),
             sync_cancel: false,
         };
-        tokio::time::timeout(Duration::from_secs(2), handle2.wait())
+        epics_base_rs::runtime::task::timeout(Duration::from_secs(2), handle2.wait())
             .await
             .expect("wait() must terminate synchronously, not hang");
         assert!(
@@ -3688,7 +3693,7 @@ mod tests {
     /// builder flag: after it returns the watcher task has stopped and no
     /// further callbacks fire. Exercised against an unreachable forced
     /// server so the watcher only fires its initial `on_disconnect`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_rs_49_wait_is_synchronous_teardown() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -3710,12 +3715,12 @@ mod tests {
             .await
             .expect("exec");
 
-        tokio::time::timeout(Duration::from_secs(2), handle.wait())
+        epics_base_rs::runtime::task::timeout(Duration::from_secs(2), handle.wait())
             .await
             .expect("wait() must terminate synchronously, not hang");
 
         let after = calls.load(Ordering::Relaxed);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
         assert_eq!(
             calls.load(Ordering::Relaxed),
             after,

--- a/crates/epics-pva-rs/src/client_native/context.rs
+++ b/crates/epics-pva-rs/src/client_native/context.rs
@@ -15,9 +15,9 @@
 //! Public API stays compatible with the previous shape so existing callers
 //! (pvget-rs, pvput-rs, pvmonitor-rs, pvinfo-rs) keep working.
 
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
 // (1 search-timeout test gated out feature-ON below; §4.2 UDP search, stage 3.)
 
+// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -3375,7 +3375,7 @@ mod tests {
     // observable soundly here. `search_engine()`'s early return makes the
     // two paths mutually exclusive by construction, so the routing decision
     // plus this client's engine cell fully pin the behavior.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn mr_r9_share_udp_with_name_servers_uses_per_client_engine() {
         let ns: SocketAddr = "127.0.0.1:5099".parse().unwrap();
         let client = PvaClient::builder()
@@ -3399,7 +3399,7 @@ mod tests {
 
     // Control: `share_udp(true)` with no name servers still shares the
     // process-wide engine — share_udp continues to save the UDP socket.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn mr_r9_share_udp_without_name_servers_uses_shared_engine() {
         let client = PvaClient::builder().share_udp(true).build();
         assert!(

--- a/crates/epics-pva-rs/src/client_native/operation.rs
+++ b/crates/epics-pva-rs/src/client_native/operation.rs
@@ -17,7 +17,6 @@
 //! The handle is constructed from any future that returns
 //! `PvaResult<T>`.
 
-// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -413,14 +412,14 @@ mod tests {
         assert!(matches!(r, Err(PvaError::Timeout)));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn interrupt_wakes_waiter_op_continues() {
         let mut op = PvaOperation::<i32>::spawn(async {
             epics_base_rs::runtime::task::sleep(Duration::from_millis(200)).await;
             Ok(7)
         });
         let interrupter = op.interrupt.clone();
-        tokio::spawn(async move {
+        epics_base_rs::runtime::task::spawn(async move {
             epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
             interrupter.notify_waiters();
         });
@@ -441,7 +440,7 @@ mod tests {
     /// a real deadline expiry and an explicit interrupt must
     /// surface as distinct variants so timeout-specific caller logic
     /// does not match an interrupt.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn timeout_and_interrupt_are_distinct_variants() {
         // Real deadline: op never completes within the window.
         let mut slow = PvaOperation::<()>::spawn(async {
@@ -458,7 +457,7 @@ mod tests {
             Ok(1)
         });
         let interrupter = op.interrupt.clone();
-        tokio::spawn(async move {
+        epics_base_rs::runtime::task::spawn(async move {
             epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
             interrupter.notify_waiters();
         });

--- a/crates/epics-pva-rs/src/client_native/operation.rs
+++ b/crates/epics-pva-rs/src/client_native/operation.rs
@@ -17,8 +17,7 @@
 //! The handle is constructed from any future that returns
 //! `PvaResult<T>`.
 
-// RTEMS-EXEC-MODEL-ALLOW(14): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -396,7 +395,7 @@ async fn wait_for_cancel(flag: Arc<std::sync::atomic::AtomicBool>) {
 mod tests {
     use super::*;
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_returns_value() {
         let mut op = PvaOperation::spawn(async { Ok::<i32, _>(42) });
         let v = op.wait(Some(Duration::from_secs(1))).await.unwrap();
@@ -404,7 +403,7 @@ mod tests {
         assert!(op.is_done());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_times_out() {
         let mut op = PvaOperation::<()>::spawn(async {
             epics_base_rs::runtime::task::sleep(Duration::from_secs(60)).await;
@@ -468,7 +467,7 @@ mod tests {
         assert!(!matches!(interrupted, Err(PvaError::Timeout)));
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_aborts_op() {
         let mut op = PvaOperation::<i32>::spawn(async {
             epics_base_rs::runtime::task::sleep(Duration::from_secs(60)).await;
@@ -492,7 +491,7 @@ mod tests {
     /// pvxs `Operation::cancel()` returns `false` once the operation has
     /// already completed (clientget.cpp:173-184 reports the prior active
     /// state). A second cancel is also `false` (idempotent).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_after_completion_reports_not_active() {
         let mut op = PvaOperation::spawn(async { Ok::<i32, _>(11) });
         assert_eq!(op.wait(Some(Duration::from_secs(1))).await.unwrap(), 11);
@@ -517,7 +516,7 @@ mod tests {
     /// `cancel_after_completion_reports_not_active` fail intermittently
     /// feature-ON. The state is built by hand so the window is held open for
     /// as long as the assertions need, rather than raced for.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_published_result_is_terminal_while_the_guard_is_still_open() {
         use std::sync::atomic::AtomicBool;
 
@@ -575,7 +574,7 @@ mod tests {
     /// cancel() is a synchronization point: a resource held by the
     /// operation future must be observably released by the time cancel()
     /// returns (pvxs "blocks until any in-progress callback has finished").
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_is_a_sync_point_resource_released() {
         use std::sync::Arc as StdArc;
         let held = StdArc::new(());
@@ -677,7 +676,7 @@ mod tests {
     /// Dropping an in-flight handle aborts the spawned task (pvxs RAII
     /// `~Operation`). The captured resource is released after the task is
     /// scheduled off — assert the abort actually happens.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn drop_aborts_in_flight_op() {
         use std::sync::Arc as StdArc;
         let held = StdArc::new(());
@@ -706,7 +705,7 @@ mod tests {
     /// Regression: a `wait` that times out while the op is
     /// still in-progress must leave the result recoverable by a later
     /// `wait` (pvxs `Operation::wait` is retriable after a timeout).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn timeout_then_wait_again_recovers_result() {
         let mut op = PvaOperation::<i32>::spawn(async {
             epics_base_rs::runtime::task::sleep(Duration::from_millis(120)).await;
@@ -722,7 +721,7 @@ mod tests {
 
     /// Repeated short timeouts (polling pattern) must not consume the
     /// result; only actual completion does.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn repeated_timeouts_do_not_consume() {
         let mut op = PvaOperation::<i32>::spawn(async {
             epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
@@ -741,7 +740,7 @@ mod tests {
     /// `cancel()` used as idempotent cleanup after an operation has already
     /// completed (but before its result is consumed) must report not-active
     /// and must NOT poison the buffered `Ok` result for a later `wait()`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_after_complete_preserves_ok_result() {
         let mut op = PvaOperation::spawn(async { Ok::<i32, _>(42) });
         // Let the task fully terminate without consuming the result: once
@@ -763,7 +762,7 @@ mod tests {
 
     /// The same precedence holds for an operation that completed with an
     /// `Err`: the real error survives a post-completion `cancel()`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_after_complete_preserves_err_result() {
         let mut op = PvaOperation::<i32>::spawn(async { Err(PvaError::Protocol("boom".into())) });
         while !op.is_done() {
@@ -779,7 +778,7 @@ mod tests {
 
     /// After one successful result read the single-consumer policy
     /// holds: a second `wait` reports the result already consumed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn second_wait_after_success_is_already_consumed() {
         let mut op = PvaOperation::spawn(async { Ok::<i32, _>(1) });
         assert_eq!(op.wait(Some(Duration::from_secs(1))).await.unwrap(), 1);

--- a/crates/epics-pva-rs/src/client_native/ops_v2.rs
+++ b/crates/epics-pva-rs/src/client_native/ops_v2.rs
@@ -18,8 +18,7 @@
 //! the full window let the server window drain to 0 and stalled ~1 RTT
 //! every `pipeline_size` updates.
 
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -7642,7 +7641,7 @@ mod tests {
     /// `teardown()` is the shared owner for `stop()`, `stop_sync()`, and
     /// `Drop`; calling it more than once (e.g. `stop_sync` then `Drop`)
     /// must be a harmless no-op.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn teardown_is_idempotent() {
         let state = idle_sub_state();
         state.teardown();
@@ -7692,7 +7691,7 @@ mod tests {
     /// A teardown that races just ahead of the INIT receive sets `stop`
     /// before the loop reaches the await; the pre-check must short-circuit
     /// to `Cancelled` WITHOUT consuming a reply that may already be queued.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn recv_monitor_init_cancels_when_stop_preset() {
         let state = idle_sub_state();
         state.stop.store(true, Ordering::Relaxed);
@@ -7710,7 +7709,7 @@ mod tests {
     }
 
     /// The happy path: a queued INIT reply is delivered as `Reply`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn recv_monitor_init_returns_reply_when_frame_arrives() {
         let state = Some(idle_sub_state());
         let (tx, mut rx) = mpsc::unbounded_channel::<Frame>();
@@ -7724,7 +7723,7 @@ mod tests {
     /// A frame stream closed before any reply is `Lost` (connection lost),
     /// distinct from a cancel — the caller maps it to ConnectionLost and
     /// lets the reconnect loop retry.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn recv_monitor_init_lost_when_stream_closed() {
         let state = Some(idle_sub_state());
         let (tx, mut rx) = mpsc::unbounded_channel::<Frame>();
@@ -7737,7 +7736,7 @@ mod tests {
 
     /// The no-handle path (plain `op_monitor`, `state == None`) cannot be
     /// cancelled, so it still simply awaits and delivers the reply.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn recv_monitor_init_no_handle_awaits_reply() {
         let state: Option<Arc<SubscriptionState>> = None;
         let (tx, mut rx) = mpsc::unbounded_channel::<Frame>();

--- a/crates/epics-pva-rs/src/client_native/ops_v2.rs
+++ b/crates/epics-pva-rs/src/client_native/ops_v2.rs
@@ -18,7 +18,6 @@
 //! the full window let the server window drain to 0 and stalled ~1 RTT
 //! every `pipeline_size` updates.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -7605,17 +7604,17 @@ mod tests {
     /// teardown owner must wake it. Model the loop's wait with a task
     /// that only awaits `cancel.notified()`; `teardown()` must make it
     /// return promptly instead of hanging forever.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn teardown_wakes_a_parked_monitor_loop() {
         let state = idle_sub_state();
         let task_state = state.clone();
-        let task = tokio::spawn(async move {
+        let task = epics_base_rs::runtime::task::spawn(async move {
             task_state.cancel.notified().await;
         });
         // Give the task a chance to reach `.notified().await`.
-        tokio::task::yield_now().await;
+        epics_base_rs::runtime::task::yield_now().await;
         state.teardown();
-        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+        epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(1), task)
             .await
             .expect("parked loop must wake on teardown, not hang")
             .expect("loop task panicked");
@@ -7629,13 +7628,16 @@ mod tests {
     /// the loop reaching its `select!` is not lost: a later `notified()`
     /// completes immediately. Without this guarantee `stop_sync()` issued
     /// on a not-yet-parked loop could still hang.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn teardown_before_park_is_not_lost() {
         let state = idle_sub_state();
         state.teardown(); // notify_one() with no waiter -> stored permit.
-        tokio::time::timeout(std::time::Duration::from_secs(1), state.cancel.notified())
-            .await
-            .expect("stored cancel permit must satisfy a later notified()");
+        epics_base_rs::runtime::task::timeout(
+            std::time::Duration::from_secs(1),
+            state.cancel.notified(),
+        )
+        .await
+        .expect("stored cancel permit must satisfy a later notified()");
     }
 
     /// `teardown()` is the shared owner for `stop()`, `stop_sync()`, and
@@ -7666,16 +7668,18 @@ mod tests {
     /// server withholds the INIT reply must complete the cancel promptly
     /// (return `Cancelled`) rather than hang the spawned monitor task
     /// forever — the regression this fix closes.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn recv_monitor_init_cancels_on_teardown_during_wait() {
         let state = idle_sub_state();
         let task_state = Some(state.clone());
         let (tx, mut rx) = mpsc::unbounded_channel::<Frame>();
-        let task = tokio::spawn(async move { recv_monitor_init(&task_state, &mut rx).await });
+        let task = epics_base_rs::runtime::task::spawn(async move {
+            recv_monitor_init(&task_state, &mut rx).await
+        });
         // Let the task reach its `select!` (silent-but-open server).
-        tokio::task::yield_now().await;
+        epics_base_rs::runtime::task::yield_now().await;
         state.teardown();
-        let out = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+        let out = epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(1), task)
             .await
             .expect("INIT recv must wake on teardown, not hang on a silent server")
             .expect("task panicked");

--- a/crates/epics-pva-rs/src/client_native/search_engine.rs
+++ b/crates/epics-pva-rs/src/client_native/search_engine.rs
@@ -18,14 +18,11 @@
 //!   that channel immediately.
 //! - Beacon anomaly throttling via [`super::beacon_throttle::BeaconTracker`].
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these four run and pass in the feature-ON
-// suite. The other two drive the UDP SEARCH transport, which only exists on
-// `tokio_backend`, so they carry that gate and the census no longer vouches for
-// them feature-ON.
 // (11 tests that spin the live UDP search engine gated out feature-ON below;
 // §4.2 defers UDP search, so their spawned timers/socket cannot run on the
 // reactor-less callback pool — stage 3.)
 
+// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -6062,7 +6059,7 @@ mod tests {
     /// bundle, so `pick_nic` forced an explicit non-loopback target onto the
     /// loopback socket (last-resort) where it could never reach the IOC.
     #[cfg(tokio_backend)]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn search_socket_bundle_not_reduced_by_intf_addr_list() {
         // The defect can only manifest where the host actually has a
         // non-loopback IPv4 NIC; on a loopback-only host the bundle is

--- a/crates/epics-pva-rs/src/client_native/server_conn.rs
+++ b/crates/epics-pva-rs/src/client_native/server_conn.rs
@@ -19,8 +19,7 @@
 //! holding an `Arc<ServerConn>` observe the closed state via [`ServerConn::is_alive`]
 //! and transition to "Reconnecting".
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -2073,7 +2072,7 @@ mod tests {
     /// frame disconnects. The pre-fix port hard-failed, so a Rust client
     /// could not reach a refuse-cred-serve-anon server (reconnect loop).
     /// `wait_for_validated` must return `Ok` on a non-success status.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn wait_for_validated_proceeds_on_auth_refused() {
         let order = ByteOrder::Little;
         let mut payload = Vec::new();

--- a/crates/epics-pva-rs/src/client_native/udp.rs
+++ b/crates/epics-pva-rs/src/client_native/udp.rs
@@ -36,9 +36,9 @@
 //! destination, which is all the fan-out predicate needs. This keeps the
 //! receive core independent of the wire codec.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
 // (1 live-UDP recv_loop test gated out feature-ON below; §4.2 UDP search, stage 3.)
 
+// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/crates/epics-pva-rs/src/server/native_source.rs
+++ b/crates/epics-pva-rs/src/server/native_source.rs
@@ -3,8 +3,7 @@
 //! Builds NTScalar and NTScalarArray `PvField` values directly from
 //! `Snapshot`s, with full alarm/timeStamp/display metadata.
 
-// RTEMS-EXEC-MODEL-ALLOW(28): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -2128,7 +2127,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_nt_enum_dereferences_value_index() {
         // pvxs `ioc/iocsource.cpp:589-593`: an NTEnum PUT is dereferenced
         // through `value.index`. A round trip through the native source
@@ -2187,7 +2186,7 @@ mod tests {
     /// `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`, i.e. the search
     /// WAS answered (a refusal can only follow a CREATE_CHANNEL, which only
     /// follows a successful search) and the create was refused.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn search_claims_every_dbd_name_but_create_gates_on_a_servable_field() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -2295,7 +2294,7 @@ mod tests {
     /// server stored ACF only as `#[allow(dead_code)]` and never
     /// called `check_access*` — every client could PUT regardless
     /// of UAG/HAG/RULE configuration.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_value_ctx_denies_when_acf_writeable_rule_unmet() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -2353,7 +2352,7 @@ ASG(SECURE) {
     /// NoAccess on the record's ASG must observe the same shape as
     /// "PV not found" (None) — the wire layer surfaces this as
     /// ECA_NORDACCESS-equivalent.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_value_ctx_denies_when_acf_no_access() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -2395,7 +2394,7 @@ ASG(LOCKED) {
 
     /// subscribe_ctx must also deny when peer has
     /// NoAccess.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn subscribe_ctx_denies_when_acf_no_access() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -2435,7 +2434,7 @@ ASG(LOCKED) {
     /// policy. Proves the RwLock-backed reload path actually
     /// influences the source's behaviour (the reload path plumbs
     /// `PvaServer::reload_acf_from` to write into this cell).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn acf_swap_takes_effect_on_next_put() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -2497,7 +2496,7 @@ ASG(SECURE) {
 
     /// When the source is built without ACF, behaviour
     /// matches the old `put_value` path — every PUT succeeds.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_value_ctx_allows_when_no_acf() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -2522,7 +2521,7 @@ ASG(SECURE) {
     /// then sees `NoAccess` in the token level and returns `None`.
     /// Previously every GET handler had to *remember* to call the
     /// ACF check by hand — now the trait method signature forces it.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_value_checked_denies_when_no_access() {
         use crate::server_native::source::ChannelSource;
         use epics_base_rs::server::records::ai::AiRecord;
@@ -2576,7 +2575,7 @@ ASG(LOCKED) {
     /// range. Pre-fix `scalar_to_epics` collapsed `ScalarValue::ULong`
     /// to `EpicsValue::Long(x as i32)`, discarding the upper 32 bits
     /// before `PvDatabase::put_pv` coerced to the target field.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn mr_r21_scalar_ulong_put_preserves_full_u64() {
         let db = Arc::new(PvDatabase::new());
         // A simple PV stores the value verbatim (`pv.set`), with no
@@ -2612,7 +2611,7 @@ ASG(LOCKED) {
     /// `pv_field_to_epics` had no `ScalarValue::ULong` array arm, so
     /// the PUT fell through to `None` and was rejected as
     /// "PUT value not representable as EpicsValue".
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn mr_r24_ulong_array_put_preserves_full_u64() {
         use epics_base_rs::server::records::waveform::WaveformRecord;
         use epics_base_rs::types::DbFieldType;
@@ -2651,7 +2650,7 @@ ASG(LOCKED) {
     /// `pv_field_to_epics` had only a `ScalarArray` arm, so the
     /// wire-decoded form fell through to `None` and the PUT was
     /// rejected as "PUT value not representable as EpicsValue".
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pf_r2_wire_typed_ulong_array_put_preserves_full_u64() {
         use crate::pvdata::TypedScalarArray;
         use epics_base_rs::server::records::waveform::WaveformRecord;
@@ -2689,7 +2688,7 @@ ASG(LOCKED) {
     /// `ScalarValue::UInt(x)` to `EpicsValue::Long(x as i32)`, so
     /// `0x8000_0000..=0xffff_ffff` was stored as a negative value.
     /// `Int64` is the lossless `epicsUInt32` carrier.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_03_scalar_uint_put_preserves_full_u32() {
         let db = Arc::new(PvDatabase::new());
         // A simple PV stores the value verbatim, isolating the
@@ -2722,7 +2721,7 @@ ASG(LOCKED) {
     /// `scalar_array_to_epics` had no `ScalarValue::UInt` arm, so the
     /// PUT fell through to `None` ("PUT value not representable as
     /// EpicsValue"). `Int64Array` carries every `epicsUInt32` element.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_03_uint_array_put_preserves_full_u32() {
         use epics_base_rs::server::records::waveform::WaveformRecord;
         use epics_base_rs::types::DbFieldType;
@@ -2757,7 +2756,7 @@ ASG(LOCKED) {
     /// a real PVA wire `uint[]` PUT decodes to
     /// `PvField::ScalarArrayTyped`; it must reach the same `Int64Array`
     /// conversion as the untyped form rather than being rejected.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_03_wire_typed_uint_array_put_preserves_full_u32() {
         use crate::pvdata::TypedScalarArray;
         use epics_base_rs::server::records::waveform::WaveformRecord;
@@ -2794,7 +2793,7 @@ ASG(LOCKED) {
     /// `testdata.cpp:596`), not saturate. The `uint` carrier is `Int64`;
     /// pre-fix `convert_to(DBF_LONG)` round-tripped through f64 and clamped
     /// `4294967295.0` to `i32::MAX` (2147483647) instead of yielding -1.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r0604_uint_scalar_put_truncates_into_signed_longout() {
         use epics_base_rs::server::records::longout::LongoutRecord;
 
@@ -2827,7 +2826,7 @@ ASG(LOCKED) {
     /// element (pvxs `convertCast` `Dest(S[i])`, `sharedarray.cpp:160-166`).
     /// `{1, 2, 0xffffffff}` lands as `{1, 2, -1}`; pre-fix the last element
     /// saturated to `i32::MAX` through the f64 round-trip.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r0604_uint_array_put_truncates_into_signed_long_waveform() {
         use epics_base_rs::server::records::waveform::WaveformRecord;
         use epics_base_rs::types::DbFieldType;
@@ -2865,7 +2864,7 @@ ASG(LOCKED) {
     /// element type now comes from the `TypedScalarArray` tag, which is
     /// present at length zero. Covers `double[]`, `string[]`, and an
     /// integer array per the finding.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_04_empty_typed_double_array_put_clears_waveform() {
         use epics_base_rs::server::records::waveform::WaveformRecord;
         use epics_base_rs::types::DbFieldType;
@@ -2894,7 +2893,7 @@ ASG(LOCKED) {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_04_empty_typed_string_array_put_accepted() {
         // `WaveformRecord` has no DBF_STRING storage, so a string array
         // lives on a simple PV, which stores the value verbatim and thus
@@ -2924,7 +2923,7 @@ ASG(LOCKED) {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_04_empty_typed_int_array_put_clears_waveform() {
         use epics_base_rs::server::records::waveform::WaveformRecord;
         use epics_base_rs::types::DbFieldType;
@@ -2960,7 +2959,7 @@ ASG(LOCKED) {
     /// alarm/timeStamp, so a later GET rebuilt them from local defaults
     /// (NO_ALARM + wall-clock-now). pvxs mailbox SharedPV assigns the
     /// whole posted value (`sharedpv.cpp:417-432`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_60_simple_pv_put_persists_alarm_and_timestamp() {
         let db = Arc::new(PvDatabase::new());
         db.add_pv("MB:PV", EpicsValue::Double(0.0)).await.unwrap();
@@ -3022,7 +3021,7 @@ ASG(LOCKED) {
     /// rule.level=1`. The fix doesn't change the equality bound;
     /// it threads the real ASL so `RULE(N, …)` with `record_asl > N`
     /// now skips the rule.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn asl_gate_skips_rules_above_record_asl() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -3091,7 +3090,7 @@ ASG(DEFAULT) {
     /// record evaluates the expression into VAL on process, so VAL flips
     /// from its unprocessed default (0) to 5 — proof the chain ran, which
     /// the old no-op `Ok(())` could never produce.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_runs_record_processing_not_noop() {
         use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -3143,7 +3142,7 @@ ASG(DEFAULT) {
     ///
     /// UDF is the witness that discriminates the two routes: `dbPut` writes
     /// the field and stops, so only a real process cycle clears it.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn external_put_on_a_passive_record_processes_it() {
         use epics_base_rs::server::records::calc::CalcRecord;
 
@@ -3307,7 +3306,7 @@ ASG(DEFAULT) {
     /// and, unlike the task, without the consumer awaiting anything: this
     /// is the property that lets an RTEMS operation thread drain a monitor
     /// without a reactor.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn the_upstream_seed_is_the_first_item_and_needs_no_await() {
         use tokio::sync::mpsc::error::TryRecvError;
 
@@ -3406,7 +3405,7 @@ ASG(DEFAULT) {
 
     /// A simple/mailbox PV has no record body; PROCESS reports unsupported
     /// rather than silently succeeding.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_simple_pv_is_unsupported() {
         let db = Arc::new(PvDatabase::new());
         db.add_pv("MAILBOX:PV", EpicsValue::Double(1.0))

--- a/crates/epics-pva-rs/src/server/native_source.rs
+++ b/crates/epics-pva-rs/src/server/native_source.rs
@@ -3,7 +3,6 @@
 //! Builds NTScalar and NTScalarArray `PvField` values directly from
 //! `Snapshot`s, with full alarm/timeStamp/display metadata.
 
-// RTEMS-EXEC-MODEL-ALLOW(3): checked - these run and pass in the feature-ON suite.
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -2252,7 +2251,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn simple_pv_monitor_observes_later_puts() {
         let db = Arc::new(PvDatabase::new());
         db.add_pv("SIMPLE:MON", EpicsValue::Double(1.0))
@@ -2278,10 +2277,11 @@ mod tests {
         .await
         .expect("PUT must succeed");
 
-        let updated = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-            .await
-            .expect("monitor must receive the PUT update within 2s")
-            .expect("monitor stream still open");
+        let updated =
+            epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("monitor must receive the PUT update within 2s")
+                .expect("monitor stream still open");
         assert_eq!(
             monitor_double(&updated),
             Some(2.0),
@@ -3191,7 +3191,7 @@ ASG(DEFAULT) {
     /// `DBE_PROPERTY` subscription (`singlesource.cpp:162-166`), so putting
     /// display/control/valueAlarm on every value update is a strict superset
     /// of C — the whole `--phase pva-monitor` `update_events` pattern.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_process_update_marks_value_alarm_time_not_the_metadata_leaves() {
         use epics_base_rs::server::records::ai::AiRecord;
 
@@ -3219,10 +3219,11 @@ ASG(DEFAULT) {
             .await
             .expect("put");
 
-        let update = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-            .await
-            .expect("an update must post within 2s")
-            .expect("stream open");
+        let update =
+            epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(2), rx.recv())
+                .await
+                .expect("an update must post within 2s")
+                .expect("stream open");
         let marked = update.marked.expect("a record update declares its marks");
 
         assert!(
@@ -3368,7 +3369,7 @@ ASG(DEFAULT) {
     /// only reports `Disconnected` when the producer is really gone. Getting
     /// this backwards would make an RTEMS drain loop tear down every idle
     /// monitor, which is why the mapping is spelled once in `from_queue_err`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn an_idle_record_monitor_is_empty_not_disconnected() {
         use epics_base_rs::server::records::ai::AiRecord;
         use tokio::sync::mpsc::error::TryRecvError;
@@ -3397,7 +3398,7 @@ ASG(DEFAULT) {
         db.put_record_field_from_ca_no_notify("AI:IDLE", "VAL", EpicsValue::Double(1.0))
             .await
             .expect("put");
-        tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        epics_base_rs::runtime::task::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
             .expect("an update must post within 2s")
             .expect("stream open");

--- a/crates/epics-pva-rs/src/server/pva_server.rs
+++ b/crates/epics-pva-rs/src/server/pva_server.rs
@@ -296,7 +296,7 @@ impl PvaServer {
         F: FnOnce(&iocsh::IocShell) + Send + 'static,
     {
         let db = self.db.clone();
-        let handle = tokio::runtime::Handle::current();
+        let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
 
         let autosave_cmds = self
             .autosave_manager
@@ -313,7 +313,7 @@ impl PvaServer {
 
         let (tx, rx) = epics_base_rs::runtime::sync::oneshot::channel();
         std::thread::spawn(move || {
-            let shell = iocsh::IocShell::new(db, handle);
+            let shell = iocsh::IocShell::new(db, bridge);
             register_fn(&shell);
             if let Some(cmds) = autosave_cmds {
                 for cmd in cmds {
@@ -353,7 +353,7 @@ impl PvaServer {
         F: FnOnce(&iocsh::IocShell) + Send + 'static,
     {
         let db = self.db.clone();
-        let handle = tokio::runtime::Handle::current();
+        let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
 
         let autosave_cmds = self
             .autosave_manager
@@ -372,7 +372,7 @@ impl PvaServer {
 
         let (tx, rx) = epics_base_rs::runtime::sync::oneshot::channel();
         std::thread::spawn(move || {
-            let shell = iocsh::IocShell::new(db, handle);
+            let shell = iocsh::IocShell::new(db, bridge);
             register_fn(&shell);
             if let Some(cmds) = autosave_cmds {
                 for cmd in cmds {

--- a/crates/epics-pva-rs/src/server/pva_server.rs
+++ b/crates/epics-pva-rs/src/server/pva_server.rs
@@ -3,7 +3,6 @@
 //! Built on top of the native runtime in [`crate::server_native`].
 
 // RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/epics-pva-rs/src/server_native/blocking.rs
+++ b/crates/epics-pva-rs/src/server_native/blocking.rs
@@ -146,7 +146,6 @@
 //! exist is not, yet.
 
 // RTEMS-EXEC-MODEL-ALLOW(16): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::io;
 use std::net::{

--- a/crates/epics-pva-rs/src/server_native/composite.rs
+++ b/crates/epics-pva-rs/src/server_native/composite.rs
@@ -14,8 +14,6 @@
 //! `rpc`, `is_writable`, `get_introspection`). `list_pvs()` is the
 //! union of every source's PV list.
 
-// RTEMS-EXEC-MODEL-ALLOW(11): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -1126,7 +1124,7 @@ mod tests {
     /// must go through the matched inner source's gate via
     /// `ChannelSource::revalidate_read`, not the composite's own
     /// permissive `access()` gate.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn aggregator_gate_observes_inner_bumps() {
         use epics_base_rs::server::access_security::AccessGate;
         struct VersionedSrc {
@@ -1221,7 +1219,7 @@ mod tests {
     /// lookup fails for names no upstream serves); `blanket` makes it
     /// report `levels` for EVERY name (the gateway's name-independent
     /// `monitor_watermarks`) versus only for the name it owns.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn composite_watermarks_come_from_the_owning_source() {
         struct WmSrc {
             serves: &'static str,
@@ -1324,7 +1322,7 @@ mod tests {
     /// version than inner B, then bumps B (which the old `max`
     /// aggregator would miss) and asserts the composite version
     /// changes.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn aggregator_detects_inner_bump_below_max() {
         use epics_base_rs::server::access_security::AccessGate;
         struct VersionedSrc {
@@ -1416,7 +1414,7 @@ mod tests {
     /// detect: replacing a source with another serving the SAME
     /// `list_pvs()` output, and changing a source's priority for the
     /// same PV name. Mirrors pvxs `beaconChange` (server.cpp:90-115).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn beacon_change_advances_on_registry_mutations() {
         let comp = CompositeSource::new();
         let v0 = comp.beacon_change();
@@ -1496,7 +1494,7 @@ mod tests {
     /// keeps a single `beaconChange` bumped by both
     /// `addSource`/`removeSource` AND `addPV`/`removePV`
     /// (server.cpp:95,113,180,189).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn beacon_change_aggregates_inner_shared_source_mutations() {
         use crate::server_native::{SharedPV, SharedSource};
 
@@ -1536,7 +1534,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn priority_order_dispatch() {
         let comp = CompositeSource::new();
         let lo: DynSource = Arc::new(PvSrc {
@@ -1559,7 +1557,7 @@ mod tests {
         assert_eq!(*n, 2);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn list_pvs_unions_sources() {
         let comp = CompositeSource::new();
         comp.add_source(
@@ -1595,7 +1593,7 @@ mod tests {
     /// `has_pv` is reached and records the account seen by
     /// `has_pv_checked`; routing `get_value_checked` through the
     /// composite must hit the credentialed path only.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn fr8_checked_ops_select_via_has_pv_checked() {
         use crate::server_native::source::ChannelContext;
         use epics_base_rs::server::access_security::AccessGate;
@@ -1714,7 +1712,7 @@ mod tests {
     /// name is removed and re-registered to a different source. A fresh
     /// resolve sees the new registry — proving the binding, not the
     /// registry, is what a live channel dispatches through.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn resolve_owner_binds_accepting_source_across_registry_change() {
         use crate::server_native::source::ChannelContext;
         let ctx = ChannelContext {
@@ -1795,7 +1793,7 @@ mod tests {
     /// never suppresses a user PV named `server`. Mirrors the built-in
     /// `__server` (order -1, non-searchable) sitting in front of a
     /// default-order user `server` PV.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn search_ors_claims_across_sources_non_searchable_host_does_not_veto() {
         /// Hosts `name` but is never search-advertised — the
         /// `ServerInfoSource`/pvxs `ServerSource` shape.
@@ -1920,7 +1918,7 @@ mod tests {
     /// refusal would have degraded to a search timeout. Sources that do not
     /// distinguish the two are unaffected — `searchable` defaults to `has_pv`,
     /// which the sibling test above still pins.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn search_advertises_a_name_the_source_refuses_at_create() {
         /// Advertised at SEARCH, refused at CREATE — the `SingleSource`
         /// `DBF_NOACCESS` shape.

--- a/crates/epics-pva-rs/src/server_native/monitor_control.rs
+++ b/crates/epics-pva-rs/src/server_native/monitor_control.rs
@@ -44,8 +44,6 @@
 //! receiver is not owned by this type, so the external consumer must
 //! call [`MonitorControlOp::note_consumed`] to decrement `pending`.
 
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -292,7 +290,7 @@ impl<T> MonitorReceiver<T> {
 mod tests {
     use super::*;
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn try_post_succeeds_below_high_watermark() {
         let (op, mut rx) = MonitorControlOp::<i32>::channel(8);
         op.set_high_watermark(4);
@@ -305,7 +303,7 @@ mod tests {
         let _ = rx.recv().await;
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn try_post_refuses_at_high_watermark() {
         let (op, _rx) = MonitorControlOp::<i32>::channel(8);
         op.set_high_watermark(2);
@@ -317,7 +315,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn force_post_bypasses_watermark() {
         let (op, _rx) = MonitorControlOp::<i32>::channel(8);
         op.set_high_watermark(1);
@@ -326,7 +324,7 @@ mod tests {
         assert_eq!(op.pending(), 2);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn note_consumed_drops_pending_on_from_sender_path() {
         // from_sender owns no MonitorReceiver, so the external consumer
         // decrements via note_consumed.
@@ -343,7 +341,7 @@ mod tests {
         op.try_post(3).expect("after consumed");
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn recv_decrements_pending_and_reopens_gate_without_manual_note() {
         // Boundary: the high-watermark gate must reopen as the consumer
         // drains, with no note_consumed call. (Regression: the receiver
@@ -370,7 +368,7 @@ mod tests {
         assert_eq!(op.pending(), 2);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn try_recv_also_decrements_pending() {
         let (op, mut rx) = MonitorControlOp::<i32>::channel(8);
         op.try_post(10).expect("post");
@@ -381,7 +379,7 @@ mod tests {
         assert_eq!(op.pending(), 0, "empty try_recv must not underflow");
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn paused_flag_observable_independently() {
         let (op, _rx) = MonitorControlOp::<i32>::channel(8);
         assert!(!op.is_paused());
@@ -391,7 +389,7 @@ mod tests {
         assert!(!op.is_paused());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn closed_receiver_returns_receiver_gone() {
         let (op, rx) = MonitorControlOp::<i32>::channel(8);
         drop(rx);

--- a/crates/epics-pva-rs/src/server_native/op_handle.rs
+++ b/crates/epics-pva-rs/src/server_native/op_handle.rs
@@ -28,8 +28,6 @@
 //! [`super::source::ChannelContext`] and drained by the connection into
 //! IOID-tagged `CMD_MESSAGE` frames before the operation's reply.
 
-// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -337,7 +335,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn exec_op_reply_delivers_value() {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let logger = RemoteLogger::log_only("TEST:PV");
@@ -357,7 +355,7 @@ mod tests {
         assert!(!op.is_open());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn exec_op_error_closes_and_delivers_message() {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let logger = RemoteLogger::log_only("TEST:PV");
@@ -371,7 +369,7 @@ mod tests {
         assert!(!op.is_open());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn exec_op_drop_without_reply_emits_err() {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let logger = RemoteLogger::log_only("TEST:PV");
@@ -384,7 +382,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn remote_logger_with_sender_delivers_to_channel() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<OpMessage>(8);
         let logger = RemoteLogger::new(tx, 77, "TEST:PV");
@@ -404,7 +402,7 @@ mod tests {
         assert_eq!(m3.ioid, 77);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn exec_op_error_does_not_emit_side_channel_message() {
         // ExecOp::error resolves the op via its reply (Status), and must
         // NOT also push a CMD_MESSAGE — pvxs sends only the op-error
@@ -422,7 +420,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn remote_logger_log_only_drops_silently() {
         // Should not panic. Tracing output is implementation detail.
         let logger = RemoteLogger::log_only("TEST:PV");

--- a/crates/epics-pva-rs/src/server_native/runtime.rs
+++ b/crates/epics-pva-rs/src/server_native/runtime.rs
@@ -1,7 +1,6 @@
 //! Top-level [`PvaServer`] runtime: spawns UDP responder + TCP listener.
 
-// RTEMS-EXEC-MODEL-ALLOW(11): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(10): checked - these run and pass in the feature-ON suite.
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
@@ -1210,7 +1209,7 @@ mod tcp_fallback_tests {
     /// rather than aborting the process. Binding to an address that is
     /// not assigned to any local interface yields `AddrNotAvailable`,
     /// which is outside the fallback set, so `start` returns `Err`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn start_returns_err_on_unbindable_address() {
         let source = Arc::new(SharedSource::new());
         let config = PvaServerConfig {

--- a/crates/epics-pva-rs/src/server_native/server_info.rs
+++ b/crates/epics-pva-rs/src/server_native/server_info.rs
@@ -40,8 +40,6 @@
 //! a user that wants to own `server` must register at an explicit order
 //! `< -1`.
 
-// RTEMS-EXEC-MODEL-ALLOW(12): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 
 use epics_base_rs::types::PvString;
@@ -460,20 +458,20 @@ mod tests {
         })
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn has_pv_only_matches_server() {
         let src = source_with(vec![]);
         assert!(src.has_pv("server").await);
         assert!(!src.has_pv("anything:else").await);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn list_pvs_is_empty_so_server_never_self_lists() {
         let src = source_with(vec!["user:pv".into()]);
         assert!(src.list_pvs().await.is_empty());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_channels_returns_sorted_deduped_names() {
         let src = source_with(vec![
             "z:pv".into(),
@@ -530,7 +528,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_info_returns_only_impllang_and_version() {
         // pvxs `op=info` is a bare struct with exactly implLang+version
         // (serversource.cpp:19-22). No guid/peerCount/channelCount.
@@ -571,7 +569,7 @@ mod tests {
         assert_eq!(names, vec!["implLang", "version"]);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_help_returns_ntscalar_string() {
         // pvxs answers a help-bearing request with an NTScalar<string>
         // BEFORE reading `op` (serversource.cpp:46-51) — so a request
@@ -636,7 +634,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_unknown_op_errors() {
         let src = source_with(vec![]);
         let (desc, value) = nturi_op("frobnicate");
@@ -649,7 +647,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_missing_op_errors() {
         let src = source_with(vec![]);
         // NTURI with an empty query — no `op`.
@@ -668,7 +666,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_flat_struct_request_op_at_top_level() {
         // pvxs custom services may send `op` at the top level rather
         // than inside `query`. `extract_op` handles both.
@@ -695,7 +693,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_query_op_wins_over_root_help() {
         // pvxs selects `args = query` then reads BOTH help and op from
         // that single view (serversource.cpp:41-53) — a root-level `help`
@@ -734,7 +732,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn rpc_present_query_does_not_fall_back_to_root_op() {
         // With a present (here empty) `query`, pvxs reads `op` ONLY from
         // the query view; a root-level `op` is not a fallback. So this
@@ -758,7 +756,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_has_no_surface_on_server() {
         // pvxs installs no `onOp` for `server`, so it has no GET surface
         // (serversource.cpp:30-94). Both the introspection prototype and
@@ -769,7 +767,7 @@ mod tests {
         assert!(src.get_value("server").await.is_none());
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_is_rejected_read_only() {
         let src = source_with(vec![]);
         let err = src.put_value("server", PvField::Null).await.unwrap_err();

--- a/crates/epics-pva-rs/src/server_native/shared_pv.rs
+++ b/crates/epics-pva-rs/src/server_native/shared_pv.rs
@@ -22,7 +22,6 @@
 //! pipeline window. We don't yet wire them into the wire-level
 //! ackCount but the API is in place for callers to set them.
 
-// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
 use std::collections::{HashMap, VecDeque};
 use std::sync::{
     Arc,
@@ -2237,7 +2236,7 @@ mod tests {
     ///
     /// Before fix: try_send returned TrySendError::Full for posts 3 and 4, so
     /// consumer saw [1, 2] and the assertion v2 == 4 failed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_r6_squash_to_tail() {
         let pv = SharedPV::new();
         pv.open(nt_scalar_int_desc(), nt_scalar_int_value(0))
@@ -2264,7 +2263,9 @@ mod tests {
         );
 
         // Queue is now empty — no more posts were made.
-        let empty = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        let empty =
+            epics_base_rs::runtime::task::timeout(std::time::Duration::from_millis(50), rx.recv())
+                .await;
         assert!(empty.is_err(), "queue must be empty after squash drain");
     }
 

--- a/crates/epics-pva-rs/src/server_native/shared_pv.rs
+++ b/crates/epics-pva-rs/src/server_native/shared_pv.rs
@@ -22,8 +22,7 @@
 //! pipeline window. We don't yet wire them into the wire-level
 //! ackCount but the API is in place for callers to set them.
 
-// RTEMS-EXEC-MODEL-ALLOW(14): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
 use std::collections::{HashMap, VecDeque};
 use std::sync::{
     Arc,
@@ -1875,7 +1874,7 @@ mod tests {
             .expect("re-add after remove succeeds");
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn shared_pv_subscribe_sees_initial_then_updates() {
         let pv = SharedPV::new();
         pv.open(nt_scalar_int_desc(), nt_scalar_int_value(0))
@@ -2052,7 +2051,7 @@ mod tests {
     /// named `SharedPV`'s attach/detach so a lazy PV opens for a
     /// GET-only client (no monitor) on first channel and closes on last,
     /// matching pvxs lazy GET/PUT/RPC/GET_FIELD coverage.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn shared_source_channel_open_close_drives_lazy_lifecycle() {
         use crate::server_native::source::{ChannelContext, ChannelSource};
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2189,7 +2188,7 @@ mod tests {
     /// `SharedPV::current()` / `introspection()`. A closed PV must report
     /// `None` on both, matching pvxs withdrawing `impl->current` so a
     /// post-close fetch throws `"open() first"` (`sharedpv.cpp:443-469`).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn shared_source_get_paths_withdraw_after_close() {
         use crate::server_native::source::ChannelSource;
 
@@ -2400,7 +2399,7 @@ mod tests {
     /// levels to the monitor loop (which fires the callbacks off the
     /// pipeline window), and `set_*_watermark` retunes them. An unknown
     /// PV / level-less source returns `None`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn shared_source_exposes_per_pv_watermark_levels() {
         use super::super::source::ChannelSource;
         let pv = SharedPV::new();
@@ -2419,7 +2418,7 @@ mod tests {
     /// mailbox handler posts through `try_post_checked`, which retains
     /// the canonical subscriber set under the lock, so a subscriber
     /// survives back-to-back delta PUTs and receives every value.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn mr_r2_put_delta_clone_drop_keeps_subscriber_alive() {
         use crate::proto::BitSet;
 
@@ -2466,7 +2465,7 @@ mod tests {
     /// `onPut` (`sharedpv.cpp:113-121`). The PV opened with a zero
     /// timestamp; after the value-only PUT the stored timeStamp must hold
     /// the current wall-clock time, not the stale zero.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r0604_mailbox_put_value_only_stamps_timestamp() {
         use crate::proto::BitSet;
         let pv = SharedPV::build_mailbox();
@@ -2491,7 +2490,7 @@ mod tests {
     /// A client that marks `timeStamp.secondsPastEpoch` keeps its own
     /// timestamp — pvxs only stamps when `!isMarked(true, true)`, so a
     /// marked child suppresses the server fill.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r0604_mailbox_put_marked_timestamp_is_preserved() {
         use crate::proto::BitSet;
         let pv = SharedPV::build_mailbox();
@@ -2514,7 +2513,7 @@ mod tests {
 
     /// A value type with no `timeStamp` field is unaffected: the PUT
     /// stores the value and the server fabricates no timeStamp.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r0604_mailbox_put_no_timestamp_field_unchanged() {
         use crate::proto::BitSet;
         let pv = SharedPV::build_mailbox();
@@ -2540,7 +2539,7 @@ mod tests {
     /// `put_delta` are rejected, and the stored value is unchanged
     /// (pvxs `sharedpv.cpp:209-227`). `build_mailbox` makes it writable;
     /// `build_readonly` rejects with the pvxs `"Read-only PV"` message.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn plain_shared_pv_rejects_put_mailbox_accepts_readonly_refuses() {
         use crate::proto::BitSet;
 
@@ -2591,7 +2590,7 @@ mod tests {
     /// explicit `close()` must still terminate the subscriber
     /// inbox — closure is an owner action, and the invariant only
     /// forbids *internal clone drops* from closing the queue.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn mr_r2_close_still_terminates_subscriber() {
         let pv = SharedPV::new();
         pv.open(nt_scalar_int_desc(), nt_scalar_int_value(0))
@@ -2616,7 +2615,7 @@ mod tests {
     /// that committed value; once `close()` runs, the inbox terminates
     /// and a later PUT is rejected with no surviving clone to deliver a
     /// post-close value.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn r0604_put_delta_store_and_delivery_serialize_with_close() {
         use crate::proto::BitSet;
         let pv = SharedPV::build_mailbox();
@@ -2701,7 +2700,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn shared_source_serves_named_pv() {
         use super::super::source::ChannelSource;
         let pv = SharedPV::new();
@@ -2727,7 +2726,7 @@ mod tests {
     /// hash fallback cannot detect — remove + re-add of the SAME name
     /// within one beacon interval, so `list_pvs()` is identical
     /// before/after — must still advance the counter.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn shared_source_beacon_change_advances_on_pv_registry_mutations() {
         use super::super::source::ChannelSource;
 

--- a/crates/epics-pva-rs/src/server_native/source.rs
+++ b/crates/epics-pva-rs/src/server_native/source.rs
@@ -3,8 +3,6 @@
 //! Uses our own [`crate::pvdata`] types, so only native types appear in the
 //! public surface.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
-
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
@@ -2751,7 +2749,7 @@ mod tests {
     /// (capacity 1024, one message per name) silently dropped names past the
     /// ring on a large flush; this unbounded per-connection queue cannot. Far
     /// exceed the old 1024 cap before draining, then assert nothing was lost.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn invalidator_never_drops_under_backlog() {
         let inv = ChannelInvalidator::new();
         let mut rx = inv.subscribe();
@@ -2774,7 +2772,7 @@ mod tests {
     /// One removal command publishes its whole removed set as a single batch,
     /// regardless of how many entries it cleared — the per-name → snapshot
     /// shape change that lets a full-cache `:flush` ride in one message.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn invalidator_delivers_one_batch_per_command() {
         let inv = ChannelInvalidator::new();
         let mut rx = inv.subscribe();
@@ -2789,7 +2787,7 @@ mod tests {
 
     /// Fan-out reaches every live subscriber, and an empty batch is a no-op
     /// (a `:flush` of an empty cache publishes nothing).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn invalidator_fans_out_and_skips_empty() {
         let inv = ChannelInvalidator::new();
         let mut a = inv.subscribe();
@@ -2813,7 +2811,7 @@ mod tests {
     /// A subscriber whose receiver was dropped is pruned on the next publish,
     /// so a high connection-churn workload does not grow the registry. The
     /// surviving subscriber keeps receiving.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn invalidator_prunes_dropped_subscribers() {
         let inv = ChannelInvalidator::new();
         let dead = inv.subscribe();

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -20,7 +20,7 @@
 //! No socket type is named anywhere in this file's production scope, and
 //! `accept::tests::the_protocol_scope_owns_no_socket` keeps it that way.
 
-// RTEMS-EXEC-MODEL-ALLOW(23): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -11209,7 +11209,7 @@ mod tests {
     /// Also pins the arm-before-read ordering: the ACK path adds credit and
     /// calls `notify_waiters()`, which stores no permit, so a waiter armed
     /// AFTER the window read would miss the refill and park forever.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_pipeline_credit_refill_wakes_the_armed_waiter() {
         use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
         let window = Arc::new(AtomicU32::new(0));
@@ -11232,9 +11232,12 @@ mod tests {
         let refill = credit.arm_refill();
         assert!(!credit.available(), "no credit → the emit gate is shut");
         assert!(
-            tokio::time::timeout(Duration::from_millis(50), wait_credit_refill(refill))
-                .await
-                .is_err(),
+            epics_base_rs::runtime::task::timeout(
+                Duration::from_millis(50),
+                wait_credit_refill(refill)
+            )
+            .await
+            .is_err(),
             "with no ACK the refill waiter must park"
         );
 
@@ -11245,9 +11248,12 @@ mod tests {
         window.fetch_add(1, Ordering::Relaxed);
         notify.notify_waiters();
         assert!(
-            tokio::time::timeout(Duration::from_millis(500), wait_credit_refill(refill))
-                .await
-                .is_ok(),
+            epics_base_rs::runtime::task::timeout(
+                Duration::from_millis(500),
+                wait_credit_refill(refill)
+            )
+            .await
+            .is_ok(),
             "an ACK refill must wake the armed waiter"
         );
         assert!(credit.available(), "the refilled window re-opens the gate");
@@ -11590,7 +11596,7 @@ mod tests {
     /// INIT->START window are delivered in order (A(seed), B, C, D) at the
     /// first START. Pre-fix the subscriber spawned only at START, so the
     /// window posts were lost and only the latest seed survived.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_init_window_posts_accrue_in_order() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 700u32);
@@ -11621,13 +11627,13 @@ mod tests {
 
         // Let the subscriber task subscribe and capture the seed (0,0,0)
         // BEFORE any post arrives.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
         // Posts arrive while the monitor is Idle (INIT->START window).
         for i in 1..=3 {
             pusher.try_post(three_field_value(i, 0, 0));
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(100)).await;
         // Invariant: an Idle monitor emits nothing before START.
         assert!(
             rx.try_recv().is_err(),
@@ -11648,7 +11654,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(250)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -11663,7 +11669,7 @@ mod tests {
     /// five posts in the INIT->START window squash to the seed + the
     /// latest, so START delivers exactly 2 frames (bounded FIFO, newest
     /// tail wins).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_backlog_bounds_to_queue_size() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (2u32, 701u32);
@@ -11689,15 +11695,15 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         // Five posts while Idle — the FIFO (seed + queueSize-1 tail) must
         // bound them to 2 total.
         for i in 1..=5 {
             pusher.try_post(three_field_value(i, 0, 0));
-            tokio::time::sleep(Duration::from_millis(15)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(15)).await;
         }
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         pvx61_drive(
             &pvx61_ctrl_frame(sid, ioid, 0x44, order),
@@ -11712,7 +11718,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(250)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -11731,7 +11737,7 @@ mod tests {
 
     /// Backlog == 0: a START with no window posts delivers the seed
     /// only.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_seed_only_no_backlog() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (3u32, 702u32);
@@ -11757,7 +11763,7 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         pvx61_drive(
             &pvx61_ctrl_frame(sid, ioid, 0x44, order),
@@ -11772,7 +11778,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(200)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -11784,7 +11790,7 @@ mod tests {
 
     /// Backlog == 1: a single window post delivers the seed + that
     /// one post.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_single_backlog() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (4u32, 703u32);
@@ -11810,10 +11816,10 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         pusher.try_post(three_field_value(1, 0, 0));
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(100)).await;
 
         pvx61_drive(
             &pvx61_ctrl_frame(sid, ioid, 0x44, order),
@@ -11828,7 +11834,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(200)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -11842,7 +11848,7 @@ mod tests {
     /// same Idle-accruing state as INIT->START: posts during the pause
     /// accrue up to queueSize and flush at the next START. Pre-fix the
     /// single `held` cell delivered only the latest pause-window value.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_stop_start_delivers_backlog_depth() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (5u32, 704u32);
@@ -11868,7 +11874,7 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         // First START drains the seed.
         pvx61_drive(
@@ -11884,7 +11890,7 @@ mod tests {
         )
         .await
         .expect("first MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
         let seed = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(seed, vec![0], "first START delivers the seed; got {seed:?}");
 
@@ -11902,12 +11908,12 @@ mod tests {
         )
         .await
         .expect("MONITOR STOP ok");
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
         for i in 1..=3 {
             pusher.try_post(three_field_value(i, 0, 0));
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(100)).await;
         // Still Idle — nothing emitted during the pause.
         assert!(
             rx.try_recv().is_err(),
@@ -11928,7 +11934,7 @@ mod tests {
         )
         .await
         .expect("second MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(250)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -11943,7 +11949,7 @@ mod tests {
     /// task is spawned at INIT with its abort guard installed in the same
     /// synchronous step, so a DESTROY arriving before any START removes
     /// the op, drops the abort, and fires the terminal `MonitorFinished`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_destroy_before_start_tears_down() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (6u32, 705u32);
@@ -11971,7 +11977,7 @@ mod tests {
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
         // Let the task subscribe and install its `MonitorFinishGuard`.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
         assert!(
             mon_fin_rx.try_recv().is_err(),
             "the subscriber is alive (Idle) before DESTROY — no finish yet"
@@ -11992,7 +11998,7 @@ mod tests {
         .await
         .expect("MONITOR DESTROY ok");
 
-        let fin = tokio::time::timeout(Duration::from_secs(2), mon_fin_rx.recv())
+        let fin = epics_base_rs::runtime::task::timeout(Duration::from_secs(2), mon_fin_rx.recv())
             .await
             .expect("teardown fires within 2s")
             .expect("MonitorFinished");
@@ -12007,7 +12013,7 @@ mod tests {
     /// subscriber; dropping the channels map (connection teardown) before
     /// any START drops the op's abort guard, aborting the task and firing
     /// the terminal `MonitorFinished`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_never_start_tears_down_on_drop() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (7u32, 706u32);
@@ -12035,12 +12041,12 @@ mod tests {
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
         // Let the task subscribe and install its guard before teardown.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         // Connection torn down before any START.
         drop(channels);
 
-        let fin = tokio::time::timeout(Duration::from_secs(2), mon_fin_rx.recv())
+        let fin = epics_base_rs::runtime::task::timeout(Duration::from_secs(2), mon_fin_rx.recv())
             .await
             .expect("teardown fires within 2s")
             .expect("MonitorFinished");
@@ -12054,7 +12060,7 @@ mod tests {
     /// Pre-fix the terminal FINISH was ungated on Executing, so an Idle-close
     /// emitted FINISH immediately and abandoned the accrued backlog. Newly
     /// reachable because the subscriber now runs from INIT.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_source_close_while_idle_holds_backlog_until_start() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (11u32, 710u32);
@@ -12080,19 +12086,19 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         // Posts arrive while the monitor is Idle (INIT->START window).
         for i in 1..=3 {
             pusher.try_post(three_field_value(i, 0, 0));
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(100)).await;
 
         // The PV closes while the monitor is STILL Idle (never STARTed): the
         // subscriber's source channel ends but no START has arrived.
         pusher.close();
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         // Invariant: an Idle monitor emits NOTHING on source-close — no
         // FINISH, no DATA. The backlog and the finish are held for a START.
@@ -12117,7 +12123,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(250)).await;
 
         // Classify every drained frame in order: DATA field-`a` values, and
         // whether the terminal FINISH followed the whole backlog.
@@ -12254,7 +12260,7 @@ mod tests {
     /// counterpart of T1). The raw subscriber accrues events from INIT and
     /// flushes them after START in order, ahead of the cooked seed's
     /// backlog.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_raw_path_accrues_in_order() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (8u32, 707u32);
@@ -12280,16 +12286,16 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         for i in 1..=3 {
             raw_tx
                 .send(pvx61_raw_event(i, order))
                 .await
                 .expect("raw event queued");
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(20)).await;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(100)).await;
         assert!(
             rx.try_recv().is_err(),
             "an Idle (pre-START) raw monitor must not emit any DATA frame"
@@ -12308,7 +12314,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(250)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -12322,7 +12328,7 @@ mod tests {
     /// raw counterpart of T2). Five events with queueSize 2 flush to
     /// exactly 2 frames (seed + latest), the same total the decoded path
     /// yields — the cooked seed counts against queueSize on both paths.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_raw_path_bounds_to_queue_size() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (9u32, 708u32);
@@ -12348,16 +12354,16 @@ mod tests {
         .await
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         for i in 1..=5 {
             raw_tx
                 .send(pvx61_raw_event(i, order))
                 .await
                 .expect("raw event queued");
-            tokio::time::sleep(Duration::from_millis(15)).await;
+            epics_base_rs::runtime::task::sleep(Duration::from_millis(15)).await;
         }
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         pvx61_drive(
             &pvx61_ctrl_frame(sid, ioid, 0x44, order),
@@ -12372,7 +12378,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(250)).await;
 
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert_eq!(
@@ -12440,7 +12446,7 @@ mod tests {
     /// the seed is pending[0] and is rechecked on pop. Pre-fix the raw seed
     /// was emitted via `seed_cooked.take()` without the recheck, so a client
     /// that lost read access still received it.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_raw_seed_rechecks_acl_on_reload() {
         use epics_base_rs::server::access_security::{AccessGate, AsgAslResolver, parse_acf};
         let order = ByteOrder::Little;
@@ -12497,7 +12503,7 @@ mod tests {
         .expect("MONITOR INIT ok");
         let _ = rx.recv().await.expect("INIT introspection reply");
         // Let the raw subscriber capture the seed under the permissive gate.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(150)).await;
 
         // ACL reload during the idle window: READ is revoked, version bumped.
         let deny = parse_acf(
@@ -12509,7 +12515,7 @@ mod tests {
         .expect("acf");
         cell.store(Some(std::sync::Arc::new(deny)));
         version.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;
 
         // START: the raw seed emit rechecks ACL, sees the deny, and emits
         // FINISH instead of the seed DATA frame.
@@ -12526,7 +12532,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(200)).await;
 
         let mut data = Vec::new();
         let mut saw_finish = false;
@@ -12623,7 +12629,7 @@ mod tests {
     /// `tests/parity/test_monitor_reload_deny_composite.rs`; this change
     /// preserved that per-event recheck arm unchanged, so that test
     /// remains its coverage.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pvx61_acl_deny_surfaces_at_init() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (10u32, 709u32);
@@ -12667,7 +12673,7 @@ mod tests {
 
         // The subscribe is denied AT INIT: the subscriber task returns
         // immediately, firing its terminal MonitorFinished.
-        let fin = tokio::time::timeout(Duration::from_secs(2), mon_fin_rx.recv())
+        let fin = epics_base_rs::runtime::task::timeout(Duration::from_secs(2), mon_fin_rx.recv())
             .await
             .expect("ACL deny tears the subscriber down at INIT within 2s")
             .expect("MonitorFinished");
@@ -12688,7 +12694,7 @@ mod tests {
         )
         .await
         .expect("MONITOR START ok");
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        epics_base_rs::runtime::task::sleep(Duration::from_millis(200)).await;
         let seq = pvx61_drain_data_a(&mut rx, &intro, order);
         assert!(
             seq.is_empty(),
@@ -19380,7 +19386,7 @@ mod tests {
     /// them (coalescing is correct for the production net-state, but a
     /// per-edge assertion needs them separated). The source-level
     /// `notify_monitor_start` edges stay in lockstep.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bridge118_gate_driver_follows_executing_edges() {
         use crate::server_native::source::MonitorGate;
 
@@ -19411,7 +19417,7 @@ mod tests {
         // `exec_rx.changed()` select arm); `bfr12_gate_reaches_a_parked_monitor`
         // covers the same path end to end through a real MONITOR.
         let mut gate_driver = MonitorGateDriver::new(Some(gate));
-        tokio::spawn(async move {
+        epics_base_rs::runtime::task::spawn(async move {
             loop {
                 let executing = *exec_rx.borrow_and_update();
                 gate_driver.apply(executing).await;
@@ -19427,7 +19433,7 @@ mod tests {
                 if log.lock().len() >= n {
                     return;
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
             }
             panic!("gate log never reached {n} entries: {:?}", log.lock());
         }
@@ -19521,7 +19527,7 @@ mod tests {
     /// Revert-verify: drop the per-iteration `gate_driver.apply(executing)`
     /// (keeping only the pre-loop application) and the log stalls at
     /// `[false]`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr12_gate_reaches_a_parked_monitor() {
         let intro = three_field_intro();
         let gate_log = Arc::new(parking_lot::Mutex::new(Vec::<bool>::new()));
@@ -19565,7 +19571,7 @@ mod tests {
                 if log.lock().len() >= n {
                     return;
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                epics_base_rs::runtime::task::sleep(std::time::Duration::from_millis(5)).await;
             }
             panic!("gate log never reached {n} entries: {:?}", log.lock());
         }

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -20,8 +20,7 @@
 //! No socket type is named anywhere in this file's production scope, and
 //! `accept::tests::the_protocol_scope_owns_no_socket` keeps it that way.
 
-// RTEMS-EXEC-MODEL-ALLOW(94): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(23): checked - these run and pass in the feature-ON suite.
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -9895,7 +9894,7 @@ mod tests {
     /// per-op Status and returned `Ok(())`, leaving a malformed-INIT peer
     /// free to keep reusing the connection. Verified for both GET and
     /// MONITOR via a present-but-truncated pvRequest value.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn init_malformed_pvrequest_value_is_connection_fatal() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -9990,7 +9989,7 @@ mod tests {
     /// no op reply, no IOID registration. The prior cursor-exhausted
     /// short-circuit to `Ok(None)` accepted the frame and could register
     /// the op while silently dropping the create-time options.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn init_descriptor_only_pvrequest_value_is_connection_fatal() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -10084,7 +10083,7 @@ mod tests {
     /// descriptor needs NO bytes is NOT fatal — it registers the op and
     /// replies, exactly as before. Guards the `decode_init_pv_request_value`
     /// fix against over-firing on the common default GET/MONITOR INIT.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn init_empty_selector_descriptor_only_registers_op() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -10177,7 +10176,7 @@ mod tests {
     /// Rust rejected it as a decode error, which the read loop treats as
     /// connection-fatal — tearing down every other channel and operation
     /// multiplexed on that circuit.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn init_null_pvrequest_descriptor_is_wildcard_not_fatal() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -11044,7 +11043,7 @@ mod tests {
     /// receive a reply subcmd of exactly `0x08` — pvxs never sets `0x80` on
     /// a server→client monitor frame. (GET/PUT/RPC replies echo their inbound
     /// INIT subcmd, which is already `0x08`, so the strip is monitor-only.)
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_pipeline_init_reply_subcmd_strips_pipeline_bit() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -11169,7 +11168,7 @@ mod tests {
 
     /// Owner path: `MonitorPipelineCredit::take` consumes exactly one window
     /// slot per call, and `available()` reports the gate the emit arm reads.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_pipeline_credit_take_decrements_window() {
         use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
         let window = Arc::new(AtomicU32::new(2));
@@ -11258,7 +11257,7 @@ mod tests {
 
     /// Owner path: a non-pipeline monitor (no window) is always emit-eligible,
     /// never waits, and touches no counter.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_pipeline_credit_no_window_is_no_op() {
         use std::sync::atomic::AtomicU64;
         let wm_seq = Arc::new(AtomicU64::new(1));
@@ -13163,7 +13162,7 @@ mod tests {
     /// is `!M.good()` → `bev.reset()` (connection-fatal). The previous
     /// `unwrap_or(4)` fabricated 4 credits from a malformed ACK on a live
     /// monitor, silently corrupting the flow-control window.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_ack_truncated_payload_is_fatal() {
         use std::sync::atomic::AtomicU32;
         let order = ByteOrder::Little;
@@ -13215,7 +13214,7 @@ mod tests {
 
     /// A well-formed MONITOR ACK refills the pipeline window by exactly
     /// the decoded count — no fabricated default.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_ack_well_formed_refills_window_by_count() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let order = ByteOrder::Little;
@@ -13267,7 +13266,7 @@ mod tests {
     /// `fetch_add` would wrap to a tiny value, leaving `acquire`'s view
     /// of the credit far below what the watermark logic computed in
     /// `usize` — the divergence pvxs avoids with a `size_t` window.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_ack_refill_saturates_instead_of_wrapping() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let order = ByteOrder::Little;
@@ -13440,7 +13439,7 @@ mod tests {
     /// (servermon.cpp:599-608) reads/validates the ACK count before any op
     /// lookup or `onStart`. Pre-fix the START block ran first, clearing the
     /// pause and firing `notify_monitor_start(true)` before the decode error.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_combined_ack_start_truncated_no_side_effect() {
         use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
         let order = ByteOrder::Little;
@@ -13516,7 +13515,7 @@ mod tests {
     /// stays cleared and `notify_monitor_start(false)` never fires. Pre-fix the
     /// STOP block stored `monitor_paused=true` and fired the stop edge before
     /// the decode error.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_combined_ack_stop_truncated_no_side_effect() {
         use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
         let order = ByteOrder::Little;
@@ -13591,7 +13590,7 @@ mod tests {
     /// pvxs (servermon.cpp:643-689) applies ACK refill THEN START, so the
     /// `onHighMark` (Resume watermark) precedes `onStart`. Pre-fix the START
     /// block ran first, reversing the order to [start, watermark].
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_combined_ack_start_wellformed_acks_before_start() {
         use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
         let order = ByteOrder::Little;
@@ -13717,7 +13716,7 @@ mod tests {
     /// Both sub-cases are asserted: without `MustReply` the response still
     /// carries the found CID (because the match is real, not a forced
     /// probe-reply), and with `MustReply` it likewise carries the CID.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn tcp_search_does_not_gate_on_advertised_protocol() {
         use crate::decode::{decode_search_response, try_parse_frame};
         use crate::server_native::{SharedPV, SharedSource};
@@ -13785,7 +13784,7 @@ mod tests {
     /// into a reply-to-everything path — a genuine name miss is still
     /// silent (pvxs serverchan.cpp:240-249 only replies on a match or
     /// MustReply).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn tcp_search_unknown_name_without_mustreply_is_silent() {
         use crate::server_native::{SharedPV, SharedSource};
 
@@ -14056,7 +14055,7 @@ mod tests {
     // sites it stands in for (`finish_exec_data_task`, `monitor_abort`) take
     // their handle from the seam and do compile on both backends.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_request_pauses_monitor_without_aborting() {
         // cancel-vs-destroy parity: pvxs serverconn.cpp:262-289
         // transitions Executing→Idle and fires onCancel, but the
@@ -14186,7 +14185,7 @@ mod tests {
     // `JoinError::is_cancelled` readout, neither of which exists on the
     // executor backend.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn cancel_request_returns_non_monitor_exec_to_idle_and_aborts_task() {
         let order = ByteOrder::Little;
         let sid: u32 = 5;
@@ -14864,7 +14863,7 @@ mod tests {
     /// `OK` echo back even for SIDs we never created, which both
     /// amplifies (1:1) and confuses correctness diagnostics in the
     /// client.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn destroy_channel_on_unknown_sid_emits_no_reply() {
         let order = ByteOrder::Little;
         let unknown_sid: u32 = 4242;
@@ -14903,7 +14902,7 @@ mod tests {
     /// (`serverchan.cpp:399-411`). The unknown-SID guard above must
     /// not regress this path: when the SID exists, the reply still
     /// fires.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn destroy_channel_on_known_sid_emits_echo() {
         let order = ByteOrder::Little;
         let sid: u32 = 11;
@@ -14960,7 +14959,7 @@ mod tests {
     /// the handler decoded the payload with the little-endian config order,
     /// byte-swapping the SID into a value no channel owned — silently
     /// dropping the request.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn handle_destroy_channel_decodes_with_frame_header_order_not_config() {
         let config_order = ByteOrder::Little;
         let inbound_order = ByteOrder::Big;
@@ -15017,7 +15016,7 @@ mod tests {
     /// decode its SID/IOID/ack-count from the frame header order. Before
     /// the fix the SID/IOID byte-swapped, the ACK matched no live op, and
     /// the credit window was never refilled.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn monitor_ack_decodes_with_frame_header_order_not_config() {
         use std::sync::atomic::{AtomicU32, Ordering};
         let config_order = ByteOrder::Little;
@@ -15074,7 +15073,7 @@ mod tests {
     /// source could never observe a channel closing: per-channel leases,
     /// upstream identities, and credential-scoped caches leaked for the
     /// life of the process.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn destroy_channel_notifies_bound_source_once() {
         struct RecordingCloseSource {
             closed: Arc<parking_lot::Mutex<Vec<String>>>,
@@ -15269,7 +15268,7 @@ mod tests {
     /// snapshots the dispatch-time credential into
     /// `CreateChannelCompletion::open_cred`, and the read loop fires the open
     /// callback from the channel's stored `open_cred`, never the current `cred`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn reauth_channel_open_callback_pinned_to_create_credential() {
         let order = ByteOrder::Little;
         let opened = empty_cred_log();
@@ -15361,7 +15360,7 @@ mod tests {
     /// DESTROY_CHANNEL after the connection re-authed to `bob/ca` must deliver
     /// `notify_channel_close` under Alice — the close identity comes from the
     /// channel's stored `open_cred`, not the connection's current credential.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn reauth_client_destroy_close_pinned_to_create_credential() {
         let order = ByteOrder::Little;
         let sid: u32 = 7;
@@ -15424,7 +15423,7 @@ mod tests {
     /// DESTROY_CHANNEL). It must also deliver `notify_channel_close` under the
     /// channel's CREATE-time identity, not whatever the connection last
     /// re-authed to.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn reauth_server_teardown_close_pinned_to_create_credential() {
         let order = ByteOrder::Little;
         let sid: u32 = 3;
@@ -15485,7 +15484,7 @@ mod tests {
     /// from `conn->cred`). A GET on a channel opened under `alice/ca`, executed
     /// after the connection re-authed to `bob/ca`, must run its ACF check as
     /// Bob — proving the fix did not over-pin operations to `open_cred`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn reauth_get_op_uses_current_connection_credential() {
         let order = ByteOrder::Little;
         let sid: u32 = 11;
@@ -15573,7 +15572,7 @@ mod tests {
     /// lingered and silently rebound to a re-created cache entry on the next
     /// event. Asserts the single-owner teardown removed only the match, sent
     /// a DESTROY_CHANNEL addressing it, and released only its report count.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn invalidate_named_channels_force_disconnects_only_matching_name() {
         let order = ByteOrder::Little;
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
@@ -15650,7 +15649,7 @@ mod tests {
     /// no-op — no teardown, no frame. The invalidation broadcast is
     /// server-wide, so most connections hold no channel under a given
     /// dropped name and must not be disturbed.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn invalidate_named_channels_unknown_name_is_noop() {
         let order = ByteOrder::Little;
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
@@ -15703,7 +15702,7 @@ mod tests {
     /// 0x00 makes the client decode the wrong shape: the bitset + value
     /// bytes carried in the frame are misread as trailing garbage and
     /// the PUT_GET readback is silently lost.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_get_response_echoes_request_subcmd() {
         use crate::pvdata::FieldDesc;
         use crate::pvdata::{PvField, PvStructure, ScalarType, ScalarValue};
@@ -15839,7 +15838,7 @@ mod tests {
     /// still emit `subcmd=0x00` in the response. Confirms the echo
     /// behaviour is symmetric — neither leaking 0x40 when not requested
     /// nor regressing the common case.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_exec_response_echoes_zero_subcmd() {
         use crate::pvdata::FieldDesc;
         use crate::pvdata::{PvField, PvStructure, ScalarType, ScalarValue};
@@ -15970,7 +15969,7 @@ mod tests {
     /// IOID at spawn time would let a re-INIT racing a slow source collide
     /// with the still-in-flight reply on one IOID. A plain GET EXEC (no
     /// `0x10`) returns the op to `Idle` on completion.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_exec_last_request_defers_op_removal_until_response_sent() {
         use crate::pvdata::FieldDesc;
         use crate::pvdata::{PvField, PvStructure, ScalarType, ScalarValue};
@@ -16153,7 +16152,7 @@ mod tests {
     /// reference made by a later operation. The negative control proves the
     /// shared cache is what closes the gap: a *fresh* cache (the pre-fix
     /// per-call behaviour) rejects the reference with a typecache miss.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn init_pv_request_descriptor_resolves_cached_reference_across_ops() {
         use crate::pvdata::FieldDesc;
         use crate::pvdata::encode::{decode_type_desc_cached, encode_type_desc};
@@ -16525,7 +16524,7 @@ mod tests {
     /// marking only `b` must produce `(10,99,30)`. Before the fix the
     /// default read the prior through `get_value`, so `a`/`c`
     /// collapsed to `0` (the wrong-context value).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r3_put_delta_default_merges_under_credentialed_read() {
         use crate::proto::BitSet;
         use crate::server_native::source::{
@@ -16646,7 +16645,7 @@ mod tests {
     /// Before the fix this test fails: a full-structure decode of a
     /// single-field-wide payload either errors (short read) or
     /// misreads `b`'s bytes as `a` and clobbers `b`/`c` with garbage.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_delta_multi_field_applies_only_changed_field() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -16777,7 +16776,7 @@ mod tests {
     /// cmd 12). A 3-field structure PUT_GET where only field `c`
     /// (bit 3) changed must apply exactly `c` and leave `a`/`b`
     /// intact, and the readback must reflect the merged value.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_get_delta_multi_field_applies_only_changed_field() {
         use crate::server_native::SharedSource;
         use crate::server_native::runtime::PvaServerConfig;
@@ -17480,7 +17479,7 @@ mod tests {
     /// `""` as the authority to `AccessGate::check`, so the
     /// matching-CA peer failed `authority_match` and was wrongly
     /// denied — its `process` hook never ran.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_honors_authority_scoped_write_rule() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -17540,7 +17539,7 @@ mod tests {
     /// does NOT match the `AUTHORITY("MyCA")` rule gets PROCESS
     /// denied and the `process` hook never runs. Confirms the fix
     /// forwards the real authority rather than blanket-granting.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_denied_for_wrong_authority() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -17631,7 +17630,7 @@ mod tests {
     /// triggering record processing on an op that never negotiated
     /// PROCESS. pvxs `serverget.cpp:421-436` resets the connection on
     /// a wrong-kind IOID.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r5_process_data_rejects_get_initialised_ioid() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -17677,7 +17676,7 @@ mod tests {
 
     /// Regression: `handle_process` must also reject a PROCESS
     /// data frame against a MONITOR-initialised IOID.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r5_process_data_rejects_monitor_initialised_ioid() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -17808,7 +17807,7 @@ mod tests {
     /// op reply and registering no IOID. The previous
     /// `decode_type_desc(..).ok().and_then(|d| decode_pv_field(..).ok())`
     /// swallowed the value error and registered the op with `Status::ok()`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr8_process_init_truncated_value_rejected_and_unregistered() {
         let order = ByteOrder::Little;
         // Valid Int descriptor, then a truncated (2-byte) i32 value.
@@ -17833,7 +17832,7 @@ mod tests {
     /// (empty body after subcmd) is a peer wire-decode fault —
     /// connection-fatal, not registered, no reply (pvxs faults the buffer
     /// and `bev.reset()`s).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr8_process_init_missing_descriptor_rejected_and_unregistered() {
         let order = ByteOrder::Little;
         let (fatal, registered, reply) = run_process_init(1, 701, &[], order).await;
@@ -17852,7 +17851,7 @@ mod tests {
     /// client's shape — descriptor + value) is accepted, registers the
     /// IOID, and replies `Status::ok()`. Guards against the rejection
     /// path over-firing on valid input.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr8_process_init_valid_pvrequest_registers_op() {
         let order = ByteOrder::Little;
         let desc = FieldDesc::Scalar(crate::pvdata::ScalarType::Int);
@@ -17881,7 +17880,7 @@ mod tests {
     /// (`dataencode.cpp:747-752`, `serverget.cpp:371-375`): connection-fatal,
     /// not registered, no reply. The prior cursor-exhausted short-circuit to
     /// `Ok(None)` accepted it and registered the op with `Status::ok()`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_init_descriptor_only_value_rejected_and_unregistered() {
         let order = ByteOrder::Little;
         // Scalar Int descriptor, no value bytes.
@@ -17954,7 +17953,7 @@ mod tests {
     /// `from_wire_type_value` wire fault — connection-fatal, not registered,
     /// no reply. The decode runs before `channel_array_init`, so the fault
     /// fires at the wire boundary exactly as pvxs `bev.reset()` does.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn array_init_descriptor_only_value_rejected_and_unregistered() {
         let order = ByteOrder::Little;
         // Scalar Int descriptor, no value bytes.
@@ -17979,7 +17978,7 @@ mod tests {
     /// operation class (here a GET). Before the fix it extracted
     /// `(intro, mask)` from whatever op existed and performed a
     /// write/readback the operation never negotiated as a PUT_GET.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r5_put_get_data_rejects_get_initialised_ioid() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -18033,7 +18032,7 @@ mod tests {
 
     /// Regression: `handle_put_get` must also reject a PUT_GET
     /// data frame against a PUT-initialised IOID.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn ex_r5_put_get_data_rejects_put_initialised_ioid() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -18093,7 +18092,7 @@ mod tests {
     /// the peer with the matching CA gets BOTH a successful PUT leg
     /// and a non-empty readback — exercising the fixed GET-leg
     /// `&ctx.authority` forwarding.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_get_readback_honors_authority() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -18201,7 +18200,7 @@ mod tests {
     /// it as a pure destroy and returned before `process_checked` ran, so the
     /// client received no processDone reply. The op must execute, reply, and
     /// only then release its IOID via the deferred completion owner.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_process_last_request_executes_then_defers_destroy() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 700u32);
@@ -18282,7 +18281,7 @@ mod tests {
     /// Pre-fix the handler treated the bit as a pure destroy, so the client
     /// got no write, no readback, and no status reply. The op must execute,
     /// reply, and only then release its IOID.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_put_get_last_request_executes_then_defers_destroy() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 701u32);
@@ -18392,7 +18391,7 @@ mod tests {
     /// GET/PUT/MONITOR/RPC in the same channel still fired back a
     /// fabricated introspection reply, polluting the wire conversation
     /// on the busy IOID.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_field_ioid_collision_with_active_op_drops_reply() {
         use crate::pvdata::FieldDesc;
         use crate::server_native::SharedSource;
@@ -18481,7 +18480,7 @@ mod tests {
     /// Companion: GET_FIELD on a CLEAN IOID (not in the channel's ops
     /// map) still emits the introspection reply. Confirms the
     /// collision guard doesn't regress the happy path.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_field_clean_ioid_emits_reply() {
         use crate::pvdata::FieldDesc;
         use crate::server_native::SharedSource;
@@ -18544,7 +18543,7 @@ mod tests {
     /// real handler and reads back the SHARED `ChannelStat` Arc the report
     /// would observe, so a future send site that bypasses `chan_tx` (or an
     /// rx charge that drops the 8-byte header) regresses this test.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_field_attributes_tx_rx_to_channel_stat() {
         use crate::pvdata::FieldDesc;
         use crate::server_native::SharedSource;
@@ -18654,7 +18653,7 @@ mod tests {
     /// report entry. One case per `DestroyCause` boundary; before the fix a
     /// single finalizer charged the channel reply unconditionally, so the
     /// client case over-counted.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn destroy_channel_tx_attribution_splits_by_cause() {
         use std::sync::atomic::Ordering;
         let order = ByteOrder::Little;
@@ -18728,7 +18727,7 @@ mod tests {
     /// Error)` (`serverintrospect.cpp:83-87`) and the `if(type)` guard at
     /// `:41-42`. The old `unwrap_or(FieldDesc::Variant)` reported success
     /// and fabricated a Variant type tree.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_field_none_introspection_replies_error_no_descriptor() {
         use crate::decode::{decode_get_field_response, try_parse_frame};
         use crate::server_native::SharedSource;
@@ -18799,7 +18798,7 @@ mod tests {
     /// Companion: a successful GET_FIELD slow path still returns the
     /// exact descriptor the source provided (no regression from the
     /// error-path fix).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn get_field_slow_path_returns_source_descriptor() {
         use crate::decode::{decode_get_field_response, try_parse_frame};
         use crate::pvdata::{FieldDesc, PvField, PvStructure, ScalarType, ScalarValue};
@@ -18882,7 +18881,7 @@ mod tests {
     /// spawns a second task — only one reply reaches the client. Mirrors
     /// pvxs `opByIOID.find(ioid)!=end()` rejection (serverintrospect.cpp:157)
     /// once the introspect op is inserted Executing (:164-178).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn slow_get_field_reserves_ioid_against_duplicate() {
         use crate::pvdata::FieldDesc;
         use crate::server_native::source::ChannelSource;
@@ -19934,7 +19933,7 @@ mod tests {
     /// a GET whose source read fails during the data phase
     /// replies with the request's data subcmd `0x00` and an error
     /// status — not an INIT `0x08` frame.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr13_get_data_phase_error_echoes_data_subcmd() {
         use crate::server_native::runtime::PvaServerConfig;
         use crate::server_native::tcp::ClientCredentials;
@@ -20037,7 +20036,7 @@ mod tests {
     /// An IOID already live on one channel makes an INIT reusing it on a
     /// *different* channel connection-fatal — pvxs scopes IOIDs to
     /// `ServerConn::opByIOID`, not per channel (serverget.cpp:378-384).
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_conn_wide_ioid_init_duplicate_across_channels_is_fatal() {
         use crate::server_native::runtime::PvaServerConfig;
         use crate::server_native::tcp::ClientCredentials;
@@ -20096,7 +20095,7 @@ mod tests {
     /// SID does not match the op's channel still destroys the op (pvxs
     /// serverconn.cpp:295-319 erases by IOID even when the channel-local erase
     /// fails). The pre-fix per-channel lookup would have leaked the op.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_conn_wide_destroy_request_routes_by_ioid_ignoring_sid() {
         let order = ByteOrder::Little;
         let ioid = 9u32;
@@ -20128,7 +20127,7 @@ mod tests {
     /// a PUT readback (`subcmd & 0x40`) whose readback GET
     /// fails replies with the request's `0x40` subcmd and an error
     /// status — not INIT `0x08`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr13_put_readback_error_echoes_0x40_subcmd() {
         use crate::server_native::runtime::PvaServerConfig;
         use crate::server_native::tcp::ClientCredentials;
@@ -20211,7 +20210,7 @@ mod tests {
     /// fix makes error replies echo the *request* subcmd uniformly, so
     /// an INIT request stays `0x08` while a data request becomes
     /// `0x00`/`0x40` — it does not flip every error to `0x00`.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr13_init_phase_error_still_echoes_0x08() {
         use crate::server_native::runtime::PvaServerConfig;
         use crate::server_native::tcp::ClientCredentials;
@@ -20337,7 +20336,7 @@ mod tests {
     /// handshake must: emit a SECOND CONNECTION_VALIDATED, replace the
     /// connection credential, update the per-peer credential record, and
     /// re-fire the auth_complete hook with the new identity.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_connection_validation_reauth_replaces_identity() {
         use std::sync::Mutex as StdMutex;
 
@@ -20474,7 +20473,7 @@ mod tests {
     /// so a rejected re-auth is a rejected credential *update*, not a logout.
     /// Pre-fix Rust committed the claim and then forced `*cred` to anonymous,
     /// stripping a live `alice/ca` connection's ACF identity.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn process_connection_validation_unadvertised_reauth_keeps_previous_credential() {
         use std::io::Cursor;
         use std::sync::Mutex as StdMutex;
@@ -20758,7 +20757,7 @@ mod autoexec_tests {
 
     /// `record._options.autoExec=false` must NOT suppress the write: pvxs
     /// never reads the option server-side, so the EXEC commits.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn autoexec_false_still_commits_the_put() {
         let after = put_through(request_with_autoexec(Some("false"))).await;
         assert_eq!(
@@ -20771,7 +20770,7 @@ mod autoexec_tests {
     /// Negative control: with the option absent the EXEC commits too — so
     /// the assertion above is pinning "the option is inert", not merely
     /// "PUT works".
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn put_without_autoexec_commits_identically() {
         let after = put_through(request_with_autoexec(None)).await;
         assert_eq!(value_of(after), 2.5);
@@ -20781,7 +20780,7 @@ mod autoexec_tests {
     /// deleted parser treated as false (`"no"`, `"0"`) and the ones it
     /// rejected outright (`"maybe"`). No server-side branch may depend on
     /// this text.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn every_autoexec_spelling_is_inert() {
         for v in ["false", "FALSE", "no", "0", "true", "maybe"] {
             let after = put_through(request_with_autoexec(Some(v))).await;
@@ -20842,7 +20841,7 @@ mod r14_tests {
         }
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn pva_r14_source_calls_no_head_of_line_block() {
         let order = ByteOrder::Little;
         let sid: u32 = 1;
@@ -21145,7 +21144,7 @@ mod bfr15_tests {
     // reached. The production path under test is backend-neutral; only the
     // way the fixture blocks is not.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr15_second_get_exec_while_executing_is_ignored_not_aborted() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 100u32);
@@ -21235,7 +21234,7 @@ mod bfr15_tests {
     // reached. The production path under test is backend-neutral; only the
     // way the fixture blocks is not.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr15_second_put_exec_while_executing_is_ignored_not_aborted() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 200u32);
@@ -21326,7 +21325,7 @@ mod bfr15_tests {
     // reached. The production path under test is backend-neutral; only the
     // way the fixture blocks is not.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr15_destroy_request_aborts_in_flight_exec_task() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 300u32);
@@ -21383,7 +21382,7 @@ mod bfr15_tests {
     /// (d) A completed EXEC returns the op to `Idle` (through the read-loop
     /// owner via `ExecFinished`/`apply_exec_finish`), so a later explicit
     /// re-EXEC is accepted as a fresh exec and runs a second source read.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr15_completed_exec_returns_op_to_idle_and_allows_reexec() {
         let order = ByteOrder::Little;
         let (sid, ioid) = (1u32, 400u32);
@@ -21462,7 +21461,7 @@ mod bfr15_tests {
     /// (e) ABA boundary: a stale completion signal (op-instance id mismatch,
     /// e.g. the ioid was removed and re-INIT'd) must NOT flip the fresh op
     /// back to `Idle`. Only an exact `monitor_op_id` match applies.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn bfr15_apply_exec_finish_ignores_stale_op_id() {
         let (sid, ioid) = (1u32, 500u32);
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
@@ -21660,7 +21659,7 @@ mod inbound_message_cap_tests {
         out
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn the_default_ceiling_refuses_an_oversized_header_without_reading_a_body() {
         let wire = header_announcing(DEFAULT_MAX_MESSAGE_SIZE as u32 + 1);
         let mut reader = std::io::Cursor::new(wire);
@@ -21686,7 +21685,7 @@ mod inbound_message_cap_tests {
 
     /// The comparison is `>`, not `>=`: a message exactly at the ceiling is
     /// admitted. An off-by-one here would refuse the largest legal message.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn a_message_exactly_at_the_ceiling_is_admitted() {
         let cap = 16usize;
         let mut wire = header_announcing(cap as u32);
@@ -21699,7 +21698,7 @@ mod inbound_message_cap_tests {
         assert_eq!(frame.payload.len(), cap);
     }
 
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn one_byte_over_the_ceiling_is_refused() {
         let cap = 16usize;
         let wire = header_announcing(cap as u32 + 1);
@@ -21714,7 +21713,7 @@ mod inbound_message_cap_tests {
     /// `None` is still expressible and still means unbounded — the same
     /// header the default ceiling refuses is accepted for buffering when the
     /// deployment opted out.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn an_explicit_none_still_means_unbounded() {
         let wire = header_announcing(DEFAULT_MAX_MESSAGE_SIZE as u32 + 1);
         let mut reader = std::io::Cursor::new(wire);

--- a/crates/epics-pva-rs/src/server_native/udp.rs
+++ b/crates/epics-pva-rs/src/server_native/udp.rs
@@ -4,8 +4,7 @@
 //! SEARCH_RESPONSE messages naming our TCP endpoint. Beacons are emitted
 //! periodically to advertise our presence.
 
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
-
+// RTEMS-EXEC-MODEL-ALLOW(6): checked - these run and pass in the feature-ON suite.
 use std::collections::HashSet;
 use std::io::Cursor;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -1469,7 +1468,7 @@ mod tests {
     /// The reply bytes must be exactly what the wire builder produces, so
     /// a driver that sends them over `std::net::UdpSocket` is byte-identical
     /// to this one.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn the_search_decoder_produces_replies_without_a_socket() {
         use crate::server_native::source::ChannelSource;
         use std::sync::Arc;
@@ -2224,7 +2223,7 @@ mod tests {
     /// for some requesters (pvxs `Search::source()`). Because the v4
     /// UDP, v6 UDP, and TCP-circuit responders all call this one rule,
     /// the endpoint scope governs every search path.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn search_matched_cids_honors_requester_endpoint() {
         use crate::pvdata::{FieldDesc, PvField};
         use crate::server_native::source::ChannelSource;
@@ -2317,7 +2316,7 @@ mod tests {
     /// v4 UDP, v6 UDP, and TCP-circuit responders all call — the v6 path
     /// previously skipped it and would answer a TLS-only client off a
     /// tcp-only server.
-    #[tokio::test]
+    #[epics_macros_rs::epics_test]
     async fn search_matched_cids_gates_on_protocol() {
         use crate::pvdata::{FieldDesc, PvField, ScalarType};
         use crate::server_native::source::ChannelSource;

--- a/crates/epics-pva-rs/src/util.rs
+++ b/crates/epics-pva-rs/src/util.rs
@@ -20,7 +20,6 @@
 //! directly.
 
 // RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use std::fmt;
 
 /// Server identity emitted in BEACON / SEARCH_RESPONSE frames.

--- a/crates/epics-pva-rs/tests/channel_array.rs
+++ b/crates/epics-pva-rs/tests/channel_array.rs
@@ -12,7 +12,6 @@
 //!    setLength / getLength round trips.
 
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 

--- a/crates/epics-pva-rs/tests/get_exec_after_init_reply.rs
+++ b/crates/epics-pva-rs/tests/get_exec_after_init_reply.rs
@@ -27,9 +27,8 @@
 //! Pre-fix the client wrote INIT+EXEC as one buffer and the GET died on a
 //! closed circuit; post-fix the EXEC is sent only after the INIT reply lands.
 
-#![cfg(test)]
-
 // RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
+#![cfg(test)]
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/epics-pva-rs/tests/heartbeat_echo.rs
+++ b/crates/epics-pva-rs/tests/heartbeat_echo.rs
@@ -20,7 +20,6 @@
 //! nextest profile rather than the gated `interop` suites.
 
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::io::{Cursor, Read};
 use std::net::TcpStream;
 use std::sync::Arc;

--- a/crates/epics-pva-rs/tests/put_bench.rs
+++ b/crates/epics-pva-rs/tests/put_bench.rs
@@ -26,7 +26,6 @@
 //! IS measured (it is the per-channel connect work).
 
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/epics-pva-rs/tests/report_info.rs
+++ b/crates/epics-pva-rs/tests/report_info.rs
@@ -12,9 +12,8 @@
 //! info, a real in-process server+client opening a channel, and an
 //! assertion that the info reaches the server report.
 
-#![cfg(test)]
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
+#![cfg(test)]
 // `ChannelSource` trait methods return `impl Future` (RPITIT); test impls
 // mirror that shape rather than `async fn`, as in the sibling test files.
 #![allow(clippy::manual_async_fn)]

--- a/crates/epics-pva-rs/tests/rpc_empty_reply.rs
+++ b/crates/epics-pva-rs/tests/rpc_empty_reply.rs
@@ -17,9 +17,8 @@
 //! unconditionally decoded a descriptor, so a pvxs server replying with the
 //! no-value form failed the decode. `RpcReply` now models both overloads.
 
-#![cfg(test)]
-
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
+#![cfg(test)]
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/epics-pva-rs/tests/rpc_pvrequest.rs
+++ b/crates/epics-pva-rs/tests/rpc_pvrequest.rs
@@ -13,9 +13,8 @@
 //! the INIT was answered with `Status::Error "invalid pvRequest mask: …"` —
 //! the RPC never ran.
 
-#![cfg(test)]
-
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
+#![cfg(test)]
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/epics-pva-rs/tests/server_info.rs
+++ b/crates/epics-pva-rs/tests/server_info.rs
@@ -12,7 +12,6 @@
 //! built-in source reports them.
 
 // RTEMS-EXEC-MODEL-ALLOW(5): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/epics-pva-rs/tests/service_framework.rs
+++ b/crates/epics-pva-rs/tests/service_framework.rs
@@ -3,7 +3,6 @@
 //! methods, then drives them via `PvaClient::pvrpc`.
 
 // RTEMS-EXEC-MODEL-ALLOW(7): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;

--- a/crates/epics-pva-rs/tests/set_byte_order_renegotiate.rs
+++ b/crates/epics-pva-rs/tests/set_byte_order_renegotiate.rs
@@ -19,7 +19,6 @@
 //! nextest profile rather than the gated `interop` suites.
 
 // RTEMS-EXEC-MODEL-ALLOW(1): checked - these run and pass in the feature-ON suite.
-
 use epics_pva_rs::server_native::MonitorStream;
 use std::io::{Cursor, Read, Write};
 use std::net::TcpStream;

--- a/crates/epics-pva-rs/tests/stability.rs
+++ b/crates/epics-pva-rs/tests/stability.rs
@@ -16,9 +16,9 @@
 //! - **P8 channel coalescing** — multiple concurrent pvget on the same PV
 //!   share a single channel/connection.
 
+// RTEMS-EXEC-MODEL-ALLOW(26): checked - these run and pass in the feature-ON suite.
 #![allow(clippy::manual_async_fn)]
 
-// RTEMS-EXEC-MODEL-ALLOW(26): checked - these run and pass in the feature-ON suite.
 // (5 live client↔server monitor tests gated out feature-ON above; stage 3.)
 
 use epics_pva_rs::server_native::MonitorStream;

--- a/crates/epics-pva-rs/tests/tls.rs
+++ b/crates/epics-pva-rs/tests/tls.rs
@@ -10,10 +10,9 @@
 //! Compiled only with the `tls` feature (ON by default) — without it the
 //! crate links no rustls, so there is nothing here to exercise.
 
+// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
 #![cfg(feature = "tls")]
 #![allow(clippy::manual_async_fn)]
-
-// RTEMS-EXEC-MODEL-ALLOW(8): checked - these run and pass in the feature-ON suite.
 
 use epics_pva_rs::server_native::MonitorStream;
 use std::sync::Arc;

--- a/crates/epics-pva-rs/tests/typed_nt.rs
+++ b/crates/epics-pva-rs/tests/typed_nt.rs
@@ -11,7 +11,6 @@
 //! tests guard against.
 
 // RTEMS-EXEC-MODEL-ALLOW(2): checked - these run and pass in the feature-ON suite.
-
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/motor-rs/src/ioc.rs
+++ b/crates/motor-rs/src/ioc.rs
@@ -114,7 +114,7 @@ impl SimMotorHolder {
                 let device_support = device_support.with_dtyp_name(dtyp_key.clone());
 
                 // Spawn poll loop on the tokio runtime (starts idle)
-                ctx.runtime_handle().spawn(poll_loop.run());
+                ctx.bridge().spawn(poll_loop.run());
 
                 holder
                     .poll_senders

--- a/crates/optics-rs/src/drivers/hsc.rs
+++ b/crates/optics-rs/src/drivers/hsc.rs
@@ -527,7 +527,7 @@ impl HscHolder {
                 let poll_loop =
                     HscPollLoop::new(cmd_rx, driver.clone(), Duration::from_millis(poll_ms));
 
-                ctx.runtime_handle().spawn(poll_loop.run());
+                ctx.bridge().spawn(poll_loop.run());
 
                 holder.poll_senders.lock().unwrap().push(cmd_tx);
                 holder.drivers.lock().unwrap().insert(port.clone(), driver);

--- a/crates/optics-rs/src/drivers/qxbpm.rs
+++ b/crates/optics-rs/src/drivers/qxbpm.rs
@@ -430,7 +430,7 @@ impl QxbpmHolder {
                 let poll_loop =
                     QxbpmPollLoop::new(cmd_rx, driver.clone(), Duration::from_millis(poll_ms));
 
-                ctx.runtime_handle().spawn(poll_loop.run());
+                ctx.bridge().spawn(poll_loop.run());
 
                 holder.poll_senders.lock().unwrap().push(cmd_tx);
                 holder.drivers.lock().unwrap().insert(port.clone(), driver);

--- a/crates/optics-rs/src/seq_runner.rs
+++ b/crates/optics-rs/src/seq_runner.rs
@@ -69,12 +69,13 @@ fn macro_or(macros: &HashMap<String, String>, key: &str, default: &str) -> Strin
 ///
 /// Returns `Ok(())` if the program was found and spawned, or `Err` with a message.
 ///
-/// Must be called with a tokio runtime handle (use `CommandContext::runtime_handle()`
-/// from st.cmd startup commands, since st.cmd runs on a non-tokio thread).
+/// Must be called with the runtime access captured for the shell thread (use
+/// `CommandContext::bridge()` from st.cmd startup commands, since st.cmd runs
+/// on a blocking thread the runtime is otherwise unreachable from).
 pub fn seq_start(
     program: &str,
     macro_str: &str,
-    handle: &tokio::runtime::Handle,
+    bridge: &epics_base_rs::runtime::task::BlockingBridge,
     db: &PvDatabase,
 ) -> Result<(), String> {
     let macros = parse_macros(macro_str);
@@ -89,7 +90,7 @@ pub fn seq_start(
                 macro_or(&macros, "GEOM", "0").parse::<i32>().unwrap_or(0),
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::kohzu_ctl::run(config, db).await {
                     eprintln!("kohzuCtl error: {e}");
                 }
@@ -105,7 +106,7 @@ pub fn seq_start(
                 macro_or(&macros, "GEOM", "0").parse::<i32>().unwrap_or(0),
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::kohzu_ctl_soft::run(config, db).await {
                     eprintln!("kohzuCtl_soft error: {e}");
                 }
@@ -119,7 +120,7 @@ pub fn seq_start(
                 &require_macro(&macros, "M_PHI2", program)?,
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::hr_ctl::run(config, db).await {
                     eprintln!("hrCtl error: {e}");
                 }
@@ -138,7 +139,7 @@ pub fn seq_start(
                 macro_or(&macros, "GEOM", "0").parse::<i32>().unwrap_or(0),
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::ml_mono_ctl::run(config, db).await {
                     eprintln!("ml_monoCtl error: {e}");
                 }
@@ -154,7 +155,7 @@ pub fn seq_start(
                 &require_macro(&macros, "mPHI", program)?,
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::orient::run(config, db).await {
                     eprintln!("orient error: {e}");
                 }
@@ -167,7 +168,7 @@ pub fn seq_start(
                 macro_or(&macros, "N", "8").parse::<usize>().unwrap_or(8),
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::filter_drive::run(config, db).await {
                     eprintln!("filterDrive error: {e}");
                 }
@@ -180,7 +181,7 @@ pub fn seq_start(
                 &require_macro(&macros, "B", program)?,
             );
             let db = db.clone();
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::pf4::run(config, db).await {
                     eprintln!("pf4 error: {e}");
                 }
@@ -192,7 +193,7 @@ pub fn seq_start(
                 &macro_or(&macros, "MONO", ""),
                 &macro_or(&macros, "VSC", ""),
             );
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::io::run(config).await {
                     eprintln!("Io error: {e}");
                 }
@@ -206,7 +207,7 @@ pub fn seq_start(
                 &require_macro(&macros, "FM", program)?,
                 &require_macro(&macros, "CM", program)?,
             );
-            handle.spawn(async move {
+            bridge.spawn(async move {
                 if let Err(e) = crate::snl::flex_combined_motion::run(config).await {
                     eprintln!("flexCombinedMotion error: {e}");
                 }
@@ -244,8 +245,12 @@ mod tests {
     #[test]
     fn test_unknown_program() {
         let rt = tokio::runtime::Runtime::new().unwrap();
+        let bridge = {
+            let _guard = rt.enter();
+            epics_base_rs::runtime::task::BlockingBridge::capture()
+        };
         let db = PvDatabase::new();
-        let result = seq_start("nonexistent", "P=x:", rt.handle(), &db);
+        let result = seq_start("nonexistent", "P=x:", &bridge, &db);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown program"));
     }

--- a/examples/mini-beamline/src/bin/mini_ioc.rs
+++ b/examples/mini-beamline/src/bin/mini_ioc.rs
@@ -401,7 +401,7 @@ async fn main() -> CaResult<()> {
                 ArgValue::String(s) => s.clone(),
                 _ => return Err("expected macros string".into()),
             };
-            optics_rs::seq_runner::seq_start(&program, &macros, ctx.runtime_handle(), ctx.db())?;
+            optics_rs::seq_runner::seq_start(&program, &macros, ctx.bridge(), ctx.db())?;
             Ok(CommandOutcome::Continue)
         },
     ));


### PR DESCRIPTION
## What

`#[epics_test]` now expands to a plain `#[test]` driving the body through `runtime::task::test_block_on`, which the build cfg selects: tokio `current_thread` on the default backend, `park_on` under `rtems-exec-model`. The four async suites (base/libcom/ca/pva) are migrated onto it — 1,251 tests total — so the feature-ON suites exercise those bodies through the exec seam instead of always hosting them on a private tokio runtime.

- `feat(runtime)`: `test_block_on` + seam `yield_now`; macro path resolution via `extern crate self` (base, libcom) with a libcom fallback since libcom cannot depend on base.
- `refactor(base)`: 995 tests; census 38 sites remain.
- `refactor(iocsh)`: `BlockingBridge` (tokio = captured `Handle`, exec = ZST/global executor) replaces `tokio::runtime::Handle` across the iocsh surface; `CommandContext::runtime_handle()` is gone, so bypassing the seam is a compile error.
- `refactor(tests)` + `refactor(pva)`: libcom 22 / ca 24 / pva 210 tests migrated; direct `tokio::time`/`tokio::spawn` calls in migrated bodies replaced with seam calls.

Tests that genuinely need a reactor (tokio::net via production code, flavored runtimes, tokio-as-subject) stay `#[tokio::test]` with `RTEMS-EXEC-MODEL-ALLOW` census markers; counts taken from the gate's own output.

## Verification

- feature-ON suites: base 3306, libcom 246, ca 582, pva 1353 (×2) — all green
- `cargo nextest run --workspace` 10196/10196; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --doc --workspace` green