### PR TITLE
client: bind the UDP SEARCH socket on every backend

### DIFF
--- a/crates/epics-bridge-rs/src/bin/realtime-pva-ioc.rs
+++ b/crates/epics-bridge-rs/src/bin/realtime-pva-ioc.rs
@@ -409,6 +409,63 @@ mod ioc {
         epics_rtems_boot::stats::stack_report(tag);
     }
 
+    /// STAGE-5 PROBE: prove a PVA SEARCH broadcast round-trips on this target.
+    ///
+    /// Drives the **real** client search engine with no name servers
+    /// configured, so what it reports on is the whole UDP path — bind, the
+    /// per-interface broadcast fanout, the server's own UDP responder, and the
+    /// SEARCH_RESPONSE decode — rather than just that a datagram left the box.
+    /// `pv` is one this IOC serves itself, so the answer comes from this
+    /// guest's own PVA server via its subnet broadcast address, which is the
+    /// only reachable responder under SLIRP.
+    ///
+    /// Its own engine and not the pvalink resolver's: a failure here must name
+    /// the transport, and a resolver that also has TCP name servers configured
+    /// would resolve through those and report success for the wrong reason.
+    #[cfg(feature = "bringup-probes")]
+    fn udp_search_report(pv: &str) {
+        use epics_base_rs::runtime::task::{block_on_sync, timeout};
+        use epics_pva_rs::client_native::search_engine::{
+            ClientSearchConfig, SearchEngine, SearchReason,
+        };
+        use std::time::Duration;
+
+        let outcome = block_on_sync(async {
+            let config = ClientSearchConfig::from_env();
+            let bport = config.broadcast_port;
+            // No name servers, no extra targets: auto-address broadcast is the
+            // only way this engine can reach anything.
+            let engine = SearchEngine::spawn_with_config(
+                config,
+                Vec::new(),
+                Vec::new(),
+                String::new(),
+                String::new(),
+                Duration::from_secs(1),
+            )
+            .await?;
+            println!("UDPSEARCH broadcast_port={bport} pv={pv}");
+            let hit = timeout(
+                Duration::from_secs(5),
+                engine.find(pv, SearchReason::Initial),
+            )
+            .await
+            .map_err(|_| {
+                epics_pva_rs::error::PvaError::Protocol("no SEARCH_RESPONSE in 5 s".into())
+            })??;
+            Ok::<_, epics_pva_rs::error::PvaError>(hit)
+        });
+
+        match outcome {
+            Ok(Ok(hit)) => println!(
+                "UDPSEARCH reply pv={pv} server={} guid={:02x?} proto={} version={}",
+                hit.server, hit.guid, hit.proto, hit.peer_version
+            ),
+            Ok(Err(e)) => eprintln!("UDPSEARCH failed pv={pv}: {e}"),
+            Err(e) => eprintln!("UDPSEARCH not runnable here: {e:?}"),
+        }
+    }
+
     /// STAGE-5 PROBE: one console report — the link registry, the ONE
     /// client's connection list, and the two link-bearing records.
     ///
@@ -791,13 +848,13 @@ mod ioc {
         // the loaded database configured none — because on a target with no
         // shell the console is the only place an operator can confirm the
         // resolver came up and how many links it pre-registered. The client
-        // reaches upstream servers over `EPICS_PVA_NAME_SERVERS` (TCP); the UDP
-        // SEARCH transport is compiled out on this target (design §4.2), so a
-        // link to a server reachable only by broadcast will not resolve.
+        // reaches upstream servers both ways now: UDP SEARCH broadcast to the
+        // interfaces' own destinations, and any `EPICS_PVA_NAME_SERVERS` over
+        // TCP.
         println!(
             "realtime-pva-ioc: pvalink resolver installed — {link_count} pva:// record \
-             link{} pre-registered; pva://... INP/OUT resolve over EPICS_PVA_NAME_SERVERS \
-             (TCP name servers; UDP search is compiled out on this target)",
+             link{} pre-registered; pva://... INP/OUT resolve over UDP SEARCH \
+             broadcast and EPICS_PVA_NAME_SERVERS (TCP)",
             if link_count == 1 { "" } else { "s" },
         );
         for name in &names {
@@ -830,6 +887,10 @@ mod ioc {
                     let _ = epics_base_rs::runtime::ioc_role::enter_ioc_role(
                         epics_base_rs::runtime::ioc_role::IocRole::ConsoleCensus,
                     );
+                    // Once, before the periodic census: the transport either
+                    // round-trips or it does not, and repeating it every 10 s
+                    // would bury the answer in the report stream.
+                    udp_search_report("RTEMS:PVA:AO");
                     let mut seq = 0u32;
                     loop {
                         thread::sleep(std::time::Duration::from_secs(10));

--- a/crates/epics-ca-rs/build.rs
+++ b/crates/epics-ca-rs/build.rs
@@ -56,9 +56,15 @@
 //! `--features rtems-exec-model` compiled the UDP transport in and panicked on
 //! it at `realtime-ca-ioc`'s first search (measured, `doc/calink-rtems-design.md`
 //! §10.10 item 2). `tokio_backend` is the predicate that means "a reactor
-//! exists", so the transport takes that one and `SearchTransport` has the
-//! single `NameServersOnly` variant on `exec_backend` — the target's shape,
-//! now reached by the host build that models the target.
+//! exists", so every arm that needs one takes that predicate — the target's
+//! shape, now reached by the host build that models the target.
+//!
+//! The SEARCH socket is no longer one of those arms. It binds on both backends
+//! through `epics_base_rs::net::search_udp::SearchUdpSocket`, whose
+//! `exec_backend` arm is a `std::net::UdpSocket` and a receive-pump thread and
+//! names no reactor. `SearchTransport` still reduces to `NameServersOnly` when
+//! the configuration asks for no UDP — that variant describes a configuration
+//! now, not a target.
 //!
 //! This is a third copy of a four-line rule, so it is pinned rather than
 //! trusted: a `const` assertion in `src/lib.rs` checks it against

--- a/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
+++ b/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
@@ -566,6 +566,52 @@ mod ioc {
         epics_rtems_boot::stats::stack_report(tag);
     }
 
+    /// PROBE: what `getifaddrs` reports on this target, and the UDP SEARCH
+    /// destination list derived from it.
+    ///
+    /// The gate gives `net::iface_v4` a compile for both embedded triples and
+    /// `nm` gives it a defined `getifaddrs` in `libbsd.a` / `libnet.a`, but
+    /// neither says the call returns an interface once the BSP's stack is up:
+    /// an RTEMS image whose libbsd has no configured `ifconfig` would return
+    /// success and an empty list, and `EPICS_CA_AUTO_ADDR_LIST` would expand to
+    /// nothing exactly as it did before the enumeration existed — a silent
+    /// no-op wearing a working build's clothes. This is the line that tells the
+    /// two apart, so it prints the raw walk and not only the derived list.
+    ///
+    /// Before the search-configuration defaults below, so it reports what the
+    /// OS has rather than what this image then decides to do with it.
+    #[cfg(feature = "bringup-probes")]
+    fn iface_report() {
+        match epics_base_rs::net::iface_v4::enumerate() {
+            Ok(ifaces) => {
+                for i in &ifaces {
+                    println!(
+                        "IFPROBE name={} ip={} flags=0x{:x} up={} lo={} bc={} p2p={} dest={:?} search={:?}",
+                        i.name,
+                        i.ip,
+                        i.flags,
+                        i.is_up() as u8,
+                        i.is_loopback() as u8,
+                        i.is_broadcast() as u8,
+                        i.is_point_to_point() as u8,
+                        i.dest,
+                        i.search_destination()
+                    );
+                }
+                println!(
+                    "IFPROBE count={} broadcast_addrs={:?} local_addr={}",
+                    ifaces.len(),
+                    epics_base_rs::net::iface_v4::broadcast_addrs(),
+                    epics_base_rs::net::iface_v4::local_addr()
+                );
+            }
+            // Printed, not panicked: an image that cannot enumerate is still a
+            // working IOC for every explicitly configured destination, and the
+            // whole point of the probe is to report the difference.
+            Err(e) => println!("IFPROBE error={e}"),
+        }
+    }
+
     /// C6 PROBE: one console report — the link registry, the shared
     /// client's circuit count, and every record the gate reads.
     ///
@@ -817,6 +863,11 @@ mod ioc {
         //     No `#[cfg]`: the funnel is portable and every backend but
         //     VxWorks' takes this as a no-op.
         epics_rtems_boot::stats::register_task();
+
+        // (0-iface) PROBE: what the OS's interface enumeration returns, before
+        //     anything in this image decides what to do with it.
+        #[cfg(feature = "bringup-probes")]
+        iface_report();
 
         // (0-probe) C6 PROBE: the target's CA search configuration.
         // `rtems_init.c:195` hands `main` a fixed one-element argv and

--- a/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
+++ b/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
@@ -23,9 +23,9 @@
 //!    [`install_calink_resolver`](epics_ca_rs::calink::install_calink_resolver)
 //!    mounts the CA external record-link resolver on the database (C
 //!    `dbCaLinkInit`, `dbCa.c:1071`), so a ` CA`-modified or `ca://...`
-//!    INP/OUT field resolves through a live `CaClient`. The client dials
-//!    `EPICS_CA_NAME_SERVERS` over TCP; the UDP SEARCH transport is compiled
-//!    out on this target.
+//!    INP/OUT field resolves through a live `CaClient`. The client binds the
+//!    UDP SEARCH socket and additionally dials `EPICS_CA_NAME_SERVERS` over
+//!    TCP, as it does on a host — see `epics_base_rs::net::search_udp`.
 //! 4. **CA front-end** — [`epics_ca_rs::server::blocking::BlockingCaServer`]: the TCP accept loop (C
 //!    `CAS-TCP`, `caservertask.c:62`) and the UDP name-search responder (C
 //!    `CAS-UDP`, `cast_server.c:113`), each on its own `std::thread`, with one
@@ -612,6 +612,103 @@ mod ioc {
         }
     }
 
+    /// UDP SEARCH PROBE: broadcast one real CA SEARCH from the client's own
+    /// socket type and wait for this IOC's own responder to answer it.
+    ///
+    /// The four things nothing else on this target proves, in one round trip:
+    /// [`SearchUdpSocket`](epics_base_rs::net::search_udp::SearchUdpSocket)
+    /// **binds**, its `send_to` reaches the broadcast address
+    /// [`iface_report`] derived, the responder receives it, and the receive
+    /// pump thread hands the reply back to an `async fn` running with no
+    /// reactor. A cross-compile gate proves none of them — `std::net::UdpSocket`
+    /// on `armv7-rtems-eabihf` type-checks whatever libbsd then does.
+    ///
+    /// Deliberately its own socket rather than the search engine's: this must
+    /// report on the transport alone, and a failure here must not be
+    /// confusable with a database, resolver or name-server fault. It runs
+    /// after the responder thread is up, because it needs an answer.
+    #[cfg(feature = "bringup-probes")]
+    fn udp_search_report(port: u16, pv: &str) {
+        use epics_base_rs::net::search_udp::SearchUdpSocket;
+        use epics_base_rs::runtime::ioc_role::IocRole;
+        use epics_base_rs::runtime::task::{block_on_sync, timeout};
+        use epics_ca_rs::protocol::{
+            CA_DO_REPLY, CA_MINOR_VERSION, CA_PROTO_SEARCH, CA_PROTO_VERSION, CaHeader,
+        };
+        use std::net::SocketAddr;
+        use std::time::Duration;
+
+        // The pump's band comes from the role, not from a number named here:
+        // this probe is a `ConsoleCensus` instrument and must not preempt
+        // client service, which is the rule
+        // `this_entry_point_names_no_scheduling_band` enforces.
+        let sock =
+            match SearchUdpSocket::bind_ephemeral(true, "PROBE-UDP", IocRole::ConsoleCensus.band())
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    println!("UDPSEARCH bind error={e}");
+                    return;
+                }
+            };
+        println!("UDPSEARCH bound={:?}", sock.local_addrs());
+
+        // VERSION then SEARCH, the two-message datagram every CA client opens
+        // with (`udpiiu.cpp::searchMsg`). Built here from `CaHeader::to_bytes`
+        // rather than through the search engine, for the reason above.
+        let mut frame = CaHeader {
+            cmmd: CA_PROTO_VERSION,
+            count: CA_MINOR_VERSION,
+            ..CaHeader::new(CA_PROTO_VERSION)
+        }
+        .to_bytes()
+        .to_vec();
+        let mut name = pv.as_bytes().to_vec();
+        name.push(0);
+        while name.len() % 8 != 0 {
+            name.push(0);
+        }
+        frame.extend_from_slice(
+            &CaHeader {
+                cmmd: CA_PROTO_SEARCH,
+                postsize: name.len() as u16,
+                data_type: CA_DO_REPLY,
+                count: CA_MINOR_VERSION,
+                cid: 0xC0DE,
+                available: 0xC0DE,
+                ..CaHeader::new(CA_PROTO_SEARCH)
+            }
+            .to_bytes(),
+        );
+        frame.extend_from_slice(&name);
+
+        let dests = epics_base_rs::net::iface_v4::broadcast_addrs();
+        if dests.is_empty() {
+            println!("UDPSEARCH no broadcast destination — nothing to send to");
+            return;
+        }
+        let outcome = block_on_sync(async {
+            for ip in &dests {
+                let dest = SocketAddr::from((*ip, port));
+                match sock.send_to(&frame, dest).await {
+                    Ok(n) => println!("UDPSEARCH sent bytes={n} pv={pv} dest={dest}"),
+                    Err(e) => println!("UDPSEARCH send error={e} dest={dest}"),
+                }
+            }
+            let mut buf = vec![0u8; 1024];
+            match timeout(Duration::from_secs(5), sock.recv(&mut buf)).await {
+                Ok(Ok(dg)) => format!(
+                    "UDPSEARCH reply n={} src={} iface_ip={:?} drops={}",
+                    dg.n, dg.src, dg.iface_ip, dg.drops
+                ),
+                Ok(Err(e)) => format!("UDPSEARCH recv error={e}"),
+                Err(_) => "UDPSEARCH no reply within 5s".to_string(),
+            }
+        })
+        .expect("the RTEMS entry point runs on a plain thread with no runtime entered");
+        println!("{outcome}");
+    }
+
     /// C6 PROBE: one console report — the link registry, the shared
     /// client's circuit count, and every record the gate reads.
     ///
@@ -947,12 +1044,11 @@ mod ioc {
         //      so every record's link fields route through it before the
         //      server answers its first client.
         //
-        //      On this target the CA client reaches upstream servers over TCP
-        //      name servers alone (`EPICS_CA_NAME_SERVERS`): the UDP SEARCH
-        //      transport is compiled out (design §6 stage C5,
-        //      `search::SearchTransport::NameServersOnly`), and every task the
-        //      resolver spawns lands on the callback pool `background_init`
-        //      started above via `runtime::task::spawn`, never a tokio runtime.
+        //      The CA client reaches upstream servers the way a host client
+        //      does — the UDP SEARCH socket plus any `EPICS_CA_NAME_SERVERS`
+        //      circuits — and every task the resolver spawns lands on the
+        //      callback pool `background_init` started above via
+        //      `runtime::task::spawn`, never a tokio runtime.
         let resolver = block_on_sync(install_calink_resolver(&db))
             .expect("the RTEMS entry point runs on a plain thread with no runtime entered");
 
@@ -1126,16 +1222,24 @@ mod ioc {
              RTEMS execution model, no tokio runtime",
             names.len()
         );
+
+        // (5-udp) PROBE: the client's SEARCH socket, end to end against this
+        //     IOC's own responder. After the responder thread above, because
+        //     it needs an answer.
+        #[cfg(feature = "bringup-probes")]
+        udp_search_report(port, "RTEMS:AO");
         // The calink resolver is mounted, so ` CA`-modified and `ca://...`
         // INP/OUT links resolve. Reported at every boot — including
         // `link_count == 0`, when the loaded database configured none —
         // because on a target with no shell the console is the only place an
         // operator can confirm the resolver came up and how many links it
-        // registered. The client reaches upstream servers over
-        // `EPICS_CA_NAME_SERVERS` (TCP); the UDP SEARCH transport is compiled
-        // out on this target, so a link to a server reachable only by
-        // broadcast will not resolve, and `EPICS_CA_ADDR_LIST` is not even
-        // parsed here.
+        // registered. The client reaches upstream servers over both paths a
+        // host client uses — the UDP SEARCH socket and any
+        // `EPICS_CA_NAME_SERVERS` TCP circuits. A `bringup-probes` build
+        // still resolves over TCP alone in practice, because it compiles in
+        // `EPICS_CA_ADDR_LIST=""` and `EPICS_CA_AUTO_ADDR_LIST=NO` below so
+        // that a C6 resolution can only have come over TCP; that is this
+        // measurement rig's configuration, not the target's capability.
         //
         // Counted against the database's DECLARED external PV set, after
         // waiting for the registry to reach it.
@@ -1165,8 +1269,7 @@ mod ioc {
         println!(
             "realtime-ca-ioc: calink resolver installed — {link_count}/{} ca:// record \
              link{} registered ({}); ` CA`-modified and ca://... INP/OUT resolve over \
-             EPICS_CA_NAME_SERVERS (TCP name servers; UDP search is compiled out \
-             on this target)",
+             UDP search and any EPICS_CA_NAME_SERVERS TCP circuits)",
             declared.len(),
             if declared.len() == 1 { "" } else { "s" },
             if declared.is_empty() {

--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -724,12 +724,9 @@ impl CaClient {
         // `mut` only for the discovery merge below, which `client-core` does
         // not have — stated as two bindings rather than one binding and a
         // silenced lint.
-        // `EPICS_CA_ADDR_LIST` names UDP SEARCH destinations, so it is parsed
-        // only where there is a UDP SEARCH socket to send from — see
-        // `search::SearchTransport` and the engine selection below.
-        #[cfg(all(feature = "client", tokio_backend))]
+        #[cfg(feature = "client")]
         let mut addr_list = parse_addr_list_with_hostnames()?;
-        #[cfg(all(not(feature = "client"), tokio_backend))]
+        #[cfg(not(feature = "client"))]
         let addr_list = parse_addr_list_with_hostnames()?;
 
         // Service discovery: explicit config wins; otherwise honour
@@ -745,13 +742,12 @@ impl CaClient {
         };
         #[cfg(feature = "client")]
         backends.extend(config.extra_backends);
-        // The one-shot scan merges into `addr_list`, which is the UDP SEARCH
-        // destination list and so exists only on `tokio_backend`. The
-        // `subscribe()` wiring below is *not* gated with it: its deltas go to
-        // the search engine, which absorbs them on either transport
-        // (`SearchTransport::add_address` logs and drops them once, through
-        // `log_dropped_udp_mutation`, when no UDP socket is bound).
-        #[cfg(all(feature = "client", tokio_backend))]
+        // The one-shot scan merges into `addr_list`, the UDP SEARCH
+        // destination list. The `subscribe()` wiring below is *not* gated with
+        // it: its deltas go to the search engine, which absorbs them on either
+        // transport (`SearchTransport::add_address` logs and drops them once,
+        // through `log_dropped_udp_mutation`, when no UDP socket is bound).
+        #[cfg(feature = "client")]
         if !backends.is_empty() {
             let mut discovered: Vec<SocketAddr> = Vec::new();
             for b in &backends {
@@ -818,28 +814,24 @@ impl CaClient {
         let (coord_tx, coord_rx) = mpsc::unbounded_channel();
 
         let search_attempts: types::SearchAttempts = Arc::new(dashmap::DashMap::new());
-        // Which search engine this client gets is a property of the *task
-        // backend*, not of its configuration and not of the target. A build
-        // whose `runtime::task::spawn` lands on the tokio runtime binds the
-        // per-NIC UDP SEARCH bundle and *additionally* uses any
-        // `EPICS_CA_NAME_SERVERS` circuits; on `exec_backend` the engine runs
-        // on a callback-pool worker with no reactor, so there is no UDP SEARCH
-        // transport compiled in at all (`search::SearchTransport` has one
-        // variant there) and this selects C's documented TCP-only
-        // name-resolution mode explicitly — the entry point stage C1 built for
-        // exactly this call site (`doc/calink-rtems-design.md` §4.5, §6 stage
-        // C5).
+        // Which search engine this client gets is a property of its
+        // *configuration*, and of nothing else. The ordinary engine binds the
+        // UDP SEARCH socket and *additionally* uses any
+        // `EPICS_CA_NAME_SERVERS` circuits; C's documented UDP-free mode
+        // (`modules/ca/src/client/CAref.html:515-520`) stays an explicit entry
+        // point — `search::name_servers_only_search_engine` — for the reason
+        // stated there: deriving it from an empty `EPICS_CA_ADDR_LIST` would
+        // silently drop UDP search for a client that starts with no
+        // destinations and expects a later `AddAddress` or discovery event to
+        // give it some.
         //
-        // `exec_backend` is either embedded target (RTEMS or VxWorks) *and* a
-        // host `--features rtems-exec-model` build. It used to be spelled
-        // `target_os = "rtems"` here, which let the hosted exec-model build
-        // take the UDP arm and panic on the bind (§10.10 item 2).
-        //
-        // The refusal is the point of selecting it here: with no UDP socket and
-        // no name server the engine could reach nothing, so an IOC booted
-        // without `EPICS_CA_NAME_SERVERS` fails *here*, at client construction,
-        // instead of presenting as every `ca://` link timing out forever.
-        #[cfg(tokio_backend)]
+        // This used to be `#[cfg(tokio_backend)]` against `#[cfg(exec_backend)]`
+        // — the embedded targets took the TCP-only engine whatever their
+        // configuration said, because `AsyncUdpV4` did not compile for them. A
+        // PV reachable only by broadcast then never resolved and said nothing:
+        // an IOC that was itself discoverable but could not discover.
+        // `epics_base_rs::net::search_udp` removed the reason, and with it the
+        // gate — a target IOC's `ca://` links now resolve the way a C IOC's do.
         let search_task = epics_base_rs::runtime::task::spawn(search::run_search_engine(
             addr_list,
             nameserver_addrs,
@@ -847,15 +839,6 @@ impl CaClient {
             search_resp_tx,
             search_attempts.clone(),
         ));
-        #[cfg(exec_backend)]
-        let search_task = {
-            epics_base_rs::runtime::task::spawn(search::name_servers_only_search_engine(
-                nameserver_addrs,
-                search_rx,
-                search_resp_tx,
-                search_attempts.clone(),
-            )?)
-        };
 
         // Wire each discovery backend's live-update stream into the
         // search engine. `discover()` above was a one-shot scan;
@@ -4767,12 +4750,8 @@ fn remove_server_channel(
     }
 }
 
-/// UDP-only, and gated with the transport that uses it: the addresses it
-/// resolves are `EPICS_CA_ADDR_LIST` SEARCH destinations, and the RTEMS target
-/// binds no UDP socket to send to them (`search::SearchTransport`).
-/// `EPICS_CA_NAME_SERVERS` entries go through `parse_nameserver_list`, which is
-/// live on every target.
-#[cfg(tokio_backend)]
+/// Resolve one `EPICS_CA_ADDR_LIST` SEARCH destination.
+/// `EPICS_CA_NAME_SERVERS` entries go through `parse_nameserver_list` instead.
 fn resolve_host(host: &str, port: u16) -> CaResult<SocketAddr> {
     // Try direct IP parse first (fast path)
     if let Ok(ip) = host.parse::<Ipv4Addr>() {
@@ -4802,9 +4781,6 @@ fn resolve_host(host: &str, port: u16) -> CaResult<SocketAddr> {
 /// re-resolve. `hostname == Some(name)` means the entry started life
 /// as a DNS name and a reconnection path may call `resolve_host`
 /// again to refresh `sock`.
-/// UDP-only; see [`resolve_host`] for why this is not compiled for the RTEMS
-/// target.
-#[cfg(tokio_backend)]
 #[derive(Debug, Clone)]
 pub(crate) struct AddrEntry {
     pub sock: SocketAddr,
@@ -4812,7 +4788,6 @@ pub(crate) struct AddrEntry {
     pub port: u16,
 }
 
-#[cfg(tokio_backend)]
 impl AddrEntry {
     pub fn new(sock: SocketAddr, hostname: Option<String>, port: u16) -> Self {
         Self {
@@ -4850,7 +4825,6 @@ impl AddrEntry {
 /// instead of permanently pinning the client to the first-resolved
 /// IP. Closes the long-standing upstream-tracking item for
 /// epics-base#488.
-#[cfg(tokio_backend)]
 pub(crate) fn parse_addr_list_with_hostnames() -> CaResult<Vec<AddrEntry>> {
     let mut addrs: Vec<AddrEntry> = Vec::new();
     let default_port = epics_base_rs::runtime::net::ca_server_port();
@@ -4918,7 +4892,6 @@ pub(crate) fn parse_addr_list_with_hostnames() -> CaResult<Vec<AddrEntry>> {
 /// Rust-only limited-broadcast safety net. Extracted from
 /// `parse_addr_list_with_hostnames` so the bcast list can be injected
 /// in unit tests (real-NIC enumeration is environment-dependent).
-#[cfg(tokio_backend)]
 fn append_auto_addr_entries(addrs: &mut Vec<AddrEntry>, bcasts: &[Ipv4Addr], server_port: u16) {
     for bcast in bcasts {
         let sock = SocketAddr::V4(SocketAddrV4::new(*bcast, server_port));

--- a/crates/epics-ca-rs/src/client/search.rs
+++ b/crates/epics-ca-rs/src/client/search.rs
@@ -65,7 +65,7 @@ async fn send_with_fanout(
         SocketAddr::V6(_) => false,
     };
     let result = if needs_fanout {
-        socket.fanout_to(buf, addr).await.map(|_| ())
+        socket.fanout_to(buf, addr, &[]).await.map(|_| ())
     } else {
         socket.send_to(buf, addr).await.map(|_| ())
     };

--- a/crates/epics-ca-rs/src/client/search.rs
+++ b/crates/epics-ca-rs/src/client/search.rs
@@ -8,36 +8,29 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
-// The UDP SEARCH transport is compiled out wherever a spawned future has no
-// tokio reactor — `cfg(exec_backend)`, which is either embedded target
-// (RTEMS or VxWorks) *and* a host `--features rtems-exec-model` build. Two
-// facts, one gate:
+// The UDP SEARCH transport is available on **every** backend.
 //
-//   * On RTEMS `AsyncUdpV4` does not exist at all (it is host-only in
-//     `epics-base-rs`): newlib has no `recvmsg`/`IP_PKTINFO` receive path and
-//     cannot read a socket's `local_addr()` back. It is gated out on VxWorks
-//     too — `tokio::net`/`socket2`/`if-addrs` do not build for either
-//     embedded target, so `AsyncUdpV4` stays one host-only module rather than
-//     splitting its absence into a separate reason per target.
-//   * On either backend-free build the engine runs on a callback-pool worker
-//     (`runtime::task::spawn`), and `tokio::net::UdpSocket` panics there —
-//     "there is no reactor running" — even when the process has a runtime
-//     somewhere else, because it is not entered on that worker.
+// It was host-only until `epics_base_rs::net::search_udp` existed, for two
+// reasons that were both about `AsyncUdpV4` rather than about UDP:
 //
-// Gating this on `not(target_os = "rtems")` named the first fact and missed
-// the second, so a hosted `rtems-exec-model` build compiled the UDP transport
-// in, selected it, and panicked at the first search
-// (`doc/calink-rtems-design.md` §10.10 item 2, measured). `tokio_backend` is
-// the predicate that means "a reactor exists" and is the one the whole UDP
-// surface below carries, so "this build binds no UDP socket" holds by
-// construction rather than by a runtime branch. The target's compiled surface
-// is unchanged: `epics_embedded_target` (RTEMS or VxWorks) implies
-// `exec_backend`.
+//   * `AsyncUdpV4` does not compile for either embedded target — it is built
+//     on `tokio::net`, `socket2` and `if-addrs`, and none of the three cross
+//     to `armv7-rtems-eabihf` or the `*-wrs-vxworks*` triples.
+//   * On any backend-free build the engine runs on a callback-pool worker
+//     (`runtime::task::spawn`), where `tokio::net::UdpSocket` panics — "there
+//     is no reactor running" — even when the process has a runtime somewhere
+//     else, because it is not entered on that worker. Gating on
+//     `not(target_os = "rtems")` named only the first reason, so a hosted
+//     `--features rtems-exec-model` build compiled the UDP transport in,
+//     selected it, and panicked at the first search
+//     (`doc/calink-rtems-design.md` §10.10 item 2, measured).
 //
-// Either way the client resolves every PV over TCP name servers through
-// `SearchTransport::NameServersOnly` (design §4.2, §4.5).
-#[cfg(tokio_backend)]
-use epics_base_rs::net::AsyncUdpV4;
+// `SearchUdpSocket` answers both: on `exec_backend` it is one wildcard socket
+// with a blocking receive pump — libca's own model (`udpiiu.cpp:174`) — so
+// nothing here needs a reactor and nothing here needs a gate.
+// `SearchTransport::NameServersOnly` remains for C's documented UDP-free mode
+// (design §4.2, §4.5); it is no longer the only mode the target has.
+use epics_base_rs::net::search_udp::{SearchDatagram, SearchUdpSocket};
 use epics_base_rs::runtime::sync::mpsc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 // The `runtime::task` seam, not `tokio::time::interval`: this engine is
@@ -56,31 +49,12 @@ use std::sync::atomic::{AtomicU32, Ordering};
 /// `handle_udp_response` parser as plain UDP search replies.
 type ParsedDatagram = (Vec<u8>, SocketAddr);
 
-/// What the engine's SEARCH-receive arm needs from one datagram.
-///
-/// The three fields `epics_base_rs::net::RecvMeta` carries that this loop
-/// reads, restated as a transport-neutral type — because `RecvMeta` is part of
-/// the UDP stack and does not exist for `armv7-rtems-eabihf`, while the
-/// `select!` arm that consumes it must still compile there (a `select!` branch
-/// cannot carry a `#[cfg]`). On the target the arm parks forever, so no value
-/// of this type is ever produced; what matters is that its *type* is nameable.
-struct SearchDatagram {
-    /// Datagram length in the caller's buffer.
-    n: usize,
-    /// Sender address.
-    src: SocketAddr,
-    /// IPv4 address of the NIC that received it — the key the per-NIC
-    /// `SO_RXQ_OVFL` drop counters are tracked under.
-    iface_ip: Ipv4Addr,
-}
-
-/// Send `buf` toward `addr`, expanding to a per-NIC fanout when the
+/// Send `buf` toward `addr`, expanding to a per-interface fanout when the
 /// destination is the limited broadcast `255.255.255.255` or an IPv4
 /// multicast group (`224.0.0.0/4`). Per-subnet broadcasts and
-/// unicast destinations route via the NIC chosen by [`AsyncUdpV4`].
-#[cfg(tokio_backend)]
+/// unicast destinations route via the interface [`SearchUdpSocket`] chooses.
 async fn send_with_fanout(
-    socket: &AsyncUdpV4,
+    socket: &SearchUdpSocket,
     buf: &[u8],
     addr: SocketAddr,
     site: &'static str,
@@ -540,9 +514,9 @@ impl SearchEngineState {
 // Search transport
 // ---------------------------------------------------------------------------
 
-/// The UDP half of the search transport: the per-NIC socket bundle, plus
-/// the destination policy and the per-destination diagnostics that only
-/// mean anything while those sockets exist.
+/// The UDP half of the search transport: the SEARCH socket, plus the
+/// destination policy and the per-destination diagnostics that only mean
+/// anything while that socket exists.
 ///
 /// Bundled into one value so a socket and the addresses it would transmit
 /// to cannot be configured independently. The membership test is whether a
@@ -553,12 +527,10 @@ impl SearchEngineState {
 /// `prev_drops_per_iface` keys the `SO_RXQ_OVFL` transition log by the NIC
 /// of the socket that received the datagram. None of the three survives the
 /// socket's absence.
-#[cfg(tokio_backend)]
 struct UdpTransport {
-    /// libca-style multi-NIC bundle: one bound socket per IPv4 interface so
-    /// `255.255.255.255` and per-subnet broadcasts each leave via the
-    /// matching NIC.
-    socket: AsyncUdpV4,
+    /// The SEARCH socket this backend has: a per-NIC bound bundle on the host,
+    /// one wildcard socket with a receive pump on `exec_backend`.
+    socket: SearchUdpSocket,
     /// Working UDP SEARCH destination list — `EPICS_CA_ADDR_LIST` as
     /// parsed at startup, plus any discovery / programmatic mutation
     /// applied since (libca `addAddrToChannelAccessAddressList`,
@@ -571,8 +543,9 @@ struct UdpTransport {
     /// occurrence, on errno change, and on recovery; suppress repeats.
     send_errors: HashMap<SocketAddr, std::io::ErrorKind>,
     /// pvxs parity: per-NIC `SO_RXQ_OVFL` counters, logged on transitions
-    /// only. Keyed on the receiving NIC's `iface_ip`, which the
-    /// `AsyncUdpV4` `RecvMeta` carries on every datagram.
+    /// only. Keyed on the receiving NIC's `iface_ip`, which
+    /// [`SearchDatagram`] carries whenever the receive path reports one — the
+    /// per-NIC bundle always does, a single wildcard socket never does.
     prev_drops_per_iface: HashMap<Ipv4Addr, u32>,
 }
 
@@ -582,7 +555,7 @@ struct UdpTransport {
 /// piece of state lives inside the variant that owns the sockets, and every
 /// UDP operation is a method on this type — so "a UDP socket is bound" and
 /// "the arm that reads it is armed" are the same match rather than two facts
-/// that can disagree. An `Option<AsyncUdpV4>` plus an `if let` at each of
+/// that can disagree. An `Option<SearchUdpSocket>` plus an `if let` at each of
 /// the fanout sites is the patch; this is the fix
 /// (`doc/calink-rtems-design.md` §4.3, mirroring the PVA client's
 /// `SearchTransport` — `doc/pvalink-rtems-design.md` §8).
@@ -590,16 +563,10 @@ struct UdpTransport {
 /// The configuration that needs the second variant is C's documented
 /// TCP-only name resolution mode (`modules/ca/src/client/CAref.html:515-520`):
 /// `EPICS_CA_NAME_SERVERS` set, `EPICS_CA_ADDR_LIST` empty and
-/// `EPICS_CA_AUTO_ADDR_LIST=NO`. On `exec_backend` it is the only mode
-/// available at all — see the module-head note on why the gate is the
-/// backend and not the target.
+/// `EPICS_CA_AUTO_ADDR_LIST=NO`. It is a configuration on every backend now;
+/// it used to be the only mode `exec_backend` had.
 enum SearchTransport {
     /// UDP SEARCH fanout and reply receive, alongside any TCP name servers.
-    ///
-    /// Compiled out on `exec_backend`, so there `NameServersOnly` is the
-    /// *only* variant: "this build binds no UDP socket" is then a property of
-    /// the type, which no later edit can reintroduce a branch around.
-    #[cfg(tokio_backend)]
     Udp(Box<UdpTransport>),
     /// No UDP socket is bound at all. Every SEARCH goes out over the
     /// configured TCP name servers (`run_nameserver_connection`), replies
@@ -623,19 +590,40 @@ fn log_dropped_udp_mutation(site: &'static str) {
     );
 }
 
+/// The EPICS priority the SEARCH socket's receive path runs at.
+///
+/// C parity, derived rather than chosen, exactly as `CAC_RECV_PRIORITY` and
+/// `CAC_SEND_PRIORITY` are (`client/transport.rs`): libca creates `CAC-UDP` at
+/// `lowestPriorityLevelAbove(lowestPriorityLevelAbove(initializing thread))`
+/// (`udpiiu.cpp:128-132`), and the thread that initializes the CA context for
+/// record links is C's `dbCaLink` worker at `epicsThreadPriorityMedium`
+/// (`dbCa.c:340`). `epicsThreadLowestPriorityLevelAbove` is `p + 1`
+/// (`os/posix/osdThread.c:883-899`, the file an RTEMS 6 build compiles — its
+/// one adjustment applies only when the scheduler's priority span is under
+/// 100, and SCHED_FIFO's is 1..254), so this is **52**: two bands above the
+/// link worker and one above the circuits' send pumps, because a SEARCH reply
+/// that is not read is a channel that never connects at all.
+///
+/// Only the `exec_backend` arm of [`SearchUdpSocket`] creates a thread to
+/// apply it to; the host arm receives on the reactor and ignores it. Stated
+/// unconditionally anyway, so the band is a fact about the CA client rather
+/// than about one build of it.
+const CAC_UDP_PRIORITY: epics_base_rs::runtime::task::ThreadPriority =
+    epics_base_rs::runtime::task::ThreadPriority::Custom(
+        epics_base_rs::runtime::task::ThreadPriority::Medium.value() + 2,
+    );
+
 impl SearchTransport {
-    /// Bind the per-NIC SEARCH socket bundle and take ownership of the UDP
-    /// destination list, so that binding a socket and deciding where it
-    /// transmits are one step.
+    /// Bind the SEARCH socket and take ownership of the UDP destination list,
+    /// so that binding a socket and deciding where it transmits are one step.
     ///
     /// `None` when the bind fails — the caller's only sane response is to
     /// abandon the engine, which is what `run_search_engine` did before this
     /// type existed.
-    #[cfg(tokio_backend)]
     fn bind_udp(addr_list: Vec<super::AddrEntry>) -> Option<Self> {
         // SO_REUSEADDR + (Linux) IP_MULTICAST_ALL=0 are applied to every
-        // per-NIC socket inside `AsyncUdpV4::bind`.
-        let socket = AsyncUdpV4::bind(0, true).ok()?;
+        // per-NIC socket inside the host arm's `AsyncUdpV4::bind`.
+        let socket = SearchUdpSocket::bind_ephemeral(true, "CAC-UDP", CAC_UDP_PRIORITY).ok()?;
         // Larger receive buffer absorbs multi-PV SEARCH response bursts.
         let _ = socket.set_recv_buffer_size(256 * 1024);
         // Apply `EPICS_CA_MCAST_TTL` (epics-base 3.16, f2a1834d). Affects
@@ -688,7 +676,6 @@ impl SearchTransport {
     /// `addAddrToChannelAccessAddressList` (`iocinf.cpp:45`).
     fn add_address(&mut self, addr: SocketAddr) {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 if !u.addr_list.iter().any(|e| e.sock == addr) {
                     let port = match addr {
@@ -711,7 +698,6 @@ impl SearchTransport {
     #[cfg(feature = "client")]
     fn remove_address(&mut self, addr: SocketAddr) {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 let before = u.addr_list.len();
                 u.addr_list.retain(|e| e.sock != addr);
@@ -730,7 +716,6 @@ impl SearchTransport {
     /// `configureChannelAccessAddressList` (`iocinf.cpp:166`).
     fn set_address_list(&mut self, list: Vec<SocketAddr>) {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 tracing::info!(count = list.len(), "ca-rs: addr_list replaced");
                 u.addr_list = list
@@ -757,23 +742,9 @@ impl SearchTransport {
     /// Parks forever without a UDP transport — the degradation shape the
     /// PVA client's optional beacon socket already used, and the reason the
     /// arm needs no `if` of its own.
-    async fn recv(&self, buf: &mut [u8]) -> std::io::Result<(SearchDatagram, u32)> {
+    async fn recv(&self, buf: &mut [u8]) -> std::io::Result<SearchDatagram> {
         match self {
-            #[cfg(tokio_backend)]
-            Self::Udp(u) => u
-                .socket
-                .recv_with_meta_with_drops(buf)
-                .await
-                .map(|(meta, drops)| {
-                    (
-                        SearchDatagram {
-                            n: meta.n,
-                            src: meta.src,
-                            iface_ip: meta.iface_ip,
-                        },
-                        drops,
-                    )
-                }),
+            Self::Udp(u) => u.socket.recv(buf).await,
             Self::NameServersOnly => {
                 let _ = buf;
                 std::future::pending().await
@@ -784,9 +755,15 @@ impl SearchTransport {
     /// Record this NIC's `SO_RXQ_OVFL` counter and log the transitions —
     /// pvxs `udp_collector.cpp:55-67` logs at debug on
     /// `prev != current && current != 0`.
-    fn note_drops(&mut self, iface_ip: Ipv4Addr, drops: u32) {
+    ///
+    /// `iface_ip` is `None` when the receive path does not report which NIC a
+    /// datagram arrived on, which is every single-socket receive path. There
+    /// is nothing to key the counter under then, so the datagram carries no
+    /// drop record — as opposed to keying every NIC's drops under one
+    /// stand-in address, which would report transitions that did not happen.
+    fn note_drops(&mut self, iface_ip: Option<Ipv4Addr>, drops: u32) {
+        let Some(iface_ip) = iface_ip else { return };
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 let prev = u.prev_drops_per_iface.insert(iface_ip, drops).unwrap_or(0);
                 if drops != 0 && drops != prev {
@@ -808,12 +785,10 @@ impl SearchTransport {
     /// Send one built SEARCH datagram to every UDP destination.
     ///
     /// Nothing is sent without a UDP transport: the destinations a datagram
-    /// would go to live inside `UdpTransport` (`#[cfg(tokio_backend)]`, so not
-    /// in scope on the exec-backend doc build), so there is no list to walk
+    /// would go to live inside [`UdpTransport`], so there is no list to walk
     /// rather than a list that must be checked for emptiness.
     async fn fanout(&mut self, frame: &[u8], site: &'static str) {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 // Split-borrow so the per-destination error-suppression map can
                 // be updated while the socket is borrowed for the send.
@@ -843,7 +818,6 @@ impl SearchTransport {
             // cached IP when it differs. Changes are logged at info so
             // operators can correlate an IOC migration with the client's
             // discovery of the new address.
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 for entry in u.addr_list.iter_mut() {
                     let prev_sock = entry.sock;
@@ -886,7 +860,6 @@ impl SearchTransport {
     fn bound_udp_addrs(&self) -> Vec<SocketAddr> {
         match self {
             Self::NameServersOnly => Vec::new(),
-            #[cfg(tokio_backend)]
             Self::Udp(u) => u.socket.local_addrs(),
         }
     }
@@ -894,16 +867,13 @@ impl SearchTransport {
     /// How many UDP SEARCH destinations this transport holds. Zero for
     /// [`Self::NameServersOnly`] by construction.
     ///
-    /// Separate from [`Self::addr_list`] because it is nameable on both
-    /// backends: `AddrEntry` is part of the UDP surface and does not exist on
-    /// `exec_backend`, so a test that asserts "this transport holds no UDP
-    /// destinations" — which is exactly the assertion that must still run
-    /// there — cannot go through a slice of it.
+    /// Separate from [`Self::addr_list`] because it answers the question
+    /// without handing out `AddrEntry`: a test that asserts "this transport
+    /// holds no UDP destinations" wants the count, not the list.
     #[cfg(test)]
     fn udp_dest_count(&self) -> usize {
         match self {
             Self::NameServersOnly => 0,
-            #[cfg(tokio_backend)]
             Self::Udp(u) => u.addr_list.len(),
         }
     }
@@ -911,15 +881,13 @@ impl SearchTransport {
     /// The current UDP SEARCH destinations. Empty for
     /// [`Self::NameServersOnly`], which has none by construction.
     ///
-    /// `tokio_backend` as well as `test`: `AddrEntry` is part of the UDP
-    /// surface and does not exist on `exec_backend`. `feature = "client"`
-    /// because its one caller — `add_then_remove_address_round_trip` — is the
-    /// runtime address-list mutation path, which `client-core` does not have.
-    #[cfg(all(test, tokio_backend, feature = "client"))]
+    /// `feature = "client"` because its one caller —
+    /// `add_then_remove_address_round_trip` — is the runtime address-list
+    /// mutation path, which `client-core` does not have.
+    #[cfg(all(test, feature = "client"))]
     fn addr_list(&self) -> &[super::AddrEntry] {
         match self {
             Self::NameServersOnly => &[],
-            #[cfg(tokio_backend)]
             Self::Udp(u) => &u.addr_list,
         }
     }
@@ -929,12 +897,14 @@ impl SearchTransport {
 // Main entry point
 // ---------------------------------------------------------------------------
 
-/// The ordinary client engine: bind the UDP SEARCH bundle and additionally
+/// The ordinary client engine: bind the UDP SEARCH socket and additionally
 /// use any `EPICS_CA_NAME_SERVERS` TCP circuits.
 ///
-/// Host-only, because binding that bundle is: the RTEMS target selects
-/// [`name_servers_only_search_engine`] instead (design §4.5).
-#[cfg(tokio_backend)]
+/// Available on every backend since `SearchUdpSocket` existed. It used to be
+/// host-only, and the embedded targets took [`name_servers_only_search_engine`]
+/// whatever their configuration said (design §4.5) — which resolved a PV only
+/// if an operator had named its server in `EPICS_CA_NAME_SERVERS`, and
+/// silently never resolved one reachable by broadcast alone.
 pub(crate) async fn run_search_engine(
     addr_list: Vec<super::AddrEntry>,
     nameserver_addrs: Vec<SocketAddr>,
@@ -963,9 +933,7 @@ pub(crate) async fn run_search_engine(
 /// with an empty EPICS_CA_ADDR_LIST and EPICS_CA_AUTO_ADDR_LIST set to
 /// \"NO\", Channel Access can be run without using UDP for name
 /// resolution." libca reaches it by registering a `SearchDestTCP` per
-/// `EPICS_CA_NAME_SERVERS` address (`cac.cpp:250-280`); it is what the RTEMS
-/// target needs, because `AsyncUdpV4` does not exist there at all
-/// (`doc/calink-rtems-design.md` §4.5).
+/// `EPICS_CA_NAME_SERVERS` address (`cac.cpp:250-280`).
 ///
 /// Selection is an **explicit entry point**, not derived from the address
 /// list being empty — deriving it would silently drop UDP search for every
@@ -983,19 +951,17 @@ pub(crate) async fn run_search_engine(
 /// Returns the engine future rather than running it, so the empty-name-server
 /// refusal is observed by the caller **before** anything is spawned.
 ///
-/// On `exec_backend` this is the *only* engine: `CaClient` selects it there
-/// (`client/mod.rs`), because `SearchTransport` has no UDP variant compiled in.
-/// That is the RTEMS target and a host `--features rtems-exec-model` build
-/// alike. On `tokio_backend` it stays capability-only — the client binds UDP —
-/// so it is dead code there outside the gate test. The `expect` covers exactly
-/// that, and is *not* applied where the call is live.
+/// Capability-only on every backend: `CaClient` binds UDP, so nothing in this
+/// crate calls it outside the gate tests. It was the sole engine on
+/// `exec_backend` while `SearchTransport` had no UDP variant there.
 #[cfg_attr(
-    all(tokio_backend, not(test)),
+    any(not(test), feature = "rtems-exec-model"),
     expect(
         dead_code,
         reason = "\
-    a client with a reactor binds UDP; this entry point is what the reactor-free \
-    exec backend selects (doc/calink-rtems-design.md §4.5, §6 stage C5)"
+    every client binds UDP; this entry point exists for C's documented \
+    UDP-free name-resolution mode (CAref.html:515-520), which no caller in \
+    this crate selects"
     )
 )]
 pub(crate) fn name_servers_only_search_engine(
@@ -1097,7 +1063,7 @@ async fn run_engine(
             }
 
             result = transport.recv(&mut recv_buf) => {
-                let Ok((meta, drops)) = result else { continue };
+                let Ok(meta) = result else { continue };
                 // drain any queued `SearchRequest` before parsing
                 // this datagram. A `Schedule{Reconnect}` enqueued by the
                 // coordinator (mod.rs ServerDisconnect / TcpClosed paths)
@@ -1117,7 +1083,7 @@ async fn run_engine(
                     fire_searches(&mut state, &immediate, &mut transport, &nameserver_send_txs).await;
                 }
                 // Surface per-NIC kernel drop transitions.
-                transport.note_drops(meta.iface_ip, drops);
+                transport.note_drops(meta.iface_ip, meta.drops);
                 handle_udp_response(&mut state, &recv_buf[..meta.n], meta.src, &response_tx);
             }
 
@@ -2388,10 +2354,11 @@ mod tests {
     /// address not in the list is a silent no-op.
     ///
     /// Async because the destination list now lives inside `UdpTransport`,
-    /// whose construction binds the per-NIC socket bundle — the point of the
-    /// sum type is that there is no way to hold UDP destinations without the
-    /// socket that would transmit to them.
-    #[cfg(all(feature = "client", tokio_backend))]
+    /// whose construction binds the SEARCH socket — the point of the sum type
+    /// is that there is no way to hold UDP destinations without the socket
+    /// that would transmit to them. Runs on both backends, which is what makes
+    /// it the mutation-path coverage for the exec backend's pumped socket too.
+    #[cfg(feature = "client")]
     #[epics_macros_rs::epics_test]
     async fn add_then_remove_address_round_trip() {
         let mut state = SearchEngineState::new();
@@ -2913,6 +2880,11 @@ mod tests {
 
         // Sniffer on loopback ephemeral. Used as the engine's
         // ONLY addr_list destination.
+        // The sniffer stands in for a CA server, so it reads the datagrams the
+        // engine sent rather than going through the engine's own transport:
+        // `AsyncUdpV4` directly, which is why these two tests stay
+        // `tokio_backend`.
+        use epics_base_rs::net::AsyncUdpV4;
         let sniffer = AsyncUdpV4::bind_single(Ipv4Addr::LOCALHOST, 0, false).expect("bind sniffer");
         let sniffer_addr = sniffer
             .local_addrs()
@@ -3015,6 +2987,11 @@ mod tests {
         let restore = std::env::var("EPICS_CA_MAX_SEARCH_PERIOD").ok();
         unsafe { std::env::set_var("EPICS_CA_MAX_SEARCH_PERIOD", "60") };
 
+        // The sniffer stands in for a CA server, so it reads the datagrams the
+        // engine sent rather than going through the engine's own transport:
+        // `AsyncUdpV4` directly, which is why these two tests stay
+        // `tokio_backend`.
+        use epics_base_rs::net::AsyncUdpV4;
         let sniffer = AsyncUdpV4::bind_single(Ipv4Addr::LOCALHOST, 0, false).expect("bind sniffer");
         let sniffer_addr = sniffer
             .local_addrs()

--- a/crates/epics-ca-rs/src/server/addr_list.rs
+++ b/crates/epics-ca-rs/src/server/addr_list.rs
@@ -6,10 +6,6 @@
 //! emitter.
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-// `IpAddr` is used only by the `if-addrs` interface-enumeration helpers, which
-// are host-only (their embedded-target stubs return empty results).
-#[cfg(not(epics_embedded_target))]
-use std::net::IpAddr;
 use std::time::Duration;
 
 use crate::protocol::CA_REPEATER_PORT;
@@ -357,45 +353,25 @@ fn parse_ipv4_list(list: &str, env_name: &str, default_port: u16) -> Vec<Ipv4Add
 /// Discover IPv4 broadcast addresses for all up, non-loopback interfaces.
 /// Returns an empty vec if interface enumeration fails (e.g. unsupported OS).
 ///
-/// Host-only: interface enumeration (`if-addrs`) does not build for RTEMS or
-/// VxWorks. The embedded build (blocking `std::net` driver) emits no
-/// beacons/broadcast, so the shared `resolve_from_env` config path takes the
-/// empty stub below.
-#[cfg(not(epics_embedded_target))]
+/// C `osiSockDiscoverBroadcastAddresses` with a wildcard match address: one
+/// UDP destination per eligible interface.
+///
+/// Every target, including RTEMS and VxWorks — the two used to take a stub that
+/// returned nothing, because the enumeration went through `if-addrs`, which
+/// builds for neither. It now goes through
+/// [`epics_libcom_rs::net::iface_v4`], which reaches them via `getifaddrs`.
+/// That stub is why a target IOC could resolve a name only through an
+/// explicitly configured name server: with no interfaces there are no
+/// broadcast addresses, so `EPICS_CA_AUTO_ADDR_LIST=YES` — C's default, and
+/// the whole of an unconfigured site's discovery — expanded to nothing.
+///
+/// Two behaviours change on the host as a consequence, both toward C:
+/// interfaces without `IFF_UP` are now skipped (`if-addrs` does not report the
+/// flag, so a configured-but-down NIC used to contribute a destination C would
+/// have rejected), and a point-to-point link now contributes its peer address
+/// (`osdNetIfAddrs.c:143`) instead of nothing.
 pub fn discover_broadcast_addrs() -> Vec<Ipv4Addr> {
-    let mut out = Vec::new();
-    let Ok(ifs) = if_addrs::get_if_addrs() else {
-        return out;
-    };
-    for iface in ifs {
-        if iface.is_loopback() {
-            continue;
-        }
-        let IpAddr::V4(_v4) = iface.ip() else {
-            continue;
-        };
-        if let if_addrs::IfAddr::V4(v4) = iface.addr {
-            if let Some(b) = v4.broadcast {
-                // Skip degenerate 0.0.0.0 broadcasts (matches libca
-                // osdNetIfAddrs.c osiSockDiscoverBroadcastAddresses, which
-                // discards interfaces whose broadcast is INADDR_ANY).
-                if b.is_unspecified() {
-                    continue;
-                }
-                if !out.contains(&b) {
-                    out.push(b);
-                }
-            }
-        }
-    }
-    out
-}
-
-/// Embedded-target stub — `if-addrs` is host-only. The blocking driver
-/// emits no beacons/broadcast, so auto-discovery yields nothing.
-#[cfg(epics_embedded_target)]
-pub fn discover_broadcast_addrs() -> Vec<Ipv4Addr> {
-    Vec::new()
+    epics_base_rs::net::iface_v4::broadcast_addrs()
 }
 
 /// C `osiLocalAddr` (libcom `osi/osdNetIfAddrs.c:167-215`, `osiLocalAddrOnce`):
@@ -407,31 +383,11 @@ pub fn discover_broadcast_addrs() -> Vec<Ipv4Addr> {
 /// cached result; the `OnceLock` mirrors that (an interface list that changes
 /// under a running client is not re-read by C either).
 ///
-/// Caveat, shared with the sibling [`discover_broadcast_addrs`]: `if_addrs`
-/// does not expose `IFF_UP`, so a down interface that still carries an address
-/// would be picked here where C skips it.
-#[cfg(not(epics_embedded_target))]
+/// The `IFF_UP` caveat this used to carry is gone: the enumeration behind it
+/// now reports the flag, so a down interface is skipped here as it is in C.
 pub fn osi_local_addr() -> Ipv4Addr {
     static CACHED: std::sync::OnceLock<Ipv4Addr> = std::sync::OnceLock::new();
-    *CACHED.get_or_init(|| {
-        let Ok(ifs) = if_addrs::get_if_addrs() else {
-            return Ipv4Addr::LOCALHOST;
-        };
-        ifs.into_iter()
-            .find_map(|iface| match (iface.is_loopback(), iface.ip()) {
-                (false, IpAddr::V4(v4)) => Some(v4),
-                _ => None,
-            })
-            .unwrap_or(Ipv4Addr::LOCALHOST)
-    })
-}
-
-/// Embedded-target stub — `if-addrs` is host-only. Falls back to
-/// `INADDR_LOOPBACK`, the same value C `osiLocalAddr` returns when interface
-/// enumeration finds no up, non-loopback `AF_INET` interface.
-#[cfg(epics_embedded_target)]
-pub fn osi_local_addr() -> Ipv4Addr {
-    Ipv4Addr::LOCALHOST
+    *CACHED.get_or_init(epics_base_rs::net::iface_v4::local_addr)
 }
 
 /// Return the IPv4 broadcast address of the up, non-loopback interface
@@ -448,114 +404,23 @@ pub fn osi_local_addr() -> Ipv4Addr {
 ///   * `match_ip` is loopback (C special-cases this to "loopback as
 ///     broadcast", but a loopback responder never needs a second
 ///     broadcast bind);
-///   * no matching interface was found, or that interface lacks a
-///     broadcast addr (point-to-point links / odd kernel configs);
+///   * no matching interface was found, or the matched one is down, or it is
+///     neither `IFF_BROADCAST` nor `IFF_POINTOPOINT`;
 ///   * the discovered broadcast is `0.0.0.0` (libcom drops these).
-#[cfg(not(epics_embedded_target))]
+///
+/// The point-to-point fallback this used to reach for by hand is now the same
+/// selection every other caller gets: `IfaceV4::search_destination` reads the
+/// one `ifa_broadaddr`/`ifa_dstaddr` pointer the OS reports and lets the flags
+/// decide which it means, exactly as C does.
 pub fn broadcast_for_ip(match_ip: Ipv4Addr) -> Option<Ipv4Addr> {
     if match_ip.is_unspecified() || match_ip.is_loopback() {
         return None;
     }
-    let ifs = if_addrs::get_if_addrs().ok()?;
-    for iface in ifs {
-        if iface.is_loopback() {
-            continue;
-        }
-        let if_addrs::IfAddr::V4(v4) = iface.addr else {
-            continue;
-        };
-        if v4.ip != match_ip {
-            continue;
-        }
-        if let Some(b) = v4.broadcast {
-            if !b.is_unspecified() {
-                return Some(b);
-            }
-        }
-        // `if_addrs` only fills `broadcast` for `IFF_BROADCAST`
-        // interfaces. For `IFF_POINTOPOINT` (VPN tun, PPP, WireGuard)
-        // C `osdNetIfAddrs.c:130-151` substitutes `ifa_dstaddr` —
-        // beacons go to the remote tunnel endpoint. Fall through to a
-        // direct `getifaddrs` walk that reads dstaddr for the
-        // matched interface.
-        #[cfg(unix)]
-        {
-            if let Some(dst) = ifa_dstaddr_for_ipv4(match_ip) {
-                return Some(dst);
-            }
-        }
-        return None;
-    }
-    None
-}
-
-/// Embedded-target stub — `if-addrs` is host-only. The blocking driver binds
-/// no secondary broadcast responder, so no per-interface broadcast is
-/// resolved.
-#[cfg(epics_embedded_target)]
-pub fn broadcast_for_ip(_match_ip: Ipv4Addr) -> Option<Ipv4Addr> {
-    None
-}
-
-/// walk `getifaddrs(3)` directly to extract `ifa_dstaddr`
-/// for the interface whose `ifa_addr` matches `match_ip` AND
-/// carries `IFF_POINTOPOINT`. The `if_addrs` crate only exposes
-/// `broadcast` for `IFF_BROADCAST` interfaces; P2P interfaces
-/// (VPN tun, PPP, WireGuard) need this path or beacons toward the
-/// tunnel peer are silently dropped from auto-expansion.
-/// Mirrors C `osdNetIfAddrs.c:130-151`. Host-only: neither the RTEMS nor the
-/// VxWorks `libc` has `getifaddrs`/`ifaddrs`, and the embedded-target
-/// `broadcast_for_ip` stub never calls this.
-#[cfg(all(unix, not(epics_embedded_target)))]
-fn ifa_dstaddr_for_ipv4(match_ip: Ipv4Addr) -> Option<Ipv4Addr> {
-    // SAFETY: `getifaddrs` returns a linked list of `ifaddrs`
-    // structs we walk read-only and free via `freeifaddrs` before
-    // returning. All pointer reads are guarded against null and
-    // the matched ipv4 octets are copied out as `[u8; 4]` before
-    // the free.
-    unsafe {
-        let mut head: *mut libc::ifaddrs = std::ptr::null_mut();
-        if libc::getifaddrs(&mut head) != 0 || head.is_null() {
-            return None;
-        }
-        let mut result: Option<Ipv4Addr> = None;
-        let mut cur = head;
-        while !cur.is_null() {
-            let entry = &*cur;
-            let next = entry.ifa_next;
-            // Must be IPv4 AF_INET with the matched ip + POINTOPOINT
-            // flag. `ifa_addr` may be null on some interfaces (no
-            // address assigned); skip those.
-            if !entry.ifa_addr.is_null()
-                && (*entry.ifa_addr).sa_family as i32 == libc::AF_INET
-                && entry.ifa_flags as libc::c_int & libc::IFF_POINTOPOINT != 0
-            {
-                let in4: &libc::sockaddr_in = &*(entry.ifa_addr as *const libc::sockaddr_in);
-                let ip_octets = u32::from_be(in4.sin_addr.s_addr).to_be_bytes();
-                let if_ip = Ipv4Addr::from(ip_octets);
-                // `ifa_dstaddr` on macOS/BSD; on Linux the `ifaddrs`
-                // struct carries the point-to-point destination in
-                // the `ifa_ifu` union field — `libc` exposes it by
-                // that name. Both are `*mut sockaddr`.
-                #[cfg(target_os = "linux")]
-                let dstaddr = entry.ifa_ifu;
-                #[cfg(not(target_os = "linux"))]
-                let dstaddr = entry.ifa_dstaddr;
-                if if_ip == match_ip && !dstaddr.is_null() {
-                    let dst4: &libc::sockaddr_in = &*(dstaddr as *const libc::sockaddr_in);
-                    let dst_octets = u32::from_be(dst4.sin_addr.s_addr).to_be_bytes();
-                    let dst_ip = Ipv4Addr::from(dst_octets);
-                    if !dst_ip.is_unspecified() {
-                        result = Some(dst_ip);
-                        break;
-                    }
-                }
-            }
-            cur = next;
-        }
-        libc::freeifaddrs(head);
-        result
-    }
+    epics_base_rs::net::iface_v4::enumerate()
+        .ok()?
+        .into_iter()
+        .find(|i| i.ip == match_ip)?
+        .search_destination()
 }
 
 #[cfg(test)]

--- a/crates/epics-ca-rs/src/server/addr_list.rs
+++ b/crates/epics-ca-rs/src/server/addr_list.rs
@@ -359,7 +359,7 @@ fn parse_ipv4_list(list: &str, env_name: &str, default_port: u16) -> Vec<Ipv4Add
 /// Every target, including RTEMS and VxWorks — the two used to take a stub that
 /// returned nothing, because the enumeration went through `if-addrs`, which
 /// builds for neither. It now goes through
-/// [`epics_libcom_rs::net::iface_v4`], which reaches them via `getifaddrs`.
+/// [`epics_base_rs::net::iface_v4`], which reaches them via `getifaddrs`.
 /// That stub is why a target IOC could resolve a name only through an
 /// explicitly configured name server: with no interfaces there are no
 /// broadcast addresses, so `EPICS_CA_AUTO_ADDR_LIST=YES` — C's default, and

--- a/crates/epics-libcom-rs/src/net/iface_v4.rs
+++ b/crates/epics-libcom-rs/src/net/iface_v4.rs
@@ -1,0 +1,605 @@
+//! IPv4 interface enumeration, on every target the workspace builds for —
+//! RTEMS and VxWorks included.
+//!
+//! # Why this exists
+//!
+//! The UDP name-search destination list is derived from the machine's
+//! interfaces: `EPICS_CA_AUTO_ADDR_LIST=YES` (C's default) expands to one
+//! broadcast address per up, non-loopback interface. Until this module existed
+//! there was no way to compute that list on `epics_embedded_target`, because
+//! the one enumerator in the workspace went through the `if-addrs` crate, which
+//! does not build for `armv7-rtems-eabihf` or the `*-wrs-vxworks*` triples. So
+//! `epics-ca-rs::server::addr_list` carried three `#[cfg(epics_embedded_target)]`
+//! stubs that returned "no interfaces", and a target IOC could reach a server
+//! only through an explicitly configured name server.
+//!
+//! It lives in `epics-libcom-rs` for the reason `runtime::socket` does:
+//! `epics-ca-rs` and `epics-pva-rs` both need it, neither may depend on the
+//! other, and this is the one crate both reach. It is also the first entry in
+//! `CRATES` in both `scripts/rtems-check.sh` and `scripts/vxworks-check.sh`, so
+//! the `unsafe` below is compiled for both embedded triples by gates that
+//! already run.
+//!
+//! # `getifaddrs`, not `SIOCGIFCONF`
+//!
+//! EPICS base has two implementations of this enumeration and picks between
+//! them per OS:
+//!
+//! * `libcom/src/osi/osdNetIfAddrs.c` — `getifaddrs(3)`. Selected by Linux,
+//!   Darwin, FreeBSD, iOS and cygwin, each of whose `os/*/osdNetIntf.c` is a
+//!   one-line `#include` of it.
+//! * `libcom/src/osi/osdNetIfConf.c` — `ioctl(SIOCGIFCONF)` walking a
+//!   `struct ifreq` array. Reached through `os/default/osdNetIntf.c`, which is
+//!   what RTEMS and vxWorks take: neither has an `osdNetIntf.c` of its own.
+//!
+//! The two compute the same list — same `IFF_UP` / `IFF_LOOPBACK` rejections,
+//! same `IFF_BROADCAST`-else-`IFF_POINTOPOINT` destination choice — and this
+//! module reproduces the `getifaddrs` one on all targets, including the two
+//! where C takes the `SIOCGIFCONF` one.
+//!
+//! That is a deliberate deviation, and the reason is that both embedded targets
+//! *do* ship `getifaddrs`; C's selection predates that rather than reflecting
+//! it. Measured headers, not assumed:
+//!
+//! | target | header | `getifaddrs` |
+//! |---|---|---|
+//! | RTEMS 5 | `arm-rtems5/<bsp>/lib/include/ifaddrs.h` | declared |
+//! | RTEMS 7 | `arm-rtems7/<bsp>/lib/include/ifaddrs.h` | declared |
+//! | VxWorks 7 | `vxsdk/sysroot/usr/h/public/net/ifaddrs.h` | declared |
+//!
+//! Taking it avoids re-deriving the BSD `_IOWR` request encoding — on VxWorks
+//! that is a *different* encoding again (`VX_IOWR`, `net/ioctl.h`), so the
+//! `SIOCGIFCONF` route would have been two hand-built ioctl number schemes plus
+//! two `struct ifreq` layouts, where `getifaddrs` is one struct that all three
+//! platforms agree on byte for byte (see [`sys`]).
+//!
+//! # What is *not* here
+//!
+//! No `ifindex`, no multicast capability, no IPv6. Those belong to
+//! `net::iface_map`, which backs the per-NIC `AsyncUdpV4` bundle and stays
+//! host-only: the embedded search transport is C's single wildcard socket
+//! (libca `udpiiu.cpp:174` opens exactly one `SOCK_DGRAM`), so it needs the
+//! destination list this module computes and nothing else about a NIC.
+
+use std::io;
+use std::net::Ipv4Addr;
+
+/// Interface flags this module reads. Values are the BSD set, and are the same
+/// three-way agreement the struct layout is: `libc`'s newlib module has
+/// `IFF_UP = 0x1`, `IFF_BROADCAST = 0x2`, `IFF_LOOPBACK = 0x8`,
+/// `IFF_POINTOPOINT = 0x10`, VxWorks' `net/if.h:192-196` has the same four
+/// values, and so does Linux. They are restated here rather than taken from
+/// `libc` because `libc` does not define them for VxWorks at all.
+pub mod flags {
+    /// Interface is administratively up. C skips everything without it
+    /// (`osdNetIfAddrs.c:100`).
+    pub const IFF_UP: u32 = 0x1;
+    /// `ifa_broadaddr` is meaningful (`osdNetIfAddrs.c:130`).
+    pub const IFF_BROADCAST: u32 = 0x2;
+    /// Loopback. C skips it (`osdNetIfAddrs.c:108`).
+    pub const IFF_LOOPBACK: u32 = 0x8;
+    /// Point-to-point link; `ifa_dstaddr` is the peer
+    /// (`osdNetIfAddrs.c:143`).
+    pub const IFF_POINTOPOINT: u32 = 0x10;
+}
+
+/// One IPv4 interface, as `getifaddrs` reported it.
+///
+/// Flat rather than an enum over broadcast/point-to-point because the BSD
+/// `struct ifaddrs` is flat: `ifa_broadaddr` and `ifa_dstaddr` are the *same*
+/// pointer, and which one it means is decided by [`flags`]. Modelling that as
+/// two variants here would invent a distinction the OS does not make and would
+/// have to be un-made again by every caller that just wants "where do I send a
+/// SEARCH through this interface" — which is [`Self::search_destination`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IfaceV4 {
+    /// Interface name (`eth0`, `en0`, ...). Diagnostic only.
+    pub name: String,
+    /// The interface's own IPv4 address (`ifa_addr`).
+    pub ip: Ipv4Addr,
+    /// `ifa_netmask`, when the platform reported one.
+    pub netmask: Option<Ipv4Addr>,
+    /// `ifa_broadaddr` / `ifa_dstaddr` — one field, meaning selected by
+    /// [`flags`]. `None` when the platform left it null.
+    pub dest: Option<Ipv4Addr>,
+    /// `ifa_flags`.
+    pub flags: u32,
+}
+
+impl IfaceV4 {
+    /// `IFF_UP`.
+    pub fn is_up(&self) -> bool {
+        self.flags & flags::IFF_UP != 0
+    }
+
+    /// `IFF_LOOPBACK`.
+    pub fn is_loopback(&self) -> bool {
+        self.flags & flags::IFF_LOOPBACK != 0
+    }
+
+    /// `IFF_BROADCAST`.
+    pub fn is_broadcast(&self) -> bool {
+        self.flags & flags::IFF_BROADCAST != 0
+    }
+
+    /// `IFF_POINTOPOINT`.
+    pub fn is_point_to_point(&self) -> bool {
+        self.flags & flags::IFF_POINTOPOINT != 0
+    }
+
+    /// Whether C would query through this interface at all: up, and not
+    /// loopback (`osdNetIfAddrs.c:100`, `:108`).
+    ///
+    /// Note that C tests `IFF_UP` and not `IFF_RUNNING`, so an interface that
+    /// is configured but has no carrier is still eligible. Reproduced rather
+    /// than improved on: an operator who brings a NIC up before the cable is
+    /// plugged in gets the same address list from both IOCs.
+    pub fn is_eligible(&self) -> bool {
+        self.is_up() && !self.is_loopback()
+    }
+
+    /// Where a UDP SEARCH addressed to "everyone on this interface" goes, or
+    /// `None` if C would not query through it.
+    ///
+    /// The whole of C's destination choice, in C's order
+    /// (`osdNetIfAddrs.c:130-151`):
+    ///
+    /// * `IFF_BROADCAST` → the broadcast address, *unless* it is `0.0.0.0`,
+    ///   which C discards (`:133`);
+    /// * else `IFF_POINTOPOINT` → the peer address, so a VPN/PPP tunnel is
+    ///   queried through its far end;
+    /// * else nothing — "CA will not query through the interface".
+    ///
+    /// The eligibility test is folded in so no caller can walk the list and
+    /// forget it. That is the bug shape this returns `Option` to prevent: a
+    /// down interface still carries an address, and a caller that only checked
+    /// `dest.is_some()` would fan SEARCH at it.
+    pub fn search_destination(&self) -> Option<Ipv4Addr> {
+        if !self.is_eligible() {
+            return None;
+        }
+        if self.is_broadcast() {
+            return self.dest.filter(|b| !b.is_unspecified());
+        }
+        if self.is_point_to_point() {
+            return self.dest;
+        }
+        None
+    }
+}
+
+/// Enumerate the machine's IPv4 interfaces.
+///
+/// Every `AF_INET` interface the OS reports, filtered by nothing: eligibility
+/// is [`IfaceV4::is_eligible`]'s job and the destination choice is
+/// [`IfaceV4::search_destination`]'s, so a caller that wants the raw list for
+/// diagnostics gets it and a caller that wants C's SEARCH destinations composes
+/// the two.
+pub fn enumerate() -> io::Result<Vec<IfaceV4>> {
+    sys::enumerate()
+}
+
+/// C `osiSockDiscoverBroadcastAddresses` with a wildcard match address: the
+/// deduplicated UDP SEARCH destination of every eligible interface.
+///
+/// The `pMatchAddr` argument C takes is not reproduced here because its two
+/// non-wildcard uses are separate functions in this workspace
+/// ([`local_addr`] and the per-interface lookup in
+/// `epics-ca-rs::server::addr_list`), and a single-caller parameter that is
+/// always the same value is the kind of surface a reviewer rightly asks about.
+///
+/// Deduplicated because two aliases on one subnet report the same broadcast
+/// address and C's caller (`addAddrToChannelAccessAddressList`) drops
+/// duplicates on insert.
+pub fn broadcast_addrs() -> Vec<Ipv4Addr> {
+    let Ok(ifaces) = enumerate() else {
+        return Vec::new();
+    };
+    let mut out: Vec<Ipv4Addr> = Vec::new();
+    for iface in ifaces {
+        if let Some(dest) = iface.search_destination() {
+            if !out.contains(&dest) {
+                out.push(dest);
+            }
+        }
+    }
+    out
+}
+
+/// C `osiLocalAddr` (`osdNetIfAddrs.c:167-216`): the address of the FIRST
+/// interface that is up, `AF_INET`, and not loopback.
+///
+/// Falls back to `INADDR_LOOPBACK` when enumeration fails or finds only
+/// loopback, which is C's fallback (`:208-213`). Not cached here — C caches
+/// behind `epicsThreadOnce`, and the caller that needs that caches it; making
+/// this function itself remember would put a process-lifetime `OnceLock` in a
+/// primitive whose whole job is to report what the OS says now.
+pub fn local_addr() -> Ipv4Addr {
+    let Ok(ifaces) = enumerate() else {
+        return Ipv4Addr::LOCALHOST;
+    };
+    ifaces
+        .into_iter()
+        .find(|i| i.is_eligible())
+        .map(|i| i.ip)
+        .unwrap_or(Ipv4Addr::LOCALHOST)
+}
+
+#[cfg(unix)]
+mod sys {
+    //! Unix, hosted and embedded alike: `getifaddrs(3)`.
+    //!
+    //! # One struct for five platforms
+    //!
+    //! [`IfAddrs`] is declared here rather than taken from `libc` because
+    //! `libc` does not have it on either embedded target: `src/unix/newlib`
+    //! declares no `ifaddrs` at all, and `src/vxworks/mod.rs` declares neither
+    //! the struct nor the function. Declaring it *only* there and using
+    //! `libc::ifaddrs` elsewhere would mean two spellings of one walk — and two
+    //! spellings is what the `libc` field name forces anyway, since Linux calls
+    //! the sixth field `ifa_ifu` and BSD calls it `ifa_dstaddr`.
+    //!
+    //! So there is one declaration, and the platforms whose `libc` *does* have
+    //! the struct check it rather than being trusted: [`LAYOUT_MATCHES_LIBC`]
+    //! is a `const` assertion against `libc::ifaddrs`, so a wrong field order
+    //! here fails to compile on Linux and macOS — the two hosted-Unix
+    //! configurations CI builds — instead of silently misreading an address on
+    //! a target no CI machine runs.
+    //!
+    //! Measured layouts, all seven fields in this order and `unsigned int` for
+    //! the flags:
+    //!
+    //! | platform | source |
+    //! |---|---|
+    //! | Linux | `libc` `src/unix/linux_like/mod.rs:151` |
+    //! | RTEMS 5 / 7 | `<bsp>/lib/include/ifaddrs.h` |
+    //! | VxWorks 7 | `usr/h/public/net/ifaddrs.h` (sixth field is a union of `ifu_broadaddr`/`ifu_dstaddr`, which is one pointer) |
+
+    use super::IfaceV4;
+    use std::ffi::CStr;
+    use std::io;
+    use std::net::Ipv4Addr;
+
+    /// The BSD `struct ifaddrs`. See the module note on why it is declared
+    /// rather than imported.
+    #[repr(C)]
+    struct IfAddrs {
+        ifa_next: *mut IfAddrs,
+        ifa_name: *mut libc::c_char,
+        ifa_flags: libc::c_uint,
+        ifa_addr: *mut libc::sockaddr,
+        ifa_netmask: *mut libc::sockaddr,
+        /// `ifa_broadaddr` and `ifa_dstaddr` are this one pointer; the flags
+        /// say which it is.
+        ifa_dstaddr: *mut libc::sockaddr,
+        ifa_data: *mut libc::c_void,
+    }
+
+    /// Does this build's `libc` agree with [`IfAddrs`], field for field?
+    ///
+    /// Only meaningful where `libc` has the struct — the embedded targets have
+    /// nothing to compare against, which is why the declaration exists. There
+    /// the assertion below is skipped and the header table in the module note
+    /// is the evidence.
+    #[cfg(not(epics_embedded_target))]
+    const LAYOUT_MATCHES_LIBC: bool = size_of::<IfAddrs>() == size_of::<libc::ifaddrs>()
+        && align_of::<IfAddrs>() == align_of::<libc::ifaddrs>()
+        && core::mem::offset_of!(IfAddrs, ifa_next)
+            == core::mem::offset_of!(libc::ifaddrs, ifa_next)
+        && core::mem::offset_of!(IfAddrs, ifa_name)
+            == core::mem::offset_of!(libc::ifaddrs, ifa_name)
+        && core::mem::offset_of!(IfAddrs, ifa_flags)
+            == core::mem::offset_of!(libc::ifaddrs, ifa_flags)
+        && core::mem::offset_of!(IfAddrs, ifa_addr)
+            == core::mem::offset_of!(libc::ifaddrs, ifa_addr)
+        && core::mem::offset_of!(IfAddrs, ifa_netmask)
+            == core::mem::offset_of!(libc::ifaddrs, ifa_netmask)
+        && core::mem::offset_of!(IfAddrs, ifa_data)
+            == core::mem::offset_of!(libc::ifaddrs, ifa_data);
+
+    #[cfg(not(epics_embedded_target))]
+    const _: () = assert!(
+        LAYOUT_MATCHES_LIBC,
+        "net::iface_v4's `struct ifaddrs` no longer matches this platform's \
+         `libc::ifaddrs`. The declaration exists because neither embedded \
+         target's `libc` has the struct; this assertion is what keeps it \
+         honest on the platforms whose `libc` does. Re-derive the field order \
+         from the platform header before changing it."
+    );
+
+    // `libc` declares `getifaddrs` for hosted Unix but not for newlib/RTEMS or
+    // VxWorks. Declaring our own on every target would be a second, clashing
+    // declaration of one symbol (`clashing_extern_declarations`, and this
+    // workspace builds with `-D warnings`), so the hosted arm calls `libc`'s
+    // and casts the out-pointer — sound precisely because the assertion above
+    // proved the two structs are one layout.
+    #[cfg(not(epics_embedded_target))]
+    unsafe fn get_ifaddrs(head: *mut *mut IfAddrs) -> libc::c_int {
+        // SAFETY: `head` is a valid out-pointer; the cast is between two
+        // structs a `const` assertion has proved layout-identical.
+        unsafe { libc::getifaddrs(head as *mut *mut libc::ifaddrs) }
+    }
+
+    #[cfg(not(epics_embedded_target))]
+    unsafe fn free_ifaddrs(head: *mut IfAddrs) {
+        // SAFETY: `head` came from `get_ifaddrs` above, i.e. from
+        // `libc::getifaddrs`, and is freed exactly once.
+        unsafe { libc::freeifaddrs(head as *mut libc::ifaddrs) }
+    }
+
+    #[cfg(epics_embedded_target)]
+    unsafe extern "C" {
+        #[link_name = "getifaddrs"]
+        fn getifaddrs_raw(ifap: *mut *mut IfAddrs) -> libc::c_int;
+        #[link_name = "freeifaddrs"]
+        fn freeifaddrs_raw(ifa: *mut IfAddrs);
+    }
+
+    #[cfg(epics_embedded_target)]
+    unsafe fn get_ifaddrs(head: *mut *mut IfAddrs) -> libc::c_int {
+        // SAFETY: `head` is a valid out-pointer, and the declaration matches
+        // `ifaddrs.h` on both embedded targets (module note).
+        unsafe { getifaddrs_raw(head) }
+    }
+
+    #[cfg(epics_embedded_target)]
+    unsafe fn free_ifaddrs(head: *mut IfAddrs) {
+        // SAFETY: `head` came from `get_ifaddrs` above and is freed once.
+        unsafe { freeifaddrs_raw(head) }
+    }
+
+    /// Read an `AF_INET` address out of a `struct sockaddr *`.
+    ///
+    /// Goes through `libc::sockaddr_in` rather than reading a family field off
+    /// `sockaddr` directly, because the two families of platform disagree about
+    /// where that field is: BSD-derived stacks (macOS, RTEMS, VxWorks) put a
+    /// one-byte `sa_len` first and the family second, Linux starts with a
+    /// two-byte family. `libc`'s per-target `sockaddr_in` already encodes which
+    /// — and on RTEMS that it is the *right* one is a build-stopping guard, not
+    /// a hope (`epics_rtems_boot`'s socket-layout refusal, whose doc names this
+    /// address list as a consumer).
+    ///
+    /// Unaligned: `ifa_addr` points into an allocation the C library laid out,
+    /// and nothing in the contract promises `sockaddr_in` alignment for a
+    /// pointer typed as `sockaddr`.
+    ///
+    /// # Safety
+    ///
+    /// `sa` must be null or point to a readable `sockaddr` whose storage is at
+    /// least `size_of::<libc::sockaddr_in>()` when its family is `AF_INET`.
+    unsafe fn sockaddr_ipv4(sa: *const libc::sockaddr) -> Option<Ipv4Addr> {
+        if sa.is_null() {
+            return None;
+        }
+        // SAFETY: the caller guarantees `sa` is readable; `read_unaligned`
+        // makes no alignment demand of its own.
+        let sin: libc::sockaddr_in = unsafe { std::ptr::read_unaligned(sa as *const _) };
+        if libc::c_int::from(sin.sin_family) != libc::AF_INET {
+            return None;
+        }
+        Some(Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr)))
+    }
+
+    pub(super) fn enumerate() -> io::Result<Vec<IfaceV4>> {
+        let mut head: *mut IfAddrs = std::ptr::null_mut();
+        // SAFETY: `head` is a valid out-pointer for the call.
+        if unsafe { get_ifaddrs(&mut head) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if head.is_null() {
+            // A success return with no list is not an error — a target with no
+            // configured interface reports exactly this — and C treats the
+            // empty walk the same way.
+            return Ok(Vec::new());
+        }
+
+        let mut out = Vec::new();
+        let mut cur = head;
+        // SAFETY: the list is `getifaddrs`-owned and stays valid until the
+        // `free_ifaddrs` below; every pointer read is null-checked, and every
+        // address is copied out before the free.
+        unsafe {
+            while !cur.is_null() {
+                let node = &*cur;
+                cur = node.ifa_next;
+
+                let Some(ip) = sockaddr_ipv4(node.ifa_addr) else {
+                    // Null `ifa_addr` (C `osdNetIfAddrs.c:65`) or a non-INET
+                    // family (`:75`) — both are skips, not failures.
+                    continue;
+                };
+                let name = if node.ifa_name.is_null() {
+                    String::new()
+                } else {
+                    CStr::from_ptr(node.ifa_name).to_string_lossy().into_owned()
+                };
+                out.push(IfaceV4 {
+                    name,
+                    ip,
+                    netmask: sockaddr_ipv4(node.ifa_netmask),
+                    dest: sockaddr_ipv4(node.ifa_dstaddr),
+                    flags: node.ifa_flags,
+                });
+            }
+            free_ifaddrs(head);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(not(unix))]
+mod sys {
+    //! Windows: no `getifaddrs`, so the `if-addrs` crate — which is what the
+    //! host enumeration used before this module existed, and which C mirrors by
+    //! giving Windows its own `os/WIN32/osdNetIntf.c` rather than including
+    //! either shared file.
+    //!
+    //! `if-addrs` does not surface `ifa_flags`, so the flags are reconstructed
+    //! from what it does report: an interface it lists is treated as up, and a
+    //! reported broadcast address is what `IFF_BROADCAST` means. That is the
+    //! same approximation the pre-existing host path made, and it is confined
+    //! to the one platform that cannot do better.
+
+    use super::{IfaceV4, flags};
+    use std::io;
+    use std::net::IpAddr;
+
+    pub(super) fn enumerate() -> io::Result<Vec<IfaceV4>> {
+        let ifs = if_addrs::get_if_addrs()?;
+        let mut out = Vec::new();
+        for iface in ifs {
+            let if_addrs::IfAddr::V4(v4) = &iface.addr else {
+                continue;
+            };
+            let IpAddr::V4(ip) = iface.ip() else {
+                continue;
+            };
+            let mut f = flags::IFF_UP;
+            if iface.is_loopback() {
+                f |= flags::IFF_LOOPBACK;
+            }
+            if v4.broadcast.is_some() {
+                f |= flags::IFF_BROADCAST;
+            }
+            out.push(IfaceV4 {
+                name: iface.name.clone(),
+                ip,
+                netmask: Some(v4.netmask),
+                dest: v4.broadcast,
+                flags: f,
+            });
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn iface(flags: u32, dest: Option<Ipv4Addr>) -> IfaceV4 {
+        IfaceV4 {
+            name: "test0".to_string(),
+            ip: Ipv4Addr::new(10, 0, 0, 5),
+            netmask: Some(Ipv4Addr::new(255, 255, 255, 0)),
+            dest,
+            flags,
+        }
+    }
+
+    /// C `osdNetIfAddrs.c:100` — a down interface is skipped even though it
+    /// still carries an address and a broadcast address.
+    #[test]
+    fn a_down_interface_is_never_a_search_destination() {
+        let down = iface(flags::IFF_BROADCAST, Some(Ipv4Addr::new(10, 0, 0, 255)));
+        assert!(!down.is_eligible());
+        assert_eq!(down.search_destination(), None);
+    }
+
+    /// C `osdNetIfAddrs.c:108`.
+    #[test]
+    fn loopback_is_never_a_search_destination() {
+        let lo = iface(
+            flags::IFF_UP | flags::IFF_LOOPBACK | flags::IFF_BROADCAST,
+            Some(Ipv4Addr::new(127, 255, 255, 255)),
+        );
+        assert_eq!(lo.search_destination(), None);
+    }
+
+    /// C `osdNetIfAddrs.c:130-135`.
+    #[test]
+    fn a_broadcast_interface_yields_its_broadcast_address() {
+        let up = iface(
+            flags::IFF_UP | flags::IFF_BROADCAST,
+            Some(Ipv4Addr::new(10, 0, 0, 255)),
+        );
+        assert_eq!(up.search_destination(), Some(Ipv4Addr::new(10, 0, 0, 255)));
+    }
+
+    /// C `osdNetIfAddrs.c:133` discards a `0.0.0.0` broadcast rather than
+    /// fanning SEARCH at the wildcard address.
+    #[test]
+    fn an_unspecified_broadcast_address_is_discarded() {
+        let up = iface(
+            flags::IFF_UP | flags::IFF_BROADCAST,
+            Some(Ipv4Addr::UNSPECIFIED),
+        );
+        assert_eq!(up.search_destination(), None);
+    }
+
+    /// C `osdNetIfAddrs.c:143-145` — the peer address, and note that C does
+    /// *not* apply the `0.0.0.0` rejection on this branch.
+    #[test]
+    fn a_point_to_point_interface_yields_its_peer_address() {
+        let p2p = iface(
+            flags::IFF_UP | flags::IFF_POINTOPOINT,
+            Some(Ipv4Addr::new(192, 168, 9, 1)),
+        );
+        assert_eq!(
+            p2p.search_destination(),
+            Some(Ipv4Addr::new(192, 168, 9, 1))
+        );
+    }
+
+    /// C `osdNetIfAddrs.c:147-151` — "CA will not query through the interface".
+    #[test]
+    fn an_interface_that_is_neither_broadcast_nor_p2p_yields_nothing() {
+        let odd = iface(flags::IFF_UP, Some(Ipv4Addr::new(10, 0, 0, 255)));
+        assert_eq!(odd.search_destination(), None);
+    }
+
+    /// The enumeration itself must run on the host CI machines. It is not
+    /// asserted to be non-empty — a container with only loopback is a valid
+    /// machine — but every entry it does report must be self-consistent.
+    #[test]
+    fn enumeration_runs_and_reports_consistent_entries() {
+        let ifaces = enumerate().expect("getifaddrs must succeed on the host");
+        for iface in &ifaces {
+            if iface.ip.is_loopback() {
+                assert!(
+                    iface.is_loopback() || iface.name.is_empty(),
+                    "an interface with a loopback address must carry IFF_LOOPBACK: {iface:?}"
+                );
+            }
+            if let Some(dest) = iface.search_destination() {
+                assert!(iface.is_up(), "a destination came from a down interface");
+                assert!(!iface.is_loopback(), "a destination came from loopback");
+                assert!(!dest.is_unspecified() || iface.is_point_to_point());
+            }
+        }
+    }
+
+    /// Loopback-only machines exist (CI containers), so this asserts the
+    /// fallback rather than a real address.
+    #[test]
+    fn local_addr_is_an_eligible_interface_or_loopback() {
+        let addr = local_addr();
+        if addr.is_loopback() {
+            return;
+        }
+        let ifaces = enumerate().expect("getifaddrs must succeed on the host");
+        assert!(
+            ifaces.iter().any(|i| i.is_eligible() && i.ip == addr),
+            "local_addr returned {addr}, which is not an eligible interface"
+        );
+    }
+
+    /// Every address `broadcast_addrs` reports must be some eligible
+    /// interface's destination, and the list must not repeat.
+    #[test]
+    fn broadcast_addrs_are_deduplicated_eligible_destinations() {
+        let addrs = broadcast_addrs();
+        let mut seen = Vec::new();
+        for a in &addrs {
+            assert!(!seen.contains(a), "broadcast_addrs repeated {a}");
+            seen.push(*a);
+        }
+        let ifaces = enumerate().expect("getifaddrs must succeed on the host");
+        for a in &addrs {
+            assert!(
+                ifaces.iter().any(|i| i.search_destination() == Some(*a)),
+                "broadcast_addrs reported {a}, which no eligible interface names"
+            );
+        }
+    }
+}

--- a/crates/epics-libcom-rs/src/net/iface_v4.rs
+++ b/crates/epics-libcom-rs/src/net/iface_v4.rs
@@ -41,11 +41,18 @@
 //! *do* ship `getifaddrs`; C's selection predates that rather than reflecting
 //! it. Measured headers, not assumed:
 //!
-//! | target | header | `getifaddrs` |
-//! |---|---|---|
-//! | RTEMS 5 | `arm-rtems5/<bsp>/lib/include/ifaddrs.h` | declared |
-//! | RTEMS 7 | `arm-rtems7/<bsp>/lib/include/ifaddrs.h` | declared |
-//! | VxWorks 7 | `vxsdk/sysroot/usr/h/public/net/ifaddrs.h` | declared |
+//! | target | header | declared | defined in |
+//! |---|---|---|---|
+//! | **RTEMS 6** (`armv7-rtems-eabihf`) | `arm-rtems6/<bsp>/lib/include/ifaddrs.h` | yes | `libbsd.a` |
+//! | RTEMS 5 | `arm-rtems5/<bsp>/lib/include/ifaddrs.h` | yes | `libbsd.a` |
+//! | RTEMS 7 | `arm-rtems7/<bsp>/lib/include/ifaddrs.h` | yes | `libbsd.a` |
+//! | **VxWorks 7** (`*-wrs-vxworks`) | `vxsdk/sysroot/usr/h/public/net/ifaddrs.h` | yes | `libnet.a` |
+//!
+//! The two bold rows are the triples this workspace builds; the RTEMS 5 and 7
+//! rows are there because the struct is unchanged across all three, so an RTEMS
+//! version bump is not a layout risk. "defined in" is `nm --defined-only`, not
+//! the header — a declaration the image cannot link is what a `cargo check`
+//! gate would have missed.
 //!
 //! Taking it avoids re-deriving the BSD `_IOWR` request encoding — on VxWorks
 //! that is a *different* encoding again (`VX_IOWR`, `net/ioctl.h`), so the

--- a/crates/epics-libcom-rs/src/net/iface_v4.rs
+++ b/crates/epics-libcom-rs/src/net/iface_v4.rs
@@ -58,7 +58,7 @@
 //! that is a *different* encoding again (`VX_IOWR`, `net/ioctl.h`), so the
 //! `SIOCGIFCONF` route would have been two hand-built ioctl number schemes plus
 //! two `struct ifreq` layouts, where `getifaddrs` is one struct that all three
-//! platforms agree on byte for byte (see [`sys`]).
+//! platforms agree on byte for byte (see the `sys` module below).
 //!
 //! # What is *not* here
 //!
@@ -247,7 +247,7 @@ mod sys {
     //! the sixth field `ifa_ifu` and BSD calls it `ifa_dstaddr`.
     //!
     //! So there is one declaration, and the platforms whose `libc` *does* have
-    //! the struct check it rather than being trusted: [`LAYOUT_MATCHES_LIBC`]
+    //! the struct check it rather than being trusted: `LAYOUT_MATCHES_LIBC`
     //! is a `const` assertion against `libc::ifaddrs`, so a wrong field order
     //! here fails to compile on Linux and macOS — the two hosted-Unix
     //! configurations CI builds — instead of silently misreading an address on

--- a/crates/epics-libcom-rs/src/net/mod.rs
+++ b/crates/epics-libcom-rs/src/net/mod.rs
@@ -43,6 +43,7 @@ pub mod iface_map;
 pub mod iface_v4;
 #[cfg(not(epics_embedded_target))]
 pub mod loopback_mcast;
+pub mod search_udp;
 
 /// pvxs ORIGIN_TAG forwarding multicast group. Mirrors the literal in
 /// `udp_collector.cpp:127`: `"224.0.0.128,1@127.0.0.1"` — TTL=1,
@@ -59,6 +60,7 @@ pub mod loopback_mcast;
 pub const ORIGIN_TAG_MCAST_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 128);
 
 pub use iface_v4::{IfaceV4, broadcast_addrs, local_addr};
+pub use search_udp::{SearchDatagram, SearchUdpSocket};
 
 #[cfg(not(epics_embedded_target))]
 pub use async_udp_v4::{

--- a/crates/epics-libcom-rs/src/net/mod.rs
+++ b/crates/epics-libcom-rs/src/net/mod.rs
@@ -4,10 +4,14 @@
 //! Two layers, split by whether they own a socket — the same split
 //! `epics_pva_rs::server_native` makes for the same reason:
 //!
-//! * **Wire constants.** Address literals the protocols embed in the
-//!   datagrams they build ([`ORIGIN_TAG_MCAST_GROUP`]). No socket, no
-//!   `tokio`, no `socket2` — compiles for every target, RTEMS and VxWorks
-//!   included.
+//! * **Wire constants and interface facts.** Address literals the protocols
+//!   embed in the datagrams they build ([`ORIGIN_TAG_MCAST_GROUP`]), and the
+//!   IPv4 interface enumeration every UDP search destination list is derived
+//!   from ([`iface_v4`]). No socket, no `tokio`, no `socket2` — compiles for
+//!   every target, RTEMS and VxWorks included. [`iface_v4`] reaches the two
+//!   embedded targets where `iface_map` cannot because it goes through
+//!   `getifaddrs`, which both of them ship, rather than through the `if-addrs`
+//!   crate, which builds for neither.
 //! * **Socket-bearing modules** — `async_udp_v4`, `iface_map`,
 //!   `loopback_mcast`. Built on `tokio::net` / `socket2` / `if-addrs`, none
 //!   of which cross to `armv7-rtems-eabihf` or the `*-wrs-vxworks*` triples,
@@ -36,6 +40,7 @@ use std::net::Ipv4Addr;
 pub mod async_udp_v4;
 #[cfg(not(epics_embedded_target))]
 pub mod iface_map;
+pub mod iface_v4;
 #[cfg(not(epics_embedded_target))]
 pub mod loopback_mcast;
 
@@ -52,6 +57,8 @@ pub mod loopback_mcast;
 /// decoder to stay host-only; the fix is to move the constant, not to copy
 /// it.
 pub const ORIGIN_TAG_MCAST_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 128);
+
+pub use iface_v4::{IfaceV4, broadcast_addrs, local_addr};
 
 #[cfg(not(epics_embedded_target))]
 pub use async_udp_v4::{

--- a/crates/epics-libcom-rs/src/net/search_udp.rs
+++ b/crates/epics-libcom-rs/src/net/search_udp.rs
@@ -151,9 +151,22 @@ impl SearchUdpSocket {
     /// limited broadcast `255.255.255.255` and for multicast groups, which a
     /// single socket would otherwise emit on one interface only.
     ///
+    /// `ifaces` is the operator's egress constraint (`EPICS_PVA_INTF_ADDR_LIST`,
+    /// pvxs `expandAddrList` over `Config::interfaces`); empty means every
+    /// eligible interface, which is the default. It is one parameter rather
+    /// than a second `fanout_on_interfaces` entry point because "which
+    /// interfaces may this leave through" is one question with a default
+    /// answer, and two functions let a caller ask it on one path and forget it
+    /// on the other.
+    ///
     /// Returns how many sends succeeded; errors only when none did.
-    pub async fn fanout_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
-        self.0.fanout_to(buf, dest).await
+    pub async fn fanout_to(
+        &self,
+        buf: &[u8],
+        dest: SocketAddr,
+        ifaces: &[Ipv4Addr],
+    ) -> io::Result<usize> {
+        self.0.fanout_to(buf, dest, ifaces).await
     }
 }
 
@@ -176,7 +189,14 @@ mod sys {
         ) -> io::Result<Self> {
             // No pump: the reactor is the pump.
             let _ = (pump_name, pump_priority);
-            AsyncUdpV4::bind(0, broadcast).map(Self)
+            // *Same* ephemeral port on every NIC, not a port per NIC. A PVA
+            // SEARCH advertises the port its reply must be sent to
+            // (`response_port`, pvxs `udp_collector.cpp:380`), and a server
+            // reached over NIC B would answer a port that only NIC A holds.
+            // The exec arm has one port by construction; binding the bundle
+            // this way makes `local_addrs().first()` a fact about the socket
+            // on both arms rather than about which NIC happens to be first.
+            AsyncUdpV4::bind_ephemeral_same_port(broadcast).map(Self)
         }
 
         pub(super) fn bind_beacon(
@@ -236,8 +256,38 @@ mod sys {
             self.0.send_to(buf, dest).await
         }
 
-        pub(super) async fn fanout_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
-            self.0.fanout_to(buf, dest).await
+        pub(super) async fn fanout_to(
+            &self,
+            buf: &[u8],
+            dest: SocketAddr,
+            ifaces: &[std::net::Ipv4Addr],
+        ) -> io::Result<usize> {
+            if ifaces.is_empty() {
+                return self.0.fanout_to(buf, dest).await;
+            }
+            let mut ok = 0usize;
+            let mut last_err: Option<io::Error> = None;
+            for ip in ifaces {
+                // Loopback carries no broadcast, and a constrained list that
+                // names only loopback yields no destination at all — which is
+                // the operator asking for nothing to leave the host.
+                if ip.is_loopback() {
+                    continue;
+                }
+                match self.0.send_via(buf, dest, *ip).await {
+                    Ok(_) => ok += 1,
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            if ok == 0 {
+                return Err(last_err.unwrap_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::AddrNotAvailable,
+                        "SEARCH fanout: no listed interface available",
+                    )
+                }));
+            }
+            Ok(ok)
         }
     }
 }
@@ -400,21 +450,26 @@ mod sys {
             self.socket.send_to(buf, dest)
         }
 
-        pub(super) async fn fanout_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+        pub(super) async fn fanout_to(
+            &self,
+            buf: &[u8],
+            dest: SocketAddr,
+            ifaces: &[Ipv4Addr],
+        ) -> io::Result<usize> {
             // One socket cannot pick its egress NIC by binding, so the
             // destination does it: each interface's own directed broadcast
             // leaves via that interface by ordinary routing. This is what
             // libca sends to in the first place — `EPICS_CA_AUTO_ADDR_LIST`
             // is exactly this list — so the expansion is C's own, not a
-            // substitute for one.
+            // substitute for one. `ifaces` narrows which interfaces
+            // contribute, the same constraint the host arm applies by
+            // choosing which NIC's socket transmits.
             let port = dest.port();
             let dests: Vec<SocketAddr> = match dest {
-                SocketAddr::V4(v4) if v4.ip().is_broadcast() => {
-                    crate::net::iface_v4::broadcast_addrs()
-                        .into_iter()
-                        .map(|ip| SocketAddr::from((ip, port)))
-                        .collect()
-                }
+                SocketAddr::V4(v4) if v4.ip().is_broadcast() => eligible_broadcast_addrs(ifaces)
+                    .into_iter()
+                    .map(|ip| SocketAddr::from((ip, port)))
+                    .collect(),
                 // A multicast group has no per-interface rewrite: the group
                 // address *is* the destination on every NIC, and one socket
                 // emits on the routing table's choice. Sending it once is all
@@ -474,6 +529,34 @@ mod sys {
                 let _ = pump.join();
             }
         }
+    }
+
+    /// The directed broadcast of every eligible interface, narrowed to
+    /// `ifaces` when that list is non-empty.
+    ///
+    /// Eligibility and the destination choice are
+    /// [`crate::net::iface_v4::IfaceV4::search_destination`]'s — C's own rule
+    /// (`osdNetIfAddrs.c:130-151`) — so a down or loopback interface
+    /// contributes nothing whether or not the operator listed it.
+    fn eligible_broadcast_addrs(ifaces: &[Ipv4Addr]) -> Vec<Ipv4Addr> {
+        if ifaces.is_empty() {
+            return crate::net::iface_v4::broadcast_addrs();
+        }
+        let Ok(all) = crate::net::iface_v4::enumerate() else {
+            return Vec::new();
+        };
+        let mut out: Vec<Ipv4Addr> = Vec::new();
+        for iface in all {
+            if !ifaces.contains(&iface.ip) {
+                continue;
+            }
+            if let Some(dest) = iface.search_destination() {
+                if !out.contains(&dest) {
+                    out.push(dest);
+                }
+            }
+        }
+        out
     }
 
     /// Read datagrams until asked to stop or the receiver is gone.

--- a/crates/epics-libcom-rs/src/net/search_udp.rs
+++ b/crates/epics-libcom-rs/src/net/search_udp.rs
@@ -2,7 +2,7 @@
 //!
 //! One type, two implementations, chosen by whether a tokio reactor exists:
 //!
-//! * `tokio_backend` — delegates to [`AsyncUdpV4`](super::async_udp_v4::AsyncUdpV4),
+//! * `tokio_backend` — delegates to `AsyncUdpV4` (`super::async_udp_v4`),
 //!   the per-NIC bundle. Unchanged behaviour: the same sockets, the same
 //!   `IP_PKTINFO` receive metadata, the same per-NIC fanout.
 //! * `exec_backend` — **one wildcard socket** plus a receive pump thread.

--- a/crates/epics-libcom-rs/src/net/search_udp.rs
+++ b/crates/epics-libcom-rs/src/net/search_udp.rs
@@ -1,0 +1,530 @@
+//! The client's UDP SEARCH socket, on **every** target.
+//!
+//! One type, two implementations, chosen by whether a tokio reactor exists:
+//!
+//! * `tokio_backend` — delegates to [`AsyncUdpV4`](super::async_udp_v4::AsyncUdpV4),
+//!   the per-NIC bundle. Unchanged behaviour: the same sockets, the same
+//!   `IP_PKTINFO` receive metadata, the same per-NIC fanout.
+//! * `exec_backend` — **one wildcard socket** plus a receive pump thread.
+//!
+//! # Why the exec arm is one socket
+//!
+//! Because that is libca's own model. `udpiiu.cpp:174` creates a *single*
+//! datagram socket bound to `INADDR_ANY:0` and reaches every subnet through
+//! the address list, not through a socket per NIC — the per-NIC bundle is an
+//! epics-rs elaboration over libca that buys accurate `RecvMeta.iface_ip` and
+//! a `255.255.255.255` fanout. Neither is a parity requirement, and neither is
+//! reachable on the embedded targets anyway: `tokio::net`, `socket2` and
+//! `if-addrs` build for none of them.
+//!
+//! The one thing the bundle bought that the target still needs is *reaching
+//! every subnet's broadcast address*. That comes from
+//! [`super::iface_v4::broadcast_addrs`] instead — the same list C's
+//! `osiSockDiscoverBroadcastAddresses` builds, which is what libca sends its
+//! SEARCHes to. So the exec arm is closer to C here than the host arm is.
+//!
+//! # Why the exec arm needs a thread
+//!
+//! There is no reactor to register the socket with: `runtime::task::spawn` runs
+//! futures on a callback-pool worker, and `tokio::net::UdpSocket` panics there
+//! ("there is no reactor running"). A blocking `recv_from` on a dedicated
+//! thread, feeding a channel the engine's `select!` can await, is the same seam
+//! the blocking CA/PVA *servers* already use for their own SEARCH responders
+//! (`epics_ca_rs::server::blocking::handle_udp_search_blocking`) and the same
+//! one `runtime::blocking_io` uses for TCP circuit pumps.
+//!
+//! Sends are **not** pumped. A UDP `send_to` either fits the socket buffer or
+//! fails with `ENOBUFS`; it does not block on a peer, so it runs inline on the
+//! engine's worker, exactly as the blocking server's `send_udp_reply` does.
+//! One thread per search engine, and a CA client has one.
+
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr};
+
+/// One received SEARCH datagram, and what the receiving path knows about it.
+///
+/// The three things a client's SEARCH-receive arm reads, in one type that is
+/// nameable on both backends — which is the whole reason it exists rather than
+/// the callers reading `AsyncUdpV4`'s `RecvMeta` directly: `RecvMeta` is part
+/// of the host-only UDP stack, and a `select!` branch cannot carry a `#[cfg]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchDatagram {
+    /// Datagram length written into the caller's buffer. A datagram longer
+    /// than the buffer is truncated, as `recvfrom(2)` truncates.
+    pub n: usize,
+    /// Sender address.
+    pub src: SocketAddr,
+    /// IPv4 address of the NIC that received it, when the receive path
+    /// reports one.
+    ///
+    /// `None` on a single wildcard socket with no `IP_PKTINFO` receive path —
+    /// libca's model, and the only one available on the embedded targets. It
+    /// keys the per-NIC `SO_RXQ_OVFL` drop log, so `None` means "this
+    /// datagram's drop counter is not per-NIC attributable" rather than
+    /// naming a NIC the platform never told us about.
+    pub iface_ip: Option<Ipv4Addr>,
+    /// The receiving NIC's kernel drop counter (`SO_RXQ_OVFL`), or 0 where the
+    /// platform has no such counter.
+    pub drops: u32,
+}
+
+/// A client's UDP SEARCH socket.
+pub struct SearchUdpSocket(sys::Sock);
+
+impl SearchUdpSocket {
+    /// Bind an ephemeral SEARCH socket.
+    ///
+    /// `pump_name` and `pump_priority` describe the receive thread the
+    /// `exec_backend` arm creates; the host arm has no thread and ignores
+    /// them. They are unconditional parameters and not `#[cfg]`-gated so that
+    /// a caller states its band once, in its own C-derived terms, without a
+    /// gate of its own — the CA client passes libca's `CAC-UDP`
+    /// (`udpiiu.cpp:128-132`), the PVA client its own.
+    pub fn bind_ephemeral(
+        broadcast: bool,
+        pump_name: &str,
+        pump_priority: crate::runtime::task::ThreadPriority,
+    ) -> io::Result<Self> {
+        sys::Sock::bind_ephemeral(broadcast, pump_name, pump_priority).map(Self)
+    }
+
+    /// `SO_RCVBUF`. Best-effort on every platform: a kernel is free to clamp.
+    pub fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
+        self.0.set_recv_buffer_size(size)
+    }
+
+    /// `IP_MULTICAST_TTL` — `EPICS_CA_MCAST_TTL` (epics-base 3.16, f2a1834d).
+    pub fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
+        self.0.set_multicast_ttl_v4(ttl)
+    }
+
+    /// Opt into the kernel's per-socket drop counter where one exists
+    /// (`SO_RXQ_OVFL`, Linux only). Diagnostic; failure is not fatal.
+    pub fn enable_so_rxq_ovfl(&self) -> io::Result<()> {
+        self.0.enable_so_rxq_ovfl()
+    }
+
+    /// Every local address this socket bound. One entry on the exec arm, one
+    /// per NIC on the host arm.
+    pub fn local_addrs(&self) -> Vec<SocketAddr> {
+        self.0.local_addrs()
+    }
+
+    /// The next SEARCH reply datagram.
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<SearchDatagram> {
+        self.0.recv(buf).await
+    }
+
+    /// Send one datagram to one destination.
+    pub async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+        self.0.send_to(buf, dest).await
+    }
+
+    /// Send the same payload toward every eligible interface — for the
+    /// limited broadcast `255.255.255.255` and for multicast groups, which a
+    /// single socket would otherwise emit on one interface only.
+    ///
+    /// Returns how many sends succeeded; errors only when none did.
+    pub async fn fanout_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+        self.0.fanout_to(buf, dest).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host: the per-NIC bundle, unchanged.
+// ---------------------------------------------------------------------------
+
+#[cfg(tokio_backend)]
+mod sys {
+    use super::{SearchDatagram, SocketAddr, io};
+    use crate::net::async_udp_v4::AsyncUdpV4;
+
+    pub(super) struct Sock(AsyncUdpV4);
+
+    impl Sock {
+        pub(super) fn bind_ephemeral(
+            broadcast: bool,
+            pump_name: &str,
+            pump_priority: crate::runtime::task::ThreadPriority,
+        ) -> io::Result<Self> {
+            // No pump: the reactor is the pump.
+            let _ = (pump_name, pump_priority);
+            AsyncUdpV4::bind(0, broadcast).map(Self)
+        }
+
+        pub(super) fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
+            self.0.set_recv_buffer_size(size)
+        }
+
+        pub(super) fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
+            self.0.set_multicast_ttl_v4(ttl)
+        }
+
+        pub(super) fn enable_so_rxq_ovfl(&self) -> io::Result<()> {
+            self.0.enable_so_rxq_ovfl()
+        }
+
+        pub(super) fn local_addrs(&self) -> Vec<SocketAddr> {
+            self.0.local_addrs()
+        }
+
+        pub(super) async fn recv(&self, buf: &mut [u8]) -> io::Result<SearchDatagram> {
+            let (meta, drops) = self.0.recv_with_meta_with_drops(buf).await?;
+            Ok(SearchDatagram {
+                n: meta.n,
+                src: meta.src,
+                iface_ip: Some(meta.iface_ip),
+                drops,
+            })
+        }
+
+        pub(super) async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+            self.0.send_to(buf, dest).await
+        }
+
+        pub(super) async fn fanout_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+            self.0.fanout_to(buf, dest).await
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exec backend: one wildcard socket + one receive pump.
+// ---------------------------------------------------------------------------
+
+#[cfg(exec_backend)]
+mod sys {
+    use super::{Ipv4Addr, SearchDatagram, SocketAddr, io};
+    use crate::runtime::task::{StackSizeClass, ThreadPriority, spawn_dedicated_thread};
+    use std::net::UdpSocket;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    /// How long a blocking `recv_from` may sit before the pump re-reads the
+    /// stop flag. Only a clean-stop seam — the same 200 ms the blocking CA
+    /// server's SEARCH responder uses, and invisible to the protocol.
+    const PUMP_WAKE_INTERVAL: Duration = Duration::from_millis(200);
+
+    /// IPv4's maximum datagram, matching every other SEARCH receive buffer in
+    /// the workspace.
+    const RECV_BUF: usize = 64 * 1024;
+
+    pub(super) struct Sock {
+        /// Shared with the pump thread. `Arc`, not `try_clone`: a `dup(2)` on
+        /// a libbsd socket fails `ENXIO` on `armv7-rtems-eabihf`.
+        socket: Arc<UdpSocket>,
+        /// Datagrams the pump has read, awaiting the engine.
+        rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<(Vec<u8>, SocketAddr)>>,
+        /// Set by `Drop`; the pump observes it between `recv_from` calls.
+        stop: Arc<AtomicBool>,
+    }
+
+    impl Sock {
+        pub(super) fn bind_ephemeral(
+            broadcast: bool,
+            pump_name: &str,
+            pump_priority: ThreadPriority,
+        ) -> io::Result<Self> {
+            let socket = Arc::new(UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?);
+            if broadcast {
+                socket.set_broadcast(true)?;
+            }
+            socket.set_read_timeout(Some(PUMP_WAKE_INTERVAL))?;
+
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            let stop = Arc::new(AtomicBool::new(false));
+            let pump_socket = Arc::clone(&socket);
+            let pump_stop = Arc::clone(&stop);
+            // `epicsThreadStackMedium`, which is what libca asks for
+            // (`udpiiu.cpp:129`). Ours does strictly less than C's CAC-UDP —
+            // it copies bytes to a channel where C runs the whole response
+            // callback on this stack — but there is one such thread per
+            // process, so matching C costs nothing worth deviating for.
+            spawn_dedicated_thread(
+                pump_name.to_string(),
+                pump_priority,
+                StackSizeClass::Medium,
+                move || pump(&pump_socket, &pump_stop, &tx),
+            )?;
+
+            Ok(Self {
+                socket,
+                rx: tokio::sync::Mutex::new(rx),
+                stop,
+            })
+        }
+
+        pub(super) fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
+            set_int_opt(
+                &self.socket,
+                sockopt::SOL_SOCKET,
+                sockopt::SO_RCVBUF,
+                size as _,
+            )
+        }
+
+        pub(super) fn set_multicast_ttl_v4(&self, ttl: u32) -> io::Result<()> {
+            set_int_opt(
+                &self.socket,
+                sockopt::IPPROTO_IP,
+                sockopt::IP_MULTICAST_TTL,
+                ttl as _,
+            )
+        }
+
+        pub(super) fn enable_so_rxq_ovfl(&self) -> io::Result<()> {
+            // `SO_RXQ_OVFL` is a Linux cmsg facility read via `recvmsg`, and
+            // this arm's receive path is `recv_from`. Reporting Ok here with
+            // `SearchDatagram::drops` always 0 would claim a counter that is
+            // never read, so it reports the honest thing instead: the
+            // diagnostic is unsupported, which every caller already treats as
+            // non-fatal.
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "SO_RXQ_OVFL needs a recvmsg receive path; this SEARCH socket uses recv_from",
+            ))
+        }
+
+        pub(super) fn local_addrs(&self) -> Vec<SocketAddr> {
+            self.socket.local_addr().into_iter().collect()
+        }
+
+        pub(super) async fn recv(&self, buf: &mut [u8]) -> io::Result<SearchDatagram> {
+            let Some((bytes, src)) = self.rx.lock().await.recv().await else {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "SEARCH receive pump stopped",
+                ));
+            };
+            // Truncate as `recvfrom(2)` truncates.
+            let n = bytes.len().min(buf.len());
+            buf[..n].copy_from_slice(&bytes[..n]);
+            Ok(SearchDatagram {
+                n,
+                src,
+                iface_ip: None,
+                drops: 0,
+            })
+        }
+
+        pub(super) async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+            self.socket.send_to(buf, dest)
+        }
+
+        pub(super) async fn fanout_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+            // One socket cannot pick its egress NIC by binding, so the
+            // destination does it: each interface's own directed broadcast
+            // leaves via that interface by ordinary routing. This is what
+            // libca sends to in the first place — `EPICS_CA_AUTO_ADDR_LIST`
+            // is exactly this list — so the expansion is C's own, not a
+            // substitute for one.
+            let port = dest.port();
+            let dests: Vec<SocketAddr> = match dest {
+                SocketAddr::V4(v4) if v4.ip().is_broadcast() => {
+                    crate::net::iface_v4::broadcast_addrs()
+                        .into_iter()
+                        .map(|ip| SocketAddr::from((ip, port)))
+                        .collect()
+                }
+                // A multicast group has no per-interface rewrite: the group
+                // address *is* the destination on every NIC, and one socket
+                // emits on the routing table's choice. Sending it once is all
+                // this arm can do.
+                _ => vec![dest],
+            };
+            let mut ok = 0usize;
+            let mut last_err: Option<io::Error> = None;
+            for d in dests {
+                match self.socket.send_to(buf, d) {
+                    Ok(_) => ok += 1,
+                    Err(e) => {
+                        tracing::debug!(
+                            target: "epics_base_rs::net",
+                            dest = %d,
+                            error = %e,
+                            "SEARCH fanout send failed"
+                        );
+                        last_err = Some(e);
+                    }
+                }
+            }
+            if ok == 0 {
+                return Err(last_err.unwrap_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::AddrNotAvailable,
+                        "SEARCH fanout: no eligible broadcast destination",
+                    )
+                }));
+            }
+            Ok(ok)
+        }
+    }
+
+    impl Drop for Sock {
+        /// Ask the pump to stop. It exits within [`PUMP_WAKE_INTERVAL`] and
+        /// releases the last `Arc<UdpSocket>` as it does.
+        ///
+        /// Not joined: `Drop` runs on the engine's worker, and blocking it for
+        /// up to one wake interval to reclaim a thread that is already leaving
+        /// trades a certain stall for no gain. The exit is unconditional — it
+        /// is the pump loop's own condition, not a later cleanup step.
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Release);
+        }
+    }
+
+    /// Read datagrams until asked to stop or the receiver is gone.
+    fn pump(
+        socket: &UdpSocket,
+        stop: &AtomicBool,
+        tx: &tokio::sync::mpsc::UnboundedSender<(Vec<u8>, SocketAddr)>,
+    ) {
+        let mut buf = vec![0u8; RECV_BUF];
+        while !stop.load(Ordering::Acquire) {
+            match socket.recv_from(&mut buf) {
+                Ok((n, src)) => {
+                    if tx.send((buf[..n].to_vec(), src)).is_err() {
+                        return;
+                    }
+                }
+                Err(e) if is_wake_timeout(e.kind()) => continue,
+                // libca `udpiiu.cpp:1090-1120` and C `cast_server.c:171-179`
+                // both keep receiving after a UDP error: an earlier SEARCH
+                // drawing an ICMP port-unreachable surfaces here as
+                // ECONNREFUSED/ECONNRESET on the *next* recv and says nothing
+                // about this socket's health.
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        io::ErrorKind::ConnectionRefused
+                            | io::ErrorKind::ConnectionReset
+                            | io::ErrorKind::Interrupted
+                    ) =>
+                {
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        target: "epics_base_rs::net",
+                        error = %e,
+                        "SEARCH receive pump stopping"
+                    );
+                    return;
+                }
+            }
+        }
+    }
+
+    /// A read-timeout expiry, which is a wake and not an error.
+    ///
+    /// Two kinds because a timed-out socket read reports `EAGAIN` on some
+    /// platforms and `EWOULDBLOCK` on others, and Rust maps them to different
+    /// `ErrorKind`s.
+    fn is_wake_timeout(kind: io::ErrorKind) -> bool {
+        matches!(kind, io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut)
+    }
+
+    #[cfg(unix)]
+    mod sockopt {
+        pub(super) const SOL_SOCKET: libc::c_int = libc::SOL_SOCKET;
+        pub(super) const SO_RCVBUF: libc::c_int = libc::SO_RCVBUF;
+        pub(super) const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
+        pub(super) const IP_MULTICAST_TTL: libc::c_int = libc::IP_MULTICAST_TTL;
+    }
+
+    #[cfg(unix)]
+    fn set_int_opt(
+        socket: &UdpSocket,
+        level: libc::c_int,
+        name: libc::c_int,
+        value: libc::c_int,
+    ) -> io::Result<()> {
+        use std::os::fd::AsRawFd;
+        // SAFETY: the fd is owned by `socket` and outlives the call; `value`
+        // is a live `c_int` and the length matches it exactly.
+        let rc = unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                level,
+                name,
+                std::ptr::addr_of!(value).cast(),
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    // A non-Unix exec backend is a host `--features rtems-exec-model` build on
+    // Windows: it exists to run the target's *scheduling* shape on a
+    // developer's machine, not its socket options. Both options this arm sets
+    // are performance/reach tuning that the SEARCH protocol does not depend
+    // on, so they report unsupported rather than pulling in a second
+    // platform's setsockopt spelling.
+    #[cfg(not(unix))]
+    mod sockopt {
+        pub(super) const SOL_SOCKET: i32 = 0;
+        pub(super) const SO_RCVBUF: i32 = 0;
+        pub(super) const IPPROTO_IP: i32 = 0;
+        pub(super) const IP_MULTICAST_TTL: i32 = 0;
+    }
+
+    #[cfg(not(unix))]
+    fn set_int_opt(_socket: &UdpSocket, _level: i32, _name: i32, _value: i32) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "socket options on a non-Unix exec-backend SEARCH socket",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::task::ThreadPriority;
+
+    fn bind() -> SearchUdpSocket {
+        SearchUdpSocket::bind_ephemeral(true, "test-CAC-UDP", ThreadPriority::Medium)
+            .expect("bind ephemeral SEARCH socket")
+    }
+
+    /// The property the whole stage exists for: a SEARCH socket binds on this
+    /// backend, whichever backend it is.
+    #[epics_macros_rs::epics_test]
+    async fn binds_and_reports_a_local_address() {
+        let sock = bind();
+        let addrs = sock.local_addrs();
+        assert!(!addrs.is_empty(), "a bound SEARCH socket has an address");
+        for a in &addrs {
+            assert_ne!(a.port(), 0, "ephemeral bind assigns a real port: {a}");
+        }
+    }
+
+    /// Round-trip one datagram through the arm this build selected — the
+    /// receive path is a reactor registration on one backend and a pump thread
+    /// on the other, and this is the assertion that does not care which.
+    #[epics_macros_rs::epics_test]
+    async fn round_trips_a_datagram_to_itself() {
+        let sock = bind();
+        let port = sock
+            .local_addrs()
+            .iter()
+            .find(|a| a.is_ipv4())
+            .expect("an IPv4 SEARCH address")
+            .port();
+        let dest = SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+
+        sock.send_to(b"CA-SEARCH", dest).await.expect("send_to");
+        let mut buf = [0u8; 64];
+        let dg =
+            crate::runtime::task::timeout(std::time::Duration::from_secs(5), sock.recv(&mut buf))
+                .await
+                .expect("a datagram sent to ourselves arrives")
+                .expect("recv");
+        assert_eq!(&buf[..dg.n], b"CA-SEARCH");
+        assert_eq!(dg.drops, 0, "a single quiet datagram overflows nothing");
+    }
+}

--- a/crates/epics-libcom-rs/src/net/search_udp.rs
+++ b/crates/epics-libcom-rs/src/net/search_udp.rs
@@ -365,6 +365,12 @@ mod sys {
             pump_name: &str,
             pump_priority: ThreadPriority,
         ) -> io::Result<Self> {
+            // `SO_RCVTIMEO`, fatal — the same call and the same fatality the
+            // blocking PVA server's UDP responder makes
+            // (`server_native::blocking`, `UDP_STOP_TICK`), which runs on both
+            // embedded targets. It is `SO_SNDTIMEO` that VxWorks rejects with
+            // `ENOPROTOOPT`, and this socket never sets one: a UDP `send_to`
+            // does not block on a peer.
             socket.set_read_timeout(Some(PUMP_WAKE_INTERVAL))?;
             let socket = Arc::new(socket);
 

--- a/crates/epics-libcom-rs/src/net/search_udp.rs
+++ b/crates/epics-libcom-rs/src/net/search_udp.rs
@@ -88,6 +88,33 @@ impl SearchUdpSocket {
         sys::Sock::bind_ephemeral(broadcast, pump_name, pump_priority).map(Self)
     }
 
+    /// Bind a **beacon listener** on a fixed port, alongside whatever server
+    /// already holds it.
+    ///
+    /// Separate constructor rather than a port argument on
+    /// [`Self::bind_ephemeral`], because the two differ in more than the port:
+    /// a listener on a well-known port must share it (`SO_REUSEADDR` +
+    /// `SO_REUSEPORT`), and it is the only shape that has multicast groups to
+    /// join afterwards. pvxs binds this one wildcard
+    /// (`udp_collector.cpp:140`) so multicast reaches it, and receives
+    /// multicast only for groups explicitly joined via
+    /// [`Self::join_multicast_v4`].
+    pub fn bind_beacon(
+        port: u16,
+        pump_name: &str,
+        pump_priority: crate::runtime::task::ThreadPriority,
+    ) -> io::Result<Self> {
+        sys::Sock::bind_beacon(port, pump_name, pump_priority).map(Self)
+    }
+
+    /// Join an IPv4 multicast group on `iface` (`IP_ADD_MEMBERSHIP`).
+    ///
+    /// `iface` is `0.0.0.0` to let the routing table choose, which is what a
+    /// single wildcard socket has to do.
+    pub fn join_multicast_v4(&self, group: Ipv4Addr, iface: Ipv4Addr) -> io::Result<()> {
+        self.0.join_multicast_v4(group, iface)
+    }
+
     /// `SO_RCVBUF`. Best-effort on every platform: a kernel is free to clamp.
     pub fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
         self.0.set_recv_buffer_size(size)
@@ -150,6 +177,33 @@ mod sys {
             // No pump: the reactor is the pump.
             let _ = (pump_name, pump_priority);
             AsyncUdpV4::bind(0, broadcast).map(Self)
+        }
+
+        pub(super) fn bind_beacon(
+            port: u16,
+            pump_name: &str,
+            pump_priority: crate::runtime::task::ThreadPriority,
+        ) -> io::Result<Self> {
+            let _ = (pump_name, pump_priority);
+            // Skips the loopback NIC, which the bundle can do and one wildcard
+            // socket cannot: a local PVA server's UDP responder already holds
+            // `127.0.0.1:<port>` with `SO_REUSEPORT`, and a co-bound client
+            // listener there would take half its inbound SEARCHes through the
+            // kernel's REUSEPORT balancing. Beacons arrive on NIC subnet
+            // broadcasts, never on the loopback address, so nothing is lost.
+            AsyncUdpV4::bind_non_loopback(port, true).map(Self)
+        }
+
+        pub(super) fn join_multicast_v4(
+            &self,
+            group: std::net::Ipv4Addr,
+            iface: std::net::Ipv4Addr,
+        ) -> io::Result<()> {
+            if iface.is_unspecified() {
+                self.0.join_multicast_v4(group)
+            } else {
+                self.0.join_multicast_v4_on(group, iface)
+            }
         }
 
         pub(super) fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
@@ -218,6 +272,9 @@ mod sys {
         rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<(Vec<u8>, SocketAddr)>>,
         /// Set by `Drop`; the pump observes it between `recv_from` calls.
         stop: Arc<AtomicBool>,
+        /// The pump thread, joined by `Drop`. `Option` only so `Drop` can
+        /// `take` it; it is `Some` for the whole life of a constructed `Sock`.
+        pump: Option<std::thread::JoinHandle<()>>,
     }
 
     impl Sock {
@@ -226,11 +283,40 @@ mod sys {
             pump_name: &str,
             pump_priority: ThreadPriority,
         ) -> io::Result<Self> {
-            let socket = Arc::new(UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?);
+            let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))?;
             if broadcast {
                 socket.set_broadcast(true)?;
             }
+            Self::with_pump(socket, pump_name, pump_priority)
+        }
+
+        pub(super) fn bind_beacon(
+            port: u16,
+            pump_name: &str,
+            pump_priority: ThreadPriority,
+        ) -> io::Result<Self> {
+            // Wildcard, which is what pvxs binds (`udp_collector.cpp:140`) so
+            // that joined multicast groups reach it. The host arm skips the
+            // loopback NIC instead; one socket cannot, and on a target with a
+            // single non-loopback NIC there is nothing to skip.
+            let socket = bind_shared_port(port)?;
+            socket.set_broadcast(true)?;
+            Self::with_pump(socket, pump_name, pump_priority)
+        }
+
+        pub(super) fn join_multicast_v4(&self, group: Ipv4Addr, iface: Ipv4Addr) -> io::Result<()> {
+            self.socket.join_multicast_v4(&group, &iface)
+        }
+
+        /// The half both constructors share: give the socket its stop-poll
+        /// cadence and start the one thread that reads it.
+        fn with_pump(
+            socket: UdpSocket,
+            pump_name: &str,
+            pump_priority: ThreadPriority,
+        ) -> io::Result<Self> {
             socket.set_read_timeout(Some(PUMP_WAKE_INTERVAL))?;
+            let socket = Arc::new(socket);
 
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
             let stop = Arc::new(AtomicBool::new(false));
@@ -240,8 +326,9 @@ mod sys {
             // (`udpiiu.cpp:129`). Ours does strictly less than C's CAC-UDP —
             // it copies bytes to a channel where C runs the whole response
             // callback on this stack — but there is one such thread per
-            // process, so matching C costs nothing worth deviating for.
-            spawn_dedicated_thread(
+            // socket and a client holds at most two, so matching C costs
+            // nothing worth deviating for.
+            let pump = spawn_dedicated_thread(
                 pump_name.to_string(),
                 pump_priority,
                 StackSizeClass::Medium,
@@ -252,6 +339,7 @@ mod sys {
                 socket,
                 rx: tokio::sync::Mutex::new(rx),
                 stop,
+                pump: Some(pump),
             })
         }
 
@@ -362,15 +450,29 @@ mod sys {
     }
 
     impl Drop for Sock {
-        /// Ask the pump to stop. It exits within [`PUMP_WAKE_INTERVAL`] and
-        /// releases the last `Arc<UdpSocket>` as it does.
+        /// Stop the pump and **wait for it**, so that the socket is closed
+        /// before `drop` returns.
         ///
-        /// Not joined: `Drop` runs on the engine's worker, and blocking it for
-        /// up to one wake interval to reclaim a thread that is already leaving
-        /// trades a certain stall for no gain. The exit is unconditional — it
-        /// is the pump loop's own condition, not a later cleanup step.
+        /// # Invariant
+        ///
+        /// **A dropped `SearchUdpSocket` MUST hold no port.** The pump shares
+        /// ownership of the socket (`Arc`), so the fd outlives this `drop` by
+        /// however long the pump takes to notice the stop flag unless `drop`
+        /// waits — and a caller that drops one SEARCH socket and binds the
+        /// same port again then loses the race with its own teardown. Joining
+        /// here makes the release happen by construction rather than
+        /// eventually.
+        ///
+        /// The wait is bounded by [`PUMP_WAKE_INTERVAL`]: the socket carries
+        /// that as its read timeout, so the pump re-reads the flag at least
+        /// that often. There is no cheaper wake — `shutdown(2)` on an
+        /// unconnected `SOCK_DGRAM` reports `ENOTCONN` on Linux and does not
+        /// interrupt the blocked `recvfrom`.
         fn drop(&mut self) {
             self.stop.store(true, Ordering::Release);
+            if let Some(pump) = self.pump.take() {
+                let _ = pump.join();
+            }
         }
     }
 
@@ -431,6 +533,54 @@ mod sys {
         pub(super) const SO_RCVBUF: libc::c_int = libc::SO_RCVBUF;
         pub(super) const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
         pub(super) const IP_MULTICAST_TTL: libc::c_int = libc::IP_MULTICAST_TTL;
+    }
+
+    /// Bind the wildcard address on a well-known port that a server on this
+    /// host already holds.
+    ///
+    /// Hand-rolled because `SO_REUSEADDR`/`SO_REUSEPORT` have to be set
+    /// *before* the bind and `std::net::UdpSocket::bind` binds as it
+    /// constructs. Same sequence, and the same reason, as the blocking CA
+    /// server's `bind_udp_search_socket`.
+    #[cfg(unix)]
+    fn bind_shared_port(port: u16) -> io::Result<UdpSocket> {
+        use std::os::fd::FromRawFd;
+        // SAFETY: `socket()` returns a fresh owned fd or -1.
+        let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, libc::IPPROTO_UDP) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // Owned immediately, so every early return below closes it via `Drop`.
+        // SAFETY: `fd` is a valid, exclusively-owned socket fd just returned.
+        let socket = unsafe { UdpSocket::from_raw_fd(fd) };
+        set_int_opt(&socket, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1)?;
+        set_int_opt(&socket, libc::SOL_SOCKET, libc::SO_REUSEPORT, 1)?;
+        // Zeroed rather than field-by-field: `sin_len` exists on the BSD
+        // targets and not on Linux, and all-zero is valid for both.
+        // SAFETY: `sockaddr_in` is plain-old-data.
+        let mut sin: libc::sockaddr_in = unsafe { std::mem::zeroed() };
+        sin.sin_family = libc::AF_INET as libc::sa_family_t;
+        sin.sin_port = port.to_be();
+        // SAFETY: `sin` is fully initialized and the length is exact.
+        let rc = unsafe {
+            libc::bind(
+                fd,
+                std::ptr::addr_of!(sin).cast(),
+                std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(socket)
+    }
+
+    #[cfg(not(unix))]
+    fn bind_shared_port(_port: u16) -> io::Result<UdpSocket> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "port-sharing bind on a non-Unix exec-backend socket",
+        ))
     }
 
     #[cfg(unix)]
@@ -501,6 +651,31 @@ mod tests {
         for a in &addrs {
             assert_ne!(a.port(), 0, "ephemeral bind assigns a real port: {a}");
         }
+    }
+
+    /// A fixed-port beacon listener binds and reports that port, on either
+    /// arm — the property the PVA client's optional beacon socket needs, and
+    /// the one the exec arm's hand-rolled `SO_REUSEPORT` bind exists for.
+    #[epics_macros_rs::epics_test]
+    async fn beacon_binds_the_port_it_was_given() {
+        // Ephemeral first, only to learn a port nothing else on this machine
+        // holds; dropped before the beacon claims it.
+        let port = {
+            let probe = bind();
+            probe
+                .local_addrs()
+                .iter()
+                .find(|a| a.is_ipv4())
+                .expect("an IPv4 SEARCH address")
+                .port()
+        };
+        let beacon = SearchUdpSocket::bind_beacon(port, "test-BEACON", ThreadPriority::Medium)
+            .expect("beacon bind");
+        assert!(
+            beacon.local_addrs().iter().any(|a| a.port() == port),
+            "a beacon listener must bind the port it was given; got {:?}",
+            beacon.local_addrs()
+        );
     }
 
     /// Round-trip one datagram through the arm this build selected — the

--- a/crates/epics-libcom-rs/src/runtime/background/future_exec.rs
+++ b/crates/epics-libcom-rs/src/runtime/background/future_exec.rs
@@ -708,6 +708,25 @@ mod tests {
         }
     }
 
+    /// Suspends, waking itself each poll, until the flag is set — the
+    /// unbounded [`YieldN`]. For tests whose subject is *that* a task is
+    /// suspended rather than how often: a fixed count makes the test thread
+    /// race the worker, because the worker may exhaust every yield before the
+    /// thread reaches its next statement.
+    struct YieldUntil(Arc<AtomicBool>);
+
+    impl Future for YieldUntil {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0.load(Ordering::Acquire) {
+                return Poll::Ready(());
+            }
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+
     /// Returns `Pending` `n` times, waking itself each time, then `Ready`.
     /// Exercises the wake-during-poll (`RUNNING_NOTIFIED`) edge on every step.
     struct YieldN(usize);
@@ -817,18 +836,28 @@ mod tests {
 
     #[test]
     fn a_yielding_task_releases_the_worker_to_a_queued_task() {
-        // Single worker, two tasks. `slow` yields many times; `quick` is queued
-        // behind it. Under the old park-a-worker design `quick` could not run
-        // until `slow` finished, so the order would be slow-then-quick. With
-        // the worker released at every suspension, `quick` — already on the
-        // ring when `slow` first re-enqueues at the TAIL — runs first.
+        // Single worker, two tasks. `slow` stays suspended until this thread
+        // releases it; `quick` is queued behind it. Under the old
+        // park-a-worker design `quick` could not run until `slow` finished, so
+        // it would never arrive at all.
+        //
+        // The gate is what makes the order an assertion rather than a race.
+        // Holding `slow` for a fixed number of yields instead leaves the
+        // executor free to burn all of them before this thread has enqueued
+        // `quick` — then "slow" arrives first through no fault of the
+        // executor, which is the flake this shape removes. Gated, `slow`
+        // *cannot* finish before "quick" is received, so "quick" arriving is
+        // itself the proof that a suspended task released the band's only
+        // worker.
         assert_eq!(DEFAULT_THREADS_PER_PRIORITY, 1);
         let pool = CallbackPool::new();
         let (tx, rx) = mpsc::channel::<&'static str>();
+        let gate = Arc::new(AtomicBool::new(false));
 
         let tx_slow = tx.clone();
+        let gate_slow = Arc::clone(&gate);
         let slow = spawn_future(&pool.handle(), CallbackPriority::Medium, async move {
-            YieldN(20).await;
+            YieldUntil(gate_slow).await;
             tx_slow.send("slow").unwrap();
         });
         let quick = spawn_future(&pool.handle(), CallbackPriority::Medium, async move {
@@ -840,6 +869,7 @@ mod tests {
             "quick",
             "a suspended task must not hold the band's only worker"
         );
+        gate.store(true, Ordering::Release);
         assert_eq!(
             rx.recv_timeout(T).unwrap(),
             "slow",

--- a/crates/epics-pva-rs/build.rs
+++ b/crates/epics-pva-rs/build.rs
@@ -103,9 +103,15 @@ const LOCAL_ACCOUNT_DB_TARGETS: &[&str] = &[
 // `--features rtems-exec-model` compiled the UDP transport in and panicked on
 // it at `realtime-pva-ioc`'s first search (measured, `doc/calink-rtems-design.md`
 // §10.10 item 2). `tokio_backend` is the predicate that means "a reactor
-// exists", so the transport takes that one and `SearchTransport` has the
-// single `NameServersOnly` variant on `exec_backend` — the target's shape,
-// now reached by the host build that models the target.
+// exists", so every arm that needs one takes that predicate — the target's
+// shape, now reached by the host build that models the target.
+//
+// The v4 SEARCH socket is no longer one of those arms. It binds on both
+// backends through `epics_base_rs::net::search_udp::SearchUdpSocket`, whose
+// `exec_backend` arm is a `std::net::UdpSocket` and a receive-pump thread and
+// names no reactor. `tokio_backend` still selects the IPv6 half, which is
+// `socket2` and `tokio::net` throughout, and `SearchTransport` still reduces
+// to `NameServersOnly` when the configuration asks for no UDP.
 //
 // This is a third copy of a four-line rule, so it is pinned rather than
 // trusted: a `const` assertion in `src/lib.rs` checks it against

--- a/crates/epics-pva-rs/src/client_native/search_engine.rs
+++ b/crates/epics-pva-rs/src/client_native/search_engine.rs
@@ -18,11 +18,12 @@
 //!   that channel immediately.
 //! - Beacon anomaly throttling via [`super::beacon_throttle::BeaconTracker`].
 
-// (11 tests that spin the live UDP search engine gated out feature-ON below;
-// §4.2 defers UDP search, so their spawned timers/socket cannot run on the
-// reactor-less callback pool — stage 3.)
+// The tests that spin a live UDP search engine now run feature-ON too: the
+// engine binds a `SearchUdpSocket` on every backend, so a mock UDP responder
+// receives the SEARCH on the exec backend exactly as it does on the host. The
+// three that stay gated are the IPv6 ones, whose subject is uninhabited there.
 
-// RTEMS-EXEC-MODEL-ALLOW(4): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(14): checked - these run and pass in the feature-ON suite.
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -30,40 +31,30 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::time::Duration;
 
-// The UDP SEARCH/beacon transport is compiled out wherever a spawned future
-// has no tokio reactor — `cfg(exec_backend)`, which is either embedded
-// target (RTEMS or VxWorks) *and* a host `--features rtems-exec-model`
-// build. Two facts, one gate:
+// The v4 UDP SEARCH/beacon transport is bound on **every** backend, through
+// `SearchUdpSocket` — one type whose `exec_backend` arm is a single wildcard
+// socket with a receive-pump thread, because there is no reactor to register
+// a `tokio::net::UdpSocket` with there.
 //
-//   * On RTEMS, newlib has no `recvmsg`/`IP_PKTINFO` original-destination
-//     recovery and `local_addr()` cannot be read back to stamp a SEARCH
-//     response port, so a UDP search would advertise port 0 and never be
-//     answered (doc/pvalink-rtems-design.md §4.2). It is gated out on
-//     VxWorks too — `AsyncUdpV4`'s `tokio::net`/`socket2`/`if-addrs` stack
-//     does not build for either embedded target, so the module stays one
-//     host-only unit rather than a per-target reason each.
-//   * On either backend-free build this engine runs on a callback-pool worker
-//     (`runtime::task::spawn`), and `tokio::net::UdpSocket` panics there —
-//     "there is no reactor running" — even when the process has a runtime
-//     somewhere else, because it is not entered on that worker.
+// It used to be compiled out on `exec_backend` entirely, for two stated
+// reasons. The second was real and is what `SearchUdpSocket` answers: this
+// engine runs on a callback-pool worker (`runtime::task::spawn`), and
+// `tokio::net::UdpSocket` panics there — "there is no reactor running" — even
+// when the process has a runtime somewhere else, because it is not entered on
+// that worker. Gating on `not(target_os = "rtems")` missed exactly that, so a
+// hosted `rtems-exec-model` build compiled the transport in, selected it, and
+// panicked at `realtime-pva-ioc`'s first search.
 //
-// Gating this on `not(target_os = "rtems")` named the first fact and missed
-// the second, so a hosted `rtems-exec-model` build compiled the UDP transport
-// in, selected it, and panicked in `bind_ephemeral_udp` at `realtime-pva-ioc`'s
-// first search (`doc/calink-rtems-design.md` §10.10 item 2, measured).
-// `tokio_backend` is the predicate that means "a reactor exists" and is the
-// one the whole `AsyncUdpV4`/`UdpSocket` surface below carries, so "no UDP in
-// this build" holds by construction. The target's compiled surface is
-// unchanged: `epics_embedded_target` (RTEMS or VxWorks) implies
-// `exec_backend`.
+// The first reason was that RTEMS could not read `local_addr()` back to stamp
+// a SEARCH response port, so it would advertise port 0 and never be answered
+// (doc/pvalink-rtems-design.md §4.2). That premise is false: it was the
+// `sin_len` libc defect, fixed in the pinned `libc` patch, and a bound socket
+// on RTEMS 6 now reports its port — MEASURED on target, `UDPSEARCH
+// bound=[0.0.0.0:55153]`.
 //
-// Either way everything the client reaches goes over TCP name servers via the
-// `SearchTransport::NameServersOnly` seam.
-#[cfg(tokio_backend)]
-use epics_base_rs::net::AsyncUdpV4;
+// What remains target-shaped is the IPv6 half alone; see [`V6Socket`].
+use epics_base_rs::net::search_udp::SearchUdpSocket;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-#[cfg(tokio_backend)]
-use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot};
 // The periodic/one-shot timers come from the `runtime::task` seam, NOT from
 // `tokio::time`: this loop is spawned through `runtime::task::spawn`, which on
@@ -78,9 +69,6 @@ use tokio::sync::{mpsc, oneshot};
 // keeps the two from being different timelines.
 use epics_base_rs::runtime::task::{Instant, Interval, interval, sleep, sleep_until};
 use tracing::debug;
-// `warn!` only fires from the UDP bind/broadcast paths, which are gated out on
-// `exec_backend` — so the import is too, or it is unused there.
-#[cfg(tokio_backend)]
 use tracing::warn;
 
 use crate::codec::PvaCodec;
@@ -373,19 +361,21 @@ impl Default for ClientSearchConfig {
 /// cannot be configured independently, and so the per-client
 /// `EPICS_PVA_*` UDP knobs are resolved once at bind time rather than
 /// re-read from the process environment each tick.
-#[cfg(tokio_backend)]
 struct UdpTransport {
-    /// Ephemeral all-NIC v4 SEARCH socket: sends SEARCH, receives the
-    /// unicast SEARCH_RESPONSE.
-    search_socket: AsyncUdpV4,
+    /// Ephemeral v4 SEARCH socket: sends SEARCH, receives the unicast
+    /// SEARCH_RESPONSE. All-NIC on the host, one wildcard socket on
+    /// `exec_backend`; either way one port, which is what
+    /// [`Self::response_port`] advertises.
+    search_socket: SearchUdpSocket,
     /// PR #205 IPv6 Stage 4: optional v6 SEARCH socket. `None` when the
-    /// host has no usable IPv6 stack.
-    search_socket_v6: Option<Arc<UdpSocket>>,
+    /// host has no usable IPv6 stack, and always `None` on `exec_backend`,
+    /// where [`V6Socket`] is uninhabited.
+    search_socket_v6: Option<V6Socket>,
     /// Beacon listener on [`Self::broadcast_port`]. `None` when the bind
     /// failed — beacon-driven fast reconnect is best-effort.
-    beacon_socket: Option<AsyncUdpV4>,
+    beacon_socket: Option<SearchUdpSocket>,
     /// PR #205 IPv6 Stage 6: optional v6 multicast beacon listener.
-    beacon_socket_v6: Option<Arc<UdpSocket>>,
+    beacon_socket_v6: Option<V6Socket>,
     /// Explicit `addr_list` UDP SEARCH targets (already merged with any
     /// programmatic extras) — every datagram is sent to each of these.
     extra_targets: Vec<SocketAddr>,
@@ -418,19 +408,15 @@ struct UdpTransport {
 /// piece of state lives inside the variant that owns the sockets, and each
 /// UDP `select!` arm is a method on this type — so "a UDP socket is bound"
 /// and "the arm that reads it is armed" are the same match rather than two
-/// facts that can disagree. An `Option<AsyncUdpV4>` plus an `if let` per arm
-/// would leave them able to disagree, and the RTEMS target
-/// (`doc/pvalink-rtems-design.md` §4.2) is precisely the configuration where
-/// they would: there is no `recvmsg`/`IP_PKTINFO` for the UDP receive path,
-/// and `local_addr()` cannot be read back to stamp a response port.
+/// facts that can disagree. An `Option<SearchUdpSocket>` plus an `if let` per
+/// arm would leave them able to disagree.
 enum SearchTransport {
     /// UDP SEARCH and beacon receive, alongside any TCP name servers.
     ///
-    /// Compiled out on `exec_backend` — there is no UDP transport to hold,
-    /// so `NameServersOnly` is the only variant and "no UDP socket" is a fact
-    /// about the type rather than a runtime branch (§4.2). See the module-head
-    /// note on why the gate is the backend and not the target.
-    #[cfg(tokio_backend)]
+    /// Built on every backend. The `exec_backend` arm of [`SearchUdpSocket`]
+    /// is one wildcard socket with a receive pump instead of a per-NIC
+    /// reactor bundle, which is libca's own model and pvxs's beacon-listener
+    /// model (`udp_collector.cpp:140`).
     Udp(Box<UdpTransport>),
     /// No UDP socket is bound at all. Every SEARCH goes out over the
     /// configured TCP name servers (`ns_task`), and every UDP arm parks
@@ -447,7 +433,6 @@ impl SearchTransport {
     /// `addr_list` is merged into them here (pva2pva client-config
     /// semantics: address-list entries are UDP SEARCH destinations on
     /// `broadcast_port`, never TCP name servers).
-    #[cfg(tokio_backend)]
     fn bind_udp(
         config: &ClientSearchConfig,
         mut extra_targets: Vec<SocketAddr>,
@@ -475,7 +460,7 @@ impl SearchTransport {
         // PR #205 IPv6 Stage 4: optional v6 send/recv socket. Used
         // alongside the v4 socket — graceful degradation when the
         // host has no usable IPv6 stack.
-        let search_socket_v6 = bind_ephemeral_udp_v6();
+        let search_socket_v6 = V6Socket::bind_search();
         // Beacon receive uses the per-client UDP port and joins the
         // per-client address-list multicast groups (pvxs `udp_port`).
         let beacon_socket = bind_beacon_udp(config.broadcast_port, &config.addr_list); // Optional.
@@ -483,7 +468,7 @@ impl SearchTransport {
         // `[::]:5076` joined to `ff0e::400`. Receives v6 multicast
         // beacons emitted by the server's Stage 5 path. None when the
         // host has no v6.
-        let beacon_socket_v6 = bind_beacon_udp_v6(config.broadcast_port);
+        let beacon_socket_v6 = V6Socket::bind_beacon(config.broadcast_port);
 
         // Merge the per-client address-list UDP SEARCH targets into
         // `extra_targets`. The list was parsed once (DNS-resolved,
@@ -539,8 +524,7 @@ impl SearchTransport {
             .unwrap_or(0);
         let response_port_v6 = search_socket_v6
             .as_ref()
-            .and_then(|s| s.local_addr().ok())
-            .map(|a| a.port())
+            .and_then(|s| s.local_port())
             .unwrap_or(response_port);
 
         Ok(Self::Udp(Box::new(UdpTransport {
@@ -563,7 +547,6 @@ impl SearchTransport {
     fn has_no_udp_destinations(&self) -> bool {
         match self {
             Self::NameServersOnly => true,
-            #[cfg(tokio_backend)]
             Self::Udp(u) => u.extra_targets.is_empty() && !u.auto_addr_list,
         }
     }
@@ -578,22 +561,23 @@ impl SearchTransport {
     /// (`stage1_name_servers_only_resolves_without_binding_udp`) rather
     /// than being production surface that happens to be tested.
     #[cfg(test)]
-    // Only consumer is the gated `stage1_name_servers_only_resolves_without_binding_udp`,
-    // so it carries the same predicate — otherwise dead code feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
     fn bound_udp_addrs(&self) -> Vec<SocketAddr> {
         match self {
             Self::NameServersOnly => Vec::new(),
             Self::Udp(u) => {
                 let mut addrs = u.search_socket.local_addrs();
                 if let Some(s) = &u.search_socket_v6 {
-                    addrs.extend(s.local_addr().ok());
+                    addrs.extend(s.local_port().map(|p| {
+                        SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, p, 0, 0))
+                    }));
                 }
                 if let Some(s) = &u.beacon_socket {
                     addrs.extend(s.local_addrs());
                 }
                 if let Some(s) = &u.beacon_socket_v6 {
-                    addrs.extend(s.local_addr().ok());
+                    addrs.extend(s.local_port().map(|p| {
+                        SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, p, 0, 0))
+                    }));
                 }
                 addrs
             }
@@ -605,8 +589,7 @@ impl SearchTransport {
     /// socket already used.
     async fn recv_search(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
         match self {
-            #[cfg(tokio_backend)]
-            Self::Udp(u) => u.search_socket.recv_from(buf).await,
+            Self::Udp(u) => u.search_socket.recv(buf).await.map(|d| (d.n, d.src)),
             Self::NameServersOnly => {
                 let _ = buf;
                 std::future::pending().await
@@ -618,7 +601,6 @@ impl SearchTransport {
     /// without a UDP transport, and equally when v6 is unavailable.
     async fn recv_search_v6(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => recv_from_v6(u.search_socket_v6.as_ref(), buf).await,
             Self::NameServersOnly => {
                 let _ = buf;
@@ -630,9 +612,8 @@ impl SearchTransport {
     /// `select!` arm: the next v4 BEACON datagram.
     async fn recv_beacon(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => match &u.beacon_socket {
-                Some(s) => s.recv_from(buf).await,
+                Some(s) => s.recv(buf).await.map(|d| (d.n, d.src)),
                 None => std::future::pending().await,
             },
             Self::NameServersOnly => {
@@ -645,7 +626,6 @@ impl SearchTransport {
     /// `select!` arm: the next v6 multicast BEACON datagram.
     async fn recv_beacon_v6(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => recv_from_v6(u.beacon_socket_v6.as_ref(), buf).await,
             Self::NameServersOnly => {
                 let _ = buf;
@@ -665,7 +645,6 @@ impl SearchTransport {
         send_errs: &mut HashSet<SocketAddr>,
     ) {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 // Pack the same entries with each family's response port. The
                 // port field is fixed-width, so the two sets batch identically
@@ -676,9 +655,9 @@ impl SearchTransport {
                     u.broadcast(frame_v4, frame_v6, send_errs).await;
                 }
             }
-            // No UDP transport (RTEMS target, or a name-servers-only host
-            // engine): nothing is packed or sent — the frames would advertise
-            // response ports that only exist inside `UdpTransport`.
+            // A name-servers-only engine: nothing is packed or sent — the
+            // frames would advertise response ports that only exist inside
+            // `UdpTransport`.
             Self::NameServersOnly => {
                 let _ = (codec, entries, send_errs);
             }
@@ -691,7 +670,6 @@ impl SearchTransport {
     /// nature — discovery has no name-server equivalent.
     async fn broadcast_discover(&self, codec: &PvaCodec, send_errs: &mut HashSet<SocketAddr>) {
         match self {
-            #[cfg(tokio_backend)]
             Self::Udp(u) => {
                 // Stamp the fixed pvxs `search_seq` ("find") rather than a fresh
                 // randomized id: the discovery-pong receive path gates on this
@@ -738,19 +716,11 @@ impl SearchEngine {
     }
 
     /// Build the SEARCH transport from the process environment: a bound UDP
-    /// socket bundle on `tokio_backend`, and
-    /// [`SearchTransport::NameServersOnly`] on `exec_backend`, where no UDP
-    /// socket can be bound (§4.2). The single place that choice is made, so
-    /// the three UDP-config spawn entry points collapse to name-servers-only
-    /// there rather than each naming `bind_udp` (which does not exist there).
-    #[cfg(tokio_backend)]
+    /// SEARCH socket plus the optional beacon listener, on every backend. The
+    /// single place that choice is made, so the three UDP-config spawn entry
+    /// points cannot drift apart.
     fn env_transport(extra_targets: Vec<SocketAddr>) -> PvaResult<SearchTransport> {
         SearchTransport::bind_udp(&ClientSearchConfig::from_env(), extra_targets)
-    }
-
-    #[cfg(exec_backend)]
-    fn env_transport(_extra_targets: Vec<SocketAddr>) -> PvaResult<SearchTransport> {
-        Ok(SearchTransport::NameServersOnly)
     }
 
     /// Spawn with an explicit per-client UDP SEARCH config (address list /
@@ -778,25 +748,13 @@ impl SearchEngine {
     }
 
     /// Build the SEARCH transport from an explicit per-client
-    /// [`ClientSearchConfig`]: a bound UDP socket bundle on `tokio_backend`,
-    /// [`SearchTransport::NameServersOnly`] on `exec_backend` (§4.2). The
-    /// config's UDP knobs (address list, ports, auto-addr) have no effect
-    /// there, where there is no UDP socket to apply them to; the caller's TCP
-    /// name servers still reach every server.
-    #[cfg(tokio_backend)]
+    /// [`ClientSearchConfig`] rather than the process environment. Its UDP
+    /// knobs (address list, ports, auto-addr) apply on every backend.
     fn config_transport(
         config: ClientSearchConfig,
         extra_targets: Vec<SocketAddr>,
     ) -> PvaResult<SearchTransport> {
         SearchTransport::bind_udp(&config, extra_targets)
-    }
-
-    #[cfg(exec_backend)]
-    fn config_transport(
-        _config: ClientSearchConfig,
-        _extra_targets: Vec<SocketAddr>,
-    ) -> PvaResult<SearchTransport> {
-        Ok(SearchTransport::NameServersOnly)
     }
 
     /// Spawn with the client's CA credentials for TCP name-server connections,
@@ -825,11 +783,10 @@ impl SearchEngine {
     /// Spawn an engine that binds **no UDP socket at all** and reaches every
     /// server over the TCP name servers alone (`EPICS_PVA_NAME_SERVERS`).
     ///
-    /// This is the RTEMS client configuration (`doc/pvalink-rtems-design.md`
-    /// §4.2): the target has no `recvmsg`/`IP_PKTINFO` for the UDP receive
-    /// path and cannot read a socket's `local_addr()` back to stamp a SEARCH
-    /// response port, so a UDP search would advertise port 0 and never be
-    /// answered. TCP name-server search needs neither.
+    /// An explicit configuration choice, not a target's capability: every
+    /// backend can bind the UDP transport, and [`Self::spawn`] does. This is
+    /// for a client that must not emit broadcast at all — a locked-down
+    /// subnet, or a gateway reached only through `EPICS_PVA_NAME_SERVERS`.
     ///
     /// It is a deliberate deviation from pvxs, which always binds its search
     /// and beacon sockets (`client.cpp:578-590`, `:638-650`) regardless of
@@ -1024,10 +981,196 @@ impl SearchEngine {
     }
 }
 
-// ── UDP socket helpers ──────────────────────────────────────────────────
+// ── The IPv6 half ───────────────────────────────────────────────────────
+
+/// The client's IPv6 SEARCH or beacon socket, where one can exist at all.
+///
+/// This is the one part of the UDP transport that does not cross to the
+/// embedded targets, and the reason is the dependency graph rather than a
+/// design choice: both binders are `socket2` (newlib has no `msghdr` /
+/// `recvmsg` / `ip_mreqn`, and neither does VxWorks's `libc` module) and the
+/// receive is `tokio::net::UdpSocket`, whose `net` feature is not enabled on
+/// either target because mio has no selector there.
+///
+/// So on `exec_backend` the type is **uninhabited**. `Option<V6Socket>` is
+/// then `None` by construction rather than by a runtime check that a build
+/// could get wrong, every method below reduces to `match *self {}`, and the
+/// `socket2`/`tokio::net` surface leaves the target's compiled unit entirely.
+/// That is the shape the whole transport used to have as a `SearchTransport`
+/// variant, kept for the half that is genuinely unreachable.
+#[cfg(tokio_backend)]
+struct V6Socket(Arc<tokio::net::UdpSocket>);
+
+#[cfg(exec_backend)]
+enum V6Socket {}
 
 #[cfg(tokio_backend)]
-fn bind_ephemeral_udp() -> PvaResult<AsyncUdpV4> {
+impl V6Socket {
+    /// PR #205 IPv6 Stage 4: a v6-only ephemeral socket used to send SEARCH
+    /// to IPv6 destinations (unicast servers from `EPICS_PVA_ADDR_LIST` and
+    /// the v6 multicast group). `None` when the host lacks IPv6 — the engine
+    /// keeps running IPv4-only.
+    ///
+    /// Sets `IPV6_V6ONLY=true` explicitly so the v6 socket cannot accept
+    /// v4-mapped traffic that would otherwise duplicate what the v4 SEARCH
+    /// socket already handles.
+    fn bind_search() -> Option<Self> {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let sock = match Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)) {
+            Ok(s) => s,
+            Err(e) => {
+                debug!("IPv6 SEARCH socket: socket() failed: {e}; v6 disabled");
+                return None;
+            }
+        };
+        if let Err(e) = sock.set_only_v6(true) {
+            debug!("IPv6 SEARCH socket: set_only_v6 failed: {e}");
+        }
+        if let Err(e) = sock.set_nonblocking(true) {
+            debug!("IPv6 SEARCH socket: set_nonblocking failed: {e}");
+            return None;
+        }
+        // Multicast TTL=1 (link-local only) is the safe default — matches
+        // pvxs `udp_collector.cpp` v6 send path.
+        if let Err(e) = sock.set_multicast_hops_v6(1) {
+            debug!("IPv6 SEARCH socket: set_multicast_hops_v6 failed: {e}");
+        }
+        let bind =
+            std::net::SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0));
+        if let Err(e) = sock.bind(&bind.into()) {
+            debug!("IPv6 SEARCH socket: bind {bind} failed: {e}; v6 disabled");
+            return None;
+        }
+        Self::adopt(sock, "IPv6 SEARCH socket")
+    }
+
+    /// PR #205 IPv6 Stage 6: a v6 beacon listener on `[::]:port` with
+    /// `SO_REUSEADDR`/`SO_REUSEPORT` + `IPV6_V6ONLY=1`, joined to the default
+    /// v6 PVA multicast group `ff0e::400`. `None` when the host lacks v6 or
+    /// the bind fails — fast-reconnect via v6 beacons is best-effort and the
+    /// v4 beacon socket keeps doing its job.
+    fn bind_beacon(port: u16) -> Option<Self> {
+        use socket2::{Domain, Protocol, Socket, Type};
+
+        let sock = match Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)) {
+            Ok(s) => s,
+            Err(e) => {
+                debug!("v6 beacon socket: socket() failed: {e}; v6 beacon recv disabled");
+                return None;
+            }
+        };
+        if let Err(e) = sock.set_only_v6(true) {
+            debug!("v6 beacon socket: set_only_v6 failed: {e}");
+        }
+        // Mirror the v4 beacon socket setup: SO_REUSEADDR + SO_REUSEPORT so
+        // a server v6 SEARCH listener on `[::]:port` and a client v6 beacon
+        // listener can coexist. The server emits beacons FROM a separate
+        // ephemeral socket, so this REUSEPORT-shared listener only receives.
+        //
+        // SO_REUSEADDR on every platform, Windows included: pvxs puts its UDP
+        // sockets through `epicsSocketEnableAddressUseForDatagramFanout`
+        // (udp_collector.cpp:136), and that libcom helper has no `#ifdef
+        // _WIN32` — the Windows carve-out belongs to the TCP time-wait helper,
+        // not this one. Skipping it here would stop a second PVA process on a
+        // Windows host from co-binding the beacon port.
+        if let Err(e) = sock.set_reuse_address(true) {
+            debug!("v6 beacon socket: set_reuse_address failed: {e}");
+        }
+        #[cfg(unix)]
+        if let Err(e) = sock.set_reuse_port(true) {
+            debug!("v6 beacon socket: set_reuse_port failed: {e}");
+        }
+        if let Err(e) = sock.set_nonblocking(true) {
+            debug!("v6 beacon socket: set_nonblocking failed: {e}");
+            return None;
+        }
+
+        let bind = SocketAddr::V6(std::net::SocketAddrV6::new(
+            Ipv6Addr::UNSPECIFIED,
+            port,
+            0,
+            0,
+        ));
+        if let Err(e) = sock.bind(&bind.into()) {
+            debug!("v6 beacon socket: bind {bind} failed: {e}; v6 beacon recv disabled");
+            return None;
+        }
+
+        let adopted = Self::adopt(sock, "v6 beacon socket")?;
+        // Join the default PVA v6 multicast group on the unspecified
+        // interface (let the OS pick). Additional groups from
+        // EPICS_PVA_ADDR_LIST are joined separately.
+        if let Err(e) = adopted.0.join_multicast_v6(&DEFAULT_V6_MULTICAST_GROUP, 0) {
+            debug!(
+                "v6 beacon socket: join_multicast_v6 ff0e::400 failed: {e}; \
+                 v6 multicast beacons will not be received"
+            );
+        }
+        Some(adopted)
+    }
+
+    fn adopt(sock: socket2::Socket, what: &str) -> Option<Self> {
+        let std_sock: std::net::UdpSocket = sock.into();
+        match tokio::net::UdpSocket::from_std(std_sock) {
+            Ok(s) => Some(Self(Arc::new(s))),
+            Err(e) => {
+                debug!("{what}: tokio adoption failed: {e}");
+                None
+            }
+        }
+    }
+
+    fn local_port(&self) -> Option<u16> {
+        self.0.local_addr().ok().map(|a| a.port())
+    }
+
+    async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
+        self.0.recv_from(buf).await
+    }
+
+    async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> std::io::Result<usize> {
+        self.0.send_to(buf, dest).await
+    }
+}
+
+#[cfg(exec_backend)]
+impl V6Socket {
+    fn bind_search() -> Option<Self> {
+        None
+    }
+
+    fn bind_beacon(_port: u16) -> Option<Self> {
+        None
+    }
+
+    fn local_port(&self) -> Option<u16> {
+        match *self {}
+    }
+
+    async fn recv_from(&self, _buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
+        match *self {}
+    }
+
+    async fn send_to(&self, _buf: &[u8], _dest: SocketAddr) -> std::io::Result<usize> {
+        match *self {}
+    }
+}
+
+// ── UDP socket helpers ──────────────────────────────────────────────────
+
+/// The band the `exec_backend` SEARCH-receive pump runs at.
+///
+/// pvxs receives SEARCH replies, beacons and client TCP traffic on one
+/// libevent loop thread (`client.cpp`), so upstream derives no separate UDP
+/// band for the client at all. Taking the TCP pumps' own band is therefore the
+/// parity answer rather than a number invented here: splitting how the work is
+/// scheduled *internally* must not change how it is scheduled relative to
+/// everything else. The host arm receives on the reactor and ignores it.
+const PVA_SEARCH_UDP_PRIORITY: epics_base_rs::runtime::task::ThreadPriority =
+    super::server_conn::PVA_CLIENT_PRIORITY;
+
+fn bind_ephemeral_udp() -> PvaResult<SearchUdpSocket> {
     // SEARCH packets embed a `response_port` that IOCs reply unicast
     // to. With per-NIC sockets we want every NIC's reply port to be
     // identical so the IOC's response lands on the right
@@ -1044,63 +1187,14 @@ fn bind_ephemeral_udp() -> PvaResult<AsyncUdpV4> {
     // `INTF_ADDR_LIST=127.0.0.1`; the interface constraint now lives only
     // in `search_targets` (auto-broadcast generation) and `broadcast`'s
     // limited-broadcast / multicast fanout egress.
-    AsyncUdpV4::bind_ephemeral_same_port(true).map_err(PvaError::Io)
-}
-
-/// PR #205 IPv6 Stage 4: bind a v6-only ephemeral UDP socket used to
-/// send SEARCH to IPv6 destinations (unicast servers from
-/// `EPICS_PVA_ADDR_LIST` and the v6 multicast group). Returns `None`
-/// when the host lacks IPv6 (bind fails) — the engine keeps running
-/// IPv4-only in that case.
-///
-/// Sets `IPV6_V6ONLY=true` explicitly so the v6 socket cannot accept
-/// v4-mapped traffic that would otherwise duplicate what the
-/// `AsyncUdpV4` search socket already handles.
-#[cfg(tokio_backend)]
-fn bind_ephemeral_udp_v6() -> Option<Arc<UdpSocket>> {
-    use socket2::{Domain, Protocol, Socket, Type};
-
-    let sock = match Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)) {
-        Ok(s) => s,
-        Err(e) => {
-            debug!("IPv6 SEARCH socket: socket() failed: {e}; v6 disabled");
-            return None;
-        }
-    };
-    if let Err(e) = sock.set_only_v6(true) {
-        debug!("IPv6 SEARCH socket: set_only_v6 failed: {e}");
-    }
-    if let Err(e) = sock.set_nonblocking(true) {
-        debug!("IPv6 SEARCH socket: set_nonblocking failed: {e}");
-        return None;
-    }
-    // Multicast TTL=1 (link-local only) is the safe default — matches
-    // pvxs `udp_collector.cpp` v6 send path.
-    if let Err(e) = sock.set_multicast_hops_v6(1) {
-        debug!("IPv6 SEARCH socket: set_multicast_hops_v6 failed: {e}");
-    }
-    let bind =
-        std::net::SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0));
-    if let Err(e) = sock.bind(&bind.into()) {
-        debug!("IPv6 SEARCH socket: bind {bind} failed: {e}; v6 disabled");
-        return None;
-    }
-    let std_sock: std::net::UdpSocket = sock.into();
-    match UdpSocket::from_std(std_sock) {
-        Ok(s) => Some(Arc::new(s)),
-        Err(e) => {
-            debug!("IPv6 SEARCH socket: tokio adoption failed: {e}");
-            None
-        }
-    }
+    SearchUdpSocket::bind_ephemeral(true, "PVAC-UDP", PVA_SEARCH_UDP_PRIORITY).map_err(PvaError::Io)
 }
 
 /// `select!`-friendly recv helper: yields the next datagram from the
 /// optional v6 socket, or parks forever when v6 is disabled. Shared by the
 /// v6 search and v6 beacon arms of [`SearchTransport`].
-#[cfg(tokio_backend)]
 async fn recv_from_v6(
-    sock: Option<&Arc<UdpSocket>>,
+    sock: Option<&V6Socket>,
     buf: &mut [u8],
 ) -> std::io::Result<(usize, SocketAddr)> {
     match sock {
@@ -1109,18 +1203,17 @@ async fn recv_from_v6(
     }
 }
 
-#[cfg(tokio_backend)]
-fn bind_beacon_udp(port: u16, addr_list: &[crate::config::Endpoint]) -> Option<AsyncUdpV4> {
-    // Skip the loopback NIC: any local pva-rs *server* has its UDP
-    // responder bound on 127.0.0.1:5076 with SO_REUSEPORT, and a
-    // co-bound client beacon socket on the same (addr, port) would
-    // race with the server for inbound SEARCH packets via the kernel's
-    // REUSEPORT load-balancing on macOS / Linux. Beacons that the
-    // local server emits go to NIC subnet broadcasts (never to the
-    // loopback addr — see `config::env::list_broadcast_addresses`
-    // which filters loopback), so dropping the loopback bind here
-    // costs nothing on the receive side.
-    let sock = match AsyncUdpV4::bind_non_loopback(port, true) {
+fn bind_beacon_udp(port: u16, addr_list: &[crate::config::Endpoint]) -> Option<SearchUdpSocket> {
+    // The host arm skips the loopback NIC, which a per-NIC bundle can do and
+    // one wildcard socket cannot: any local pva-rs *server* has its UDP
+    // responder bound on 127.0.0.1:5076 with SO_REUSEPORT, and a co-bound
+    // client beacon socket on the same (addr, port) would race with the
+    // server for inbound SEARCH packets via the kernel's REUSEPORT
+    // load-balancing on macOS / Linux. Beacons that the local server emits go
+    // to NIC subnet broadcasts (never to the loopback addr — see
+    // `config::env::list_broadcast_addresses`, which filters loopback), so
+    // dropping the loopback bind costs nothing on the receive side.
+    let sock = match SearchUdpSocket::bind_beacon(port, "PVAC-beacon", PVA_SEARCH_UDP_PRIORITY) {
         Ok(s) => s,
         Err(e) => {
             debug!("beacon socket bind to {port} failed: {e}; fast-reconnect disabled");
@@ -1136,80 +1229,6 @@ fn bind_beacon_udp(port: u16, addr_list: &[crate::config::Endpoint]) -> Option<A
     Some(sock)
 }
 
-/// PR #205 IPv6 Stage 6: bind a v6 beacon listener on `[::]:port` with
-/// `SO_REUSEADDR`/`SO_REUSEPORT` + `IPV6_V6ONLY=1`, then join the
-/// default v6 PVA multicast group `ff0e::400`. Returns `None` when the
-/// host lacks v6 or the bind fails — fast-reconnect via v6 beacons is
-/// best-effort, the v4 beacon socket keeps doing its job.
-#[cfg(tokio_backend)]
-fn bind_beacon_udp_v6(port: u16) -> Option<Arc<UdpSocket>> {
-    use socket2::{Domain, Protocol, Socket, Type};
-
-    let sock = match Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)) {
-        Ok(s) => s,
-        Err(e) => {
-            debug!("v6 beacon socket: socket() failed: {e}; v6 beacon recv disabled");
-            return None;
-        }
-    };
-    if let Err(e) = sock.set_only_v6(true) {
-        debug!("v6 beacon socket: set_only_v6 failed: {e}");
-    }
-    // Mirror the v4 beacon socket setup: SO_REUSEADDR + SO_REUSEPORT so
-    // a server v6 SEARCH listener on `[::]:port` and a client v6 beacon
-    // listener can coexist. The server emits beacons FROM a separate
-    // ephemeral socket, so this REUSEPORT-shared listener only receives.
-    //
-    // SO_REUSEADDR on every platform, Windows included: pvxs puts its UDP
-    // sockets through `epicsSocketEnableAddressUseForDatagramFanout`
-    // (udp_collector.cpp:136), and that libcom helper has no `#ifdef
-    // _WIN32` — the Windows carve-out belongs to the TCP time-wait helper,
-    // not this one. Skipping it here would stop a second PVA process on a
-    // Windows host from co-binding the beacon port.
-    if let Err(e) = sock.set_reuse_address(true) {
-        debug!("v6 beacon socket: set_reuse_address failed: {e}");
-    }
-    #[cfg(unix)]
-    if let Err(e) = sock.set_reuse_port(true) {
-        debug!("v6 beacon socket: set_reuse_port failed: {e}");
-    }
-    if let Err(e) = sock.set_nonblocking(true) {
-        debug!("v6 beacon socket: set_nonblocking failed: {e}");
-        return None;
-    }
-
-    let bind = SocketAddr::V6(std::net::SocketAddrV6::new(
-        Ipv6Addr::UNSPECIFIED,
-        port,
-        0,
-        0,
-    ));
-    if let Err(e) = sock.bind(&bind.into()) {
-        debug!("v6 beacon socket: bind {bind} failed: {e}; v6 beacon recv disabled");
-        return None;
-    }
-
-    let std_sock: std::net::UdpSocket = sock.into();
-    let tokio_sock = match UdpSocket::from_std(std_sock) {
-        Ok(s) => Arc::new(s),
-        Err(e) => {
-            debug!("v6 beacon socket: tokio adoption failed: {e}");
-            return None;
-        }
-    };
-
-    // Join the default PVA v6 multicast group on the unspecified
-    // interface (let the OS pick). Additional groups from
-    // EPICS_PVA_ADDR_LIST are joined separately.
-    if let Err(e) = tokio_sock.join_multicast_v6(&DEFAULT_V6_MULTICAST_GROUP, 0) {
-        debug!(
-            "v6 beacon socket: join_multicast_v6 ff0e::400 failed: {e}; \
-             v6 multicast beacons will not be received"
-        );
-    }
-    Some(tokio_sock)
-}
-
 /// Project `EPICS_PVA_ADDR_LIST` endpoints to their multicast join
 /// targets. Each entry is `(group, iface)`:
 ///
@@ -1223,7 +1242,6 @@ fn bind_beacon_udp_v6(port: u16) -> Option<Arc<UdpSocket>> {
 /// An unresolvable `@iface` spec is skipped (logged). Pure given IP-literal
 /// `@iface` forms (`resolve_iface_v4` passthrough), so the projection is
 /// testable without real NIC multicast.
-#[cfg(tokio_backend)]
 fn addr_list_multicast_targets(
     endpoints: &[crate::config::Endpoint],
 ) -> Vec<(Ipv4Addr, Option<Ipv4Addr>)> {
@@ -1259,13 +1277,12 @@ fn addr_list_multicast_targets(
 /// disable the rest of the discovery path.
 ///
 /// A group with an explicit `@iface` modifier is joined on that interface
-/// alone via [`AsyncUdpV4::join_multicast_v4_on`]; a modifier-less group is
-/// joined on every external NIC. The previous code dropped the `@iface`
-/// and called the all-NIC [`AsyncUdpV4::join_multicast_v4`] for every
-/// group — the same `@iface`-dropping defect as the server beacon-join
-/// path, fixed here in the same change.
-#[cfg(tokio_backend)]
-pub(crate) fn join_addr_list_multicast(sock: &AsyncUdpV4, endpoints: &[crate::config::Endpoint]) {
+/// alone; a modifier-less group passes `0.0.0.0`, which the host arm expands
+/// to every external NIC and the exec arm hands to the routing table. The
+/// previous code dropped the `@iface` and joined all-NIC for every group —
+/// the same `@iface`-dropping defect as the server beacon-join path, fixed
+/// here in the same change.
+fn join_addr_list_multicast(sock: &SearchUdpSocket, endpoints: &[crate::config::Endpoint]) {
     // The endpoints were resolved once at config-build time through the
     // single address-list parser (`parse_endpoints_with_port`): split on
     // WHITESPACE only (pvxs `split_addr_into` — the comma is endpoint
@@ -1273,18 +1290,10 @@ pub(crate) fn join_addr_list_multicast(sock: &AsyncUdpV4, endpoints: &[crate::co
     // bracketed-v6 resolved the same way the active-SEARCH path does. We
     // keep only the V4 multicast groups here.
     for (group, iface) in addr_list_multicast_targets(endpoints) {
-        match iface {
-            Some(iface_ip) => match sock.join_multicast_v4_on(group, iface_ip) {
-                Ok(()) => debug!("joined multicast group {group} on interface {iface_ip}"),
-                Err(e) => debug!("join_multicast_v4_on {group}@{iface_ip} failed: {e}"),
-            },
-            None => {
-                if let Err(e) = sock.join_multicast_v4(group) {
-                    debug!("join_multicast_v4 for {group} failed: {e}");
-                } else {
-                    debug!("joined multicast group {group}");
-                }
-            }
+        let iface_ip = iface.unwrap_or(Ipv4Addr::UNSPECIFIED);
+        match sock.join_multicast_v4(group, iface_ip) {
+            Ok(()) => debug!("joined multicast group {group} on interface {iface_ip}"),
+            Err(e) => debug!("join_multicast_v4 {group}@{iface_ip} failed: {e}"),
         }
     }
 }
@@ -2169,14 +2178,12 @@ async fn maybe_poke(
 /// unicast target); `false` for broadcast / multicast.
 /// [`UdpTransport::broadcast`] uses it to pick which pre-built frame variant
 /// to send.
-#[cfg(tokio_backend)]
 #[derive(Clone, Copy, Debug)]
 struct SearchTarget {
     addr: SocketAddr,
     unicast: bool,
 }
 
-#[cfg(tokio_backend)]
 impl SearchTarget {
     fn broadcast(addr: SocketAddr) -> Self {
         Self {
@@ -2192,7 +2199,6 @@ impl SearchTarget {
     }
 }
 
-#[cfg(tokio_backend)]
 fn search_targets(
     bport: u16,
     auto_addr_list: bool,
@@ -2289,46 +2295,6 @@ fn search_targets(
     targets
 }
 
-/// Fan a limited-broadcast / multicast SEARCH out of exactly the
-/// `EPICS_PVA_INTF_ADDR_LIST` interfaces. Loopback is skipped — it cannot
-/// carry broadcast, and `list_broadcast_addresses_on` yields no broadcast
-/// target for a loopback-only list, so this is never reached for one.
-/// Best-effort: succeeds if any listed interface accepted the send, else
-/// returns the last error. With the all-NIC search bundle this reproduces
-/// the egress of the pre-fix interface-constrained bundle's `fanout_to`,
-/// while leaving explicit unicast to route across the full bundle via
-/// `pick_nic`.
-#[cfg(tokio_backend)]
-async fn fanout_on_interfaces(
-    socket: &AsyncUdpV4,
-    packet: &[u8],
-    dest: SocketAddr,
-    client_interfaces: &[Ipv4Addr],
-) -> std::io::Result<()> {
-    let mut ok = 0usize;
-    let mut last_err: Option<std::io::Error> = None;
-    for ip in client_interfaces {
-        if ip.is_loopback() {
-            continue;
-        }
-        match socket.send_via(packet, dest, *ip).await {
-            Ok(_) => ok += 1,
-            Err(e) => last_err = Some(e),
-        }
-    }
-    if ok > 0 {
-        Ok(())
-    } else {
-        Err(last_err.unwrap_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::AddrNotAvailable,
-                "no listed EPICS_PVA_INTF_ADDR_LIST interface available for broadcast fanout",
-            )
-        }))
-    }
-}
-
-#[cfg(tokio_backend)]
 impl UdpTransport {
     async fn broadcast(
         &self,
@@ -2387,11 +2353,10 @@ impl UdpTransport {
                         // all-NIC so explicit unicast routes via `pick_nic` below.
                         // Per-subnet directed broadcasts and explicit unicast take
                         // the `send_to` path.
-                        if client_interfaces.is_empty() {
-                            socket.fanout_to(pkt_v4, t).await.map(|_| ())
-                        } else {
-                            fanout_on_interfaces(socket, pkt_v4, t, client_interfaces).await
-                        }
+                        socket
+                            .fanout_to(pkt_v4, t, client_interfaces)
+                            .await
+                            .map(|_| ())
                     } else {
                         socket.send_to(pkt_v4, t).await.map(|_| ())
                     }
@@ -3298,7 +3263,6 @@ mod tests {
     use super::*;
     use crate::proto::{ByteOrder, WriteExt, encode_string_into};
     // Used only by the gated TCP-name-server tests (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
     use crate::proto::ControlCommand;
     use serial_test::serial;
 
@@ -4751,10 +4715,9 @@ mod tests {
     /// the Multi responder at deadline even with empty `accumulated`,
     /// so the user-visible future resolves to `Vec::new()` and any
     /// outer `PvaClient::timeout` gets a chance to apply.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "current_thread")]
     #[serial(epics_env)]
     async fn find_all_returns_empty_when_no_responder() {
@@ -4800,10 +4763,9 @@ mod tests {
     /// placed in a sid-hashed bucket up to 30 s away and never
     /// fired (the channel-layer timeout would have cancelled the
     /// caller's oneshot before any tick processed it).
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "current_thread")]
     #[serial(epics_env)]
     async fn reconnect_search_broadcasts_within_one_tick() {
@@ -4895,10 +4857,9 @@ mod tests {
     /// reintroduce a caller-side timeout (or change `find_all`'s
     /// empty-deadline behaviour to fire for `find` too) and
     /// silently revive the disconnect-storm bug.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "current_thread")]
     #[serial(epics_env)]
     async fn reconnect_find_does_not_complete_without_response() {
@@ -4978,10 +4939,9 @@ mod tests {
     /// We observe the BEHAVIOUR (SEARCH packet timing on a sniffer),
     /// not internal state, because internal fields aren't part of
     /// the engine's public contract.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "current_thread")]
     #[serial(epics_env)]
     async fn hurry_up_kicks_pending_searches_at_fast_tick_cadence() {
@@ -5074,10 +5034,9 @@ mod tests {
     ///
     /// Slack: ±500 ms per gap to absorb scheduler / mio jitter on
     /// loaded CI. Total runtime ~4 s.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "current_thread")]
     #[serial(epics_env)]
     async fn retry_escalation_pvxs_pattern() {
@@ -5148,9 +5107,11 @@ mod tests {
     /// `extra_targets`, and verifies `find()` resolves to the server's
     /// TCP endpoint. Regression guard against the v6 send path being
     /// dropped or the v6 recv arm losing the SEARCH_RESPONSE.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
+    // Gated to `tokio_backend`, and not because of the reactor: the subject is
+    // the IPv6 half, and `V6Socket` is uninhabited on `exec_backend` (both its
+    // binders are `socket2`, its receive is `tokio::net`). A v6 assertion there
+    // would be asserting about a socket that cannot exist.
+    #[cfg(tokio_backend)]
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial(epics_env)]
@@ -5242,9 +5203,11 @@ mod tests {
     /// port, and the advertised `response_port` inside the frame must
     /// equal it. Before the fix the v6 frame carried the v4 socket port
     /// (≠ source) and this assertion fails.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
+    // Gated to `tokio_backend`, and not because of the reactor: the subject is
+    // the IPv6 half, and `V6Socket` is uninhabited on `exec_backend` (both its
+    // binders are `socket2`, its receive is `tokio::net`). A v6 assertion there
+    // would be asserting about a socket that cannot exist.
+    #[cfg(tokio_backend)]
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial(epics_env)]
@@ -5314,7 +5277,7 @@ mod tests {
         // Use a unique broadcast port for this test so we don't fight
         // a parallel test or a local pva-rs IOC for the well-known
         // 5076 socket. Picks via OS-coordinated probe, drops, then
-        // passes the port directly to `bind_beacon_udp_v6`.
+        // passes the port directly to `V6Socket::bind_beacon`.
         let pick_port = || {
             let s = std::net::UdpSocket::bind("[::1]:0").expect("v6 probe bind");
             let p = s.local_addr().unwrap().port();
@@ -5323,16 +5286,11 @@ mod tests {
         };
         let port = pick_port();
 
-        let sock = bind_beacon_udp_v6(port)
+        let sock = V6Socket::bind_beacon(port)
             .expect("v6 beacon socket must bind on a host with IPv6 enabled");
-        let local = sock.local_addr().expect("local_addr");
-        assert!(
-            matches!(local.ip(), IpAddr::V6(_)),
-            "beacon socket must be IPv6; got {local}"
-        );
         assert_eq!(
-            local.port(),
-            port,
+            sock.local_port(),
+            Some(port),
             "beacon socket must bind the EPICS_PVA_BROADCAST_PORT we set"
         );
 
@@ -5344,9 +5302,11 @@ mod tests {
     /// recv arm decodes the beacon, the BeaconTracker observes the
     /// (server_addr, guid) pair, and `beacon_guid_for(addr)` returns
     /// the GUID we sent. Guards the full recv-decode-track chain.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
+    // Gated to `tokio_backend`, and not because of the reactor: the subject is
+    // the IPv6 half, and `V6Socket` is uninhabited on `exec_backend` (both its
+    // binders are `socket2`, its receive is `tokio::net`). A v6 assertion there
+    // would be asserting about a socket that cannot exist.
+    #[cfg(tokio_backend)]
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial(epics_env)]
@@ -5457,7 +5417,6 @@ mod tests {
     /// handle and is expected to `abort()` it.
     // Every caller is a gated TCP-name-server test, so it carries the same
     // predicate — otherwise dead code feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
     fn spawn_mock_name_server(
         ns_listener: tokio::net::TcpListener,
         ns_addr: SocketAddr,
@@ -5471,7 +5430,6 @@ mod tests {
     /// (clientconn.cpp:160-165, 496).
     // Same predicate as its wrapper: every caller is a gated
     // TCP-name-server test — otherwise dead code feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
     fn spawn_mock_name_server_watch(
         ns_listener: tokio::net::TcpListener,
         ns_addr: SocketAddr,
@@ -5641,7 +5599,6 @@ mod tests {
     /// assertion does not have to wait out the 15 s default.
     // Reactor-dependent: `interval`/`sleep` inside `ns_task` land on the
     // reactor-less callback pool feature-ON. Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial(epics_env)]
     async fn ns_circuit_echoes_like_an_ordinary_connection() {
@@ -5700,7 +5657,6 @@ mod tests {
     // Reactor-dependent: `dial_pva`'s tokio arm and `sleep` inside `ns_task`
     // land on the reactor-less callback pool feature-ON. Gated out
     // feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn ns_task_exits_when_the_engine_is_gone() {
         use tokio::net::TcpListener;
@@ -5761,10 +5717,9 @@ mod tests {
     /// With EPICS_PVA_AUTO_ADDR_LIST=NO the only resolution path is the TCP
     /// NS — pre-fix find() would time out because the NS was never wired into
     /// the search path; post-fix it resolves within the timeout.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial(epics_env)]
     async fn pva_r4_tcp_nameserver_persistent_peer() {
@@ -5831,10 +5786,9 @@ mod tests {
     ///
     /// The resolution half is what proves the degradation is not merely inert:
     /// SEARCH still goes out (over TCP) and the response still lands.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial(epics_env)]
     async fn stage1_name_servers_only_resolves_without_binding_udp() {
@@ -5909,10 +5863,9 @@ mod tests {
     /// name-server connections exactly as on normal servers (clientconn.cpp:215-263),
     /// rather than forcing anonymous. Captures the client's CONNECTION_VALIDATION
     /// reply on the mock NS and asserts the negotiated method + credentials.
-    // Reactor-dependent: spins the UDP search engine, whose spawned timers and
-    // socket land on the reactor-less callback pool feature-ON (§4.2 UDP search
-    // deferred). Gated out feature-ON (stage 3).
-    #[cfg(not(feature = "rtems-exec-model"))]
+    // `tokio::test` for the flavor, not for the transport: the engine binds a
+    // `SearchUdpSocket` on either backend, and this runs in the feature-ON
+    // suite (counted by the file's census marker).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial(epics_env)]
     async fn pva_rs_51_tcp_nameserver_selects_ca_with_credentials() {

--- a/crates/epics-pva-rs/src/client_native/server_conn.rs
+++ b/crates/epics-pva-rs/src/client_native/server_conn.rs
@@ -230,7 +230,7 @@ pub(crate) type DynWrite = Box<dyn tokio::io::AsyncWrite + Unpin + Send>;
 /// circuit (`tcpiiu.cpp:677-682`); pvxs derives one, and passing it twice is
 /// how this side states that its two pumps are one band by intent rather than
 /// by an API that could not express the difference.
-const PVA_CLIENT_PRIORITY: epics_base_rs::runtime::task::ThreadPriority =
+pub(super) const PVA_CLIENT_PRIORITY: epics_base_rs::runtime::task::ThreadPriority =
     epics_base_rs::runtime::task::ThreadPriority::Custom(18);
 
 /// Every TCP dial this client makes, on a bounded set of permanent threads.

--- a/crates/epics-pva-rs/src/config/env.rs
+++ b/crates/epics-pva-rs/src/config/env.rs
@@ -8,11 +8,8 @@
 //! not set, matching pvxs's `Config::server()` behavior.
 
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
-// Only the interface-enumeration surface is v4-specific, and that is
-// host-only (not `epics_embedded_target`) — see `Config`.
-#[cfg(not(epics_embedded_target))]
 use std::net::Ipv4Addr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
 /// Expand `$(VAR)` and `${VAR}` references in `input` against the
@@ -318,24 +315,22 @@ impl From<SocketAddr> for Endpoint {
 /// valid spec). Errs when the name has no IPv4 address so the caller can
 /// fall back (best-effort) rather than silently mis-route.
 ///
-/// Host-only: interface enumeration goes through `if-addrs`, which neither
-/// newlib (RTEMS) nor VxWorks's `libc` module provides `getifaddrs`/
-/// `ifaddrs` for (design doc §8.1). Every caller is in the host-only async
-/// I/O layer, so neither embedded target has a user for it; an embedded
-/// interface enumerator (libbsd `getifaddrs` or an ioctl walk, on whichever
-/// target grows one) is owed when the blocking PVA driver lands (§9 phase 6
-/// item 7).
-#[cfg(not(epics_embedded_target))]
+/// Enumerates through [`epics_base_rs::net::iface_v4`] rather than
+/// `if-addrs`, so it exists on every target. That is the enumerator the
+/// design doc's §8.1 item owed: newlib and VxWorks's `libc` module expose no
+/// `getifaddrs`, and `iface_v4` is the workspace's own walk against the BSP's
+/// interface table. The client's UDP SEARCH path needs `@iface` to resolve on
+/// the embedded targets too, and a name that silently failed to resolve there
+/// would send a multicast join out the wrong interface.
 pub fn resolve_iface_v4(spec: &str) -> Result<Ipv4Addr, String> {
     if let Ok(v4) = spec.parse::<Ipv4Addr>() {
         return Ok(v4);
     }
-    let ifaces = if_addrs::get_if_addrs().map_err(|e| format!("get_if_addrs failed: {e}"))?;
+    let ifaces = epics_base_rs::net::iface_v4::enumerate()
+        .map_err(|e| format!("interface enumeration failed: {e}"))?;
     for iface in ifaces {
         if iface.name == spec {
-            if let if_addrs::IfAddr::V4(v4) = iface.addr {
-                return Ok(v4.ip);
-            }
+            return Ok(iface.ip);
         }
     }
     Err(format!("interface {spec:?} has no IPv4 address"))
@@ -1335,24 +1330,19 @@ pub fn server_beacon_endpoints_opt() -> Option<Vec<Endpoint>> {
 /// requests / BEACONs across all subnets the host is attached to.
 /// Skips loopback and interfaces without a broadcast address.
 ///
-/// Host-only (not `epics_embedded_target`) for the same reason as
-/// [`resolve_iface_v4`].
-#[cfg(not(epics_embedded_target))]
+/// Enumerates through [`epics_base_rs::net::iface_v4`], so it exists on every
+/// target — see [`resolve_iface_v4`]. The eligibility and destination rules
+/// are `IfaceV4::search_destination`'s, which are C's
+/// (`osdNetIfAddrs.c:130-151`): up and non-loopback, the broadcast address
+/// unless it is `0.0.0.0`, else a point-to-point peer. The `if-addrs` version
+/// this replaces tested neither `IFF_UP` nor the point-to-point case, so a
+/// configured-but-down NIC contributed a destination and a VPN tunnel
+/// contributed none.
 pub fn list_broadcast_addresses(port: u16) -> Vec<SocketAddr> {
-    let mut out = Vec::new();
-    let Ok(ifaces) = if_addrs::get_if_addrs() else {
-        return out;
-    };
-    for iface in ifaces {
-        if iface.is_loopback() {
-            continue;
-        }
-        if let if_addrs::IfAddr::V4(v4) = iface.addr {
-            if let Some(bcast) = v4.broadcast {
-                out.push(SocketAddr::new(IpAddr::V4(bcast), port));
-            }
-        }
-    }
+    let mut out: Vec<SocketAddr> = epics_base_rs::net::iface_v4::broadcast_addrs()
+        .into_iter()
+        .map(|ip| SocketAddr::new(IpAddr::V4(ip), port))
+        .collect();
     // Always include limited broadcast as a fallback.
     out.push(SocketAddr::new(IpAddr::V4(Ipv4Addr::BROADCAST), port));
     out
@@ -1377,27 +1367,24 @@ pub fn list_broadcast_addresses(port: u16) -> Vec<SocketAddr> {
 ///   loopback-only list (`127.0.0.1`) yields an empty set and no
 ///   broadcast traffic leaves the host.
 ///
-/// Host-only (not `epics_embedded_target`) for the same reason as
-/// [`resolve_iface_v4`].
-#[cfg(not(epics_embedded_target))]
+/// Enumerates through [`epics_base_rs::net::iface_v4`], so it exists on every
+/// target — see [`resolve_iface_v4`].
 pub fn list_broadcast_addresses_on(interfaces: &[Ipv4Addr], port: u16) -> Vec<SocketAddr> {
     if interfaces.is_empty() || interfaces.iter().any(|ip| ip.is_unspecified()) {
         return list_broadcast_addresses(port);
     }
     let mut out = Vec::new();
     let mut any_non_loopback = false;
-    if let Ok(ifaces) = if_addrs::get_if_addrs() {
+    if let Ok(ifaces) = epics_base_rs::net::iface_v4::enumerate() {
         for want in interfaces {
             if want.is_loopback() {
                 continue;
             }
             for iface in &ifaces {
-                if let if_addrs::IfAddr::V4(v4) = &iface.addr {
-                    if &v4.ip == want {
-                        any_non_loopback = true;
-                        if let Some(bcast) = v4.broadcast {
-                            out.push(SocketAddr::new(IpAddr::V4(bcast), port));
-                        }
+                if &iface.ip == want {
+                    any_non_loopback = true;
+                    if let Some(dest) = iface.search_destination() {
+                        out.push(SocketAddr::new(IpAddr::V4(dest), port));
                     }
                 }
             }

--- a/doc/calink-rtems-design.md
+++ b/doc/calink-rtems-design.md
@@ -797,6 +797,12 @@ Which means: for CA, UDP search is deferred in §6 because it is *not needed for
 a record link*, not because it is *blocked*. That is a weaker reason, and the
 plan should say so rather than borrowing PVA's stronger one.
 
+> **DELIVERED 2026-07-28.** The CA client binds its SEARCH socket on every
+> backend through `epics_base_rs::net::search_udp::SearchUdpSocket`, at
+> libca's own `CAC-UDP` band (`udpiiu.cpp:128-132`). Measured on target:
+> `UDPSEARCH reply n=40 src=10.0.2.15:5064`. The analysis above is why it
+> was cheap; §6's ordering is unchanged.
+
 ### 4.5 What the target actually needs
 
 For stage C5's on-target gate, the guest IOC needs exactly:

--- a/doc/pvalink-rtems-design.md
+++ b/doc/pvalink-rtems-design.md
@@ -530,6 +530,18 @@ Any future "pvalink compiles for RTEMS" green must not be read as
 
 ### 4.2 TCP-only search works; UDP search must be a later stage
 
+> **DELIVERED 2026-07-28 — this section records the ordering, not the
+> current state.** The v4 UDP SEARCH transport is bound on every backend
+> now, through `epics_base_rs::net::search_udp::SearchUdpSocket`. Fact 3
+> below was the `sin_len` libc defect (§3.2), fixed in the pinned `libc`
+> patch: `local_addr()` reads back on RTEMS 6, MEASURED. Fact 1 stays true
+> and is why TCP-only came first; fact 2 stays true. What is still absent
+> is the IPv6 half alone — both its binders are `socket2` and its receive
+> is `tokio::net`, so `V6Socket` is an uninhabited enum on `exec_backend`.
+> Measured on target: `UDPSEARCH reply pv=RTEMS:PVA:AO
+> server=10.0.2.15:5075 proto=tcp version=2`, resolved by broadcast with no
+> name server configured.
+
 Three independent measured facts converge on the same ordering.
 
 1. **PVA is reachable over TCP alone.** `doc/rtems-scope-b-session-handoff.md`

--- a/doc/vxworks-port.md
+++ b/doc/vxworks-port.md
@@ -395,9 +395,11 @@ The script's whole matrix: six libs — `epics-libcom-rs`, `epics-base-rs`,
 `epics-bridge-rs` (`qsrv-core,pvalink`) — both bins with and without
 `bringup-probes`, and the ratchet row `epics-pva-rs --features client`, whose
 extracted count is **0 target errors**. That is the same zero the RTEMS gate
-reports, for the same reason (UDP search gated out, so `SearchTransport` has
-its single `NameServersOnly` variant) but through `epics_embedded_target`
-rather than `cfg(target_os = "rtems")`.
+reports, for the same reason (at the time of this run, UDP search gated out, so
+`SearchTransport` had its single `NameServersOnly` variant) but through
+`epics_embedded_target` rather than `cfg(target_os = "rtems")`. The zero has
+since survived the v4 SEARCH transport being compiled back **in** on both
+targets — see [§5.6](#56-udp-search-on-target).
 
 Run under shape 3 of §1.2 — stock `nightly` plus an explicit
 `VXWORKS_CARGO_CONFIG` patch pointing at the bring-up checkout (content now
@@ -622,6 +624,61 @@ the TLS spec of `doc/rtems-tls-spec-deviation.md`
 cargo +nightly build --target "$TGT" -Zbuild-std=std,panic_abort -Zjson-target-spec --release --config 'profile.release.strip="symbols"' --config 'profile.release.lto="fat"' --config profile.release.codegen-units=1 -p epics-ca-rs --bin realtime-ca-ioc --no-default-features --features client-core
 # Row5 fat+cgu1 PVA  (same configs) -p epics-bridge-rs --bin realtime-pva-ioc --no-default-features --features qsrv-core,pvalink
 ```
+
+### 5.6 UDP search on target
+
+Measured 2026-07-28, after the v4 SEARCH transport was compiled back in on
+both embedded targets. The subject is `epics_base_rs::net::search_udp::
+SearchUdpSocket`'s `exec_backend` arm, whose two portability risks here were
+never anything but compiled: `SO_RCVTIMEO` on the pump — this target refuses
+`SO_SNDTIMEO` with `ENOPROTOOPT` (§7), which is reason enough to doubt any
+timeout sockopt — and the raw-`libc` `SO_REUSEADDR`/`SO_REUSEPORT` bind the
+beacon shape needs.
+
+An RTP that binds the socket and nothing else, `x86_64-wrs-vxworks` release,
+1,736,544 B, on the §6 rig at 1024M:
+
+```
+-> VXUDP start exec_backend=true
+VXUDP ifaces local=10.0.2.15 broadcast=[10.255.255.255]
+VXUDP iface name=gei0 ip=10.0.2.15 up=true lo=false bcast=true search=Some(10.255.255.255)
+VXUDP iface name=lo0 ip=127.0.0.1 up=true lo=true bcast=false search=None
+VXUDP bound=[0.0.0.0:55599]
+VXUDP roundtrip sent=12 recv=12 src=127.0.0.1:55599 text=SEARCH-PROBE
+VXUDP fanout broadcast sends=1
+VXUDP beacon bound=[0.0.0.0:55600]
+VXUDP rebind_after_drop ok=[0.0.0.0:55600]
+VXUDP droptest ephemeral=59084
+VXUDP droptest reclaimed=[0.0.0.0:59084] same_port=true
+```
+
+Seven facts, each one an arm that had only been type-checked before:
+
+* **`exec_backend=true`** — the executor arm is what ran, by target predicate,
+  with `rtems-exec-model` absent (§2.1).
+* **Interface enumeration works.** `iface_v4` reads `gei0` and `lo0` off this
+  stack, and `search_destination()` gives the directed broadcast for `gei0` and
+  `None` for loopback — C's `osdNetIfAddrs.c:130-151` rule, on a BSD stack that
+  is not the one it was written against.
+* **`local_addrs()` reads back.** The RTEMS `sin_len` defect
+  (`doc/rtems-libc-sockaddr-len-bug.md`) has no counterpart here; the socket
+  can advertise the `response_port` a SEARCH frame carries.
+* **`SO_RCVTIMEO` is accepted.** The pump's `set_read_timeout` is fatal by
+  design and did not fire.
+* **The pump delivers.** `sent=12 recv=12` is a datagram through the pump
+  thread and its channel, not through a reactor.
+* **`fanout_to` expands the limited broadcast to one eligible NIC** — `gei0`,
+  loopback excluded.
+* **`Drop` releases the port synchronously.** An ephemeral socket sets no
+  `SO_REUSEPORT`, so a beacon can only take port 59084 back once `Drop` has
+  joined the pump thread that co-owns it. This is the on-target shape of the
+  host regression `beacon_binds_the_port_it_was_given`. The beacon→beacon
+  rebind on the line above proves less, since both set `SO_REUSEPORT`.
+
+No `FAIL` line, no ED&R entry, no exception. Rig: `~/vx-udps` on `gv100`,
+ports 51634/55164/55175, ftpd 2261, passive 60050-60055, console socket
+`/tmp/vxcon-udps.sock` — a port-shifted copy of §6, because that box also runs
+two long-lived RTEMS guests that must survive.
 
 ---
 

--- a/scripts/rtems-check.sh
+++ b/scripts/rtems-check.sh
@@ -478,17 +478,19 @@ fi
 #     29  after stages 1 and 2  cascade gone with search_engine's TcpStream
 #     28  after server_conn's unconditional tokio::net import was removed
 #      0  after stage 4         UDP transport cfg-gated out of the target build
+#      0  after the v4 SEARCH socket landed — transport compiled IN, still 0
 #
-# Stage 4 closed the remaining 28 (§5): the whole UDP SEARCH/beacon transport —
-# `client_native::udp`, the legacy `client_native::search`, and every UDP-only
-# item in `search_engine.rs` (the `SearchTransport::Udp` variant, `UdpTransport`
-# and its `bind_udp`/broadcast, the bind/join/fanout helpers, `SearchTarget`) —
-# is `#[cfg(not(target_os = "rtems"))]`. On the target `SearchTransport` has the
-# single `NameServersOnly` variant, so "no UDP socket" is a fact about the type
-# rather than a runtime branch, and the three UDP-config spawn entry points
-# construct `NameServersOnly` through `env_transport`/`config_transport`. This is
-# what lets the `epics-bridge-rs:realtime-pva-ioc --features qsrv-core,pvalink` bin
-# above pull `epics-pva-rs/client` and still compile for the target.
+# Stage 4 closed the remaining 28 (§5) by gating the whole UDP SEARCH/beacon
+# transport out of the target build. The v4 half is now compiled back IN and the
+# count is still zero: `search_engine.rs` binds through `SearchUdpSocket`, whose
+# `exec_backend` arm is one `std::net::UdpSocket` plus a receive-pump thread, and
+# `config::env`'s interface enumeration goes through
+# `epics_base_rs::net::iface_v4` instead of `if-addrs`. What stays absent is the
+# IPv6 half alone: `V6Socket` is an uninhabited enum there, so `socket2` and
+# `tokio::net` leave the target's compiled unit entirely — which is what keeps
+# this number at zero while the `epics-bridge-rs:realtime-pva-ioc --features
+# qsrv-core,pvalink` bin above pulls `epics-pva-rs/client` and still compiles
+# for the target.
 #
 # The count stays pinned even at zero: a probe that regressed the client back
 # off the target would raise it, and this comparison is what turns that into a
@@ -586,5 +588,5 @@ else
     log "crate and target binary compiles for the generated native-TLS spec, in"
     log "both the portability and the image configuration."
 fi
-log "PVA client (--features client): $PVA_CLIENT_TARGET_ERRORS target errors (UDP transport cfg-gated out)."
+log "PVA client (--features client): $PVA_CLIENT_TARGET_ERRORS target errors (v4 UDP transport compiled in; only the IPv6 half is absent)."
 log "CA client: built, not probed (CRATE_FEATURES[epics-ca-rs]=client-core)."

--- a/scripts/rtems-check.sh
+++ b/scripts/rtems-check.sh
@@ -167,8 +167,8 @@ CRATES=(epics-libcom-rs epics-base-rs epics-ca-rs epics-pva-rs epics-rtems-boot 
 # CHOICE. `qsrv-core,pvalink` and not the full `qsrv`: `qsrv` additionally
 # implies `qsrv-bin` machinery this target never runs, but `pvalink` — the
 # pva:// record-link resolver — is now on the target (design stage 4). It pulls
-# `epics-pva-rs/client`, whose UDP transport is cfg-gated out so the client
-# compiles for the triple (the ratchet probe below measures zero), and does NOT
+# `epics-pva-rs/client`, whose v4 UDP transport compiles for the triple through
+# `SearchUdpSocket` (the ratchet probe below measures zero), and does NOT
 # pull `tls`/`pkcs12` (no `ring`, no `getrandom 0.2`) because the bridge's
 # `epics-pva-rs` dependency is `default-features = false`. Before stage 4 this
 # was `qsrv-core` alone, because `client_native` was 47 errors on this target
@@ -556,14 +556,15 @@ fi
 #      0  stage C5              UDP SEARCH cfg-gated out of the target build
 #
 # Stage C5 closed the remaining 10 the way PVA stage 4 closed its 28, and for
-# the same reason: they were all UDP. On the target `search::SearchTransport`
-# has the single `NameServersOnly` variant — `UdpTransport`, `bind_udp`, the
-# fanout/DNS-refresh helpers, `run_search_engine` and the whole
-# `EPICS_CA_ADDR_LIST` parse (`AddrEntry`, `resolve_host`,
-# `parse_addr_list_with_hostnames`, `append_auto_addr_entries`) are
-# `#[cfg(not(target_os = "rtems"))]`. "No UDP socket" is a fact about the type,
-# not a runtime branch, and `CaClient::new_with_config` reaches
-# `name_servers_only_search_engine` by `cfg` rather than by choice.
+# the same reason: they were all UDP. That row is history, not the current
+# shape: the SEARCH socket has since come back, on every backend, through
+# `SearchUdpSocket`. `UdpTransport`, `bind_udp`, the fanout/DNS-refresh
+# helpers, `run_search_engine` and the whole `EPICS_CA_ADDR_LIST` parse
+# (`AddrEntry`, `resolve_host`, `parse_addr_list_with_hostnames`,
+# `append_auto_addr_entries`) are ungated, and `CaClient::new_with_config`
+# reaches `name_servers_only_search_engine` by configuration rather than by
+# `cfg`. "No UDP socket" is still a fact about the type — `NameServersOnly`
+# holds none — but it is no longer a fact about the target.
 #
 # The probe is RETIRED rather than left pinned at zero, and the replacement is
 # STRICTER, not looser: `CRATE_FEATURES[epics-ca-rs]="client-core"` above makes

--- a/scripts/vxworks-check.sh
+++ b/scripts/vxworks-check.sh
@@ -593,7 +593,7 @@ log "VxWorks gate (toolchain $TOOLCHAIN): every crate and target binary compiles
 log "for $TARGET, in the portability configuration — which is the only"
 log "configuration this target has, permanently: there is no C of ours to link,"
 log "so there is no image-closure cfg for a second one to name."
-log "PVA client (--features client): $VXWORKS_PVA_CLIENT_TARGET_ERRORS target errors (UDP transport cfg-gated out)."
+log "PVA client (--features client): $VXWORKS_PVA_CLIENT_TARGET_ERRORS target errors (v4 UDP transport compiled in; only the IPv6 half is absent)."
 log "CA client: built, not probed (CRATE_FEATURES[epics-ca-rs]=client-core)."
 # Repeated at the end, not only at the top: a green summary is what gets pasted
 # into a report, and it must say which resolution the rows measured — the

--- a/scripts/vxworks-check.sh
+++ b/scripts/vxworks-check.sh
@@ -549,12 +549,12 @@ fi
 #
 # Zero is MEASURED on the box against the merged tree, not carried over from
 # the RTEMS gate's identical-looking zero. The two zeroes have the same cause —
-# the UDP search/beacon transport is gated out, so `SearchTransport` has its
-# single `NameServersOnly` variant and "no UDP socket" is a fact about the type
-# rather than a runtime branch — but on RTEMS that gating is spelled
-# `cfg(target_os = "rtems")`, which is FALSE for `target_os = "vxworks"`. A gate
-# that assumed the RTEMS zero would have been asking cargo to compile the
-# hosted tokio/UDP path for a tier-3 target that has no tokio.
+# the v4 SEARCH transport binds through `SearchUdpSocket`, whose `exec_backend`
+# arm names no tokio and no `socket2`, and only the IPv6 half is left out — but
+# the arms that reach that shape used to be spelled `cfg(target_os = "rtems")`,
+# which is FALSE for `target_os = "vxworks"`. A gate that assumed the RTEMS
+# zero would have been asking cargo to compile the hosted tokio/UDP path for a
+# tier-3 target that has no tokio.
 #
 # What makes it zero here is the embedded-target cfg that widened those arms to
 # cover both RTOSes. This ratchet is therefore only meaningful on a tree that


### PR DESCRIPTION
On the exec backend the CA and PVA *clients* bound no UDP socket by type, so a target IOC's own `ca://`/`pva://` record links resolved only through an explicitly configured `EPICS_*_NAME_SERVERS` — a PV reachable only by broadcast never connected, and did so silently. Both targets are verified at runtime, not just cross-compiled: RTEMS resolves `RTEMS:PVA:AO` by broadcast with no name server (the reply's GUID matches the IOC's own), and the VxWorks transcript with its seven claims is in `doc/vxworks-port.md` §5.6. The IPv6 half stays out of the embedded targets deliberately — `V6Socket` is an uninhabited enum there, which is why both ratchets still read 0 target errors with v4 compiled in.