### PR TITLE
fix(ca-server): give the blocking driver's clients SO_KEEPALIVE, as C does

### DIFF
--- a/crates/epics-ca-rs/src/server/blocking.rs
+++ b/crates/epics-ca-rs/src/server/blocking.rs
@@ -1116,7 +1116,17 @@ fn handle_client_blocking(
     acf: SharedAcf,
     tcp_port: u16,
 ) -> CaResult<()> {
-    let _ = stream.set_nodelay(true);
+    // C `create_client` sets both of these and refuses the client —
+    // `destroy_client`, `return NULL` — when either `setsockopt` fails
+    // (`caservertask.c:1444`, `:1456`), so neither is best-effort here.
+    // KEEPALIVE is what bounds a client that stops reading: `write_frame_locked`
+    // parks in `write_all` under the send lock, exactly as C parks in `send`
+    // under `SEND_LOCK`, and in C it is the keepalive probe failing that ends
+    // it. The hosted driver sets it in `tcp::accept_loop` through `socket2`,
+    // which does not build for the embedded triples — so this path had no
+    // reaper at all until the option came from `runtime::socket`.
+    stream.set_nodelay(true).map_err(CaError::Io)?;
+    epics_base_rs::runtime::socket::enable_keepalive(&stream).map_err(CaError::Io)?;
     // `None` (no configured cap) leaves the socket in pure blocking mode — C
     // `rsrv`'s default (`camsgtask` blocks in `recv` with no idle cap).
     // `set_read_timeout` sets SO_RCVTIMEO on Unix (incl. RTEMS) and is portable

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -129,9 +129,16 @@ mod cap_parse_tests {
 /// Per-socket send timeout. Without this, a client that stops
 /// reading (frozen GUI, dead viewer holding the socket open) causes
 /// every server `write` to block once the kernel send buffer fills,
-/// stalling the whole per-client dispatcher task. C rsrv defaults
-/// SO_SNDTIMEO to 5 s; we honour the same default and let
-/// `EPICS_CAS_SEND_TMO` override.
+/// stalling the whole per-client dispatcher task.
+///
+/// **This has no C counterpart.** `SO_SNDTIMEO` appears nowhere in epics-base,
+/// and rsrv's `create_client` sets only `TCP_NODELAY`, `SO_KEEPALIVE`,
+/// `SO_SNDBUF` and `SO_RCVBUF` (`caservertask.c:1444-1483`); `cas_send_bs_msg`
+/// then loops on a blocking `send()` under `SEND_LOCK` with no bound at all
+/// (`caserverio.c:43`), and it is the keepalive probe that eventually ends such
+/// a client. So the 5 s here is this port's own choice and
+/// `EPICS_CAS_SEND_TMO` its own knob — [`crate::estdlib`] classifies it as
+/// exactly that, a variable outside C's `ENV_PARAM` table.
 #[cfg(not(epics_embedded_target))]
 fn send_timeout() -> Duration {
     static RESOLVED: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
@@ -1465,9 +1472,10 @@ async fn accept_loop(
                 .with_interval(Duration::from_secs(5));
             let _ = sock.set_keepalive(true);
             let _ = sock.set_tcp_keepalive(&keepalive);
-            // SO_SNDTIMEO is set as a defence-in-depth (matches C
-            // rsrv default 5s, configurable via EPICS_CAS_SEND_TMO),
-            // but on a non-blocking tokio socket the kernel does NOT
+            // SO_SNDTIMEO is set as a defence-in-depth — this port's own
+            // 5 s, not C's; rsrv sets no send timeout anywhere (see
+            // `send_timeout`) — but on a non-blocking tokio socket the
+            // kernel does NOT
             // apply it — a stuck client where the kernel send buffer
             // fills would still leave `poll_write` Pending forever.
             // The actual stall guard is the `tokio::time::timeout`

--- a/crates/epics-libcom-rs/src/runtime/socket.rs
+++ b/crates/epics-libcom-rs/src/runtime/socket.rs
@@ -133,6 +133,30 @@ pub fn tcp_connect(
     sys::tcp_connect(remote, local, opts, timeout)
 }
 
+/// Enable `SO_KEEPALIVE` on an already-accepted TCP connection.
+///
+/// The one option here applied *after* the socket exists rather than before it
+/// binds: a server does not construct the sockets it serves, it accepts them.
+/// It still belongs here, because "reach `setsockopt` without `socket2` on the
+/// embedded triples" is the whole reason this module exists, and a keepalive
+/// setter written at a call site would be the third hand-rolled copy of that
+/// twenty lines (`epics-tools-rs::procserv::client::set_keepalive` is the
+/// second).
+///
+/// The error is returned, not swallowed. C treats this option as required —
+/// `create_client` calls `destroy_client` and refuses the connection when it
+/// fails (`caservertask.c:1456`) — so the caller gets to make C's decision.
+///
+/// Only the flag is set, which is all C sets. The idle/probe tuning the hosted
+/// CA driver adds through `socket2` (`epics-ca-rs::server::tcp`, 15 s + 5 s) is
+/// deliberately not reproduced: `TCP_KEEPIDLE` is a Linux spelling, BSD-derived
+/// stacks call it `TCP_KEEPALIVE`, and neither has been measured on RTEMS or
+/// VxWorks. A target's default idle is therefore what applies here, as it is in
+/// C.
+pub fn enable_keepalive(sock: &TcpStream) -> io::Result<()> {
+    sys::enable_keepalive(sock)
+}
+
 #[cfg(not(epics_embedded_target))]
 mod sys {
     //! Hosted: `socket2` already owns the pre-bind option surface and its
@@ -235,6 +259,10 @@ mod sys {
                 Err(_) => Err(e),
             },
         }
+    }
+
+    pub(super) fn enable_keepalive(sock: &TcpStream) -> io::Result<()> {
+        socket2::SockRef::from(sock).set_keepalive(true)
     }
 }
 
@@ -435,6 +463,11 @@ mod sys {
         Ok(unsafe { TcpStream::from_raw_fd(owned.into_raw()) })
     }
 
+    pub(super) fn enable_keepalive(sock: &TcpStream) -> io::Result<()> {
+        use std::os::fd::AsRawFd;
+        set_bool_opt(sock.as_raw_fd(), libc::SOL_SOCKET, libc::SO_KEEPALIVE)
+    }
+
     /// RTEMS: plain blocking connect, no deadline.
     ///
     /// C parity, not a shortcut: `__rtems__` selects `USE_SOCKTIMEOUT`
@@ -541,6 +574,53 @@ mod tests {
 
     fn localhost(port: u16) -> SocketAddr {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port))
+    }
+
+    /// Read the flag back off the socket, because "the call returned `Ok`" and
+    /// "the option is on" are different claims — C checks the `setsockopt`
+    /// status and this checks the state that status is supposed to mean.
+    #[cfg(unix)]
+    #[test]
+    fn enable_keepalive_actually_sets_so_keepalive() {
+        use std::os::fd::AsRawFd;
+
+        let listener = tcp_listener(localhost(0), SocketOptions::REUSE_ADDRESS, 4).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let client = TcpStream::connect(localhost(port)).unwrap();
+        let (accepted, _) = listener.accept().unwrap();
+
+        let mut before: libc::c_int = 0;
+        let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+        // SAFETY: `accepted` owns a live socket for the borrow; `before`/`len`
+        // are sized as SO_KEEPALIVE's `c_int` optval expects.
+        let rc = unsafe {
+            libc::getsockopt(
+                accepted.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                std::ptr::addr_of_mut!(before).cast(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 0, "getsockopt failed: {}", io::Error::last_os_error());
+        assert_eq!(before, 0, "the fixture must start with the option off");
+
+        enable_keepalive(&accepted).expect("SO_KEEPALIVE");
+
+        let mut after: libc::c_int = 0;
+        // SAFETY: as above.
+        let rc = unsafe {
+            libc::getsockopt(
+                accepted.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_KEEPALIVE,
+                std::ptr::addr_of_mut!(after).cast(),
+                &mut len,
+            )
+        };
+        assert_eq!(rc, 0, "getsockopt failed: {}", io::Error::last_os_error());
+        assert_ne!(after, 0, "SO_KEEPALIVE not enabled");
+        drop(client);
     }
 
     #[test]


### PR DESCRIPTION
The blocking CA driver had no half-open reaper at all on the embedded targets: its unbounded `write_all` under the send lock is C parity (`cas_send_bs_msg` blocks in `send()` under `SEND_LOCK` too), but C survives it because `create_client` sets `SO_KEEPALIVE`, and our hosted driver sets it through `socket2`, which does not build for RTEMS or VxWorks. Second commit removes a C-parity claim for `SO_SNDTIMEO`/`EPICS_CAS_SEND_TMO`, neither of which exists in epics-base.