### PR TITLE
release: v0.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,86 @@
 # Changelog
 
+## v0.25.3 — 2026-07-30
+
+Patch release. The CA and PVA *clients* now bind a UDP SEARCH socket on the
+embedded targets, closing a gap that made a broadcast-only PV silently
+unreachable from an RTEMS or VxWorks IOC. Both halves are verified on target,
+not merely cross-compiled. The CA blocking server's accepted clients get
+`SO_KEEPALIVE`, as C's do. Workspace version 0.25.2 -> 0.25.3.
+
+### The clients bind a SEARCH socket on every backend
+
+On `exec_backend` the CA and PVA clients bound no UDP socket **by type**: the
+transport was selected by `cfg`, so a target IOC's own `ca://` and `pva://`
+record links could resolve only through an explicitly configured
+`EPICS_CA_NAME_SERVERS` / `EPICS_PVA_NAME_SERVERS`. A PV reachable only by
+broadcast never connected, and did so without a diagnostic. The server side was
+already complete; this was the client half alone.
+
+- **`epics_base_rs::net::search_udp::SearchUdpSocket`** is the one type both
+  clients bind. On `tokio_backend` it delegates to the existing per-NIC
+  `AsyncUdpV4` bundle unchanged. On `exec_backend` it is a single wildcard
+  `std::net::UdpSocket` plus a receive-pump thread — libca's own model
+  (`udpiiu.cpp:174` creates one socket, not a per-NIC bundle). `Drop` joins the
+  pump: the pump co-owns the socket, so a stop flag alone leaves the port held
+  for up to the pump's wake interval and the next bind fails `AddrInUse`.
+
+- **`epics_base_rs::net::iface_v4`** enumerates IPv4 interfaces through
+  `getifaddrs`, which RTEMS 6 and VxWorks 7 both provide, replacing the
+  `if-addrs` dependency that builds for neither. `IfaceV4::search_destination()`
+  is C's rule from `osdNetIfAddrs.c:130-151`. The stubs it replaces returned
+  nothing on the embedded targets, so `EPICS_CA_AUTO_ADDR_LIST=YES` — C's
+  default, and the whole of an unconfigured site's discovery — expanded to an
+  empty list there.
+
+- **`fanout_to` takes the operator's egress constraint as a parameter** rather
+  than exposing a second entry point, so "which interfaces may this leave
+  through" is one question with a default answer instead of one a caller can
+  ask on one path and forget on another.
+
+- Two host-visible behaviour changes follow from sourcing everything through
+  `iface_v4`, both toward C: interface enumeration now tests `IFF_UP`, and
+  point-to-point peer addresses are included.
+
+- The IPv6 half stays out of the embedded targets deliberately. Both its
+  binders are `socket2` and its receive is `tokio::net`, so `V6Socket` is an
+  uninhabited enum on `exec_backend` — `Option<V6Socket>` is `None` by
+  construction and neither crate reaches the target's compiled unit. That is
+  why both cross-compile ratchets still read zero target errors with the v4
+  transport compiled in.
+
+### Measured on target
+
+- RTEMS 6 (QEMU xilinx-zynq-a9): `realtime-pva-ioc` resolved `RTEMS:PVA:AO` by
+  broadcast with **no name server configured** — the SEARCH response carried
+  the IOC's own GUID.
+- VxWorks 7 (`x86_64-wrs-vxworks`): a probe RTP exercised the bind, the
+  interface walk, the pump round-trip, the broadcast fanout and the
+  `Drop`-releases-the-port regression. `SO_RCVTIMEO` is accepted here; it is
+  `SO_SNDTIMEO` that this target refuses with `ENOPROTOOPT`, and the pump sets
+  none. Transcript and its seven claims: `doc/vxworks-port.md` §5.6.
+
+### A wedged CA client is reaped again on the embedded targets
+
+`handle_client_blocking` had no `SO_KEEPALIVE`. `write_frame_locked` parks in
+`write_all` under the send lock, which is C's shape — `cas_send_bs_msg` loops on
+a blocking `send()` under `SEND_LOCK` with no bound either — and C survives it
+because `create_client` sets the option on every accepted socket. The hosted
+driver did so through `socket2`, which builds for neither embedded triple, so
+the reactor-free driver had the option nowhere.
+`runtime::socket::enable_keepalive` now carries it, and `set_nodelay` stops
+being best-effort in the same breath: C refuses the client when either option
+fails.
+
+### One flaky executor test closed
+
+`a_yielding_task_releases_the_worker_to_a_queued_task` held its slow task for
+a fixed number of yields and asserted the queued task arrived first — true
+only if the test thread enqueues that task before the worker exhausts the
+count, which under load it does not. The slow task is now gated by the test
+thread, so its own stated precondition holds by construction. Measured at
+5/400 failures pinned to one CPU before, 0/400 after.
+
 ## v0.25.2 — 2026-07-28
 
 Patch release. Three on-target rounds on the VxWorks 7 guest and the armv7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "bitflags",
  "chrono",
@@ -994,7 +994,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "cc",
  "libc",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2241,7 +2241,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3209,7 +3209,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3828,7 +3828,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"


### PR DESCRIPTION
Patch: no BREAKING footer over the 5 commits since v0.25.2, and the three `-pub fn` lines in the diff are cfg-stub arms folded into one ungated definition, all three still public at HEAD. Dry-run packaged and verified all 19 crates at 0.25.3.