### PR TITLE
release: v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,94 @@
 # Changelog
 
-## Unreleased
+## v0.25.0 — 2026-07-24
+
+Minor release. RTEMS 6 goes from "type-checks" to a verified embedded target —
+a reactor-free execution model, blocking CA/PVA drivers, worker-pool thread
+accounting, and `pva://`/`ca://` links, all measured on QEMU/BSP hardware — and
+Linux PREEMPT_RT becomes a first-class real-time deployment with
+priority-inheritance locking proven on a real RT kernel. The runtime/socket
+layer is extracted into the new `epics-libcom-rs` crate, and the async test
+suites move onto `#[epics_test]`, whose driver is selected by the build's
+backend. Four breaking API changes (epics-ca-rs, epics-pva-rs) plus one on the
+iocsh surface. Workspace version 0.24.3 -> 0.25.0, internal
+`[workspace.dependencies]` pins move to 0.25.0 in lockstep.
+
+### Breaking
+
+- **epics-ca-rs: the audit and replay writers go through the filesystem
+  seam.** File-backed constructors take the seam handle instead of opening
+  `std::fs` paths directly, so the RTEMS target and tests control the sink.
+
+- **epics-pva-rs: the ACF host is derived from the peer socket, never from
+  the wire.** A client-asserted host name can no longer influence access
+  decisions; `with_server_derived(peer)` is the single funnel.
+
+- **epics-pva-rs: `ChannelSource` returns the monitor stream, not an
+  `mpsc` receiver.** Custom sources hand back the stream type; the server
+  owns queueing/pipelining uniformly (this is what lets one source serve
+  both the tokio and the RTEMS blocking drivers).
+
+- **epics-pva-rs: the RTEMS dependency gate moved off `server_native::tcp`
+  onto the accept path**, so the module surface compiled for the target no
+  longer drags the tokio server in.
+
+- **epics-base-rs: the iocsh surface no longer traffics in
+  `tokio::runtime::Handle`.** `CommandContext::runtime_handle()` is gone;
+  `CommandContext::bridge()` returns a `runtime::task::BlockingBridge`
+  (tokio backend: a captured handle; exec backend: the global executor), and
+  `IocShell::new` / `optics-rs::seq_start` take the bridge. Registered
+  commands become startable on runtimes without a tokio reactor — RTEMS
+  included — and a command that tries to smuggle a raw handle is now a
+  compile error.
+
+### RTEMS 6 (armv7-rtems-eabihf)
+
+The workspace cross-compiles and *boots*: `rtems-ca-ioc` and `rtems-pva-ioc`
+serve CA and PVA (including QSRV Q:group PVs) from a libbsd BSP, verified on
+QEMU xilinx-zynq with live client traffic.
+
+- **Reactor-free execution model** (`rtems-exec-model`): the `runtime::task`
+  seam routes `spawn`/timers to a cooperative band-priority background
+  executor (release-on-Pending, re-enqueue-on-wake), and connection I/O runs
+  on parked blocking threads (`park_on`). No tokio reactor exists on target.
+- **Blocking protocol drivers**: sans-io CA server/client and the PVA
+  server/client byte paths run on dedicated blocking threads with the same
+  wire behavior as the async drivers (refusal parity, recv accumulation
+  caps, ECA_TOLARGE/ECA_ALLOCMEM).
+- **Thread accounting via worker pools**: CA server clients, PVA connection
+  sets, and every protocol dial borrow threads from bounded pools
+  (capacity = fd wall − 1, so the refusal path always keeps a descriptor),
+  closing the per-thread 128 B RTEMS TLS leak and the per-attempt creation
+  residue. A CA circuit is retired the moment either pump dies (per-circuit
+  death guard), so a dial broken after establish always reaches the redial
+  owner.
+- **`pva://` and `ca://` links on target**: pvalink and calink run over
+  name-server TCP search (no UDP socket on the target arm), mounted in the
+  IOC binaries; on-target two-IOC gates pass for both.
+- **Scanning hoisted into the IOC core** (`ScanOwner`), and QSRV group
+  drains moved to a dedicated thread — never a shared band worker.
+- **Real thread priorities**: every IOC thread is banded
+  (`posix = 56 + epics`, a deliberate deviation from base-on-RTEMS-6's
+  linear map, recorded in `doc/`), measured on target via SCHED_FIFO.
+- **Toolchain**: `epics-rtems-boot` carries the boot shim and link
+  contract; the `has-thread-local: true` target-spec deviation is applied
+  automatically by a rustc wrapper — plain `cargo build` is the whole
+  interface, and `./scripts/rtems-check.sh` type-checks the closure without
+  a cross toolchain.
+
+### Linux PREEMPT_RT
+
+- **`epics-base-rs/linux-rt`**: the record-gate and scan-side lock family
+  becomes `PTHREAD_PRIO_INHERIT` priority-inheritance mutexes; every gate
+  scope was restructured to hold zero awaits (dbProcess parity), external
+  link opens are staged at iocInit (dbCaAddLink parity), and link puts go
+  through dbCa-parity staging.
+- **Opt-in SCHED_FIFO banding** on hosted targets via
+  `EPICS_RS_ALLOW_RT_PRIORITY=YES` (default on for RTEMS, off elsewhere).
+- **Measured**: on a PREEMPT_RT kernel the record-gate priority inversion
+  collapses from 24.9 ms to 10.1 ms worst-case with PI on
+  (`doc/rtlinux-rt-measurement.md`); the scan leg is solved by FIFO
+  (84.7×). `examples/rt-probe` is the measurement rig.
 
 ### New crate: `epics-libcom-rs`
 
@@ -12,26 +100,65 @@
 
   **No downstream source change.** `epics-base-rs` re-exports both modules at
   their original paths (`pub use epics_libcom_rs::{net, runtime};`), so
-  `epics_base_rs::runtime::…` and `epics_base_rs::net::…` resolve as before,
-  and so does `crate::runtime::…` inside `epics-base-rs` itself. `WallTime`
-  moved with its producer and is re-exported at `epics_base_rs::types::
-  WallTime`. Not one call site in the workspace changed.
+  `epics_base_rs::runtime::…` and `epics_base_rs::net::…` resolve as before.
+  `WallTime` moved with its producer and is re-exported at
+  `epics_base_rs::types::WallTime`. Both feature levers are forwarded, so
+  `--features epics-base-rs/linux-rt` and
+  `--features epics-base-rs/rtems-exec-model` are unchanged for callers.
 
-  Both feature levers are forwarded, so `--features epics-base-rs/linux-rt`
-  and `--features epics-base-rs/rtems-exec-model` are unchanged for callers.
+- **Two seams that used to be intra-crate are now pinned at compile time**
+  (`const _: () = assert!(…)`): the scanOnce band count against the
+  periodic-rate count, and the `exec_backend`/`tokio_backend` predicate both
+  build scripts derive against `epics_libcom_rs::EXEC_BACKEND` — a feature
+  forward that stops being wired fails the build instead of splitting the
+  workspace across two task backends.
 
-- **Two seams that used to be intra-crate are now pinned at compile time.**
-  The extraction removed the shared crate that made them implicit, so each is
-  now a `const _: () = assert!(…)` that fails the build rather than a comment
-  that can drift:
+### optics-rs (SNL)
 
-  - the scanOnce worker's band against the periodic-rate count —
-    `epics-base-rs`'s `PERIODIC_SCANS.len()` against
-    `epics-libcom-rs`'s `PERIODIC_SCAN_BAND_COUNT`;
-  - the `exec_backend` / `tokio_backend` predicate, derived by both crates'
-    build scripts, against `epics_libcom_rs::EXEC_BACKEND` — so a
-    `rtems-exec-model` forward that stops being wired is a compile error
-    instead of a workspace split across two task backends.
+- **SNL `pvPut` now translates to put-and-process, not put-and-post.**
+  seq's `pvPut` is a CA put — dbPutField semantics: write the field, then
+  process through the PP gate. The ports wrote-and-posted without ever
+  processing, so every readback the state machines maintain stayed
+  UDF/INVALID forever. All 70 sites across the six SNL ports now go through
+  the dbPutField fire-and-forget tier, carrying the writer origin (simple-PV
+  posts are origin-tagged end to end) so a record's own posts are not
+  mistaken for external CA puts. (#57)
+
+### Testing: `#[epics_test]`
+
+- **The backend picks the test driver, not the test.** `#[epics_test]`
+  expands to a plain `#[test]` driving the body through
+  `runtime::task::test_block_on` — tokio `current_thread` on the default
+  backend, `park_on` under `rtems-exec-model` — so the feature-ON suites
+  exercise 1,251 migrated test bodies through the exec seam.
+  Reactor-bound tests (tokio::net via production code, flavored runtimes,
+  tokio-as-subject) stay `#[tokio::test]`, and each crate's
+  `rtems_exec_model_gate` census pins their exact count — a new unmarked
+  `#[tokio::test]` fails the gate. (#58)
+
+### CI
+
+- New standing gates: the RTEMS closure type-check, `linux-rt`,
+  `rtems-exec-model` (plus a 50-iteration exec-backend cancel stress job),
+  and `no-default-features`. `cargo fmt` runs in CI
+  (thanks @bolinocroustibat, #50; also #51, #53).
+
+### Fixed
+
+- **epics-ca-rs**: the server's per-client worker pool capacity is 141
+  (fd wall − 1) — at 142 the wall client's accept fails ENFILE before the
+  pool can refuse, so the documented ECA_ALLOCMEM refusal could never
+  execute; a refusal that happens after accept needs a descriptor to happen
+  on. Also: nameserver recv cap; circuit-retirement redial ownership (see
+  RTEMS section).
+- **epics-base-rs**: both iocsh threads are banded at
+  `ThreadPriority::Iocsh`; CP link holders process on access-rights loss
+  (dbCa.c:1076-1102 parity); `cancel()`/`is_done()` terminal state has a
+  single owner (`reached_terminal_state`), fixing an exec-backend
+  cancel/completion race pre-existing on the seam.
+- **epics-pva-rs**: monitor connection transitions are owned by
+  `ConnEventOwner`; `SubscriptionHandle::wait` removed; the gateway
+  disconnect boundary fires on plain upstream loss.
 
 ## v0.24.3 — 2026-07-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -992,7 +992,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "cc",
  "libc",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2238,7 +2238,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3206,7 +3206,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3825,7 +3825,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.24.3"
+version = "0.25.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,30 +29,30 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.24.3"
+version = "0.25.0"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.24.0" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.24.0" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.24.0" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.24.0" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.24.0" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.24.0" }
-epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.24.0" }
-epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.24.0" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.24.0" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.24.0" }
-motor-rs = { path = "crates/motor-rs", version = "0.24.0" }
-std-rs = { path = "crates/std-rs", version = "0.24.0" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.24.0" }
-optics-rs = { path = "crates/optics-rs", version = "0.24.0" }
-mca-rs = { path = "crates/mca-rs", version = "0.24.0" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.24.0" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.24.0", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.24.0" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.25.0" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.25.0" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.25.0" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.25.0" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.25.0" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.25.0" }
+epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.25.0" }
+epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.25.0" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.25.0" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.25.0" }
+motor-rs = { path = "crates/motor-rs", version = "0.25.0" }
+std-rs = { path = "crates/std-rs", version = "0.25.0" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.25.0" }
+optics-rs = { path = "crates/optics-rs", version = "0.25.0" }
+mca-rs = { path = "crates/mca-rs", version = "0.25.0" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.25.0" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.25.0", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.25.0" }
 
 
 # RTEMS 6 (armv7-rtems-eabihf) needs libc definitions that the published crate

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ records with the full areaDetector plugin chain from a single `cargo build`.
 
 - **Channel Access** — client & server (UDP name resolution + TCP circuit, beacons, repeater)
 - **pvAccess** — client & server (search engine, monitor/get/put/RPC, ORIGIN_TAG forwarding)
-- **QSRV bridge** — records as NTScalar/NTEnum/NTNDArray and Group PVs (C++ QSRV JSON compatible)
+- **QSRV bridge** — records as NTScalar/NTEnum/NTNDArray and Group PVs (C++ QSRV JSON compatible), `pva://` / `ca://` database links (pvalink/calink)
 - **IOC runtime** — 35 base record types, .db loader, link chains, scan scheduling, ACF access security, iocsh, autosave, calc engine
 - **asyn** — actor-based async port driver framework
 - **motor** — 9-phase state machine, coordinate transforms, backlash compensation
@@ -43,7 +43,7 @@ The umbrella crate pulls in what you select by feature:
 
 ```toml
 [dependencies]
-epics-rs = { version = "0.24", features = ["ad"] }
+epics-rs = { version = "0.25", features = ["ad"] }
 ```
 
 ```rust
@@ -74,8 +74,8 @@ through the umbrella crate — depend on them directly when needed.
 You can also depend on sub-crates directly:
 
 ```toml
-epics-base-rs = "0.24"  # just the IOC runtime
-epics-ca-rs   = "0.24"  # just Channel Access
+epics-base-rs = "0.25"  # just the IOC runtime
+epics-ca-rs   = "0.25"  # just Channel Access
 ```
 
 ## Workspace
@@ -255,6 +255,10 @@ Coverage includes wire-format golden packets (CA + PVA), pvxs interop
 fixtures, record processing and link chains, 46 golden tests against compiled
 C `tableRecord.c` output, and `examples/regression-ioc` — an end-to-end IOC
 that pins fixed wire behavior across releases.
+
+Async tests use `#[epics_test]`, whose driver follows the build's backend:
+re-running a crate's suite with `--features rtems-exec-model` exercises the
+same test bodies on the reactor-free exec backend that RTEMS uses.
 
 `epics-oracle-rs` is the differential oracle: it boots a C `softIoc` and the
 Rust IOC on the same `.db` and diffs their observable CA/PVA behavior. It

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -204,7 +204,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # host-facing feature that pulls this dependency — `qsrv`, `pvalink`,
 # `pva-gateway`, `dual-ioc` — so host builds resolve exactly as before. Only
 # `qsrv-core`, the RTEMS selection, gets the reduced set.
-epics-pva-rs = { path = "../epics-pva-rs", version = "0.24.0", optional = true, default-features = false }
+epics-pva-rs = { path = "../epics-pva-rs", version = "0.25.0", optional = true, default-features = false }
 # `epics-ca-rs` stays inherited, but NOT because its defaults are empty — they
 # stopped being empty at `274a734b`, which introduced the `client-core`/`client`
 # split and made `default = ["client"]`. The reason is narrower and is a fact
@@ -215,7 +215,7 @@ epics-pva-rs = { path = "../epics-pva-rs", version = "0.24.0", optional = true, 
 # none of them — measured with `cargo tree -p epics-bridge-rs
 # --no-default-features --features qsrv-core,pvalink`, which does not name it.
 # So `default-features = false` here would change nothing the target compiles,
-# while costing the second hand-written `version = "0.24.0"` that the
+# while costing the second hand-written `version` pin that the
 # `epics-pva-rs` entry above had to accept for a real reason.
 #
 # If a target feature ever does pull it, this entry needs the same treatment


### PR DESCRIPTION
Version bump 0.24.3 → 0.25.0 (minor: four `!`-marked breaking changes in epics-ca-rs/epics-pva-rs plus the iocsh `BlockingBridge` surface), the v0.25.0 CHANGELOG section, and README pointers. Release content: RTEMS 6 target support, Linux PREEMPT_RT, `epics-libcom-rs` extraction, SNL put-process fix, `#[epics_test]` migration — see CHANGELOG for the full section.