### PR TITLE
chore(release): bump workspace version to 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,106 @@
 # Changelog
 
+## v0.25.1 — 2026-07-26
+
+Patch release. VxWorks 7 (`x86_64-wrs-vxworks`) joins RTEMS 6 as a supported
+embedded target, reached by generalizing the RTEMS cfg into a capability cfg
+rather than by adding a second OS special case. Both embedded targets now take
+their `libc` fixes from one pinned public fork branch, which is what lets the
+VxWorks closure be type-checked in CI instead of only on the bring-up box.
+Also: a mandatory IOC thread that cannot start is now process-fatal instead of
+silently absent, and the `release-embedded` profile plus
+`scripts/embedded-image.sh` give both targets a deployable-image entry point.
+Additive API only; no breaking changes. Workspace version 0.25.0 -> 0.25.1.
+
+### VxWorks 7 (x86_64-wrs-vxworks)
+
+- **`epics_embedded_target` replaces `target_os = "rtems"` as the porting
+  cfg.** Every arm that meant "this target has no reactor, no ambient OS
+  services, one address family" now keys on the capability rather than the OS
+  name, in `epics-libcom-rs`, `epics-base-rs`, `epics-ca-rs`, `epics-pva-rs`
+  and `epics-bridge-rs`; the arms that are genuinely RTEMS-specific (the boot
+  shim, the BSP link contract) deliberately stay on `target_os`. Adding the
+  second embedded target touched cfg predicates, not protocol code.
+
+- **The statistics funnel becomes a per-OS backend selection.**
+  `epics-rtems-boot` owns it for both targets: `MemUsage` fields are
+  individually optional, so a target reports only what its OS can answer, and a
+  VxWorks backend binds `taskIdSelf`, `taskInfoGet`, `rtpIoTableSizeGet` and
+  mimalloc's `current_commit` for the task, stack, fd and memory census. The fd
+  walk is bounded by `rtpIoTableSizeGet` (a `size_t` return, per `ioLib.h:533`)
+  rather than `sysconf`. The console census moved into the same funnel, so
+  `epics-ca-rs` and `epics-bridge-rs` print one format on both targets.
+
+- **`scripts/vxworks-check.sh`**, the portability gate: a binary census plus
+  every target row, on the same bidirectional-census discipline as
+  `rtems-check.sh`. VxWorks also gets its own SCHED_FIFO priority mapping in
+  `epics-libcom-rs`'s task layer and its own entropy source for the PVA server
+  GUID.
+
+- **One libc fork branch for both embedded targets.** The workspace pin moves
+  to `physwkim/libc` branch `epics-rs-0.2`, which now carries the VxWorks
+  `pread`/`pwrite`/`killpg`/`getentropy` shims alongside the RTEMS
+  sockaddr/type-width fixes. A manifest `[patch.crates-io]` never reaches
+  `-Zbuild-std`, which resolves std against rust-src's own
+  `library/Cargo.lock`, so the new `scripts/libc-std-patch.sh` derives a
+  config-level patch from that same pin — a clone of the pinned rev relabelled
+  to the libc version the toolchain's lock demands, emitted as an alias entry
+  so the workspace graph keeps the committed resolution while the std graph
+  takes the relabelled copy. `vxworks-check.sh` and `scripts/embedded-image.sh`
+  both call it, leaving the manifest line the single source of truth for what
+  libc is compiled.
+
+- **The VxWorks closure is now type-checked in CI.** With the patched libc
+  public, the `vxworks-census` job installs the same stock `nightly` +
+  `rust-src` as `rtems-closure` and runs the whole gate rather than the census
+  alone. Linking stays on the bring-up box, because a `.vxe` needs the
+  proprietary Wind River SDK — a gap now stated as a fact rather than left as
+  an absent gate.
+
+- `doc/vxworks-port.md` documents the target and toolchain contract, the cfg
+  architecture, the priority model, and what was measured on target: 11/11 gate
+  rows, CA and PVA round-trips over the wire, the census blocks verbatim, and
+  (§5.5) a five-row strip/LTO size matrix for both targets and both binaries.
+
+### Runtime and asyn
+
+- **A mandatory IOC thread whose spawn fails is now process-fatal.** Such a
+  thread resolved its own spawn `Result` with `.expect(..)`, and on a
+  `panic = "unwind"` target that kills only the calling thread — measured on a
+  VxWorks RTP, an `EAGAIN` from the periodic-scan spawn left the process
+  answering CA with zero periodic scanning. `MandatoryThread` makes the failure
+  process-fatal, matching C, where a rate that was never created wedges
+  `iocInit`; the areaDetector plugin data threads route through it.
+
+- **`asyn-rs` port creation is fallible.** `create_port_runtime` ended in
+  `.expect(..)` too, so a `*Configure` line whose port thread failed to start
+  unwound iocsh while later st.cmd lines ran against a port that did not exist.
+  A port whose runtime thread cannot start is now never registered, matching
+  `registerDriver`'s unwind-before-`ellAdd` order in C.
+
+### Embedded images
+
+- **`release-embedded` profile and `scripts/embedded-image.sh`.** Cargo has no
+  target-conditional profile, so the "what do we ship" default lives at the
+  entry point: `./scripts/embedded-image.sh <rtems|vxworks> <ca|pva>` builds on
+  a profile inheriting `release` with `strip = "symbols"`, `lto = "fat"`,
+  `codegen-units = 1`. Measured against the dev images the gates build: RTEMS
+  CA 122,884,636 B -> 4,604,848 B, VxWorks CA 116,768,688 B -> 4,287,696 B,
+  both boot-verified and round-tripped. A plain `cargo build --release` is
+  unchanged.
+
+- **The target IOC binaries are renamed `realtime-ca-ioc` and
+  `realtime-pva-ioc`** (were `rtems-ca-ioc` / `rtems-pva-ioc`), since they now
+  serve two embedded targets.
+
+### Fixes
+
+- `epics-pva-rs`: `SO_SNDTIMEO` is best-effort on the blocking accept path.
+  VxWorks returns `ENOPROTOOPT`, which was fatal and closed every accepted
+  connection.
+- `epics-ca-rs`, `epics-pva-rs`: a failing `peer_addr()` is logged before the
+  accepted connection is dropped.
+
 ## v0.25.0 — 2026-07-24
 
 Minor release. RTEMS 6 goes from "type-checks" to a verified embedded target —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "bitflags",
  "chrono",
@@ -993,7 +993,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "cc",
  "libc",
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2240,7 +2240,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3208,7 +3208,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3827,7 +3827,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ records with the full areaDetector plugin chain from a single `cargo build`.
 - **areaDetector** — NDArray, driver base, 26 plugins (Stats/ROI/FFT/file writers/PVA push/…)
 - **synApps modules** — std (epid/throttle/timestamp), scaler, optics, mca
 - **Drivers** — MQTT broker bridge, Modbus TCP/RTU/ASCII
-- **Targets** — Linux/macOS/Windows (x86_64 + arm64), RTEMS 6, Linux PREEMPT_RT
+- **Targets** — Linux/macOS/Windows (x86_64 + arm64), RTEMS 6, VxWorks 7, Linux PREEMPT_RT
 
 ## Installation
 
@@ -202,8 +202,38 @@ RTEMS_BSP_PREFIX=/path/to/bsp cargo +nightly build --release --locked \
 The custom target spec this workspace deviates on (`has-thread-local: true`,
 `doc/rtems-tls-spec-deviation.md`) is applied automatically by a rustc-wrapper
 wired in `.cargo/config.toml` — plain `cargo build` is the whole interface.
-The full build manual, including the PVA/QSRV image and the spec escape hatch,
-is in [`crates/epics-rtems-boot/README.md`](crates/epics-rtems-boot/README.md).
+`./scripts/embedded-image.sh rtems ca` builds the same binary on the
+`release-embedded` profile (strip + fat LTO), which is what a deployment ships:
+4.6 MB against the dev build's 122.9 MB. The full build manual, including the
+PVA/QSRV image and the spec escape hatch, is in
+[`crates/epics-rtems-boot/README.md`](crates/epics-rtems-boot/README.md).
+
+## Build for VxWorks 7 (x86_64-wrs-vxworks)
+
+VxWorks 7 is the second embedded target, reached through the same
+`epics_embedded_target` cfg rather than a second OS special case. It is also
+tier-3, so it needs a nightly toolchain with `rust-src` and `-Zbuild-std`, but
+being a builtin triple it needs no custom spec:
+
+```bash
+# census, then type-check the whole VxWorks closure — no SDK needed
+./scripts/vxworks-check.sh
+
+# deployable RTP image (needs the Wind River SDK: wr-cc and the RTP libs)
+./scripts/embedded-image.sh vxworks ca
+```
+
+Both embedded targets take their `libc` fixes from one pinned public fork
+branch (`physwkim/libc`, `epics-rs-0.2`). A manifest `[patch.crates-io]` does
+not reach `-Zbuild-std`, which resolves std against rust-src's own lock, so
+`scripts/libc-std-patch.sh` derives a config-level patch from that same pin;
+`vxworks-check.sh` and `embedded-image.sh` both call it, leaving the manifest
+line the single source of truth for what libc is compiled. That is what lets
+the closure be type-checked on a stock nightly, CI included. Linking stays on a
+box with the SDK — producing or booting a `.vxe` is the one half no runner can
+do. The target contract, the cfg architecture, and what was measured on target
+(gate rows, CA/PVA round-trips, image sizes) are in
+[`doc/vxworks-port.md`](doc/vxworks-port.md).
 
 ## Run on RT Linux (PREEMPT_RT)
 


### PR DESCRIPTION
Patch release covering what PR #60 landed: VxWorks 7 as a second embedded
target behind the generalized `epics_embedded_target` cfg, the per-OS
statistics funnel with its VxWorks census, `MandatoryThread` and fallible
`create_port_runtime` making an unstartable IOC thread fail loudly instead of
leaving a half-built IOC running, and the `release-embedded` profile with
`scripts/embedded-image.sh` as the deployable-image entry point.

The bump touches `[workspace.package] version` only. The
`[workspace.dependencies]` pins and the hand-written `epics-pva-rs` pin in
`epics-bridge-rs` stay at 0.25.0, since those are caret requirements a patch
satisfies; the repo moves them in lockstep only on a minor. A `BREAKING` scan
over `v0.25.0..main` returns nothing.

The README gains a VxWorks 7 build section beside the RTEMS one, and both now
point at `scripts/embedded-image.sh` — the RTEMS line with its measured size,
4.6 MB against the dev build's 122.9 MB.