### PR TITLE
doc: retire the claim that MSG_DONTWAIT is what bounds a send

### DIFF
--- a/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
+++ b/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
@@ -653,9 +653,11 @@ mod ioc {
     ///   writer pump did while the deadline depended on that socket option
     ///   taking. On a target that refuses the option this thread has nothing
     ///   entitled to reclaim it.
-    /// * **fixed** — `write_frame_deadline`, which owns its own wait
-    ///   (`poll(POLLOUT, remaining)` + `send(MSG_DONTWAIT)`) and so cannot be
-    ///   disarmed by the option being absent.
+    /// * **fixed** — `write_frame_deadline`, which owns the socket's blocking
+    ///   mode and polls `POLLOUT` for what the deadline has left, so it cannot
+    ///   be disarmed by the option being absent — nor by a send flag the target
+    ///   ignores, which is what `MSG_DONTWAIT` turned out to be on Darwin
+    ///   (`doc/darwin-send-dontwait-gap.md`).
     ///
     /// Both legs print their elapsed time and their outcome. A leg that
     /// *completes* says so: silence is never read as a bound here, and a frame

--- a/crates/epics-libcom-rs/src/runtime/blocking_io.rs
+++ b/crates/epics-libcom-rs/src/runtime/blocking_io.rs
@@ -961,10 +961,14 @@ fn wait_writable(sock: &TcpStream, deadline: Instant) -> io::Result<bool> {
 /// send buffer fills, it waits until the *whole* buffer is queued
 /// (`tcp_sendmsg` parks in `sk_stream_wait_memory`). So waiting for `POLLOUT`
 /// first is not enough on its own — the very next `write` re-enters the same
-/// unbounded wait one byte later. `MSG_DONTWAIT` makes the send itself
-/// per-call non-blocking, and unlike `O_NONBLOCK` it does not touch the file
-/// description, which matters because the reader pump shares this exact
-/// descriptor (see the module docs on why it is shared and not `dup`ed).
+/// unbounded wait one byte later. The socket is non-blocking for as long as it
+/// is live ([`own_blocking_mode`]), so the send takes what there is room for and
+/// returns; `MSG_DONTWAIT` rides on top as the per-call form of the same ask.
+///
+/// That mode is on the file description the reader pump shares (see the module
+/// docs on why it is shared and not `dup`ed), which is what [`wait_readable`]
+/// exists for: the reader polls before reading rather than parking in `read`,
+/// so sharing the description with a non-blocking writer costs it nothing.
 ///
 /// A full buffer surfaces as `EAGAIN`/`WouldBlock`, which returns the caller to
 /// [`wait_writable`] and therefore to the deadline.

--- a/doc/vxworks-circuit-wedge-on-target-measurement.md
+++ b/doc/vxworks-circuit-wedge-on-target-measurement.md
@@ -649,6 +649,13 @@ drivers share:
   flag rather than `O_NONBLOCK` because the reader pump shares this exact file
   description and must not be switched to non-blocking underneath.
 
+  **The second sentence is superseded (v0.25.2).** The flag is not a bound —
+  XNU decides from `so_state & SS_NBIO` and ignores what the caller passes, and
+  this target was never measured honouring it — so `write_frame_deadline` owns
+  the mode after all. Switching the shared description is safe because the
+  reader pump was converted with it: it polls `POLLIN` instead of parking in
+  `read`. See `doc/darwin-send-dontwait-gap.md`.
+
 Waiting for `POLLOUT` alone is not enough, and getting that wrong cost a round:
 a blocking `write` on a stream socket does not return a short count when the
 send buffer fills, it waits until the *whole* buffer is queued, so the write

--- a/doc/vxworks-port.md
+++ b/doc/vxworks-port.md
@@ -689,9 +689,12 @@ no `setcap`, and `net.ipv4.ip_unprivileged_port_start=1024`.
   fatally, so a CA client on this target established no circuits at all.
   The first fix for that made the option best-effort and was a workaround; the
   round that closed it moved the bound inside `write_frame_deadline`
-  (`poll(POLLOUT, remaining)` + `send(MSG_DONTWAIT)`), so the send deadline no
-  longer depends on a socket option any target may refuse and `SO_SNDTIMEO` is
-  now set nowhere in the write path. Measured on target in one boot against a
+  (`poll(POLLOUT, remaining)` over a socket the function itself puts in
+  non-blocking mode), so the send deadline no longer depends on a socket option
+  any target may refuse and `SO_SNDTIMEO` is now set nowhere in the write path.
+  That first landed resting on `send(MSG_DONTWAIT)` rather than on the mode,
+  which Darwin ignores and this target was never measured honouring; corrected
+  in v0.25.2, `doc/darwin-send-dontwait-gap.md`. Measured on target in one boot against a
   peer that accepts and never reads: the bounded path returned at **2016 ms
   against a 2000 ms deadline**, the old path had not returned **127.5 s** later
   and still held its descriptor (§5.1). This removes `SEND_TICKS_PER_DEADLINE`


### PR DESCRIPTION
Doc-comment and markdown only. The one that matters is `write_some` in `blocking_io.rs`: its "unlike `O_NONBLOCK` it does not touch the file description" argued for the design v0.25.2 removed, so it read as a reason to undo the fix.