### PR TITLE
doc(rtems): recover 13 design and audit records stranded on a diverged local main

### DIFF
--- a/doc/pi-lock-evaluation.md
+++ b/doc/pi-lock-evaluation.md
@@ -306,3 +306,215 @@ same change as 0a/0b, while that context is open.
 * **The three modified files are uncommitted.** If the concurrent panel amends
   or drops those edits, rows marked ⚠ **moved** revert and §6 steps 0a/0b return
   to the list.
+
+---
+
+## §8 `epics-pva-rs` lock sweep — closing §7's named gap
+
+Read-only. Appendable to `doc/pi-lock-evaluation.md` as §8; lock IDs continue the
+parent table's numbering (parent ends at L15).
+
+**Provenance.** `crates/epics-pva-rs` read in
+`/home/stevek/work/epics-rs/.caucus/worktrees/integration` @ **`2ce9bd11`**
+(branch `integration/rtems-scope-b`). HEAD unchanged start to end, but the
+working tree **went dirty mid-sweep** (as in §0): a concurrent panel's
+`PvaServerConfig` extraction modified `server_native/{mod,runtime,tcp}.rs` and
+added `server_native/config.rs`. Re-verified against the final state — `tcp.rs`
+is unaffected in every respect cited here (still 21,378 lines, test module still
+at `:8097`, production still lock-free, imports still `:25`/`:26`/`:30`);
+`runtime.rs` lost 494 lines to `config.rs` and **both** are lock-free in
+production; only `mod.rs`'s gate line numbers shifted +3, and the numbers below
+are the post-move ones. Planned-thread classification is against
+`doc/pva-rtems-item7-design.md` in that same worktree. (d) is answered: **pvxs is
+present** at `/home/stevek/work/epics-modules/pvxs` @ `9348ebc` — the
+CLAUDE.md-listed `/Users/stevek/...` path does not exist on this host, the
+documented fallback does.
+
+---
+
+### §8.0 Headline — three findings
+
+**1. The PVA protocol scope is lock-free, and that is the opposite of the base
+picture.** `server_native/tcp.rs` production (lines 1-8096; the test module
+starts at `:8097`) contains **zero** `Mutex`/`RwLock`/`Condvar` — the only match
+in 8096 lines is the words `Arc<Mutex<SrvWrite>>` inside a doc comment at
+`:2841` explaining what the design *replaced*. Per-connection state is carried
+by `Arc`, `AtomicU32`/`AtomicU64` and `tokio::sync::mpsc` (`tcp.rs:25-30`).
+`udp.rs`, `runtime.rs`, `accept.rs`, `monitor_control.rs`, `op_handle.rs` and
+`server_info.rs` are likewise lock-free in production — as is the newly
+extracted `config.rs`. So the whole 21,378-line
+TCP module contributes **no rows to this table**. Item 7's thread-per-connection
+split therefore does not multiply lock contention in the protocol path — a
+materially better starting position than `epics-base-rs`, where 25 shared locks
+sit under the record path.
+
+**2. Where the port does hold locks, they are almost all `parking_lot` — so
+unlike the parent sweep, PI is actually reachable here.** Of **21 distinct
+server-side locks**, 17 are `parking_lot`, 3 are `std::sync`, and exactly
+**one** is `tokio::sync` (L23, the ACF cell). The parent table's dominant class —
+park_on-PI-invisible, 14 of 25 — is here a **single row**. `epics-pva-rs` never
+re-exports `runtime::sync`, so it never fell into the naming trap that made
+`database/mod.rs:19` and `pv.rs:4` silently async.
+
+**3. The item-7 design assigns no thread priorities, so it would re-open the
+exact asymmetry §6 steps 0a/0b just closed for CA.** `rg -i "priorit|ThreadPriority|apply_to_current_thread"`
+over `doc/pva-rtems-item7-design.md` returns **nothing**. The three planned
+threads — `PVAS-client {peer}` (`§2` of that doc, replacing `tcp.rs:2539`),
+`PVAS-UDP` (replacing the `:962-975` spawn), `PVAS-beacon` (replacing
+`udp.rs:500`) — would run SCHED_OTHER while the callback bands that *post* to
+them run 59-71. Every "shared" row below is shared precisely across that line.
+
+---
+
+### §8.1 (a)+(b)+(c) The table
+
+**Kind** as in §2: `PL` = `parking_lot`, `STD` = `std::sync` (both kernel-visible,
+PI-able by replacement), `TOK` = `tokio::sync` (awaited; park_on-invisible).
+
+**Shared?** — the blocking PVA driver does not exist yet, so per the brief every
+row is classified against the *planned* item-7 threads, not live ones. `now` =
+already shared today on the hosted tokio server; `item 7` = becomes shared when
+the planned threads land; `gated` = module is `#[cfg(not(target_os = "rtems"))]`
+today (`server_native/mod.rs:24,34,36,41,43` — `accept`, `peers`, `runtime`,
+`tcp`, `udp`) so it has no RTEMS presence until item 7 un-gates it.
+
+| # | lock | decl / evidence | Kind | shared? | class | pvxs parity |
+|---|---|---|---|---|---|---|
+| **L16** | `SharedPV::inner` | `shared_pv.rs:468` `Arc<Mutex<Inner>>` (`parking_lot`, import `:31`); ~30 acquisitions `:495`-`:975`; write side `try_post_checked` `:650`, `put_delta` `:798`; read side `:602`,`:610`,`:640` | **PL** | **now** — cb band posts, connection thread reads | **replace-with-PI** — the top row of this sweep | `sharedpv.cpp:37` `mutable epicsMutex lock` — **PI on RTOS** |
+| **L17** | `MonitorQueue::inner` | `shared_pv.rs:159` `Mutex<MonitorQueueInner<T>>` (PL); producer `post` `:235`,`:239`,`:282`,`:305`; consumer `try_recv` `:347`,`:348` | **PL** | **now** — producer is the posting band, consumer is the per-connection thread | **replace-with-PI** — the cleanest high/low split in the crate | `servermon.cpp:57` `mutable epicsMutex lock` — **PI on RTOS** |
+| **L18** | `PvRegistry::pvs` | `shared_pv.rs:1218` `Mutex<HashMap<String, SharedPV>>` (PL); `:1287`,`:1332`,`:1348`,`:1391`,`:1399`,`:1404`,`:1412`,`:1417`,`:1426`,`:1448` | **PL** | **item 7** — `PVAS-UDP` search + `PVAS-beacon` `list_pvs` vs. registration | **accept-with-bounded-CS** (§8.2) | no counterpart — pvxs `StaticSource` is reactor-confined |
+| **L19** | `PvRegistry::invalidator` | `shared_pv.rs:1245` `Mutex<Option<ChannelInvalidator>>` (PL); `:1295`, `:1392` — **both taken while `pvs` is held**, ordering pvs→invalidator | **PL** | **item 7** | **accept-with-bounded-CS**; one `Option` clone | — |
+| **L20** | `CompositeSource::entries` | `composite.rs:38`,`:65` `Arc<parking_lot::RwLock<Vec<SourceEntry>>>`; writes `:108`,`:128`, read `:160` | **PL** | **item 7** — every channel lookup from every connection thread | **accept-with-bounded-CS** — writes are registration-time only | — (reactor-confined) |
+| **L21** | `RemoteLogQueue::queued` | `source.rs:51` `Arc<Mutex<Vec<RemoteLogMessage>>>` (`std::sync`, import `:7`); `:66` push, `:76` drain via `mem::take` | **STD** | **item 7** | **accept-with-bounded-CS** — push/`mem::take`, no allocation held | `log.cpp` uses `epicsMutex` |
+| **L22** | `ChannelInvalidator::subscribers` | `source.rs:440` `Arc<std::sync::Mutex<Vec<mpsc::UnboundedSender<Arc<[String]>>>>>`; `:457`, `:470` | **STD** | **item 7** | **accept-with-bounded-CS** — `Vec` retain over subscriber senders | — |
+| **L23** | PVA `AcfCell` | `server/native_source.rs:30` `Arc<RwLock<Option<AccessSecurityConfig>>>` — **tokio** (import `:21`); written `pva_server.rs:145`,`:162` `.write().await`; read in base at `access_security.rs:317` `.read().await` | **TOK** | **item 7** — read on every access check from every connection thread | **(c) park_on — PI-invisible**; also **accept** (read-mostly, written only by `reload_acf_from`/`clear_acf`) | `asLock` family; pvxs delegates to base |
+| **L24** | `PeerEntry` ×3: `report_info` `peers.rs:47`, `credentials` `:130`, `channels_by_sid` `:137` | all `parking_lot::Mutex`; `:68`,`:168`,`:179`,`:186`,`:247`,`:254`,`:320`,`:323`,`:329` | **PL** ×3 | **gated** → item 7 | **accept-with-bounded-CS** — per-peer, and the introspection reader is the only cross-thread acquirer | **none** — pvxs `serverconn.h`/`server.h` declare **no mutex at all** |
+| **L25** | `PeerRegistry::inner` | `peers.rs:201` `parking_lot::RwLock<HashMap<SocketAddr, Arc<PeerEntry>>>`; `:210` insert, `:214` remove, `:229`/`:265` read — `:229-254` holds the registry read **across** `channels_by_sid.lock()` and `report_info.lock()`, ordering registry→entry→channel | **PL** | **gated** → item 7 | **accept-with-bounded-CS**, with the nesting named (§8.2) | **none** — same as L24 |
+| **L26** | `client_native` ×11: `channel.rs:77` `state` (PL RwLock, import `:26`), `:80` `transition_lock` (**tokio**, import `:27`), `:100`,`:112`,`:128`,`:143`,`:155`,`:186`,`:195`,`:196`,`:203` (PL) | see decls | mixed **PL**/**TOK** | **never** — `#[cfg(feature = "client")]` (`lib.rs:22`,`:24`; `Cargo.toml:97`), and the client is gate-out territory on RTEMS by explicit scope decision (`Cargo.toml:93-95`) | **out of scope** — one-line note, not classified | `clientimpl.h` uses `epicsMutex` |
+| **L27** | `client_native` rest: `server_conn.rs:111`,`:923` (PL), `context.rs:376` (PL RwLock), `beacon_throttle.rs:72` (PL RwLock), `udp.rs:86`,`:87`,`:211` (`std::sync`), `ops_v2.rs:1908`,`:1917` (PL) | see decls | mixed | **never** — same gate as L26 | **out of scope** | `udp_collector.cpp:597` `epicsMutex lock` |
+
+**Server-side totals (L16-L25): 21 distinct locks** — 17 `PL`, 3 `STD`, 1 `TOK`.
+Client-side (L26-L27): 20 further locks, all behind `feature = "client"`, not
+classified.
+
+**(c) The park_on set is one row: L23.** It is the only `tokio::sync` primitive
+a planned blocking PVA thread would wait on, and it reaches
+`access_security.rs:317`'s `.read().await` — under a `PVAS-client` thread that
+becomes `block_on_sync` → `park_on` → `std::thread::park()`
+(`epics-base-rs/src/runtime/task.rs:80`), invisible to the kernel PI chain for
+the reasons given in §3. Consequence for L23 specifically is mild: it is a
+read-mostly cell whose only writers are `reload_acf_from`/`clear_acf`
+(`pva_server.rs:145`,`:162`), so the inversion window is an operator action, not
+a steady-state path. **No other PVA lock is park_on-reachable** — which is why
+the parent sweep's dominant class is nearly empty here.
+
+---
+
+### §8.2 (b) Rationale for the non-obvious rows
+
+**replace-with-PI (L16, L17).** Both are `parking_lot` mutexes with no `.await`
+in the critical section (guaranteed by type — `parking_lot::MutexGuard` is
+`!Send`). Both sit exactly on the band/connection boundary: the poster is
+whatever thread drives record processing (a callback band in an IOC), the reader
+is the per-connection thread that item 7 will create. **L17 is the higher-value
+of the two**: it is the narrowest lock with the clearest producer/consumer split
+(`post` `:235` vs `try_recv` `:347`), so a PI swap there is a contained change.
+L16 is the broader one (~30 acquisition sites) and should follow L17.
+
+Note the nesting: `try_post_checked` (`:650`) and `put_delta` (`:798`) hold
+`SharedPV::inner` **while** calling `tx.post(...)` (`:664`, `:837`), which takes
+`MonitorQueue::inner`. Ordering is uniformly L16→L17. Any PI conversion must
+convert them together or the donated priority stops at the outer lock.
+
+**accept-with-bounded-CS (L18-L22, L24, L25).** Bounds, stated:
+* **L18** — one hash probe plus a `SharedPV` clone (itself an `Arc`); the two
+  cross-lock sites (`:1391-1392`, `:1287-1295`) additionally clone one `Option`.
+* **L19** — a single `Option<ChannelInvalidator>` clone.
+* **L20** — writes only at source registration (`:108`, `:128`); the hot path is
+  the `:160` read, a `Vec` iteration over registered sources (small N).
+* **L21** — `Vec::push` and `mem::take` (`:76`); the drain moves the buffer out
+  rather than iterating under the lock.
+* **L22** — `Vec` retain over subscriber senders.
+* **L24/L25** — per-peer fields; the only cross-thread reader is the
+  introspection/`snapshot` path (`:229-254`, `:320-329`). Bound is O(peers ×
+  channels) **and it is held across two nested locks**, so it is the one
+  "accept" row with a real tail: a `snapshot` during a large channel population
+  blocks peer insert/remove at `:210`/`:214`. Acceptable because `snapshot` is
+  an operator/introspection call, not a per-datagram path — but that is the
+  invalidating condition, and it should be named in the code rather than left to
+  a reader to infer.
+
+**No remove-the-sharing rows.** The parent table had two (L8 subset, L14) because
+base holds init-time-write state behind runtime locks. The PVA server does not:
+L20's writes are registration-time but the lock is still needed for the hot read
+path (sources can be added after start), and L18/L19 are genuinely dynamic.
+
+---
+
+### §8.3 (d) pvxs parity — and why it is mostly "no counterpart"
+
+pvxs @ `9348ebc`. Where pvxs holds a lock, it is an `epicsMutex` — i.e. the same
+`PTHREAD_PRIO_INHERIT` / `RTEMS_INHERIT_PRIORITY` family established in §5:
+
+* `sharedpv.cpp:37` `mutable epicsMutex lock` (guards typedef'd at `:22-23`,
+  taken at `:86`,`:167`,`:197`,`:214`,`:239`,`:259`,`:267`,`:283`) ↔ **L16**.
+* `servermon.cpp:57` `mutable epicsMutex lock` (`:111`,`:201`,`:267`,`:305`,
+  `:331`) ↔ **L17**.
+* `udp_collector.cpp:597` `epicsMutex lock` ↔ **L27** (client side).
+
+But for the rows that came out of *our* threading model, pvxs has nothing to
+compare against: `rg "epicsMutex|Guard G\("` over `server.cpp`, `serverconn.cpp`,
+`server.h`, `serverconn.h`, `serverimpl.h` returns **zero matches**. pvxs runs
+one libevent reactor thread and confines connection and peer state to it, so
+there is no peer-registry lock to be PI or not (**L24, L25**), and no
+source-registry lock on the hot path (**L20**).
+
+**The parity verdict is therefore two-sided, and the second half is the
+important one:**
+
+1. Both locks pvxs *does* have are PI on an RTOS; neither of our counterparts
+   (L16, L17) is. That is a straight parity gap, and it is fixable by type
+   replacement because both are `parking_lot`.
+2. Four of our rows exist **only because item 7 replaces one reactor with N
+   threads** (L20, L24, L25, and L18's cross-thread reader). Item 7 does not
+   inherit these from pvxs — it creates them. The §6 execution order should
+   treat them as new debt introduced by the port's threading model, not as
+   parity work.
+
+This also retires the caveat in the brief ("pvxs single-reactor has no
+lock-per-lock analogue anyway"): it has an analogue for exactly the two rows
+that matter most, and its *absence* elsewhere is itself the finding.
+
+---
+
+### §8.4 Where this fits in §6's execution order
+
+These do not displace §6 steps 1-2; they slot in as a PVA track that only
+becomes live when item 7 lands.
+
+| slot | step | rationale |
+|---|---|---|
+| **before item 7 stage C** | **Assign priorities to `PVAS-client`, `PVAS-UDP`, `PVAS-beacon` in the item-7 design.** The design currently names none (§8.0 finding 3). C has no PVA precedent, but `ThreadPriority::CaServerLow`/`CaServerHigh` (`task.rs:370-371`) is the obvious mapping, matching what `blocking.rs:200`/`:669` just did for CA. Cheapest possible moment is before the threads are written. | prevents re-opening the asymmetry §6 0a/0b closed |
+| **with §6 step 3-4** | **L17 → PI, then L16 → PI** (in that order; convert together per the L16→L17 nesting). Both `parking_lot`, both with a pvxs `epicsMutex` precedent. | closes the only genuine C++-parity lock gap in the crate |
+| **with §6 step 7** | **L23** — inherits whatever §6 step 1 decides for tokio-locked shared cells; low urgency (operator-action writer only). | shares L1's constraint, not its severity |
+| **item 7 review gate** | **Name L25's `snapshot` bound in code**, and re-check L18/L20 if sources or PVs become registerable from a datagram path. | the two "accept" rows with a stated invalidating condition |
+
+---
+
+### §8.5 What this sweep does not establish
+
+* **Nothing measured** — static analysis only, same caveat as §7.
+* **The producer identity for L16/L17 is inferred from the API, not traced to a
+  band.** `SharedPV::post`'s only production callers inside `epics-pva-rs` are
+  its own internals; the cross-crate producer lives in `epics-bridge-rs`
+  (`qsrv/pva_adapter.rs:85` `PvaPvHandle::post`, whose own
+  `subscribers: Arc<parking_lot::Mutex<...>>` at `:50`/`:67`/`:93` is a **22nd
+  lock in a crate this brief did not scope**). Whether that call arrives on a
+  callback band or a tokio worker depends on the bridge's emission path, which I
+  did not trace.
+* **`epics-bridge-rs` was not swept** — `pva_adapter.rs:50` is one confirmed
+  shared lock there; the population is unknown. That is the next gap, exactly as
+  `epics-pva-rs` was this one.
+* **Client-side (L26, L27, 20 locks) is enumerated but not classified**, per the
+  RTEMS scope decision at `Cargo.toml:93-95`. If a PVA gateway on RTEMS ever
+  comes back into scope, that classification is owed.

--- a/doc/pi-lock-evaluation.md
+++ b/doc/pi-lock-evaluation.md
@@ -518,3 +518,210 @@ becomes live when item 7 lands.
 * **Client-side (L26, L27, 20 locks) is enumerated but not classified**, per the
   RTEMS scope decision at `Cargo.toml:93-95`. If a PVA gateway on RTEMS ever
   comes back into scope, that classification is owed.
+
+---
+
+## §9 `epics-bridge-rs` lock sweep + the L16/L17 producer trace
+
+Read-only. Appendable to `doc/pi-lock-evaluation.md` as §9; lock IDs continue
+after §8's L27.
+
+**Provenance.** `crates/epics-bridge-rs` read in
+`/home/stevek/work/epics-rs/.caucus/worktrees/integration` @ **`42a42abf`**
+(branch `integration/rtems-scope-b`) — the concurrent panel's `PvaServerConfig`
+extraction, in flight during §8, has landed; HEAD moved `2ce9bd11` → `42a42abf`
+before this sweep began. HEAD `42a42abf` and a **clean** working tree at start,
+mid-sweep and end — no file cited here went dirty, so no re-verification was
+owed.
+
+**(d) column skipped.** qsrv's upstream is `pva2pva`/`qsrv`, which is not on this
+host: `/home/stevek/work/epics-modules` holds 30 modules but no `pva2pva` or
+`qsrv` (nearest neighbours are `pvxs` and `ca-gateway`), and `/home/stevek/codes`
+holds four unrelated projects. Per the brief this is a skip, not a stop — and
+the bridge is largely port-original anyway, so most rows would have no
+counterpart even with the source present.
+
+---
+
+### §9.0 The L16/L17 producer trace — §8.5's deferred question, answered
+
+**The answer overturns §8's classification of L16/L17.** I traced the emission
+path hop by hop and it does not lead where §8 assumed.
+
+**Hop chain, starting where the brief said to start:**
+
+| hop | site | what it does |
+|---|---|---|
+| 1 | `qsrv/pva_adapter.rs:85` `PvaPvHandle::post` | validates against the canonical descriptor, then `*self.latest.lock() = Some(value.clone())` (`:92`) and `let mut subs = self.subscribers.lock()` (`:93`) — **L28/L29 below** |
+| 2 | `ad-plugins-rs/src/pva.rs:70` `self.handle.post(payload)` | the only production caller anywhere in the workspace |
+| 3 | `ad-plugins-rs/src/pva.rs:62` `NDPluginProcess::process_array` | the plugin trait method containing hop 2 |
+| 4 | `ad-core-rs/src/plugin/runtime.rs:598` `self.processor.process_array(array, &self.pool)` | inside `process_and_publish` (`:581`) |
+| 5 | `ad-core-rs/src/plugin/runtime.rs:1913` `guard.process_and_publish(&msg.array)` | inside `plugin_data_loop` |
+| 6 | `ad-core-rs/src/plugin/runtime.rs:1751-1753` `thread::Builder::new().name(format!("plugin-data-{port_name}")).spawn(...)` | **the driving thread** |
+
+**The driving thread is `plugin-data-{port}`, a plain `std::thread` at default
+priority.** `rg "apply_to_current_thread|ThreadPriority"` over `crates/ad-core-rs/src`
+and `crates/ad-plugins-rs/src` returns **nothing** — it is SCHED_OTHER, not a
+callback band, not a tokio worker, not iocsh.
+
+**And this path never touches L16/L17 at all.** `PvaPvHandle` (`pva_adapter.rs:48-102`)
+is an *independent reimplementation* of the pvxs `SharedPV::post` contract, not a
+wrapper over `epics_pva_rs::SharedPV`: it owns its own `latest` (`:49`) and
+`subscribers` (`:50`) `parking_lot` mutexes and posts to `mpsc::Sender`s. Every
+mention of `SharedPV` in `pva_adapter.rs` (`:45`, `:77`, `:100`, `:113`, `:340`)
+is a doc comment citing pvxs as the *model*.
+
+**So who does drive L16/L17? Nothing in production.** `rg` for `SharedPV` /
+`try_post_checked` / `.try_post(` across the workspace excluding `epics-pva-rs`
+itself returns hits in exactly one file — `crates/epics-bridge-rs/tests/pva_gateway.rs`
+(`:61`, `:237`, `:344`, `:901`, `:1060`, `:1126`, `:1244`, `:1353`, `:1484`) —
+plus the doc comments above. **`SharedPV`/`MonitorQueue` are a public API surface
+for external embedders, exercised in-tree only by tests.**
+
+**The real IOC monitor path bypasses them entirely.** A records-backed PVA
+monitor is served by `MonitorStream::Upstream` (`server_native/source.rs:1739`)
+wrapping `UpstreamMonitor::from_db` (`:1912-1921`), which holds a
+`epics_base_rs::server::database::db_access::DbSubscription` (`:1913`) — i.e. it
+rides the **base** subscription machinery (§2's **L7**, `ProcessVariable::subscribers`,
+a tokio Mutex and already classified park_on-PI-invisible), never
+`shared_pv.rs`'s locks.
+
+**Consequences — three corrections to §8:**
+
+1. **L16/L17's "replace-with-PI" has no high-priority acquirer today, and item 7
+   does not create one.** Item 7 changes the *consumer* side (per-connection
+   threads); the *producer* side only exists when an external embedder posts.
+   The classification should be downgraded from "the top row of this sweep" to
+   **replace-with-PI, but unranked — no in-tree producer**. The pvxs parity gap
+   (`sharedpv.cpp:37`/`servermon.cpp:57` are `epicsMutex`) is real and still
+   worth closing for embedders, but it is not on any hot path this workspace
+   runs.
+2. **The row that *does* have a live producer is L29** (`PvaPvHandle::subscribers`),
+   and its producer is `plugin-data-{port}` at default priority — so it is a
+   low↔low pair today, not a band↔connection pair.
+3. **§8's L7 cross-reference was the right lock all along.** The IOC monitor path
+   the bridge actually uses lands on base's L7, which the parent sweep already
+   classified as park_on-PI-invisible.
+
+---
+
+### §9.1 (a)+(b)+(c) The table
+
+**Kind** as in §2/§8: `PL` = `parking_lot`, `STD` = `std::sync`, `TOK` =
+`tokio::sync` (park_on-invisible when reached from a blocking thread).
+
+**Shared?** — `hosted` = live today on the hosted tokio server; `item 7` =
+becomes relevant only if the bridge is ported to the RTEMS blocking driver;
+`host-only` = gateway subsystems with no RTEMS story at all.
+
+| # | lock | decl / evidence | Kind | shared? | class |
+|---|---|---|---|---|---|
+| **L28** | `PvaPvHandle::latest` | `qsrv/pva_adapter.rs:49` `Arc<parking_lot::Mutex<Option<PvField>>>`; `:92` write, `:117` read | **PL** | **hosted** — `plugin-data-{port}` writes, connection task reads | **accept-with-bounded-CS** — one `Option<PvField>` swap/clone |
+| **L29** | `PvaPvHandle::subscribers` | `qsrv/pva_adapter.rs:50` `Arc<parking_lot::Mutex<Vec<mpsc::Sender<PvField>>>>`; `:93` post-retain, `:125` subscribe | **PL** | **hosted** — see §9.0; producer is SCHED_OTHER today | **replace-with-PI** *conditionally* — only once `plugin-data-*` gets a priority (§9.3) |
+| **L30** | `PVA_PV_REGISTRY` | `qsrv/pva_adapter.rs:143` `std::sync::Mutex<HashMap<String, PvaPvHandle>>`; `:155` insert, `:163` `mem::take` drain | **STD** | **hosted**, init-time | **remove-the-sharing** — a global drained once by `take_registered_pva_pvs`; an init-time handoff, not shared state |
+| **L31** | `BridgeSource::pva_pvs` | `qsrv/pva_adapter.rs:194` `Arc<RwLock<HashMap<String, PvaPvHandle>>>` — **tokio** (import `:13`); ~10 `.read().await`: `:291`,`:337`,`:489`,`:526`,`:787`,`:1001`,`:1016`,`:1034`,`:1054` | **TOK** | **item 7** — read on every channel op | **(c) park_on — PI-invisible**; also **accept** (read-mostly after init) |
+| **L32** | `BridgeProvider` ×5: `groups` `qsrv/provider.rs:628` (PL RwLock), `record_cache` `:641` (**tokio** RwLock), `access_cell` `:647` (PL RwLock), `base_group_defs` `:656` (PL), `group_files` `:668` (PL) | mixed | **item 7** | 4× **accept-with-bounded-CS** (map/vec lookups, init-time writes); `record_cache` is **(c) PI-invisible** |
+| **L33** | qsrv group `atomic_write_lock` | `qsrv/group_config.rs:64` `Arc<tokio::sync::Mutex<()>>` | **TOK** | **item 7** — the group-atomic-put gate | **(c) park_on — PI-invisible**; the bridge's `dbScanLockMany` analogue, and it inherits **L1**'s whole problem (§3) |
+| **L34** | `PvaLinkResolver` ×6: `link_options` `pvalink/integration.rs:59`, `out_link_options` `:66`, `db` `:71`, `scan_targets` `:78` (PL RwLock), `forwarders` `:84` (PL Mutex), `qsrv` `:95` (PL RwLock) | **PL** ×6 | **hosted, and genuinely high↔low** — `impl LinkSet for PvaLinkResolver` (`:1115`), registered at `:837` `db.register_link_set("pva", …)`, so these are acquired during **record processing** | **replace-with-PI** — the highest-value rows in this crate (§9.2) |
+| **L35** | `PvaLink` ×5: `latest` `pvalink/link.rs:153`, `notify_rx` `:178`, `out_scratch` `:205`, `disconnect_time` `:222`,`:300`, `snap_alarm` `:248` | **PL** ×5 (import `:8`) | **hosted**, same record-processing path as L34 | **replace-with-PI** (`latest`, `disconnect_time`); **accept-with-bounded-CS** (`notify_rx`, `out_scratch`, `snap_alarm`) |
+| **L36** | `LinkRegistry` ×3: `map` `pvalink/registry.rs:81`, `pending` `:91`, `channel_records` `:98` | **PL** ×3 RwLock (import `:9`) | **hosted**, link open/close | **accept-with-bounded-CS** — hash probes; writes at link attach/detach |
+| **L37** | `ChannelEntry` ×3: `state` `pva_gateway/channel_cache.rs:81`, `latest_raw` `:99` (PL RwLock), `drop_poke` `:106` (PL Mutex) | **PL** ×3 | **host-only** | **accept-with-bounded-CS** |
+| **L38** | `ChannelCache` ×2: `entries` `pva_gateway/channel_cache.rs:597` (**tokio** Mutex, import `:34`), `cleanup_task` `:599` (PL Mutex) | mixed | **host-only** | **(c) PI-invisible** (`entries`); **accept** (`cleanup_task`) |
+| **L39** | `GatewaySource` ×3: `upstream_pool` `pva_gateway/source.rs:333` (PL Mutex, import `:18`), `asg_resolver` `:353` (**tokio** RwLock, import `:19`), `upstream_caches` `:375` (PL Mutex) | mixed | **host-only** | **accept-with-bounded-CS**; `asg_resolver` **(c) PI-invisible** |
+| **L40** | CA-gateway `PvCache` + per-entry: `entries: HashMap<String, Arc<RwLock<GwPvEntry>>>` `ca_gateway/cache.rs:282` and the cache itself `Arc<RwLock<PvCache>>` (`upstream.rs:227`,`:245`,`:293`; `server.rs:347`,`:829`; `command.rs:86`,`:117`) — **tokio** RwLock (import `cache.rs:34`) | **TOK** ×2 | **host-only** | **(c) PI-invisible**; note `cache.rs:335-341`/`:365` already document collect-then-act to bound the outer guard |
+| **L41** | `UpstreamManager` ×2: `subs` `ca_gateway/upstream.rs:303`, `pending` `:307` (PL Mutex) | **PL** ×2 | **host-only** | **accept-with-bounded-CS** |
+| **L42** | stats ×2: `per_host` `ca_gateway/stats.rs:161`, `last_refresh` `:169` — **tokio** Mutex (import `:100`) | **TOK** ×2 | **host-only** | **(c) PI-invisible**; also **accept** (introspection path) |
+| **L43** | downstream ×3: `log` `ca_gateway/downstream.rs:74` (PL Mutex), `server` `:278`, `replay_state` `:287` (**tokio** Mutex, import `:29`) | mixed | **host-only** | **accept**; the two tokio ones **(c) PI-invisible** |
+| **L44** | putlog ×2: `file` `ca_gateway/putlog.rs:135`, `bytes_written` `:139` — **tokio** Mutex (import `:68`) | **TOK** ×2 | **host-only** | **(c) PI-invisible**; held across `tokio::fs` I/O — the longest critical section in this table |
+| **L45** | beacon ×2: `last` `ca_gateway/beacon.rs:25`, `pulse` `:34` — **std::sync** Mutex (import `:14`) | **STD** ×2 | **host-only** | **accept-with-bounded-CS** — one `Instant`/`Option<Arc>` |
+
+**Totals: 45 distinct production locks** — 29 `PL`, 13 `TOK`, 3 `STD`. By
+subsystem: qsrv 10 (L28-L33), pvalink 14 (L34-L36), pva_gateway 8 (L37-L39),
+ca_gateway 13 (L40-L45).
+
+**(c) the park_on-reachable set: L31, L32's `record_cache`, L33, L38's `entries`,
+L39's `asg_resolver`, L40 ×2, L42 ×2, L43 ×2, L44 ×2 = 13 locks.** Only three of
+those (L31, L32-`record_cache`, L33) are in a subsystem item 7 could ever reach;
+the other ten are gateway-only and have no RTEMS story. **L33 is the one that
+matters**: it is the group-atomic-put gate, structurally the same problem as
+**L1** — a tokio `Mutex` standing in for `dbScanLockMany` — and it inherits §3's
+conclusion verbatim.
+
+---
+
+### §9.2 Why L34/L35 are the real find in this crate
+
+Unlike L16/L17, the pvalink rows have a **traced, live, high-priority acquirer**:
+`PvaLinkResolver` implements base's `LinkSet` (`pvalink/integration.rs:1115`) and
+is registered into the database at `:837` (`db.register_link_set("pva", Arc::new(resolver.clone()))`).
+Link resolution therefore runs inside record processing — on a callback band or
+`scanOnce` — while the same locks are taken by the monitor-forwarder side
+(`scan_once` at `:1003`, reaching `process_record_with_links` at `:1104` and
+`process_record_with_links_already_locked` at `:1100`).
+
+That makes L34/L35 the only rows in §8+§9 combined that are simultaneously
+(i) `parking_lot`, so PI is reachable by type replacement, (ii) contended across
+a genuine high/low boundary, and (iii) on a path this workspace actually runs.
+They outrank L16/L17 — which §8 nominated on an assumption this trace has now
+disproved.
+
+**One caveat that bounds the claim.** The forwarder side is spawned through a raw
+`tokio::runtime::Handle` (`integration.rs:36`, `:156`, `:417` `self.handle.spawn(run_notify_forwarder(...))`,
+`:829`), **not** through the `runtime::task` seam. So on the hosted backend the
+forwarder is a tokio worker (SCHED_OTHER) and the record-processing side is the
+band — a real high↔low pair. There is no exec-backend variant of this pair today,
+for the reason in §9.3.
+
+---
+
+### §9.3 Two findings outside the lock table
+
+**1. `epics-bridge-rs` uses the `runtime::task` seam exactly once.**
+`rg "runtime::task::spawn|epics_base_rs::runtime::task"` over
+`crates/epics-bridge-rs/src` returns a single production hit —
+`qsrv/pva_adapter.rs:1436`. Against that, raw `tokio::spawn` /
+`tokio::runtime::Handle` appear in 10 production files, `pvalink/integration.rs`
+alone holding 42. The crate is **not** RTEMS-gated in its own manifest
+(`rg rtems crates/epics-bridge-rs/Cargo.toml crates/epics-bridge-rs/src/lib.rs`
+→ nothing), so its RTEMS status is *undeclared* rather than *excluded*. I did not
+verify what the RTEMS build actually compiles, so I am not claiming a live seam
+violation — the accurate statement is: **if the bridge ever enters the RTEMS
+build, those sites are seam bypasses and would need auditing first.** That is a
+prerequisite finding for any "port qsrv to RTEMS" item, and it is cheap to close
+by declaring the crate host-only now.
+
+**2. The `plugin-data-{port}` thread has no priority.** `ad-core-rs/src/plugin/runtime.rs:1751-1753`
+(and a second at `:2296-2298`) spawn named `std::thread`s that drive all NDArray
+plugin processing, including hop 2 of §9.0. No `apply_to_current_thread` exists
+anywhere in `ad-core-rs` or `ad-plugins-rs`. In C, areaDetector plugin threads are
+created with an explicit `epicsThreadPriority` per plugin. This is the same class
+of gap as §6 step 2's `CAS-UDP`/periodic-scan/iocsh holes, in a crate neither §6
+nor §8 looked at.
+
+---
+
+### §9.4 Where this fits in §6's execution order
+
+| slot | step | rationale |
+|---|---|---|
+| **revises §6 step 4** | **Demote L16/L17.** They keep the pvxs parity gap but lose their ranking — no in-tree producer (§9.0). Convert for embedder correctness, not for latency. | §8 ranked them on an assumption this trace disproved |
+| **new, alongside §6 step 3** | **L34/L35 → PI.** `parking_lot`, live high↔low, on the record-processing path. The best-evidenced PI candidates found in three sweeps. | §9.2 |
+| **with §6 step 2** | **Give `plugin-data-{port}` a priority** (`runtime.rs:1751`, `:2296`), matching C's per-plugin `epicsThreadPriority`. Until then L29's producer/consumer are both SCHED_OTHER and its PI classification is inert. | §9.3 finding 2 |
+| **before any qsrv-on-RTEMS item** | **Declare `epics-bridge-rs` host-only, or audit its 40+ raw-spawn sites against the seam.** | §9.3 finding 1 |
+| **follows §6 step 1** | **L33** — the group-atomic-put gate inherits L1's decision exactly. | §9.1 |
+
+---
+
+### §9.5 What this sweep does not establish
+
+* **Nothing measured** — static analysis, same caveat as §7 and §8.5.
+* **I did not verify what the RTEMS build compiles.** §9.3 finding 1 is stated as
+  conditional for that reason; confirming it needs a `--target` build, which is
+  outside a read-only sweep.
+* **`ad-core-rs` / `ad-plugins-rs` were not swept for locks** — I entered them only
+  to complete the §9.0 hop chain. `runtime.rs:95` shows at least one
+  `Arc<Mutex<Option<Arc<NDArray>>>>` on the plugin path; the population is
+  unknown and is the next gap, exactly as `epics-bridge-rs` was this one.
+* **Test-only locks were excluded throughout**, using the last `#[cfg(test)]` in
+  each file as the boundary. `pva_gateway/source.rs` has an early `#[cfg(test)]`
+  at `:25` as well as the module at `:1982`; the `:1982` boundary is the one used.

--- a/doc/pi-lock-evaluation.md
+++ b/doc/pi-lock-evaluation.md
@@ -1,0 +1,308 @@
+# PI-lock evaluation — roadmap 4b, prerequisite for any hard-RT claim
+
+Read-only investigation. No files edited. Every claim carries file:line.
+
+## Provenance — and a mid-investigation tree move
+
+* **Worktree:** `/home/stevek/work/epics-rs/.caucus/worktrees/manual-ca-sans-io`
+  @ **`051b7851`** (`test(ca): gate the C-interop suites out of the
+  rtems-exec-model build`). HEAD was `051b7851` when I started and is still
+  `051b7851` now.
+* **But the working tree is NOT clean, and it changed under me.** `git status`
+  shows three files with uncommitted edits from the concurrent panel:
+  `runtime/task.rs` (+485/-…), `runtime/background/delayed_timer.rs` (+11),
+  `epics-ca-rs/src/server/blocking.rs` (+18), plus one untracked new file
+  `epics-base-rs/tests/rt_priority_default_off.rs`. Those edits landed
+  **between** my first read of those files and my verification pass. Two of them implement
+  what my first draft was about to recommend. Everything below is re-verified
+  against the **current working tree**, and the affected rows are marked
+  ⚠ **moved**.
+* **C reference:** `/home/stevek/work/epics-base` @ `669a25697`. Present, so the
+  reference-source rule is satisfied — no STOP.
+
+---
+
+## §0 Headline — four findings
+
+**1. Real-time priority is opt-in and off by default, so today no priority
+inversion is possible at all — by construction.**
+⚠ **moved.** `RtPolicy` (`task.rs:469-505`) resolves
+`EPICS_RS_ALLOW_RT_PRIORITY` (`task.rs:459`) once per process; absent or unset
+⟹ `RtPolicy::Disabled` (`task.rs:480`). `apply_to_current_thread_under`
+short-circuits on it: `RtPolicy::Disabled => PriorityApplied::Disabled`
+(`task.rs:547`) — **no scheduler call is made** (`task.rs:529-530`). With the
+switch off every thread in the process is SCHED_OTHER at the same nominal
+priority, and "priority inversion" is not a well-defined condition.
+
+This reframes roadmap 4b: it is not a live-bug hunt. It is *pre-work for the
+configuration that does not ship yet* — the state of the tree when
+`EPICS_RS_ALLOW_RT_PRIORITY=1` becomes the supported RT mode. Everything below
+should be read as "what breaks when the switch is turned on", not "what is
+broken now".
+
+**2. The PI mutex already exists and is used by nothing.**
+`runtime::sync::PriorityInheritanceMutex<T>` (`sync.rs:27`) is a real
+`pthread_mutex_t` + `PTHREAD_PRIO_INHERIT` (`sync.rs:47-83`) behind the
+`linux-rt` feature; `sync.rs:33` is the `parking_lot::Mutex` fallback and
+`is_pi_mutex_active()` (`sync.rs:36`) the diagnostic. Workspace-wide `rg` for
+`PriorityInheritanceMutex` outside `sync.rs` returns **two hits, both prose** —
+a comment at `epics-base-rs/Cargo.toml:94` and `docs/epics_base_missing_features.md:238`
+(which marks the item ✅ DONE). **Zero production call sites**, and
+`linux-rt = []` (`Cargo.toml:98`) is enabled by no target, profile or default.
+So 4b is not "add PI mutexes"; it is "decide which existing locks should have
+been one, and wire it".
+
+**3. The most safety-critical lock — the `dbScanLock` analogue — is a tokio
+async mutex, which no PI mechanism can ever cover.**
+`RecordLockRegistry` holds `Arc<Mutex<()>>` per record where `Mutex` is
+`tokio::sync::Mutex` (`record_lock.rs:70`, field at `:83`, `gate_for` at `:93`,
+`lock_record` at `:140`). Its own doc calls it the direct analogue of
+`dbCommon::lock`/`dbScanLock` (`record_lock.rs:8`, `:42`). In C that lock is
+`epicsMutexMustCreate()` (`dbLock.c:86`) ⟹ `PTHREAD_PRIO_INHERIT`
+(`posix/osdMutex.c:71-85`) / `RTEMS_INHERIT_PRIORITY`
+(`RTEMS-score/osdMutex.c:72`). A blocking thread waiting on it in Rust sits in
+`std::thread::park()` (`task.rs:80`) holding no kernel-visible lock — see §3.
+
+**4. The thread-priority asymmetry I found has just been closed for the CA
+server and the timer — but not for periodic scan or iocsh.**
+⚠ **moved.** `apply_to_current_thread` now has **six** non-test call sites:
+callback bands (`callback_executor.rs:301`), scanOnce (`scan_once.rs:181`),
+`spawn_blocking_with_priority` (`task.rs:755`), and — new in the uncommitted
+diff — `cbTimer` → `ScanHigh` (`delayed_timer.rs:234`), `CAS-client-blocking`
+→ `CaServerLow` (`blocking.rs:200`), `CAS-event-blocking` →
+`Custom(CaServerLow-1)` (`blocking.rs:669-671`). Still **none**: periodic scan
+tasks (`scan_event.rs:87-92`), both iocsh threads (`ioc_app.rs:695`, `:1030`),
+the `CAS-UDP` thread (`bin/rtems-ca-ioc.rs:159`), and all hosted tokio workers.
+
+---
+
+## §1 Thread inventory: who runs at what priority
+
+Priorities apply **only** when `EPICS_RS_ALLOW_RT_PRIORITY` is on (finding 1).
+
+| thread | created at | EPICS priority | applied? |
+|---|---|---|---|
+| `cbLow` | `callback_executor.rs:293`,`:301` | `ScanLow-1` = 59 (`:97-103`) | yes |
+| `cbMedium` | same | `ScanLow+4` = 64 | yes |
+| `cbHigh` | same | `ScanHigh+1` = 71 | yes |
+| `scanOnce` | `scan_once.rs:172`,`:181` | `ScanLow` = 60 | yes |
+| `cbTimer` | `delayed_timer.rs:225`,`:234` | `ScanHigh` = 70 | ⚠ **yes, new** |
+| `CAS-client-blocking <peer>` | `blocking.rs:192`,`:200` | `CaServerLow` = 20 (`task.rs:370`) | ⚠ **yes, new** |
+| `CAS-event-blocking <peer>` | `blocking.rs:659`,`:669` | `CaServerLow-1` = 19 | ⚠ **yes, new** |
+| `CAS-UDP` | `bin/rtems-ca-ioc.rs:159` | — | **no** |
+| periodic scan | `scan_event.rs:87`,`:92` (`tokio::task::JoinSet`) | — | **no** |
+| `iocsh-startup` / `iocsh-after-ioc-running` | `ioc_app.rs:695`, `:1030` | — | **no** |
+| tokio workers (hosted) | tokio runtime | — | **no** |
+
+Two structural notes:
+
+* The band mapping is C-faithful (`callback_executor.rs:98` cites
+  `epicsThread.h:84`), and the new CA values cite `caservertask.c:109` and
+  `:560`/`:1508`. So the *intended* ordering is now CA server (19/20) **below**
+  scan/callback (59-71), matching C.
+* **On the RTEMS/exec backend the classes collapse anyway.**
+  `runtime::task::spawn` routes every async tail to `spawn_future(…,
+  DEFAULT_SPAWN_PRIORITY, …)` and `DEFAULT_SPAWN_PRIORITY =
+  CallbackPriority::Medium` (`future_exec.rs:105`) — so CA async tails and
+  record-processing callbacks share one cbMedium worker there, regardless of the
+  `CaServerLow` values above. And on RTEMS `apply_priority_impl` is the
+  `#[cfg(not(target_os = "linux"))]` arm returning `PriorityApplied::Unsupported`
+  (`task.rs:715-719`), so **no priority is applied on the actual RTEMS target at
+  all**. The band structure is advisory-only there.
+
+---
+
+## §2 (a)+(b) The shared-lock table
+
+"Shared" = acquired by at least one thread from the higher-priority set
+{cb bands, scanOnce, cbTimer} and at least one from the lower set {CA threads,
+iocsh, periodic scan, tokio workers}.
+
+**Kind:** `PL` = `parking_lot`, `STD` = `std::sync` — both kernel-visible
+futexes, PI-able by type replacement. `TOK` = `tokio::sync` — awaited; reached
+from a blocking thread only via `park_on`, **invisible to the kernel PI chain**
+(question (c), §3).
+
+| # | lock | decl / evidence | Kind | class | C counterpart |
+|---|---|---|---|---|---|
+| **L1** | per-record advisory write gate `Arc<Mutex<()>>` | `record_lock.rs:70`,`:83`,`:110`,`:126`; taken by `lock_record` `:140` / `lock_records` `:171` | **TOK** | **(c) park_on — PI-invisible** §3 | `dbCommon::lock`, `epicsMutexMustCreate` `dbLock.c:86`, PI on |
+| **L2** | `RecordLockRegistry::gates` | `record_lock.rs:83` `std::sync::Mutex<HashMap<..>>`, entered in `gate_for` `:93` | **STD** | **replace-with-PI** — cheapest win | `lockSetsGuard`, `dbLock.c:48`,`:62` |
+| **L3** | per-record data `Arc<parking_lot::RwLock<RecordInstance>>` | `database/mod.rs:107`,`:230`,`:591`,`:1368`,`:1682`,`:1696`; 96 acquisitions in `database/processing.rs`, 42 in `links.rs`, 38 in `field_io.rs`, 65 in `database/mod.rs` | **PL** | **replace-with-PI** | the same `dbCommon::lock` (C has one lock; the port has two) |
+| **L4** | `PvDatabase::records` registry | `database/mod.rs:230` `parking_lot::RwLock<HashMap<..>>` | **PL** | **accept-with-bounded-CS** (§4) | `dbBase` GPHENTRY lookup, no per-op mutex in C |
+| **L5** | `PvDatabase::aliases` | `database/mod.rs:270`,`:597`; read via `resolve_alias` inside `lock_record` (`record_lock.rs:142`) | **PL** | **accept-with-bounded-CS** | — |
+| **L6** | `ProcessVariable::value` | `pv.rs:322`,`:370` `parking_lot::RwLock<EpicsValue>` | **PL** | **replace-with-PI** | record field storage under `dbCommon::lock` |
+| **L7** | `ProcessVariable::subscribers` | `pv.rs:323`,`:371` — `crate::runtime::sync::Mutex` (`pv.rs:4`) = tokio (`sync.rs:3`); CA takes it as `block_on_sync(pv.subscribers.lock())` (`blocking.rs:2008`), also `:852`, `:970` | **TOK** | **(c) park_on — PI-invisible** §3 | monitor list under the record lock |
+| **L8** | 11 `PvDatabase` fields: `simple_pvs` `:229`, `scan_index` `:244`, `load_order` `:250`, `cp_links` `:256`, `external_cp_links` `:265`, `external_resolver` `:297`, `search_resolver` `:299`, `existence_gate` `:303`, `link_sets` `:308`, `subroutine_registry` `:333`, `breaktable_registry` `:340` — all bare `RwLock` = tokio (`database/mod.rs:19`) | **TOK** ×11 | **(c) PI-invisible**; 6 are **remove-the-sharing** (§4) | `dbScan.c:122`,`:139` `event_lock`/`ioscan_lock` are epicsMutex, PI on |
+| **L9** | ACF config cell `Arc<tokio::sync::RwLock<Option<AccessSecurityConfig>>>` | `access_security.rs:169`,`:185`,`:201`; CA's `SharedAcf` alias `blocking.rs:132`,`:142`,`:153`,`:617` | **TOK** | **(c) PI-invisible** + **accept** (read-mostly) | `asLock` (epicsMutex family) |
+| **L10** | `TRAP_WRITE_REGISTRY` | `access_security.rs:1000-1005` `OnceLock<std::sync::RwLock<Vec<..>>>`; read at `:993`,`:1025`,`:1055` | **STD** | **accept-with-bounded-CS** | `asTrapWriteListener` list |
+| **L11** | CA event ring `EvQue::inner`, `ques` | `event_queue.rs:82`,`:258`,`:458`,`:472` `std::sync::Mutex` | **STD** | **replace-with-PI** | ring buffer under `client->eventLock` |
+| **L12** | callback band queue `PriorityQueue::state` + `wake` | `callback_executor.rs:32`,`:137`,`:139`,`:146`,`:152` `std::sync::Mutex`/`Condvar` | **STD** | **replace-with-PI** — highest leverage | `callbackQueue[].lock` (`epicsRingBytes` + `epicsEventId`) |
+| **L13** | `RecordInstance::metadata_cache`, async-completion `tx` | `record_instance.rs:61`,`:729` `StdMutex` | **STD** | **accept-with-bounded-CS** | — |
+| **L14** | autosave per-set gate | `autosave/manager.rs:67`,`:82`,`:309`,`:317` `Arc<tokio::sync::Mutex<()>>` | **TOK** | **remove-the-sharing** (§4) | `save_restore` task-local |
+| **L15** | `IfaceMap` cache | `net/iface_map.rs:15`,`:51`,`:63` `parking_lot::Mutex` | **PL** | **not shared** — CA/PVA UDP only, no high-prio acquirer; listed for completeness | `osiSockDiscoverBroadcastAddresses` |
+
+Totals: **15 rows / 25 distinct locks** (L8 is 11). **14 are `tokio::sync`**
+(L1, L7, L8×11, L9, L14), **5 `std::sync`** (L2, L10, L11, L12, L13),
+**5 `parking_lot`** (L3, L4, L5, L6, L15).
+
+---
+
+## §3 (c) The park_on set — why PI mutexes cannot reach them
+
+`block_on_sync` (`task.rs:112`) picks one of three mechanisms: `Err(NotBlockable)`
+on a current-thread runtime (`:115`), `tokio::task::block_in_place` on a
+multi-thread worker (`:116`), and otherwise `park_on`. On a plain `std::thread`
+with no runtime entered — *every* thread in the blocking CA driver, both iocsh
+threads, `CAS-UDP` — it takes the `park_on` arm, which polls and calls
+**`std::thread::park()`** (`task.rs:66`, `:80`).
+
+The consequence, stated precisely:
+
+> A thread blocked in `std::thread::park()` waiting for a `tokio::sync::Mutex`
+> is, to the kernel, a thread sleeping on a futex owned by **nobody**. The
+> kernel has no record that it is waiting for a resource another thread holds.
+> Priority inheritance is a kernel mechanism that walks owner pointers; there is
+> no owner pointer. **Adding `PriorityInheritanceMutex` anywhere in the
+> workspace changes nothing for L1, L7, L8, L9 or L14 — 14 of the 25 locks.**
+
+Two further properties, both worse than the C behaviour:
+
+* **Wake order is FIFO, not priority.** `tokio::sync::Mutex` is explicitly fair:
+  waiters are served in arrival order. C's `epicsMutex` on RTEMS is created
+  `RTEMS_PRIORITY|RTEMS_BINARY_SEMAPHORE|RTEMS_INHERIT_PRIORITY|…`
+  (`RTEMS-score/osdMutex.c:72`) — `RTEMS_PRIORITY` makes the wait queue
+  **priority-ordered**. So even setting inheritance aside, a cbHigh waiter on L1
+  queues behind however many CA client threads arrived first.
+* **`OwnedMutexGuard` means L1 holders *can* await while holding.**
+  `lock_record` returns a `'static` `OwnedMutexGuard` (`record_lock.rs:110`,
+  `:121`, `:126`) precisely so the guard can be held across await points. That is
+  what makes L1 unconvertible to a blocking lock without a design change — it is
+  not an oversight, it is the current contract.
+
+**The (c) class is the dominant one and its fix is not a lock swap.** It is
+either (i) move the state onto a blocking lock — sound only if no holder ever
+awaits while holding, which L1 currently violates by design — or (ii) remove the
+sharing. L1 must be answered before any hard-RT claim; §6 orders it first.
+
+---
+
+## §4 (b) Rationale for the non-obvious classifications
+
+**replace-with-PI (L2, L3, L6, L11, L12).** All five are `parking_lot`/`std`
+locks whose critical sections contain no await — guaranteed by type, since
+`parking_lot::RwLockWriteGuard` and `std::sync::MutexGuard` are `!Send` and a
+holder cannot cross an await point and still compile. Each is genuinely
+contended between a high- and a low-priority thread. These are exactly the rows
+`PriorityInheritanceMutex` was written for. **L12 is the highest-value of the
+five**: every callback submission from every thread in the process passes
+through it (`callback_executor.rs:137`), so it is the one lock where a
+SCHED_OTHER submitter can delay a SCHED_FIFO-71 band worker's own dequeue.
+
+**accept-with-bounded-CS (L4, L5, L10, L13).** Bounds, stated rather than
+asserted:
+
+* **L4** — the bound rests on a lock discipline the code already documents and
+  I verified at all 10 map-read sites in `database/processing.rs`:
+  *"Never hold `records.read()` across `rec.write()`"* (`processing.rs:681-683`).
+  Seven sites are collect-then-act — take the map read in a scope block, clone
+  the `Arc`, drop it (`:685-687`, `:704-706`, `:981-983`, `:1092-1094`,
+  `:1270-1272`, `:4427-4430`, `:4920-4922`). The remaining three hold the map
+  read across a per-record **read**, never a write (`:802-804`, `:819-822`,
+  `:869-872`). Lock ordering is uniformly records→instance. Bound: one hash
+  probe plus an `Arc` clone; no allocation beyond the clone, no I/O, no nested
+  write.
+* **L5** — same shape, one alias hash probe (`record_lock.rs:142`).
+* **L10** — iteration over registered trap listeners, typically 0 or 1
+  (`access_security.rs:1000-1005`).
+* **L13** — one `Option` take/replace (`record_instance.rs:61`, `:729`).
+
+These stay as they are **provided** the write-set stays init-time. The
+invalidating change is dynamic record creation after `iocInit`; that condition
+should be named in the code rather than left implicit.
+
+**remove-the-sharing (L8 subset, L14).** L14's autosave gates are per-save-set
+and touched by the RT band only because save-on-change is driven from record
+processing; routing that through the existing callback queue (a submission, not
+a lock acquisition) removes the contention entirely. Within **L8**,
+`external_resolver` (`:297`), `search_resolver` (`:299`), `existence_gate`
+(`:303`), `subroutine_registry` (`:333`), `breaktable_registry` (`:340`) and
+`load_order` (`:250`) are written at IOC init and read-only afterwards; the
+structural fix is `ArcSwap`/`OnceLock`, which **removes six of the eleven L8
+locks from the table** rather than reclassifying them.
+
+---
+
+## §5 (d) C parity — what is an `epicsMutex` in C base
+
+Confirmed against `/home/stevek/work/epics-base` @ `669a25697`:
+
+* POSIX: `epicsMutex` sets `PTHREAD_PRIO_INHERIT` on both the default and
+  recursive attribute (`modules/libcom/src/osi/os/posix/osdMutex.c:71-75`), with
+  a **runtime probe** — it constructs a temporary mutex and on failure falls
+  back to `PTHREAD_PRIO_NONE` (`:77-86`). `epicsMutexShowAll` reports
+  "PI is/is not enabled" (`:199-205`). `DONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING`
+  `#undef`s the whole thing (`:50-52`) — so PI is build-configurable in C too,
+  not an unconditional guarantee.
+* RTEMS: `RTEMS_PRIORITY|RTEMS_BINARY_SEMAPHORE|RTEMS_INHERIT_PRIORITY|RTEMS_NO_PRIORITY_CEILING|RTEMS_LOCAL`
+  (`os/RTEMS-score/osdMutex.c:72`) — inheritance **and** a priority-ordered wait
+  queue.
+* Every lock this evaluation cares about is in that family: `dbLock.c:86`
+  `ls->lock = epicsMutexMustCreate()` (what `dbScanLock` takes, `dbLock.c:184`;
+  `dbScanLockMany` at `:384`); `dbLock.c:48`,`:62` `lockSetsGuard`;
+  `dbScan.c:75` per-scan-list `lock`; `dbScan.c:122` `event_lock`;
+  `dbScan.c:139` `ioscan_lock`.
+
+**Parity verdict.** C protects the record lock, the lock-set registry, the event
+list and the scan lists with PI + priority-ordered mutexes. The port protects
+the same four with, respectively, a tokio async mutex (L1), a std mutex (L2), a
+std mutex (L11) and tokio RwLocks (L8). **Zero of the four are PI today**, and
+the first and fourth cannot become PI without changing their type.
+
+One thing the port already has right: C's probe-and-fall-back
+(`osdMutex.c:77-86`) is the same posture as `PriorityApplied::BestEffortFailed`
+(`task.rs:428`, `:693`, `:711`) and the new `RtPolicy` switch — C also has an
+opt-out. The Rust side does not need to invent a policy; it needs to apply the
+one it has.
+
+---
+
+## §6 Recommended execution order
+
+Ordered by (blocker for a hard-RT claim) × (cost). Steps 1 and 2 of my first
+draft are struck through — the concurrent panel implemented them while this
+investigation was running.
+
+| # | step | why here | size |
+|---|---|---|---|
+| ~~0a~~ | ~~give the CA blocking threads a priority~~ | ⚠ **DONE, uncommitted** — `blocking.rs:200`, `:669` | — |
+| ~~0b~~ | ~~give `cbTimer` a priority~~ | ⚠ **DONE, uncommitted** — `delayed_timer.rs:234` | — |
+| **1** | **Decide L1.** Either make the record gate a blocking PI mutex — which requires removing the hold-across-await contract that `OwnedMutexGuard` exists to provide (`record_lock.rs:110`,`:121`,`:126`), a real design change — or accept it and **withdraw the hard-RT claim for the write path**. Nothing else in this list matters until this is answered: L1 is `dbScanLock`, and every write and every process pass takes it. | it is the one lock C most clearly protects and the port most clearly does not | design first, then **L** |
+| **2** | **Finish the priority sweep.** `CAS-UDP` (`bin/rtems-ca-ioc.rs:159`), periodic scan (`scan_event.rs:87-92`), both iocsh threads (`ioc_app.rs:695`,`:1030`) still apply none. Periodic scan is the one that matters — it is a `JoinSet` tokio task, so giving it a priority means moving it off the tokio pool, not adding a line. | completes what 0a/0b started; without it the RT set still has holes | **S** for CAS-UDP/iocsh, **M** for scan |
+| **3** | **L12 → PI.** The callback-queue mutex is on every submission path from every thread; highest contention-per-line in the table. | one lock, whole-process effect | **S** |
+| **4** | **L2, L11 → PI**, then **L6, L3 → PI**, ascending by call-site count (L2 one site, L11 three, L6 two, L3 ~240). L3 and L6 are `RwLock`s and the PI type is mutex-only (`sync.rs:27`) — this step needs either a PI rwlock or an explicit decision to demote them, with the read-concurrency cost stated. | the rows PI was written for | **M**, and L3 alone is **L** |
+| **5** | **Remove six of the eleven L8 locks** — init-time-write state to `ArcSwap`/`OnceLock`. Structural: shrinks the table instead of reclassifying it. | reduces the surface steps 6-7 apply to | **M** |
+| **6** | **L14, then L7 and L9** — the remaining park_on set. L14 by routing save-on-change through the callback queue. L7 and L9 follow whatever step 1 decides; they share L1's constraint. | dependent on step 1 | **M** |
+| **7** | **Make it reachable and measurable.** `linux-rt` is declared (`Cargo.toml:98`) and enabled nowhere; `is_pi_mutex_active()` (`sync.rs:36`) has no caller. Wire the feature into the RT profile alongside `EPICS_RS_ALLOW_RT_PRIORITY`, and report it at startup mirroring C's "PI is enabled" line (`osdMutex.c:205`). Add a latency regression that fails when a low-priority holder delays a high-priority waiter beyond a stated bound. | without this every step above is unverifiable, and 4b cannot be closed | **M** |
+
+Step 2's cheap half (CAS-UDP, iocsh) is three lines and is worth doing in the
+same change as 0a/0b, while that context is open.
+
+---
+
+## §7 What this evaluation does not establish
+
+* **Nothing was measured.** Every claim is static analysis. Whether any of these
+  inversions bites depends on `EPICS_RS_ALLOW_RT_PRIORITY` being on at all
+  (`task.rs:459`), on `CAP_SYS_NICE` (`task.rs:678-679` warns when the switch is
+  on but the process may not have permission), on core count and on load. The
+  order in §6 is a correctness order, not a measured-impact order.
+* **No RTEMS-target verification.** All priority reasoning is the Linux
+  SCHED_FIFO path (`task.rs:559-711`, `#[cfg(target_os = "linux")]`). On RTEMS
+  `apply_priority_impl` returns `PriorityApplied::Unsupported`
+  (`task.rs:715-719`), so no priority is applied on the real target today. That
+  is a separate gap from PI and belongs with RTEMS bring-up.
+* **`epics-pva-rs` was not swept.** The brief named the CA blocking threads and
+  the base background threads; the PVA server's locks are a further population.
+* **The three modified files are uncommitted.** If the concurrent panel amends
+  or drops those edits, rows marked ⚠ **moved** revert and §6 steps 0a/0b return
+  to the list.

--- a/doc/pva-rtems-item7-design.md
+++ b/doc/pva-rtems-item7-design.md
@@ -381,9 +381,33 @@ item 7 as a single unit.
    EPICS priority to `PVAS-client {peer}`, `PVAS-UDP`, or `PVAS-beacon` —
    which would re-open, for PVA, the exact asymmetry `blocking.rs:200`/`:669`
    closed for CA (SCHED_OTHER server threads sharing L16/L17 with 59–71
-   callback bands). pvxs offers no per-thread precedent (one reactor thread),
-   so the anchor is C's CA server: **recommend** `CaServerLow` (20) for
-   `PVAS-client`, `CaServerLow-1` (19) for `PVAS-UDP`/`PVAS-beacon`, applied
-   via `apply_to_current_thread` at thread start, same shape as
-   `blocking.rs:200`. Cheapest moment is stage C, when the threads are first
-   written — not a retrofit after.
+   callback bands).
+
+   ~~pvxs offers no per-thread precedent (one reactor thread), so the anchor is
+   C's CA server: recommend `CaServerLow` (20) for `PVAS-client`,
+   `CaServerLow-1` (19) for `PVAS-UDP`/`PVAS-beacon`.~~ **CORRECTED
+   2026-07-21 — that premise was false and the numbers with it.** pvxs *does*
+   assign server thread priorities, and it has two loops, not one:
+
+   | pvxs thread | source | priority |
+   |---|---|---|
+   | `PVXTCP` acceptor/reactor | `pvxs/src/server.cpp:388` `acceptor_loop("PVXTCP", epicsThreadPriorityCAServerLow-2)` | **18** |
+   | `PVXUDP` collector | `pvxs/src/udp_collector.cpp:93` `loop("PVXUDP", epicsThreadPriorityCAServerLow-4)` | **16** |
+
+   with `#define epicsThreadPriorityCAServerLow 20`
+   (`epics-base/modules/libcom/src/osi/epicsThread.h:82`). All three citations
+   re-verified line by line at pvxs `9348ebc`.
+
+   So the parity target is **18 for every per-connection thread** (reader,
+   operation, writer) — upstream that entire body of work is *one* thread at 18,
+   so splitting it three ways must not change its priority relative to anything
+   else — and **16 for `PVAS-UDP`/`PVAS-beacon`**. Applied via
+   `apply_to_current_thread` at thread start, same shape as CA's
+   `blocking.rs:200`. Cheapest moment is still stage C, when the threads are
+   first written — not a retrofit after.
+
+   **Reference-path note.** The global reference list gives pvxs as
+   `/Users/stevek/codes/epics-modules/pvxs`; that path does not exist on this
+   machine. The tree was found at `/home/stevek/work/epics-modules/pvxs`
+   (`9348ebc`) and the discrepancy is recorded here rather than silently
+   substituted.

--- a/doc/pva-rtems-item7-design.md
+++ b/doc/pva-rtems-item7-design.md
@@ -372,3 +372,18 @@ item 7 as a single unit.
    `phase6/pva-rtems-dep-gate` merged first, then the CA branch. Three unmerged
    branches are now on item 7's critical path: `manual-ca-sans-io`,
    `pva-channelsource-ring`, `pva-rtems-dep-gate`.
+   **RESOLVED 2026-07-21:** all three are merged into the local branch
+   `integration/rtems-scope-b` (design doc §9), gates green at `2ce9bd11`.
+   Stages C–G build there.
+
+5. **PVAS thread priorities** (added 2026-07-21, from
+   `doc/pi-lock-evaluation.md` §8.0 finding 3 / §8.4). This design assigns no
+   EPICS priority to `PVAS-client {peer}`, `PVAS-UDP`, or `PVAS-beacon` —
+   which would re-open, for PVA, the exact asymmetry `blocking.rs:200`/`:669`
+   closed for CA (SCHED_OTHER server threads sharing L16/L17 with 59–71
+   callback bands). pvxs offers no per-thread precedent (one reactor thread),
+   so the anchor is C's CA server: **recommend** `CaServerLow` (20) for
+   `PVAS-client`, `CaServerLow-1` (19) for `PVAS-UDP`/`PVAS-beacon`, applied
+   via `apply_to_current_thread` at thread start, same shape as
+   `blocking.rs:200`. Cheapest moment is stage C, when the threads are first
+   written — not a retrofit after.

--- a/doc/pva-rtems-stage-cd-design.md
+++ b/doc/pva-rtems-stage-cd-design.md
@@ -1,0 +1,469 @@
+# item-7 stage C (blocking accept driver) + stage D (blocking UDP search responder) — scoping
+
+Read-only investigation. No source file was edited.
+
+**Measured at:** worktree `/home/stevek/work/epics-rs/.caucus/worktrees/integration`,
+branch `integration/rtems-scope-b`, HEAD **`44681c76`** at start **and** end
+(unchanged). Working tree was **clean at start**; at end it was **dirty in one
+file** — see the box below. Every `file:line` is from HEAD `44681c76` unless
+the path says `epics-base` or `pvxs`.
+
+> ⚠ **The tree went dirty under the concurrent panel mid-investigation.**
+> `crates/epics-pva-rs/src/server_native/blocking.rs` is modified but
+> uncommitted (**+298 / −22**, `git diff --stat`), and the change is an
+> **in-flight stage-4 implementation** (`ConnRegistry`, `ConnWake`, a
+> registration guard). All `blocking.rs` line numbers below are therefore
+> quoted against `git show 44681c76:crates/epics-pva-rs/src/server_native/blocking.rs`
+> — the committed, reproducible blob, which is what I read. **§2.4
+> re-verifies every affected conclusion against the dirty tree**, and one
+> premise of §2 changes as a result. No other cited file went dirty
+> (`git status --porcelain` listed only this one).
+
+Both commits named in the brief are confirmed ancestors of the measured HEAD:
+
+- `44681c76` "feat(pva): blocking thread-per-connection server driver (item 5 stage 3)" — *is* HEAD.
+- `aa1af842` "refactor(pva): make the UDP search decode socket-free".
+
+**Baseline build**, `cargo +nightly check -p epics-pva-rs --lib
+--no-default-features -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf`:
+**exit 0, exactly 4 warnings.** Those 4 warnings are the measurement instrument
+for §3.
+
+---
+
+## 0. Summary of findings
+
+1. **Stage C does NOT force stage 4.** `serve_connection_blocking` tears down
+   its own connection completely and self-sufficiently
+   (`blocking.rs:440-457`), and CA's shipped accept loop deliberately does not
+   track client threads at all. Stage 4's socket registry is only needed to end
+   *live* connections *from outside* — a `stop()` semantic CA does not have
+   today either. §2. **But the ordering question is now moot**: the concurrent
+   panel is landing stage 4 in the working tree as I write, and its
+   `ConnRegistry` makes registration a *typed* requirement of
+   `serve_connection_blocking`. Stage C should be written against it. §2.4.
+2. **CA gives stage C a structural template, not reusable code.** Every one of
+   the eight reuse candidates is a ~10-40 line shape that must be re-typed
+   against PVA types; nothing is literally shareable because
+   `BlockingCaServer` is generic over neither the source nor the
+   per-connection handler. §1.
+3. **pvxs DOES assign server thread priorities** — the tree the brief named as
+   possibly-absent was found at a different local path, so the reference-source
+   stop condition was not met (§4.0). The values are
+   `epicsThreadPriorityCAServerLow-2` (TCP, `server.cpp:388`) and
+   `epicsThreadPriorityCAServerLow-4` (UDP, `udp_collector.cpp:93`) = **18 and
+   16**. This **contradicts item-7 decision 5's proposed "CaServerLow/19"** —
+   the parity values are 18/16, not 19. §4.
+4. **Stage D's blocker is a module boundary, not missing code.** The
+   socket-free core `process_search_datagram` and its four helpers all still
+   live *inside* `udp.rs`, which is `#[cfg(not(target_os = "rtems"))]`
+   (`mod.rs:58-59`). `aa1af842` made the function socket-free but left it
+   quarantined. Stage D's first move is the same extraction that `mod.rs:24-27`
+   records for `tcp.rs`. §3.2.
+5. **`rtems-pva-ioc` (stage G) has a shorter gap than expected**:
+   `PvDatabaseSource` is already un-gated (`server/mod.rs:10` carries no `cfg`)
+   and compiles on RTEMS today. What is missing is exactly stage C + stage D +
+   a `[[bin]]` entry. §5.
+
+---
+
+## 1. The RTEMS accept loop — reuse from CA vs write new
+
+CA's blocking driver is `crates/epics-ca-rs/src/server/blocking.rs` (2417
+lines; production ends at the `#[cfg(test)]` boundary `:984`).
+
+### 1.1 Reuse candidates, per element
+
+| # | Element | CA `file:line` | Reusable how | What PVA must write new |
+|---|---|---|---|---|
+| C1 | Server struct holding `listener: TcpListener` + `shutdown: AtomicBool` | `blocking.rs:139-146` (flag at `:144`) | **Shape only** | `BlockingPvaServer` with the PVA-side fields: `DynSource`, `PvaServerConfig`, `Arc<PeerRegistry>`, `ChannelInvalidator`, `guid`, `tcp_port` |
+| C2 | `bind()` — bind before any thread exists, so the port is owned by construction | `blocking.rs:150-165` (`TcpListener::bind` at `:155`) | **Verbatim shape**, different arg list | Nothing structural; carries the [[ca-server-port-ownership]] invariant across unchanged |
+| C3 | `serve(&self)` accept loop over `listener.incoming()` | `blocking.rs:176-232` | **Shape only** | Body differs: CA spawns 1 thread/client, PVA spawns 1 thread that then forks into 3 inside `serve_connection_blocking` |
+| C4 | Shutdown-flag re-check *both* on `Ok` and on `Err` arms | `blocking.rs:182` and `:219` | **Verbatim logic** | — |
+| C5 | `shutdown()` — wake the parked `accept()` by dialing our own `local_addr()` | `blocking.rs:234-243` | **Verbatim logic** | — |
+| C6 | Per-connection thread naming + priority application at thread top | `blocking.rs:200` (`apply_to_current_thread(ThreadPriority::CaServerLow)`) | **Shape**; the priority *value* changes | See §4 — PVA parity is `CaServerLow-2`, and there are 3 threads per connection, not 1 |
+| C7 | `tcp_port()` accessor for the SEARCH reply to advertise | `blocking.rs:245-247` | **Verbatim** | — |
+| C8 | UDP: `serve_udp_search(socket)` → `handle_udp_search_blocking(socket, …, &shutdown)` | `blocking.rs:263-265`, fn at `:446` | **Shape only** | PVA's datagram core is a different function (§3.2) |
+| C9 | UDP bind with `SO_REUSEADDR`+`SO_REUSEPORT` via raw `libc`, `#[cfg(unix)]` / `#[cfg(not(unix))]` arms | `bind_udp_search` `:277`; `bind_udp_search_socket` `:302` (unix) and `:341` (non-unix) | **Verbatim shape** | PVA already has a bind path but it is in gated `udp.rs` (`bind_udp` `udp.rs:137`) |
+| C10 | 200 ms `set_read_timeout` on the UDP socket so the recv loop can observe `shutdown` between datagrams | `blocking.rs:456` (`Duration::from_millis(200)`), loop `:469`, `recv_from` `:470` | **Verbatim logic** | — |
+| C11 | `block_on_sync` around the async decode from a plain thread | `blocking.rs:502-507` | **Verbatim idiom** | `process_search_datagram` is `async fn` (`udp.rs:954`) with exactly one `.await` (`search_matched_cids`, seen at the +121 offset) — same treatment applies |
+
+### 1.2 What is genuinely new (nothing in CA to copy)
+
+- **The three-thread fan-out.** CA's client handler is one thread
+  (`handle_client_blocking`, spawned at `blocking.rs:190-207`). PVA's
+  `serve_connection_blocking` internally starts reader + operation + writer
+  (module doc `blocking.rs:1-50`). The accept loop therefore spawns **one**
+  thread which itself becomes the operation thread — so an N-client PVA server
+  costs `3N+2` threads against CA's `N+2`. That is a stated RTEMS budget item
+  that CA never had to declare.
+- **The constructor arguments.** `serve_connection_blocking`
+  (`blocking.rs:384-391` at HEAD) takes `stream, peer, source, config,
+  peer_entry, channel_invalidator` — **six**; the in-flight stage-4 work adds a
+  seventh, `registry: &ConnRegistry` (§2.4). On the host these are assembled in
+  `accept.rs`:
+  `ChannelInvalidator::new()` at `accept.rs:69`, `PeerEntry::new(is_tls_client)`
+  at `:240`, `peers_for_task.insert(peer, …)` at `:241`. The RTEMS accept loop
+  must reproduce that assembly — `accept.rs` itself is
+  `#[cfg(not(target_os = "rtems"))]` (`mod.rs:29-30`) and cannot be reached.
+- **`PvaServerConfig` construction.** `config.rs` is un-gated (`mod.rs:39`) and
+  offers `Default` (`config.rs:337`), `isolated()` (`:385`) and `with_env()`
+  (`:409`). `with_env()` is the IOC-correct one; it needs no new work, only a
+  call site.
+
+---
+
+## 2. Composition: accept loop × 3 per-connection threads × `PvaServer::stop`
+
+Answered from the actual teardown code, not from intent.
+
+### 2.1 `PvaServer` cannot participate at all
+
+`PvaServer` lives in `runtime.rs`, which is `#[cfg(not(target_os = "rtems"))]`
+(`mod.rs:45-46`). Its fields are `Option<tokio::task::JoinHandle<…>>` for
+udp/udp_v6/tcp plus three `tokio::task::AbortHandle`
+(`runtime.rs:95-106`), and `impl Drop for PvaServer` (`runtime.rs:134-153`)
+calls `.abort()` on each. There is no RTEMS-reachable code path here. So the
+question is not "how does stage C compose with `PvaServer::stop`" but "what is
+the RTEMS analogue of stop", and the answer is C5 above: an `AtomicBool` plus a
+self-connect.
+
+### 2.2 Per-connection teardown is already self-sufficient — stage 4 not required
+
+`blocking.rs:440-457`, verbatim ordering:
+
+1. `drop(frame_tx)` — the only strong sender (the adapter holds a weak handle),
+   so the writer drains its queue, sees `None`, exits.
+2. `writer.join()`.
+3. `stream.shutdown(Shutdown::Both)` **on its own fd** — this is what returns
+   the reader's `read`, which is parked with an effectively-infinite
+   `SO_RCVTIMEO`.
+4. `reader.join()`.
+5. `drop(room)` — releases any producer parked on a full queue.
+
+The module doc states the boundary explicitly (`blocking.rs:46-50`):
+
+> Server-wide shutdown (a socket registry walked by `PvaServer::stop`) and the
+> writer-exit `oneshot` arm are stage 4 (§4.2b, §4.3). This module tears down
+> only its own connection, and does it without either.
+
+### 2.3 CA proves the semantic is shippable without a registry
+
+CA's `serve()` (`blocking.rs:176-232`) spawns each client thread and **drops
+the `JoinHandle`** — the threads are detached and exit on client disconnect.
+`shutdown()` (`:234-243`) stops the *accept loop* only; a live CA client
+connection survives a `shutdown()` until its peer goes away. That is the
+shipped, tested RTEMS CA semantic today.
+
+**Conclusion (2), as of HEAD `44681c76`:** stage C can be written **without**
+stage 4. It inherits CA's semantic: `stop()` = "stop accepting; live
+connections drain on their own disconnect". Stage 4's socket registry upgrades
+that to "stop also terminates live connections promptly", which is a strictly
+additional capability, not a prerequisite. The one honest caveat to record in
+the stage-C commit message: step 3 above shuts the socket *from inside its own
+connection*, so a connection whose peer never disconnects and never sends will
+hold 3 threads until process exit. That is precisely the gap stage 4 closes,
+and it is the same gap CA ships with.
+
+### 2.4 Re-verification against the dirty tree — one premise changes
+
+The uncommitted `blocking.rs` in the working tree **implements stage 4**. The
+concurrent panel got there first. Measured against the dirty file:
+
+| Anchor | at `44681c76` | in the working tree |
+|---|---|---|
+| Module doc "# Not here" | `:46` | `:83` — and its text now reads "The **accept loop** that owns a `ConnRegistry` … is item 7", i.e. the *only* remaining "not here" is stage C itself |
+| `pub fn serve_connection_blocking` | `:384` | `:625`, with a **7th parameter**: `registry: &ConnRegistry` |
+| `drop(frame_tx)` | `:452` | `:702` |
+| Reader wake | `stream.shutdown(Shutdown::Both)` on its own fd, `:454` | `registration.wake()` — the same syscall, but issued only through a registry-minted `ConnWake` handle |
+| `drop(room)` | `:456` | `:712`, followed by `drop(registration)` at `:715` (the sole removal path) |
+| `#[cfg(test)]` boundary | `:467` | `:725` |
+| New public API | — | `ConnRegistry` `:216`, `::new` `:227`, `::stop` `:240`, `::live_connections` `:255` |
+
+The doc block at `:61-71` states the invariant explicitly (MUST register before
+either thread starts, stay registered until both join; MUST NOT shut a socket
+or deregister other than through a registry-issued handle), and it notes that
+the §4.2b `oneshot`/seventh-`select!`-arm design was rejected in favour of the
+socket wake precisely so `tcp.rs` stays untouched.
+
+**What this changes, and what it does not:**
+
+- **Unchanged — the answer to question (2).** Stage C still does not *force*
+  stage 4: per-connection teardown was self-sufficient before, and remains so.
+  The conclusion was correct at the HEAD it was measured at.
+- **Changed — the premise.** "Stage 4 is future work" is false in the working
+  tree. Once that work commits, stage C is no longer *choosing* CA's
+  drain-on-disconnect semantic; it must **own a `ConnRegistry`**, because the
+  7th parameter makes registration non-optional by type. The §1.1 C1 row must
+  add `ConnRegistry` to `BlockingPvaServer`'s fields, and C5's shutdown becomes
+  two operations: set the accept flag + self-connect (CA's shape, `:234-243`)
+  **and** `ConnRegistry::stop()` to end live connections.
+- **Improved — the caveat above is retired.** The "3 threads held until process
+  exit for a silent peer" gap that §2.3 flagged is exactly what
+  `ConnRegistry::stop` closes. Stage C written against the working tree ships
+  *better* stop semantics than CA does today.
+- **Execution-order impact.** §5.4 lists stage 4 last. If the in-flight work
+  lands first, stage C should be written directly against `ConnRegistry`
+  rather than written to CA's weaker semantic and then retro-fitted.
+  Re-verify the parameter list at the actual commit before starting stage C —
+  it moved once already during a single investigation.
+
+---
+
+## 3. The 4-warning residue as a completion criterion
+
+Baseline (measured, exit 0):
+
+| # | Warning | Site |
+|---|---|---|
+| W1 | use of deprecated `fetch_update` | `tcp.rs:1404` |
+| W2 | associated function `PeerEntry::new` is never used | `peers.rs:141` |
+| W3 | methods `insert` and `remove` are never used (`PeerRegistry`) | `peers.rs:209`, `:214` |
+| W4 | fields `reply_addr`, `reply_port`, `unicast`, `protocols`, `consumed` are never read (`SearchRequest`) | `search.rs:53` |
+
+**Correction to the brief's wording:** it is `PeerEntry::new` +
+`PeerRegistry::{insert, remove}`. `PeerRegistry::new` at `peers.rs:205` is
+`pub` and is therefore *not* dead — the brief's `PeerRegistry::{new,insert,remove}`
+overstates by one.
+
+### 3.1 Stage C retires W2 and W3
+
+The only production callers today are host-only: `PeerEntry::new` at
+`accept.rs:240`, `.insert` at `accept.rs:241`, `.remove` at `accept.rs:338`
+(all inside the `cfg(not(rtems))` module). Uses at `blocking.rs:654` and
+`:911` are past the `:467` `#[cfg(test)]` boundary and do not count on a `--lib`
+check. A stage-C accept loop that mirrors `accept.rs:240-241` and removes the
+entry on connection exit retires both warnings **by construction** — if stage C
+lands and W2/W3 persist, the accept loop is not tracking peers, which is a
+defect, not noise.
+
+### 3.2 Stage D retires W4 — but the first move is an extraction
+
+All five fields are read only inside `udp.rs`, which is gated (`mod.rs:58-59`):
+
+- `reply_addr` / `reply_port` — `udp.rs:1009-1011`, `:1041-1042`, `:1065`
+- `unicast` — `udp.rs:846`, `:997`
+- `protocols` — `udp.rs:1395-1397` (the protocol gate) and `udp.rs:1770-1771`
+  (the forward-frame re-encoder)
+- `consumed` — `udp.rs:1031-1033`, `:1108`
+
+`queries` is *not* in the dead set because `search.rs:197-198`
+(`matched_cids_for_requester`) reads it, and `tcp.rs:5908` calls that.
+
+Note a **documentation defect found in passing**: `search.rs:34-37` claims
+"TCP only consults `queries` and `protocols` (and `seq` for the response
+echo)", but the compiler reports `protocols` unread on RTEMS — i.e. the TCP
+SEARCH path (`tcp.rs:5866-5913`) does *not* consult `protocols`. Doc and code
+disagree; not fixed here (read-only task), recorded under UNFIXED.
+
+**The structural finding.** `aa1af842` made `process_search_datagram`
+socket-free — its signature (`udp.rs:954-965`) takes `&DynSource`, a frame
+slice, addresses and ports, and returns `Vec<SearchOutput>`; it has exactly one
+`.await` and no tokio type. But it, and every helper it needs, is still inside
+the gated module:
+
+| Symbol | `udp.rs` line | Gated? |
+|---|---|---|
+| `process_search_datagram` | `:954` | yes |
+| `SearchOutput` | `:911` | yes |
+| `Origin` | `:1466` | yes |
+| `search_matched_cids` | `:1381` | yes |
+| `try_build_forward_frame` | `:844` | yes |
+| `filter_inbound` | `:890` | yes |
+
+So stage D is **not** "write a recv loop around an available core" — it is
+first an extraction of the socket-free half of `udp.rs` into an un-gated module
+(`search_engine.rs` or similar), then a ~60-line blocking loop shaped like C8 +
+C10 + C11. This is the identical move `mod.rs:24-27` records for `tcp.rs`:
+
+> the four items that held `tcp` back were fixed at source rather than gated
+> around (config and SEARCH protocol lifted out of the host-only modules that
+> held them …)
+
+Preferring the extraction over "copy the decode logic into a new RTEMS module"
+matters: a copy re-opens the whole family of SEARCH-parity bugs on a second
+code path.
+
+### 3.3 Completion criterion
+
+After stage C **and** stage D, the RTEMS `--lib` check must show **exactly 1
+warning** (W1, `fetch_update`, unrelated to item 7 and pre-existing). Any of
+W2/W3/W4 surviving is a measurable incompleteness, not noise.
+
+---
+
+## 4. Thread priorities — pvxs upstream parity
+
+### 4.0 Reference-source disposition
+
+The brief named `/Users/stevek/codes/epics-modules/pvxs`. That path is
+**absent** on this host (it is a macOS path; this is Linux). Per the
+reference-source rule the required action is *search locally first, and stop
+only if the search finds nothing*. The search **found** the tree at
+**`/home/stevek/work/epics-modules/pvxs`** (the fallback path the previous
+round already used, at `9348ebc`). The stop condition was therefore not met and
+I proceeded. Flagging the path discrepancy explicitly rather than silently
+substituting.
+
+### 4.1 pvxs assigns priorities — the answer is not "none"
+
+`epicsThreadPriorityCAServerLow = 20`
+(`/home/stevek/work/epics-base/modules/libcom/src/osi/epicsThread.h:82`).
+
+| pvxs thread | Site | Priority expr | Value |
+|---|---|---|---|
+| TCP acceptor + connection reactor (`PVXTCP`) | `src/server.cpp:388` (`Server::Pvt::Pvt`, member `acceptor_loop`) | `epicsThreadPriorityCAServerLow-2` | **18** |
+| UDP search collector (`PVXUDP`) | `src/udp_collector.cpp:93` (`Pvt::Pvt`, member `loop`) | `epicsThreadPriorityCAServerLow-4` | **16** |
+| Client TCP loop (`PVXCTCP`) — *client side, not server* | `src/client.cpp:1386` | `epicsThreadPriorityCAServerLow` | 20 |
+| `IfMapDaemon` (interface-map refresher) | `src/evhelper.cpp:727` | `epicsThreadPriorityMin` | 0 |
+| `SigInt` handler — *not a server thread* | `src/util.cpp:302` | `epicsThreadPriorityMax` | 99 |
+
+### 4.2 Consequences for stage C
+
+1. **item-7 decision 5 (`43fd50bd`) proposed `CaServerLow`/19 for the PVAS-*
+   threads. The upstream-parity values are 18 (TCP) and 16 (UDP).** 19 matches
+   neither. Recommend re-pointing decision 5 to 18/16 with these citations, or
+   recording an explicit deviation with a reason.
+2. **pvxs is one thread per role; we are three per connection.** pvxs's single
+   `acceptor_loop` does accept + read + decode + write for all connections at
+   priority 18. Our reader/operation/writer split has no upstream per-thread
+   analogue. The parity-preserving assignment is therefore **all three at 18**,
+   because upstream that work is one thread at 18 — splitting the work must not
+   silently change its scheduling class. Any deviation from uniform-18 (e.g.
+   raising the writer) is a design decision that needs its own justification,
+   not a default.
+3. **The ordering is deliberate and must be preserved**: UDP search (16) runs
+   *below* TCP service (18), which runs *below* CA's `CaServerLow` (20). A
+   flood of SEARCH datagrams must not starve established connections. Our
+   RTEMS CA server already sits at 20 (`epics-ca-rs/src/server/blocking.rs:200`)
+   with its event thread at `Custom(CaServerLow-1)` = 19 (`:669`). Adopting
+   18/16 for PVA slots the whole PVA front-end below the whole CA front-end,
+   which matches a co-hosted C IOC running both.
+4. **This costs nothing today.** Priority application is opt-in
+   (`EPICS_RS_ALLOW_RT_PRIORITY`, see `pi-lock-evaluation.md` §0 and
+   [[pi-locks-park-on-invisible]]) and on RTEMS `apply_priority_impl` is the
+   non-Linux arm returning `Unsupported`. The call sites should still be
+   written at stage C — retro-fitting priority calls into three thread spawns
+   later is exactly the "assign at stage C not retrofit" position decision 5
+   already took. Only the *numbers* in decision 5 need correcting.
+
+---
+
+## 5. The smallest `rtems-pva-ioc` (stage G) with zero bridge dependency
+
+Template: `crates/epics-ca-rs/src/bin/rtems-ca-ioc.rs` (whole file read;
+`ioc` module gated `#[cfg(any(target_os = "rtems", feature = "rtems-exec-model"))]`
+at `:60`).
+
+### 5.1 What already exists and needs nothing
+
+| Need | Status | Evidence |
+|---|---|---|
+| A `ChannelSource` backed by the record database | **exists, un-gated** | `PvDatabaseSource` `server/native_source.rs:33`, `new` `:46`, `new_with_acf` `:55`; `impl ChannelSource` `:583`. `server/mod.rs:10` declares `pub mod native_source;` with **no `cfg`**, unlike its neighbours `iocsh` (`:8-9`), `pva_server` (`:11-12`) which are gated |
+| DB load from `.db` text on a bare target | exists | `IocBuilder` + `block_on_sync(builder.build())`, `rtems-ca-ioc.rs:92-105` — reusable verbatim, base-side |
+| Callback pool / delayed timer / scanOnce before records | exists | `background_init()`, `rtems-ca-ioc.rs:112` |
+| Per-connection server driver | exists | `server_native/blocking.rs:384` `serve_connection_blocking` |
+| Server config | exists, un-gated | `config.rs` (`mod.rs:39`), `with_env()` `:409` |
+| Peer bookkeeping types | exist, un-gated | `peers.rs` (`mod.rs:44`) — currently the source of W2/W3 |
+| SEARCH reply builder | exists, un-gated | `search.rs` (`mod.rs:49`): `parse_search_request:82`, `matched_cids_for_requester:197`, `build_search_response_proto:220` |
+| RTEMS dep split in the manifest | exists | `epics-pva-rs/Cargo.toml:139` `[target.'cfg(not(target_os="rtems"))'.dependencies]`, `:152` the rtems arm |
+
+### 5.2 What does **not** exist yet — the actual gap list
+
+1. **Stage C**: `BlockingPvaServer` — `bind` / `serve` / `shutdown` /
+   `tcp_port` (§1.1 C1-C7), owning a `ConnRegistry` once the in-flight stage-4
+   work commits (§2.4). ~150 lines.
+2. **Stage D part 1**: extraction of the socket-free SEARCH core out of the
+   gated `udp.rs` into an un-gated module (§3.2, 6 symbols).
+3. **Stage D part 2**: `bind_udp_search` for PVA + `handle_udp_search_blocking`
+   equivalent (§1.1 C8-C11). ~90 lines.
+4. **A GUID for the server.** `random_guid()` is `udp.rs:47` — *gated*. The
+   SEARCH reply cannot be built without one, so this is a fifth symbol for the
+   §3.2 extraction list. (`try_fill_secure` at `udp.rs:62`/`:70` is its
+   `cfg`-split helper and comes with it.)
+5. **A `[[bin]]` target.** `crates/epics-pva-rs/Cargo.toml:193-221` declares
+   six binaries, *every one* `required-features = ["client"]`. There is no
+   server-side binary at all. A `rtems-pva-ioc` entry must be added with no
+   `client` requirement — otherwise the RTEMS build pulls the entire client
+   stack.
+6. **A `rtems-exec-model` feature on `epics-pva-rs`.** The CA binary's gate is
+   `cfg(any(target_os = "rtems", feature = "rtems-exec-model"))`
+   (`rtems-ca-ioc.rs:60`), which is what makes it testable on a host. `rg` of
+   `epics-pva-rs/Cargo.toml` shows no such feature; without it the binary is
+   RTEMS-target-only and un-testable in CI.
+
+### 5.3 Explicitly NOT needed
+
+- **No bridge dependency.** `PvDatabaseSource` reaches `PvDatabase` directly
+  from `epics-base-rs`. This is the zero-bridge path §5 of the previous round
+  asserted, now confirmed by the un-gated `server/mod.rs:10`. The
+  `bridge-rtems-walls.md` conclusion (bridge blocked by
+  `epics-bridge-rs/Cargo.toml:93`'s unconditional `tokio/full`) therefore does
+  **not** block stage G.
+- **No beacons.** Beacon send is `udp.rs:78` (`bind_beacon_send_v6`) and the
+  beacon timer machinery; PVA discovery works on SEARCH/response alone. Leave
+  beacons gated for the minimal IOC and record it as a known deviation.
+- **No ACF.** `PvDatabaseSource::new` (`:46`) takes no ACF; `new_with_acf`
+  (`:55`) is the opt-in. The CA binary makes the same choice
+  (`rtems-ca-ioc.rs:130`, permissive default).
+- **No `PvaServer` / `runtime.rs`.** §2.1.
+
+### 5.4 Suggested execution order
+
+1. Stage D part 1 (the extraction) — it is pure code movement, retires nothing
+   by itself, but unblocks both D-part-2 and the GUID need, and is the change
+   most likely to conflict with a concurrent panel.
+2. Stage C (`BlockingPvaServer`) — retires W2, W3.
+3. Stage D part 2 (the UDP responder) — retires W4. RTEMS `--lib` warnings
+   should now read exactly 1.
+4. Stage G (`rtems-pva-ioc` binary + `rtems-exec-model` feature).
+5. Stage 4 (socket registry) — only now, as the upgrade from CA's
+   drain-on-disconnect semantic to prompt termination.
+
+---
+
+## 6. Report
+
+**Tested:**
+
+- `git rev-parse HEAD` on the integration worktree — pass (`44681c76` at start and end, unchanged)
+- `git status --porcelain` at start — pass (clean)
+- `git status --porcelain` at end — **dirty**: `crates/epics-pva-rs/src/server_native/blocking.rs` modified (+298/−22) by the concurrent panel. Handled, not ignored: citations re-pointed to the `44681c76` blob and every affected conclusion re-verified in §2.4
+- `git merge-base --is-ancestor 44681c76 HEAD` / `aa1af842 HEAD` — pass (both ancestors)
+- `cargo +nightly check -p epics-pva-rs --lib --no-default-features -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf` — pass (exit 0, 4 warnings, enumerated in §3)
+- Locate pvxs reference tree — pass (found at `/home/stevek/work/epics-modules/pvxs` @ `9348ebc`; the brief's `/Users/...` path absent, §4.0)
+- pvxs server thread-priority enumeration — pass (5 sites, §4.1)
+- `epicsThreadPriorityCAServerLow` numeric value from local epics-base — pass (`epicsThread.h:82` = 20)
+- Per-connection teardown path read verbatim (`blocking.rs:440-457`) — pass
+- CA accept/shutdown path read verbatim (`blocking.rs:176-243`) — pass
+- CA UDP responder path read verbatim (`blocking.rs:446-507`) — pass
+- Dead-field read-site enumeration for all 5 `SearchRequest` fields — pass (all in gated `udp.rs`, §3.2)
+- `PeerRegistry::new` visibility check — pass (`peers.rs:205` is `pub`, brief's wording corrected)
+- `server/mod.rs` gate audit for `native_source` — pass (un-gated, `:10`)
+- `epics-pva-rs` `[[bin]]` audit — pass (6 bins, all `required-features = ["client"]`)
+- Re-verification of all 7 `blocking.rs` anchors against the dirty working tree — pass (§2.4 table; §2's conclusion survives, its premise does not)
+
+**Failed:** none.
+
+**UNFIXED:**
+
+- **Doc/code disagreement at `search.rs:34-37`.** The comment claims the TCP
+  SEARCH path consults `protocols`; the RTEMS compiler reports `protocols`
+  never read, and `tcp.rs:5866-5913` confirms it is not consulted. Not fixed —
+  this task is read-only. Whoever lands stage D should decide whether TCP
+  *should* gate on `protocols` (a behaviour change) or the comment is simply
+  stale (a doc fix).
+- **item-7 decision 5 (`43fd50bd`) carries the wrong priority number.** It
+  proposes `CaServerLow`/19; upstream parity is 18 (TCP) / 16 (UDP) per §4.1.
+  Not corrected — that doc lives on `main`, outside this read-only scope.
+- **W1 (`fetch_update` deprecation, `tcp.rs:1404`)** is pre-existing and
+  unrelated to item 7; left as the expected 1-warning residue.
+- **This doc is one commit stale by construction.** The in-flight stage-4 work
+  in the working tree (§2.4) is uncommitted, so its final shape — parameter
+  list, `ConnRegistry` API, line numbers — can still move before it lands.
+  §1.1 C1/C5 and §5.2 item 1 must be re-checked against the actual commit
+  before stage C is written. I did not read the uncommitted work beyond the
+  anchors needed to re-verify my own claims, because it is another panel's
+  in-progress change.
+
+**Fixed:** none — no source file was edited, no commit was made, as instructed.

--- a/doc/pva-rtems-stage-g-design.md
+++ b/doc/pva-rtems-stage-g-design.md
@@ -1,0 +1,527 @@
+# item-7 stage G — scoping `rtems-pva-ioc`
+
+Read-only investigation. No source file was edited, no commit made. One
+`cargo check` was run (mutates only `target/`).
+
+**Measured at:** worktree `/home/stevek/work/epics-rs/.caucus/worktrees/integration`,
+branch `integration/rtems-scope-b`, HEAD **`1c27465c`** ("feat(pva):
+BlockingPvaServer, the RTEMS accept loop (item 7 stage C)") at start **and**
+end. Working tree **clean** at both. Stage C confirmed as HEAD itself.
+
+**Measured baseline:** `cargo +nightly check -p epics-pva-rs --lib
+--no-default-features -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf`
+→ **exit 0, 2 warnings.** Stage C retired the two `peers.rs` warnings exactly
+as `doc/pva-rtems-stage-cd-design.md` §3.1 predicted. The residue is now W1
+(`fetch_update` deprecation, `tcp.rs:1404`, unrelated) and W4 (`SearchRequest`'s
+five dead fields, `search.rs:53`, stage D's). The completion criterion is
+holding on its own terms.
+
+---
+
+## 0. The five findings that decide stage G
+
+1. **Stage G does not need stage D.** Our server answers SEARCH **over the TCP
+   circuit** (`tcp.rs:5866`, `:5908`, `:5913`), and both pvxs
+   (`config.cpp:589-590`, `client.cpp:621-633`) and our own client
+   (`client_native/context.rs:168`, `:218-225`) support
+   `EPICS_PVA_NAME_SERVERS`. So an `rtems-pva-ioc` with **no UDP at all** is
+   fully reachable by a host client today. §5. This also makes PVA *easier*
+   than CA under QEMU SLIRP, not harder — it needs one TCP forward and no
+   datagram path whatsoever.
+2. **The GUID is broken right now, not merely at risk.** `PvaServerConfig`
+   defaults `guid: [0u8; 12]` (`config.rs:343`); the only assignment anywhere
+   in the crate is `runtime.rs:231` (`config.guid = random_guid()`), and
+   `runtime.rs` is host-only. `BlockingPvaServer::bind` never touches it
+   (`blocking.rs:829-853` — verified by `rg guid blocking.rs`: zero hits). So
+   **a stage-G IOC built on stage C serves SEARCH replies with an all-zero
+   GUID**, on host and on RTEMS alike. §3.
+3. **The Cargo.toml problem is worse than "add a `[[bin]]`".**
+   `epics-ca-rs` has `default = []` (`Cargo.toml:2`), which is *why* the
+   no-`required-features` trick works there. `epics-pva-rs` has
+   `default = ["tls", "pkcs12", "client"]` (`Cargo.toml`, `[features]` head),
+   and `tls` pulls `getrandom 0.2`, which the manifest's own comment calls
+   "the crate that does not build for RTEMS". A bare
+   `cargo check --bin rtems-pva-ioc --target armv7-rtems-eabihf` therefore
+   fails on dependencies, not on our code. §2.
+4. **The zero-bridge claim holds, walked in code.** `PvDatabaseSource` →
+   `DbSubscription::subscribe_with_mask` → `UpstreamMonitor::from_db` →
+   `recv_event().await`, with the source comment stating "The subscription IS
+   the stream: `marked_update` runs as the server pulls, so no task stands
+   between the two" (`native_source.rs:877-882`). Nothing in that chain is
+   gated or bridge-dependent. §4.
+5. **Two corrections to my own earlier docs.** (a) `epics-pva-rs` declares
+   **8** bins, not 6, and `mshim-rs` (`Cargo.toml:228-230`) has **no**
+   `required-features` — so the "all bins are client-gated" statement in
+   `doc/pva-rtems-stage-cd-design.md` §5.2 item 5 is wrong. (b) `mshim-rs`
+   imports `server_native::udp::ForwardableDatagram` and `tokio::net::UdpSocket`
+   (`mshim-rs.rs:35-37`), both RTEMS-gated, so the RTEMS command must stay
+   `--bin rtems-pva-ioc` and must never become `--bins`.
+
+---
+
+## 1. `rtems-ca-ioc.rs` step by step, and the PVA equivalent
+
+Template read in full: `crates/epics-ca-rs/src/bin/rtems-ca-ioc.rs`, 245 lines.
+
+| # | CA step | CA `file:line` | PVA equivalent | Status |
+|---|---|---|---|---|
+| 1 | `background_init()` — callback bands, delayed timer, scanOnce worker (C `callbackInit`) | `:112` | **identical** — same `epics_base_rs::runtime::task::background_init` | exists |
+| 2 | `load_database()` — argv are `.db` paths, else `DEMO_DB`; `block_on_sync(IocBuilder::build())` | `:80-84`, `:92-105`, `:115` | **identical, verbatim reusable** — `IocBuilder` is base-side and PVA-agnostic | exists |
+| 3 | `db.all_record_names()`, sorted | `:122-124` | **identical** | exists |
+| 4 | port + TCP bind: `cas_server_port()` → `BlockingCaServer::bind((0.0.0.0, port), db, acf)` | `:129-137` | `PvaServerConfig::default().with_env()` (`config.rs:409`) then `BlockingPvaServer::bind((0.0.0.0, port), source, config)` (`blocking.rs:829`) | **differs — 3 args, and the source must be built first** |
+| 5 | UDP search bind: `bind_udp_search(0.0.0.0:port)` | `:138-144` | **no equivalent exists** — stage D | **missing; §5 shows it is not required** |
+| 6 | thread `CAS-TCP` → `server.serve()` | `:146-155` | thread `PVAS-accept` → `server.serve()` (`blocking.rs:880`). Note `serve()` **applies `PVA_SERVER_PRIORITY` itself** (`:881`), where CA applies priority inside the per-client spawn (`server/blocking.rs:200`) | exists, slightly different shape |
+| 7 | thread `CAS-UDP` → `server.serve_udp_search(udp)` | `:157-166` | **no equivalent** — stage D | **missing; skip for stage G** |
+| 8 | banner + one line per record | `:168-176` | same shape, different text | trivial |
+| 9 | `tcp_thread.join()` then `udp_thread.join()`; runs until killed | `:182-194` | one thread to join; `shutdown()` exists (`blocking.rs:971-978`) but, as in CA, nothing calls it | simpler |
+
+### 1.1 What PVA needs that CA does not
+
+| Need | Why CA has no analogue | Where it comes from |
+|---|---|---|
+| **A `PvaServerConfig`** | `BlockingCaServer::bind` takes `(addr, db, acf)` — no config object at all | `config.rs`, un-gated (`mod.rs:39`); `Default` `:337`, `with_env()` `:409`, `isolated()` `:385` |
+| **A `DynSource`** | CA's server takes the `PvDatabase` directly | `DynSource = Arc<dyn ChannelSourceObj>` (`source.rs:2081`); the blanket `impl<T: ChannelSource + 'static> ChannelSourceObj for T` (`source.rs:2352`) is what lets `Arc::new(PvDatabaseSource::new(db))` coerce. Host precedent: `pva_server.rs:210` |
+| **A GUID** | CA has no server-identity concept on the wire | **nothing supplies one on this path today** — §3 |
+| **A protocol string** for SEARCH replies (`"tcp"`) | CA's reply carries no protocol field | passed into `build_search_response_proto` at `tcp.rs:5918` |
+| **`--no-default-features` on every RTEMS command** | `epics-ca-rs` `default = []` | §2 |
+
+### 1.2 What CA needs that PVA does not
+
+- **The ACF cell.** CA threads `Arc<RwLock<Option<AccessSecurityConfig>>>`
+  through `bind` (`rtems-ca-ioc.rs:130`). PVA's `PvDatabaseSource::new(db)`
+  (`native_source.rs:46`) omits ACF entirely; `new_with_acf` (`:55`) is the
+  opt-in. Stage G should use `new`, matching CA's permissive default, and say
+  so in the banner.
+- **A second socket.** With §5's name-server path, stage G binds exactly one
+  socket. CA needs two (TCP + UDP) because CA has no TCP-search fallback.
+
+### 1.3 What the binary does *not* have to do
+
+`BlockingPvaServer::bind` already does inside itself what `accept.rs:69-70`
+does on the host: constructs the `ChannelInvalidator` and calls
+`source.set_channel_invalidator(...)` (`blocking.rs:836-840`). It also
+constructs the `PeerRegistry` (`:846`) and the `ConnRegistry` (`:848`). So the
+binary assembles **none** of stage 4's machinery — a real simplification
+relative to what `doc/pva-rtems-stage-cd-design.md` §1.2 anticipated.
+
+---
+
+## 2. The `[[bin]]` entry and the `rtems-exec-model` feature
+
+### 2.1 What it must look like
+
+```toml
+# The RTEMS PVA IOC entry point (design doc §9.5 / item 7 stage G).
+# Deliberately NOT given `required-features`, for the reason
+# epics-ca-rs/Cargo.toml:226-231 gives: a required-features gate makes cargo
+# silently *skip* the target instead of building it, turning the RTEMS gate
+# into a vacuous pass.
+#
+# UNLIKE epics-ca-rs (default = []), this crate's default features include
+# `tls` -> getrandom 0.2, which does not build for RTEMS. So the RTEMS command
+# MUST carry --no-default-features:
+#   cargo +nightly check -p epics-pva-rs --bin rtems-pva-ioc \
+#     --no-default-features -Zbuild-std=std,panic_abort \
+#     --target armv7-rtems-eabihf
+[[bin]]
+name = "rtems-pva-ioc"
+path = "src/bin/rtems-pva-ioc.rs"
+```
+
+and in `[features]`:
+
+```toml
+# Routes the `runtime::task` seam to the RTEMS executor backend on a host, so
+# the RTEMS entry point is runnable and testable off-target. Mirrors
+# epics-ca-rs/Cargo.toml:106. NOT in `default`.
+rtems-exec-model = ["epics-base-rs/rtems-exec-model"]
+```
+
+### 2.2 What it must NOT do — five specific traps
+
+1. **Must not carry `required-features = [...]`.** That is the whole point of
+   the CA precedent (`epics-ca-rs/Cargo.toml:226-231`): cargo *skips*
+   unsatisfied bins silently, so the RTEMS check would pass while building
+   nothing. A loud dependency failure is strictly better than a silent skip.
+2. **Must not be added to `default`.** `rtems-exec-model` in `default` would
+   route the *hosted* task seam to the executor backend for every consumer of
+   the crate.
+3. **Must not rely on `--bins`.** `mshim-rs` has no `required-features`
+   (`Cargo.toml:228-230`) and imports `server_native::udp` +
+   `tokio::net::UdpSocket` (`mshim-rs.rs:35-37`), both RTEMS-gated. `--bins`
+   on the RTEMS target fails on mshim, not on us. Always name the bin.
+4. **Must not try to solve the default-features problem by narrowing
+   `default`.** Cargo has no per-target feature defaults, and dropping `tls`
+   from `default` would change every existing consumer's build. The honest fix
+   is the documented `--no-default-features` command, and a CI line that runs
+   exactly that command so it cannot rot.
+5. **Must not gate the binary body on `target_os = "rtems"` alone.** Copy CA's
+   predicate verbatim — `#[cfg(any(target_os = "rtems", feature =
+   "rtems-exec-model"))]` (`rtems-ca-ioc.rs:60`, `:197`) with the refusing stub
+   `main` for the hosted default (`:202-211`). That predicate is what makes
+   §5's rung −1 possible at all.
+
+### 2.3 Carry the guard test across
+
+`rtems-ca-ioc.rs:214-245` is a source-inspection test asserting the file never
+names `tokio::main` / `tokio::net` / `tokio::time` / `tokio::spawn` /
+`Runtime::new` / `Builder::new_multi_thread` / `block_in_place` / `block_on(`,
+assembled with `concat!` so the test body cannot self-match. Its rationale
+(`:220-226`) applies identically to PVA: tokio's `rt` features survive on the
+RTEMS target, so `cargo check` alone cannot catch a runtime constructor. Copy
+it. `blocking.rs:993-999` already carries the same `production_scope` helper
+idiom, so the crate has the pattern.
+
+---
+
+## 3. The GUID — traced end to end, and it is already broken
+
+### 3.1 The chain
+
+```
+PvaServerConfig::default()          config.rs:343   guid: [0u8; 12]
+  └─ with_env()                     config.rs:409   does NOT touch guid
+BlockingPvaServer::bind(...)        blocking.rs:829 does NOT touch guid
+  └─ (rg guid blocking.rs → 0 hits)
+tcp.rs SEARCH handler               tcp.rs:5913-5919
+  └─ build_search_response_proto(config.guid, ...)   ← ships [0u8;12]
+```
+
+The only assignment in the crate is `runtime.rs:224-231`
+(`let guid = random_guid(); ... config.guid = guid;`) and `runtime.rs` is
+`#[cfg(not(target_os = "rtems"))]` (`mod.rs:45-46`). The doc comment on the
+field even says "The runtime fills this from `random_guid()`"
+(`config.rs:47-49`) — which is precisely the assumption the blocking driver
+breaks.
+
+**So this is not a future RTEMS risk. A `BlockingPvaServer` built today, on
+any platform, advertises GUID `000000000000`.**
+
+### 3.2 Second defect: `random_guid` is unreachable on RTEMS anyway
+
+`random_guid` lives at `udp.rs:47`, inside the RTEMS-gated module
+(`mod.rs:58-59`). Its entropy helper is `try_fill_secure`, which under
+`#[cfg(unix)]` reads `/dev/urandom` (`udp.rs:63-69`) and under
+`#[cfg(not(unix))]` returns `false` (`udp.rs:70-72`).
+
+**RTEMS is `target_family = ["unix"]`** (verified from
+`rustc --print target-spec-json --target armv7-rtems-eabihf`), so it takes the
+`/dev/urandom` arm — and if that file does not exist on the BSP,
+`File::open(...).is_ok()` is simply `false` and the code falls **silently**
+into the time+PID fallback (`udp.rs:52-59`):
+
+```rust
+let now = SystemTime::now().duration_since(UNIX_EPOCH)...;  // 8 bytes
+let pid = std::process::id().to_le_bytes();                  // 4 bytes
+```
+
+On RTEMS/QEMU both inputs are near-constant: EPICS base sets the clock to a
+**fixed** `1397460606` at boot when there is no RTC, and its comment says the
+RTC "seems to be missing with libbsd and qemu"
+(`epics-base/modules/libcom/RTEMS/posix/rtems_init.c:958-966`); and RTEMS is
+single-process, so `process::id()` is a constant. **Two boots of the same image
+would produce GUIDs differing only by elapsed ticks since boot** — and with a
+10 ms tick (`rtems_config.c:33-35`) that is a handful of low bits.
+
+So the GUID chain has **three** distinct problems, in increasing subtlety:
+
+| # | Problem | Where | Detectable by |
+|---|---|---|---|
+| G1 | blocking driver never sets a GUID → all-zero | `blocking.rs:829-853` vs `runtime.rs:231` | a host unit test (§3.4) |
+| G2 | `random_guid` is inside the RTEMS-gated module | `udp.rs:47` | `cargo check --target rtems` once G1 is fixed |
+| G3 | the fallback is near-deterministic on RTEMS | `udp.rs:52-59` + fixed boot clock | only a two-boot comparison, or a host test that forces the fallback |
+
+### 3.3 What a degenerate GUID actually does to a client
+
+Not hypothetical — three concrete behaviours, read from pvxs:
+
+1. **It silences the duplicate-PV-name diagnostic.** `client.cpp:938-943`: when
+   a second SEARCH reply arrives for an already-connected channel, pvxs
+   compares `chan->guid != guid` and logs
+   `Duplicate PV name %s from %s and %s`. Two different servers both reporting
+   GUID 0 compare *equal*, so the warning never fires and the operator never
+   learns two IOCs are serving the same record.
+2. **It defeats server-restart detection.** `client.cpp:807`: a beacon whose
+   GUID differs from the cached one triggers the server-change path
+   (`cur.guid != msg.guid || cur.peerVersion != msg.peerVersion`,
+   `:807-824`). A constant GUID across reboots (G3) makes a restarted IOC look
+   like the same server that never went away.
+3. **It breaks gateway loop-avoidance.** `Context::ignoreServerGUIDs`
+   (`client.cpp:454-460`, checked at `:881-883`) is how a PVA gateway refuses
+   to search its own upstream. Ignoring one all-zero-GUID server ignores every
+   other one too.
+
+Our own client has the same semantics — `expected_guid` on the channel
+(`client_native/channel.rs:57`, set from the reply at `:960-962` with a comment
+citing pvxs `procSearchReply` parity) and a beacon tracker keyed on GUID
+(`beacon_throttle.rs:33`, `:136`).
+
+**All three failures are silent.** Nothing logs, nothing errors, and rungs 1–5
+of an acceptance ladder would pass with an all-zero GUID.
+
+### 3.4 The cheapest in-tree test — and it beats a reboot rung
+
+A host test under `--features rtems-exec-model`, in the stage-G binary's own
+`#[cfg(test)]` module, closes G1 outright and needs no guest:
+
+```rust
+#[test]
+fn the_served_config_carries_a_nonzero_guid() {
+    let config = build_server_config();          // the binary's own helper
+    assert_ne!(config.guid, [0u8; 12],
+               "SEARCH replies would advertise a null server identity");
+}
+
+#[test]
+fn two_servers_in_one_process_get_distinct_guids() {
+    assert_ne!(build_server_config().guid, build_server_config().guid);
+}
+```
+
+The second one also catches G3's *mechanism* — a fallback keyed on a coarse
+clock would collide when two configs are built in the same tick. That is
+exactly the RTEMS failure, reproduced on a host in microseconds.
+
+**But the test is the guard, not the fix.** Per the structural-over-patch rule,
+the fix is to make the null GUID **unrepresentable**:
+
+- **Preferred:** move `random_guid` + `try_fill_secure` out of the gated
+  `udp.rs` into the un-gated `config.rs` — where the field they exist to fill
+  already lives — and have `PvaServerConfig::default()` call it. Then no
+  construction path can produce a zero GUID, `runtime.rs:231`'s manual
+  assignment becomes redundant, and G1 and G2 close together. This is the same
+  extract-don't-copy move `mod.rs:24-27` records for `tcp.rs`.
+- **Weaker alternative:** have `BlockingPvaServer::bind` fill the GUID when it
+  is zero. That is a runtime check on an illegal state rather than a
+  construction that cannot produce it, and it leaves `PvaServerConfig` still
+  able to represent a null identity. Mention it only as a fallback.
+
+G3 remains open regardless and is `[VERIFY-ON-BOX]`: does the
+`xilinx_zynq_a9_qemu` BSP present `/dev/urandom`? If not, the fallback needs a
+better entropy source on RTEMS — `libc` declares `getentropy`
+(`newlib/rtems/mod.rs:143`) and `arc4random_buf` (`:145`) for this target, so
+the symbols exist to build one.
+
+---
+
+## 4. Does `PvDatabaseSource` really give a zero-bridge db-backed server?
+
+Walked, not asserted.
+
+**Gating.** `crates/epics-pva-rs/src/server/mod.rs:10` declares
+`pub mod native_source;` with **no `cfg`**, where its neighbours `iocsh`
+(`:8-9`) and `pva_server` (`:11-12`) are both `#[cfg(not(target_os = "rtems"))]`.
+Confirmed again at this HEAD.
+
+**Construction.** `PvDatabaseSource::new(db: Arc<PvDatabase>)`
+(`native_source.rs:46`). `impl ChannelSource for PvDatabaseSource`
+(`:583`). `Arc::new(...)` coerces to `DynSource` through the blanket impl at
+`source.rs:2352`.
+
+**The six operations a `pvxget`/`pvxinfo`/`pvxmonitor` needs, each traced:**
+
+| Client op | `ChannelSource` method | `native_source.rs` | Reaches |
+|---|---|---|---|
+| SEARCH match | `searchable` | `:642` | `db.has_name…` |
+| channel create | `has_pv` | `:626` | `db.find_entry` |
+| `pvxinfo` (type only) | `get_introspection` | `:648` | record snapshot → `FieldDesc` |
+| `pvxget` | `get_value` / `read_checked` | `:660` / `:687` | `snapshot_for(db, name)` `:572` |
+| `pvxput` | `put_value` | `:708` | record processing |
+| `pvxmonitor` | `subscribe_checked_opts_marked` | `:842` | see below |
+| `pvxlist` | `list_pvs` | `:588` | `all_record_names` + `all_simple_pv_names` + `all_alias_names` |
+
+**The monitor path in full** (`native_source.rs:865-882`):
+
+```rust
+let sub = DbSubscription::subscribe_with_mask(&db, &name, 0,
+                                              crate::nt::monitor_mask().bits()).await?;
+// The subscription IS the stream: `marked_update` runs as the server pulls,
+// so no task stands between the two.
+Some(MonitorStream::Upstream(UpstreamMonitor::from_db(sub, marked_update)))
+```
+
+`UpstreamMonitor::from_db` (`source.rs:1912-1921`) stores
+`UpstreamSub::Db(sub)` and a plain `fn` mapper; `recv` (`:1945-1955`) awaits
+`s.recv_event()` directly. **No spawned task, no channel, no bridge type**, and
+the comment at `:866-870` records that the mask is the union of pvxs's two
+subscriptions so DBE_PROPERTY events arrive.
+
+**Against `DEMO_DB`'s three records** (`rtems-ca-ioc.rs:80-84` — `ao`,
+`longout`, `stringout`): all three are ordinary records reached through
+`db.find_entry` → the record arm, i.e. the `DbSubscription` path above, not the
+`PvEntry::Simple` arm at `:886+`. The NT mapping is exercised by existing tests
+in the same file — `numeric_nt_declares_display_form_enum` (`:1535`),
+`integer_nt_limits_take_the_value_type` (`:1581`),
+`string_nt_omits_control_value_alarm_and_numeric_display` (`:1616`) — which
+between them cover exactly the double / integer / string shapes `DEMO_DB`
+produces.
+
+**Verdict:** the §5 claim from the stage-C/D doc holds. Zero bridge dependency,
+zero gated module, and the RTEMS `--lib` check compiles all of it (exit 0
+above). The `bridge-rtems-walls.md` finding
+(`epics-bridge-rs/Cargo.toml:93`'s unconditional `tokio/full`) does not touch
+this path.
+
+**One caveat worth stating:** `AcfCell = Arc<RwLock<…>>` at
+`native_source.rs:30` is a **tokio** `RwLock` (`use tokio::sync::RwLock` at
+`:21`). It is lock L23 in `doc/pi-lock-evaluation.md` §8 — the sole
+park_on-invisible row in that sweep. Using `PvDatabaseSource::new` (no ACF)
+rather than `new_with_acf` keeps it out of the stage-G path entirely.
+
+---
+
+## 5. The rung −1 equivalent for PVA
+
+### 5.1 Discovery: no UDP needed
+
+Our TCP SEARCH handler is at `tcp.rs:5860-5920` — `parse_search_request`
+(`:5866`), `matched_cids_for_requester` (`:5908`), reply gated on
+`!matched.is_empty() || req.must_reply` (`:5912`, pvxs `serverchan.cpp:240-249`
+parity), `build_search_response_proto` (`:5913`). It is in the un-gated `tcp`
+module (`mod.rs:57`).
+
+pvxs reads `EPICS_PVA_NAME_SERVERS` into `Config::nameServers`
+(`config.cpp:589-590`), and `client.cpp:621-633` / `:676-681` establishes a TCP
+connection to each and searches over it. Our own client does the same —
+`config::env::name_servers()` (`context.rs:168`), builder
+`name_servers(...)` (`:218-225`), fed to the SearchEngine as persistent search
+peers (`:385-386`).
+
+**Consequence:** the whole PVA ladder runs over one TCP port. Under QEMU that is
+`hostfwd=tcp:127.0.0.1:5075-:5075` and nothing else — no UDP forward, no
+broadcast question, and §0 finding 4 of the acceptance plan is not even needed
+for PVA.
+
+### 5.2 The golden capture, once the binary exists
+
+Mirror `doc/rtems-acceptance-golden.txt`'s structure. Use a non-standard port —
+never bind 5075/5076 in a test.
+
+```
+# terminal 1 — the IOC under test, on a host, exec-model backend
+EPICS_PVAS_SERVER_PORT=15075 \
+  cargo run -p epics-pva-rs --bin rtems-pva-ioc \
+    --no-default-features --features rtems-exec-model
+
+# terminal 2 — every host-side command, all TCP-only
+export EPICS_PVA_AUTO_ADDR_LIST=NO
+export EPICS_PVA_NAME_SERVERS=127.0.0.1:15075
+
+pvxinfo   RTEMS:AO RTEMS:LO RTEMS:MSG        # (a) type + GUID
+pvxget    RTEMS:AO RTEMS:LO RTEMS:MSG        # (b) values
+pvxget -F tree RTEMS:AO                      # (c) full structure WITH type id
+pvxmonitor RTEMS:LO &                        # (d) baseline update
+pvxput    RTEMS:LO 42                        # (e) update propagates
+pvxget    RTEMS:LO                           # (f) readback negative control
+```
+
+**Capture (a)–(f) verbatim into `doc/pva-acceptance-golden.txt`**, then have
+every guest-side rung assert equality modulo the port. Repeat the same six with
+our own tools (`pvinfo-rs`, `pvget-rs`, `pvmonitor-rs`, `pvput-rs`, which need
+the `client` feature, so a **second** host build) so the golden file records
+both client implementations — a divergence between them on the same server is
+itself a finding.
+
+### 5.3 Three things the CA golden run taught us that apply here
+
+1. **Do not predict the formatting.** The CA capture retired an UNFIXED item by
+   showing `caget` prints `1.5`, not `1.500` — `PREC=3` does not apply to a
+   default `DBR_DOUBLE` request. The PVA analogue is `display.precision`, and
+   whether `pvxget`'s default output honours it is exactly the kind of thing to
+   *capture*, not assert. (Relevant history: `pvxs` PR #196 fixed a
+   `display.precision` drop upstream — see the CBUG-G1 note.)
+2. **The first monitor update is `<undefined> … UDF NO_ALARM`, and that is
+   correct.** A record that has never been processed is UDF. The PVA analogue
+   is an initial monitor whose `alarm.status` reflects UDF/INVALID and whose
+   timestamp is the zero/boot time. **Assert it as the baseline; do not chase
+   it.** This is the single most likely thing to be misread as a stage-G bug.
+3. **Keep the readback negative control.** `pvxput` then `pvxget` proves the
+   monitor update came from record processing, not from a client-side cache.
+
+### 5.4 The type-id trap — mandatory, per [[pvxget-delta-omits-top-struct-id]]
+
+`pvxget`'s **default Delta output omits the top-level structure id**: a GET
+reply never sets the root bit, so `epics:nt/NTScalar:1.0` does not appear.
+Any rung that asserts the NT type **must** use `pvxget -F tree` or `pvxinfo` —
+line (c) above exists solely for this. Asserting the type from default `pvxget`
+output produces a false negative that looks exactly like a server-side NT
+mapping bug, and would cost a day on the guest where it is hardest to debug.
+
+### 5.5 One extra PVA-only rung
+
+**GUID distinctness across restarts.** Kill and restart the IOC, re-run
+`pvxinfo`, assert the reported GUID **differs**. On a host this is seconds; on
+the guest it is a reboot. Given §3, run it on the host first — and note that
+with G1 unfixed this rung fails immediately and correctly, which makes it the
+cheapest possible proof that G1 is real.
+
+---
+
+## 6. Ordered plan
+
+1. **Fix the GUID structurally** (§3.4): move `random_guid`/`try_fill_secure`
+   into un-gated `config.rs`, fill it in `PvaServerConfig::default()`, add the
+   two host tests. Closes G1 + G2. Do this **before** the binary, so the binary
+   is never written against a broken default.
+2. **Add `rtems-exec-model` to `epics-pva-rs`** (§2.1) and confirm
+   `cargo nextest run -p epics-pva-rs --features rtems-exec-model` is green.
+3. **Write `src/bin/rtems-pva-ioc.rs`** as CA's steps 1–4, 6, 8, 9 with step 5
+   and 7 omitted (§1), plus the copied source-inspection guard test (§2.3).
+4. **Add the `[[bin]]` entry** with the manifest comment spelling out the
+   `--no-default-features` asymmetry (§2.1), and a CI line running exactly that
+   RTEMS command.
+5. **Rung −1 on the host** (§5.2) → `doc/pva-acceptance-golden.txt`, including
+   the restart-GUID rung (§5.5) and the `-F tree` type assertion (§5.4).
+6. **Only then** stage D (UDP search responder), which upgrades discovery from
+   name-server-only to broadcast, retires W4, and needs its own priority
+   constant (pvxs `udp_collector.cpp:93` = `CAServerLow-4` = **16**; the
+   existing `PVA_SERVER_PRIORITY` is `Custom(18)` at `blocking.rs:144`, so 16
+   is a *new* constant, not a reuse).
+
+---
+
+## 7. Report
+
+**Tested:**
+
+- `git rev-parse HEAD` at start and end — pass (`1c27465c`, unchanged)
+- `git status --porcelain` at start and end — pass (clean both times)
+- `git merge-base --is-ancestor 1c27465c HEAD` — pass (stage C is HEAD)
+- `cargo +nightly check -p epics-pva-rs --lib --no-default-features -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf` — **pass, exit 0, 2 warnings** (W1 `tcp.rs:1404`, W4 `search.rs:53`). Stage C retired the two `peers.rs` warnings as predicted
+- Read `crates/epics-ca-rs/src/bin/rtems-ca-ioc.rs` in full (245 lines) — pass
+- `BlockingPvaServer` surface read (`blocking.rs:810-978`) — pass
+- `rg guid crates/epics-pva-rs/src/server_native/blocking.rs` — pass, **zero hits** (the G1 evidence)
+- GUID assignment audit workspace-wide — pass (sole production assignment `runtime.rs:231`, host-only; default `[0u8;12]` `config.rs:343`)
+- `random_guid`/`try_fill_secure` read (`udp.rs:47-72`) — pass
+- pvxs GUID semantics read (`client.cpp:807-824`, `:881-883`, `:918-943`, `:454-460`) — pass
+- Our client GUID semantics read (`client_native/channel.rs:950-962`, `beacon_throttle.rs:33`,`:136`) — pass
+- `PvDatabaseSource` → `DbSubscription` → `UpstreamMonitor::from_db` walked (`native_source.rs:842-882`, `source.rs:1912-1955`) — pass
+- `server/mod.rs` gate audit — pass (`native_source` un-gated at `:10`)
+- `DynSource` coercion path — pass (`source.rs:2081`, blanket impl `:2352`, host precedent `pva_server.rs:210`)
+- `epics-pva-rs` feature/bin audit — pass (`default = ["tls","pkcs12","client"]`; **8** bins; `mshim-rs` has no `required-features`)
+- `epics-ca-rs` feature audit — pass (`default = []` — the asymmetry that breaks the CA precedent)
+- TCP SEARCH path — pass (`tcp.rs:5860-5920`)
+- Name-server support both clients — pass (pvxs `config.cpp:589-590`, `client.cpp:621-633`; ours `context.rs:168`,`:218-225`)
+- `PVA_SERVER_PRIORITY` — pass (`blocking.rs:144` = `Custom(18)`, matching the corrected pvxs parity)
+- EPICS base fixed-boot-clock evidence for G3 — pass (`rtems_init.c:958-966`, `rtems_config.c:33-35`)
+
+**Failed:** none.
+
+**UNFIXED:**
+
+- **G1 — `BlockingPvaServer` serves an all-zero GUID.** Present on every
+  platform at this HEAD, not only RTEMS. Not fixed: read-only task. §3.4 gives
+  the structural fix and the two host tests.
+- **G2 — `random_guid` is unreachable from the RTEMS build** (gated `udp.rs:47`).
+- **G3 — the RTEMS entropy fallback is near-deterministic** (fixed boot clock +
+  constant PID). `[VERIFY-ON-BOX]`: whether `/dev/urandom` exists on
+  `xilinx_zynq_a9_qemu`.
+- **W4 remains** (`search.rs:53`, five dead `SearchRequest` fields) — stage D's,
+  unchanged and expected.
+- **Correction owed to `doc/pva-rtems-stage-cd-design.md` §5.2 item 5**: it says
+  all six bins are `required-features = ["client"]`. There are **8** bins and
+  `mshim-rs` has none. That doc is on `main`, outside this read-only scope.
+- **Stage D still needs a second priority constant** (16, per
+  `udp_collector.cpp:93`); `PVA_SERVER_PRIORITY` = 18 is not it.
+
+**Fixed:** none — no source file was edited, no commit was made, as instructed.

--- a/doc/rtems-acceptance-golden.txt
+++ b/doc/rtems-acceptance-golden.txt
@@ -1,0 +1,59 @@
+# Rung -1 golden capture — `rtems-ca-ioc` on Linux under `--features rtems-exec-model`
+#
+# Captured 2026-07-21 from integration/rtems-scope-b @ 1c27465c, host
+# x86_64 Linux, EPICS base C tools from /home/stevek/work/epics-base/bin/linux-x86_64.
+# Port 15064 throughout (never bind 5064 in a test); on the guest the same
+# lines appear with 5064 substituted.
+#
+# Every later rung of doc/rtems-runtime-acceptance-plan.md asserts equality
+# against THIS file. It exists so the expected output is a measurement rather
+# than a prediction.
+#
+# It already settles one open question the plan flagged: PREC=3 on RTEMS:AO
+# does NOT apply to the default DBR_DOUBLE request — caget prints 1.5, not
+# 1.500.
+
+=== rung 1: IOC console (stdout) ===
+rtems-ca-ioc: serving 3 records on CA port 15064 (TCP + UDP search), RTEMS execution model, no tokio runtime
+rtems-ca-ioc: RTEMS:AO
+rtems-ca-ioc: RTEMS:LO
+rtems-ca-ioc: RTEMS:MSG
+
+=== rung 4: caget -t RTEMS:AO RTEMS:LO RTEMS:MSG ===
+1.5
+7
+rtems-ca-ioc
+
+=== rung 4: caget (default formatting) ===
+RTEMS:AO                       1.5
+RTEMS:LO                       7
+RTEMS:MSG                      rtems-ca-ioc
+
+=== rung 3: cainfo RTEMS:AO ===
+RTEMS:AO
+    State:            connected
+    Host:             localhost:15064
+    Access:           read, write
+    Native data type: DBF_DOUBLE
+    Request type:     DBR_DOUBLE
+    Element count:    1
+
+=== rung 5: camonitor RTEMS:LO, spanning a caput ===
+RTEMS:LO                       <undefined> 7 UDF NO_ALARM
+RTEMS:LO                       2026-07-21 21:45:45.154147 42  
+#
+# Note the first update: timestamp <undefined>, severity UDF NO_ALARM. The
+# record has never been processed at that point, so this is the correct
+# baseline, not a defect — assert it, do not "fix" it on the guest.
+# The second line's timestamp is wall-clock and is the one field that will
+# differ on the guest.
+
+=== rung 5: caput RTEMS:LO 42 ===
+Old : RTEMS:LO                       7
+New : RTEMS:LO                       42
+
+=== rung 5 negative control: caget -t RTEMS:LO after the put ===
+42
+#
+# This is what proves the monitor update came from record processing rather
+# than a cached client-side value.

--- a/doc/rtems-authz-permissive-on-failure-audit.md
+++ b/doc/rtems-authz-permissive-on-failure-audit.md
@@ -1,0 +1,661 @@
+# Permissive-on-failure audit of the CA and PVA authorization paths
+
+**Measured at** integration worktree `/home/stevek/work/epics-rs/.caucus/worktrees/integration`,
+HEAD **`b594b18a7e70905ac607803e8bbc55bc469c166f`** (`fix(rtems): every IOC thread
+states a stack class — the first ceiling`), working tree **clean**.
+
+Reading began at `51cef3f2` while the sibling panel's A6 stack-class fix was
+still uncommitted (6 modified files). It landed as `b594b18a` mid-audit.
+`git diff --stat 51cef3f2..b594b18a` touches six files; two of them carry
+citations of mine (`epics-ca-rs/src/bin/rtems-ca-ioc.rs`,
+`epics-ca-rs/src/server/blocking.rs`) and **both citations were re-read and
+re-verified at `b594b18a`** (`rtems-ca-ioc.rs:140-141`,
+`blocking.rs:134`). Every other file cited here is byte-identical across the
+two commits. **Nothing in this audit was written; no file was edited, no
+commit made.**
+
+**Reference trees** (upstream comparison, read-only):
+- EPICS base (C) — `/home/stevek/work/epics-base`
+- pvxs (C++) — `/home/stevek/work/epics-modules/pvxs` @ `9348ebc` (`1.5.2-20-g9348ebc`)
+- ca-gateway (C++) — `/home/stevek/work/epics-modules/ca-gateway` @ `0666f21`
+  (**not** in the CLAUDE.md reference list; found by local search, present)
+
+---
+
+## 0. What was audited, and the one fact that reshapes the question
+
+### 0.1 Scope
+
+Every point at which an *identity* value enters an authorization comparison in
+the CA server, the PVA server, and the two gateways that reuse their gates:
+
+| identity | source | consumer |
+|---|---|---|
+| CA account | `CA_PROTO_CLIENT_NAME` (wire) | ACF UAG |
+| CA host | `CA_PROTO_HOST_NAME` (wire) **or** peer IP | ACF HAG, gateway `DENY FROM` |
+| CA method/authority | mTLS chain, cap-token | ACF `METHOD`/`AUTHORITY` |
+| PVA account | `CONNECTION_VALIDATION` `user` (wire) | ACF UAG |
+| PVA host | `CONNECTION_VALIDATION` `host` (**wire**) | ACF HAG, gateway control ACF |
+| PVA roles | `getpwnam`/`getgrouplist` on the account | ACF `role/<name>` UAG members |
+| PVA method/authority | advertised-method gate, x509 chain | ACF `METHOD`/`AUTHORITY` |
+| HAG member set | forward DNS at ACF-parse time | ACF HAG |
+| `.pvlist` `DENY FROM` set | forward DNS at pvlist-load time | gateway admission |
+
+### 0.2 The EPICS ACF model has no DENY construct — this corrects my own §A5
+
+`RuleAccess` is `{ None, Read, Write }` with `None` as `#[default]`
+(`epics-base-rs/src/server/access_security.rs:440-449`), and `compute_rules`
+(`:766-862`) starts at `AccessLevel::NoAccess` and only ever **raises** it:
+
+```rust
+let mut access = AccessLevel::NoAccess;          // :766
+...
+if access == AccessLevel::ReadWrite { break; }   // :778
+if rule_rank(rule_access(rule)) <= rule_rank(access) { continue; }  // :781
+```
+
+There is no rule form that lowers a granted level. This is faithful to C
+`asComputePvt` (cited at `:724-728`).
+
+**Consequence for the sentinel question the task poses:** inside the ACF engine
+a non-matching sentinel can only ever *fail to raise* access, i.e. it is
+uniformly fail-CLOSED. My Task N §A5 wrote that `unresolved:<host>` means "a
+rule meant to grant denies **and a DENY FROM rule fails to deny**" — the second
+half is wrong for the ACF engine, because no such rule exists there.
+
+The unsafe half of the asymmetry is real, but it lives in exactly one place:
+the **gateway `.pvlist` `DENY FROM`** construct (§2.2, §4). That is the only
+DENY primitive in the tree, and §4 treats it in both directions per site as
+asked.
+
+### 0.3 Method
+
+Every hit below was read in its file, not classified from a grep line. Verdicts
+are **ALLOW** (a failed or degenerate lookup widens access), **DENY** (it
+narrows access), **ERROR** (it refuses / propagates), or **NO-OP**.
+Upstream comparison is stated per site with the C/C++ file:line, because a
+deviation where **we are more permissive than upstream** is a different finding
+from one where we merely differ.
+
+---
+
+## 1. ALLOW — ranked
+
+### A1 (worst). The PVA server takes its ACF host identity off the wire; pvxs never does
+
+**Site:** `epics-pva-rs/src/server_native/tcp.rs:2767-2769`
+
+```rust
+("host", PvField::Scalar(crate::pvdata::ScalarValue::String(v))) => {
+    creds.host = v.as_str_lossy().into_owned();
+}
+```
+
+That is the **only** write to `ClientCredentials::host` in the crate
+(`rg 'host\s*=' server_native/tcp.rs` → one production hit, `:2768`; the other
+three are `let cred_host = cred.host.clone()` at `:6649`, `:6801`, `:6953`).
+It is never derived from, checked against, or reconciled with the peer address.
+
+It propagates into `ChannelContext.host` at **10** literal sites
+(`tcp.rs:4319, 4663, 4897, 5023, 5407, 6429, 6524, 7228, 7314, 7533`) — each of
+which builds the context with the real `SocketAddr` sitting in the adjacent
+field:
+
+```rust
+let ctx = crate::server_native::source::ChannelContext {
+    peer,                                 // tcp.rs:4316 — the trustworthy value
+    account: cred.account.clone(),
+    method:  cred.method.clone(),
+    host:    cred.host.clone(),           // tcp.rs:4319 — the wire value
+    ...
+```
+
+and reaches the ACF gate at **16** production call sites:
+`tcp.rs:1991, 4379, 4404, 4702, 5069, 6439, 6695, 6843, 6998, 7039, 7349`;
+`server_native/composite.rs:216`; `server_native/source.rs:760`;
+`epics-bridge-rs/src/pva_gateway/control.rs:596` and
+`pva_gateway/source.rs:519, 2015`.
+(`native_source.rs:1260/1269/1280` and `:3120…:3420` are inside
+`#[cfg(test)] mod tests` at `native_source.rs:1209` — test-only, excluded.)
+
+**Comparison performed:** `compute_rules` HAG match,
+`access_security.rs:820-827` — `members.iter().any(|m| m.eq_ignore_ascii_case(&host_lc))`.
+
+**Verdict: ALLOW.** A PVA client chooses the string that is matched against
+every `HOST(...)` HAG. Any rule scoped `HAG(trusted)` is satisfied by sending
+`host: "<whatever trusted contains>"` in the `ca` auth body.
+
+**Upstream:** pvxs has **no `host` field in `ClientCredentials` at all**
+(`src/pvxs/srvcommon.h:36-55` — `peer`, `iface`, `method`, `account`, `raw`,
+`roles()`). QSRV derives the ACF host from the socket:
+
+```cpp
+Credentials::Credentials(const server::ClientCredentials& clientCredentials) {
+    SockAddr addr(clientCredentials.peer);
+    addr.setPort(0);
+    host = std::string(SB()<<addr.map6to4());        // ioc/credentials.cpp:27-29
+```
+
+and hands exactly that to `asAddClient` (`ioc/securityclient.cpp:25-30`). The
+wire auth body is retained only as `C->raw` (`serverconn.cpp:232`) and is never
+consulted for authorization. **We are strictly more permissive than pvxs**, and
+the thing pvxs makes structurally impossible is what we do by default.
+
+**The code already documents the correct invariant and violates it — twice:**
+
+- `server_native/config.rs:545-548`:
+  *"Host name claim from the `ca` auth, when present. **Informational only —
+  never trust it for access decisions** over the network hostname /
+  mTLS-verified peer."*
+- `server_native/source.rs:99-100`:
+  *"**Reverse-resolved host name.** Empty when DNS lookup failed."*
+
+Neither is true of the value assigned. There is no reverse DNS anywhere in
+either server's identity path — the only DNS call in the whole authorization
+surface is the forward `to_socket_addrs` in `hag_members`
+(`access_security.rs:1507`), at ACF-parse time (verified by
+`rg 'lookup_addr|reverse|gethostbyaddr|to_socket_addrs'` over
+`epics-ca-rs/src/server`, `epics-pva-rs/src/server_native`,
+`epics-base-rs/src/server`: one hit, `access_security.rs:1507`).
+
+**`asCheckClientIP` does not reach PVA.** It has exactly six references in the
+workspace, all in `epics-ca-rs/src/server/tcp.rs` (`:842` production, `:7642-7668`
+tests). `rg as_check_client_ip crates/epics-pva-rs` returns nothing. An
+operator who hardens an IOC by setting `asCheckClientIP=1` hardens the CA
+circuit and leaves the PVA circuit exactly as it was — while simultaneously
+switching HAG members to dotted quads, which makes A2 worse.
+
+**Structural fix available in place:** `ChannelContext.peer` is already carried
+alongside (`source.rs:92`), so `host` can be derived from it at the 10
+construction sites, matching `credentials.cpp:27-29` (strip port, map6to4). The
+wire value belongs in the `raw`/diagnostic position pvxs puts it in.
+
+**Reachable on:** every platform. RTEMS adds nothing here — this is a
+host-Linux defect first.
+
+---
+
+### A2. The HAG sentinel and the dotted-quad HAG are both typeable by a PVA client
+
+**Sites:** `access_security.rs:1499-1529` (`hag_members`) composed with A1.
+
+Under `asCheckClientIP=1`, `hag_members` resolves each HAG entry at parse time
+and stores either a dotted quad (`:1516`) or the literal sentinel
+`format!("unresolved:{m}")` (`:1517`, `:1526`) — byte-identical to C
+(`asLibRoutines.c:1244`: `static const char unresolved[] = "unresolved:";`).
+
+On the **CA** side the matched identity is then `HostIdentity::Pinned(peer.ip())`
+(`epics-ca-rs/src/server/tcp.rs:842-844`), a dotted quad that can never equal
+`"unresolved:lab-pc1"` and cannot be chosen by the client. Sound.
+
+On the **PVA** side the matched identity is the wire string (A1). Therefore:
+
+- a client can send `host: "unresolved:lab-pc1"` and **match the sentinel** — a
+  HAG whose DNS lookup failed at load time becomes a *password* that anyone who
+  can read the `.acf` (or guess the hostname) can type;
+- a client can send `host: "192.0.2.7"` and match a HAG entry that the operator
+  believed was pinned to one machine's address.
+
+**Verdict: ALLOW**, and specifically an ALLOW created by the *failure* path
+(the sentinel exists only because a lookup failed).
+
+**Upstream:** unreachable in pvxs/QSRV — see A1; the host there is the socket
+peer, so no sentinel is ever typeable.
+
+**Reachable on:** every platform, but only when `asCheckClientIP=1`. On RTEMS,
+where DNS depends on DHCP having completed and on a resolver that
+`rtems_init.c` never configures beyond `/etc/dhcpcd.conf`
+(`epics-rtems-boot/csrc/rtems_init.c:165-188`), the `unresolved:` branch is the
+*expected* branch rather than the exceptional one, so A2 is additionally
+reachable there and additionally likely.
+
+---
+
+### A3. A verified mTLS chain whose leaf CN cannot be extracted silently becomes a self-asserted identity
+
+**Sites:**
+- `epics-pva-rs/src/auth/tls.rs:1211-1217` — `subject_common_name` returns
+  `None` for an absent CN, an empty CN, or one containing NUL.
+- `:1330-1342` — `x509_credentials_from_chain` is `Option`-returning and
+  short-circuits on that `None` (`let account = subject_common_name(leaf)?;`).
+- `server_native/accept.rs:271-283` — the result is stored as
+  `ConnInit::x509_identity: Option<X509Credentials>`.
+- `server_native/tcp.rs:3094-3098`:
+
+```rust
+let x509_locked = x509_identity.is_some();
+let mut cred = match x509_identity {
+    Some(id) => ClientCredentials::x509(id),
+    None     => ClientCredentials::anonymous(),
+};
+```
+
+`x509_locked == false` is exactly the plaintext path: `process_connection_validation`
+takes the `else` branch at `:2595` and **commits the client's
+`CONNECTION_VALIDATION` claim** (`:2632-2638`).
+
+**Verdict: ALLOW.** A peer that completed a full mutual-TLS handshake against
+the configured trust roots — i.e. one the operator believes is cryptographically
+identified — is handed the same self-asserted `method="ca", account=<anything>`
+path as an unauthenticated plaintext peer, on a cert-content technicality. The
+downgrade is silent: no `warn!` fires on the `None`.
+
+The narrower sibling case is sound and worth stating: when the chain has no
+self-signed CA at its end, `authority` is left empty (`:1339-1342`,
+`auth/x509.rs:32-34`), and an empty authority fails
+`rule.authority.iter().any(...)` at `access_security.rs:836-840` — DENY. Only
+the *account* extraction failure escalates, because it takes the whole
+credential with it.
+
+**Upstream:** **cannot be compared from this machine.** The local pvxs checkout
+(`1.5.2-20-g9348ebc`) has **no TLS support at all** — `ls src` shows no
+`ossl.cpp`, and `rg 'fill_credentials|X509'` over `src/*.cpp src/*.h` returns
+nothing. The `x509` method, `METHOD(...)`/`AUTHORITY(...)` ACF clauses and
+`PeerCredentials` that our port cites are from a pvxs version / branch not
+present here. See §7.C1.
+
+**Reachable on:** hosted only in practice — the `tls` feature is not in the
+RTEMS build (§6).
+
+---
+
+### A4. A `getpwnam` miss turns the account name into a role of the same name
+
+**Site:** `epics-pva-rs/src/auth/plain.rs:210-214`
+
+```rust
+let pw = libc::getpwnam(account_cstr.as_ptr());
+if pw.is_null() {
+    return vec![account.to_string()];
+}
+```
+
+and the same fallback on four further degenerate inputs (`:202` embedded NUL,
+`:223` non-UTF-8 `pw_name`, `:227` re-`CString` failure, `:264` the
+no-local-account-DB target arm).
+
+`roles` reaches `compute_rules` and matches `role/<name>` UAG members:
+
+```rust
+m == user || matches!(m.strip_prefix("role/"), Some(role) if roles.iter().any(|r| r == role))
+// access_security.rs:805-809
+```
+
+**Verdict: ALLOW.** A client claiming `user: "operators"` on a server where no
+passwd entry `operators` exists is granted `roles = ["operators"]` and satisfies
+`UAG(x) { role/operators }`. The role assertion is self-service whenever the
+lookup misses.
+
+**Upstream:** **exact parity — this is pvxs's own fallback.**
+
+```cpp
+passwd *user = getpwnam(account.c_str());
+if(!user) {
+    roles.insert(account);
+    return; // don't know who this is        // pvxs src/osgroups.cpp:56-60
+}
+```
+
+and QSRV pushes it as `role/<role>` (`ioc/credentials.cpp:43-45`). So this is a
+finding of the *lower* severity class the task defines — shared with upstream,
+not a deviation. It is listed here anyway because RTEMS changes its
+probability from "rare" to "always", see below, and because the two-line
+structural fix (deny when the account is unknown, rather than trusting it)
+would be a deliberate deviation the user has to sign off.
+
+**Reachable on:** every platform. **On RTEMS it is guaranteed for every account
+but `root`** — libcsupport synthesizes `/etc/passwd` containing only
+`root::0:0::::` before reading it (the box's measurement of `pwdgrp.c:201`
+preceding the `fopen` at `:203`), so every non-root `getpwnam` misses. Our
+build additionally selects the `#[cfg(not(local_account_db))]` arm on RTEMS
+(`plain.rs:253-265`), which reaches the *same* `vec![account]` result by a
+different route. Either way, on RTEMS `roles == [account]` for every PVA client,
+always, and `role/<name>` UAG rules are pure self-assertion there.
+
+---
+
+### A5. `cap-tokens`: a client opts out of token verification by omitting the prefix
+
+**Site:** `epics-ca-rs/src/server/tcp.rs:2554-2588`
+
+```rust
+state.username = match (&state.cap_token_verifier, raw.starts_with("cap:")) {
+    (Some(v), true) => match v.verify(&raw, state.tls_channel_binding.as_ref()) {
+        Ok(claims)  => { state.auth_method = "cap-token".into(); ... claims.sub }
+        Err(e)      => { tracing::warn!(...); "unverified".to_string() }
+    },
+    _ => raw,                                        // :2587
+};
+```
+
+The `_ => raw` arm fires whenever the payload does not start with `cap:` — i.e.
+whenever the client declines to present a token. Configuring a
+`TokenVerifier` (`ca_server.rs:337-342`) therefore adds a credential path
+without removing the un-credentialed one, and no "tokens required" mode exists:
+`rg 'require_token'` over `epics-ca-rs/src` returns nothing.
+
+**Verdict: ALLOW.** The verifier is advisory. A client that wants
+`username = "alice"` sends `alice`; a client that wants it verified sends
+`cap:<token>`. Both land in the same `state.username` that
+`access_for_asg(..., &self.username, ...)` (`tcp.rs:1008`) matches against UAG.
+
+The failure arm itself is well-built and should not be changed: a rejected
+token becomes the fixed literal `"unverified"` rather than folding
+attacker-controlled bytes into the ACF identity and the audit log
+(`:2573-2585`), and `"unverified"` matches no UAG unless one names it.
+Note only that a plaintext client can *also* type `unverified`, so the sentinel
+identifies a state, not a client.
+
+**Upstream:** none — `cap-tokens` is an epics-rs extension with no C
+counterpart. Not a deviation; an in-house gap.
+
+**Reachable on:** hosted only, and only under `--features cap-tokens` (default
+off). `epics-ca-rs/src/server/mod.rs:23` gates part of the surface on
+`all(feature = "cap-tokens", not(target_os = "rtems"))`.
+
+---
+
+### A6. No ACF attached ⇒ ReadWrite for everyone — including the state RTEMS boots in
+
+**Sites:** three, one per gate:
+
+- `epics-base-rs/src/server/access_security.rs:314-319` —
+  `AccessGateInner::Open => (AccessLevel::ReadWrite, false)` and
+  `Required { acf, .. }` with `*guard == None` → the same.
+- `epics-ca-rs/src/server/tcp.rs:1055-1059` (simple PV) and `:1104-1106`
+  (record field) — `else { (AccessLevel::ReadWrite, false) }`.
+
+**Verdict: ALLOW**, and **exact upstream parity**:
+
+```c
+#define asCheckGet(asClientPvt) (!asActive || ((asClientPvt)->access >= asREAD))
+#define asCheckPut(asClientPvt) (!asActive || ((asClientPvt)->access >= asWRITE))
+/* epics-base modules/libcom/src/as/asLib.h:46-49 */
+```
+
+with `int asActive = FALSE;` (`asLibRoutines.c:44`) and
+`asAddClient` returning `S_asLib_asNotActive` before doing anything
+(`:374`). An IOC with no ACF is unrestricted in C too.
+
+Two things make it worth naming rather than dismissing:
+
+1. **Upstream degrades into this state on an ACF *load failure*.**
+   `asInitFile` prints `ERROR asInitFile: Can't open file '%s'` to stderr and
+   returns `S_asLib_badConfig` (`asLibRoutines.c:179-183`); `asActive = TRUE`
+   is only reached at `:169` on the success path. A C IOC whose `.acf` is
+   missing keeps running fully permissive. **Our port is better here and should
+   stay that way:** `CaServerBuilder::acf_file` returns `Err(CaError::Io)` on a
+   read failure (`epics-ca-rs/src/server/ca_server.rs:181-186`), so the caller
+   must decide — see §3.
+2. **It is the state the RTEMS image boots in, unconditionally.**
+   `epics-ca-rs/src/bin/rtems-ca-ioc.rs:140-141`:
+
+   ```rust
+   let acf = Arc::new(tokio::sync::RwLock::new(None));
+   let server = match BlockingCaServer::bind((Ipv4Addr::UNSPECIFIED, port), db, acf) {
+   ```
+
+   There is no ACF, no path to load one from (the IMFS has no files), and no
+   environment to name one with (`rtems_init.c` calls `setenv` zero times —
+   Task N §A-fixed). So on target the entire §1 ranking above is moot in one
+   direction and sharpened in the other: **today every RTEMS PVA/CA client has
+   ReadWrite on everything**, and A1–A4 describe what happens the moment an ACF
+   is compiled in.
+
+---
+
+## 2. The DENY construct, and the one place we are more permissive than upstream on it
+
+### 2.1 `.pvlist DENY FROM` — DNS failure is handled correctly (fail-closed)
+
+`epics-bridge-rs/src/ca_gateway/pvlist.rs:190-197`, `:202-243`: a `DENY FROM`
+host that fails to resolve is dropped from the rule's host set with a `WARN`;
+if **all** of a rule's hosts fail, `from_hosts` ends empty and
+`is_global_deny` (`:117`) promotes the rule to a **global** deny. That is
+fail-closed in the direction a DENY rule needs, and it is cited to C's own
+two-pass parser (`gateAs.cc:504-507`, `:540-556`). IPv6 literals are dropped
+the same way with the same collapse, cited to `aToIPAddr` being AF_INET-only.
+
+**Verdict: DENY (sound).** This is the counter-example that proves the sentinel
+asymmetry was thought about somewhere: the ACF engine stores a never-matching
+sentinel because a non-match is safe there, and the pvlist collapses to a
+global deny because a non-match would be unsafe there.
+
+### 2.2 …but the write-side enforcement point feeds it the wrong identity type
+
+**Site:** `epics-bridge-rs/src/ca_gateway/upstream.rs:1603`
+
+```rust
+if pvlist.is_host_denied(&pv_name, &ctx.host) {
+```
+
+`ctx` is a `WriteContext` (`epics-base-rs/src/server/pv.rs:48-56`) built by the
+CA server at `epics-ca-rs/src/server/tcp.rs:4367-4371`:
+
+```rust
+let ctx = epics_base_rs::server::pv::WriteContext {
+    user: state.username.clone(),
+    host: state.hostname.as_str().to_string(),   // the HostIdentity string
+    peer: state.peer.clone(),                    // "ip:port" — the real thing
+};
+```
+
+Under CA's default (`asCheckClientIP == 0`) `state.hostname` is
+`HostIdentity::Claimed(...)` — **the name the client sent in
+`CA_PROTO_HOST_NAME`** (`tcp.rs:798`, `:847`, claimed at `:2483-2484`).
+
+`is_host_denied` compares that against `from_hosts`, whose documented
+post-`resolve_hosts` invariant is *"every non-empty `from_hosts` vec contains
+only IP-address strings, so `is_host_denied` can compare them directly against
+the TCP peer IP that callers pass"* (`pvlist.rs:199-201`, restated at
+`:286-291`, `:411-413`).
+
+Two consequences, both provable without running anything:
+
+1. **Type mismatch.** A dotted quad never equals a claimed host *name*, so under
+   the default configuration `DENY FROM` **never fires on the write path** for
+   any client that claims a normal hostname.
+2. **Client-controlled even when it does.** A client that claims
+   `HOST_NAME = "10.0.0.9"` selects which `DENY FROM` row applies to it — and by
+   claiming anything else, selects none.
+
+**The same policy is evaluated correctly at the other enforcement point.**
+`epics-bridge-rs/src/ca_gateway/server.rs:640`:
+
+```rust
+Some(addr) => pvlist.match_name_for_host(&name, &addr.ip().to_string()),
+```
+
+— the real peer IP, exactly as the invariant asks. So the two call sites of one
+policy disagree about what a host is, and the write side holds the untrusted
+one.
+
+**Upstream does the opposite by construction.** ca-gateway `gateServer.cc:1518-1533`:
+
+```cpp
+if(getAs()->isDenyFromListUsed()) {
+    char hostname[GATE_MAX_HOSTNAME_LENGTH];
+    // Get the hostname and check if it is allowed
+    //getClientHostName(ctx, hostname, sizeof(hostname));     // <- abandoned
+    struct sockaddr_in sockAdd = clientAddress.getSockIP();
+    ...
+    ipAddrToDottedIP(pSockAdd,hostname,sizeof(hostname));
+```
+
+The commented-out `getClientHostName` is the claimed-name path they deliberately
+did not take, and `gateAs.cc:456` states the matching half:
+*"All deny from rules with host names will be converted to ip addresses."*
+
+**Verdict: ALLOW, and a deviation where we are more permissive than upstream on
+the only DENY primitive in the tree.** By the task's own severity rule this
+ranks with A1. It is filed here rather than in §1 only because it is in
+`epics-bridge-rs` rather than the two servers proper.
+
+**Structural fix available in place:** `WriteContext.peer` (`pv.rs:54-55`) is
+already carried; the write path needs the same `addr.ip().to_string()` the
+search path uses (port-stripped), not `ctx.host`.
+
+---
+
+## 3. Verified fail-closed / fail-loud — what was checked and found sound
+
+Listed so the scoping is checkable, and because three of these are structural
+ports worth not regressing.
+
+| # | site | failure / degeneracy | verdict |
+|---|---|---|---|
+| S1 | `access_security.rs:766` `compute_rules` | any unmatched identity | **DENY** — starts `NoAccess`, only raises |
+| S2 | `access_security.rs:685-691`, `:714-723` | ASG name missing **and** no `DEFAULT` | **DENY** — explicit *"fail CLOSED rather than open"* comment; C always synthesises `DEFAULT` (`asLibRoutines.c:107`) |
+| S3 | `access_security.rs:440-449` | `RuleAccess` derive | **DENY** — `#[default] None` ⇒ `RULE(N, NONE)` is `asNOACCESS` |
+| S4 | `access_security.rs:850-853` + `epics-ca-rs/.../tcp.rs:994-1003` | CALC-gated rule with a bad input, an uncompilable expression, or **no INP resolver installed** | **DENY** — `unwrap_or(false)` on both eval and compile; `None => false` when no resolver |
+| S5 | `epics-ca-rs/src/server/tcp.rs:739-768` | client tries to overwrite a pinned host identity | **NO-OP by type** — `HostIdentity::claim` is a no-op on `Pinned`; the illegal transition is unrepresentable, not runtime-checked. Faithful to `camessage.c:839-843` / `caservertask.c:1425-1437` |
+| S6 | `epics-ca-rs/src/server/tcp.rs:2423-2434`, `:2501-2512` | `HOST_NAME`/`CLIENT_NAME` after the first channel | **ERROR** — `ECA_INTERNAL`, claim ignored; matches C `host_name_action`/`client_name_action` |
+| S7 | `epics-ca-rs/src/server/tcp.rs:2445-2465`, `:2520-2539` | unterminated or >511-byte name | **ERROR** — reply + `CaError::Protocol` (disconnect), matching C's `RSRV_ERROR` |
+| S8 | `epics-pva-rs/.../tcp.rs:2606`, `:2614-2638` | client selects an unadvertised auth method (e.g. claims `x509` over plaintext) | **DENY** — `advertised` is computed from the *effective* method and `*cred` is committed **only** on the advertised path; a rejected re-auth leaves the previous identity in force. Mirrors pvxs `serverconn.cpp:221-241` including the candidate-not-committed shape |
+| S9 | `epics-pva-rs/.../tcp.rs:2577`, `:2606` | truncated / undecodable auth body | **ERROR** — `?`-propagated, connection-fatal, mirroring pvxs `bev.reset()` (`serverconn.cpp:211-216`). The comment at `:2512-2520` records the pre-fix behaviour, which was an ALLOW of exactly this audit's shape (`method="ca", account="ca"`) |
+| S10 | `epics-pva-rs/.../tcp.rs:2465-2467`, `:2770-2775` | client advertises `groups`/`roles` on the wire | **DENY by construction** — every constructor funnels through `with_server_roles()`, which overwrites `roles` from `osd_get_roles(account)`; the wire field is matched and discarded |
+| S11 | `epics-pva-rs/.../tcp.rs:2793-2795` | `method == "ca"` with an empty `user` | **DENY** — `Ok(None)` ⇒ caller keeps `anonymous()`; matches `serverconn.cpp:229-231` |
+| S12 | `epics-ca-rs/src/server/ca_server.rs:181-186` | ACF file unreadable | **ERROR** — `Err(CaError::Io)`; **louder than C**, which prints to stderr and runs on permissive (`asLibRoutines.c:179-183`) |
+| S13 | `epics-bridge-rs/.../upstream.rs:1619-1625` | CA client never sent `CLIENT_NAME` | **DENY** — empty user refuses the put whenever the ACF has any rule |
+| S14 | `epics-bridge-rs/.../control.rs:592-604` | gateway control RPC with no control ACF configured | **DENY** — `None => false` |
+| S15 | `auth/tls.rs:1211-1217`, `:1383-1386`, `:1400-1405` | CN empty or containing NUL | **rejected at extraction** — correct in isolation; the *consequence* of the resulting `None` is A3 |
+| S16 | `auth/x509.rs:32-34`, `tls.rs:1339-1342` | chain has no self-signed CA at its end | **DENY** — empty `authority` fails `AUTHORITY(...)` at `access_security.rs:836-840` |
+
+---
+
+## 4. The sentinel asymmetry, per site, in both directions
+
+The task asks for this explicitly rather than assumed one way.
+
+| sentinel | where produced | matched against | under a grant rule | under a deny rule |
+|---|---|---|---|---|
+| `unresolved:<host>` | `access_security.rs:1517`, `:1526` (forward DNS failed at ACF-parse time, `asCheckClientIP=1` only) | HAG member list | **safe** — never matches, rule fails to grant (§0.2: the only outcome the ACF engine has) | **n/a — the ACF engine has no deny rule.** Not "safe by luck": structurally absent |
+| `unresolved:<host>` | same | HAG member list, **PVA path** | **unsafe** — the client picks the identity string (A1), so it can type the sentinel and match it (**A2**) | n/a |
+| `invalidhost.` | `auth/plain.rs:14`, `:26-28` — **client-side** only, when `gethostname()` fails | the server's HAG, as a claimed host | **safe on CA** (a claimed name matches only a name-form HAG, which is what the operator wrote); **client-controlled on PVA** (A1) — but no worse than any other string it could send | n/a |
+| `nobody` | `auth/plain.rs:13`, `:19-21` — client-side, when the user lookup fails | UAG members | as above: safe unless an operator writes `UAG(x) { nobody }`, which would then be satisfiable by anyone | n/a |
+| `unverified` | `epics-ca-rs/.../tcp.rs:2584` — cap-token verification failed | UAG members | **safe** — matches nothing unless named; deliberately *designed* to be namable so an ACF can single it out. Caveat: a plaintext client can type it too, so it names a state, not a client | n/a |
+| dropped host / empty `from_hosts` | `pvlist.rs:190-197` — `DENY FROM` host failed to resolve | `.pvlist` deny set | n/a | **safe** — the rule is promoted to a **global** deny (`is_global_deny`, `:117`) rather than silently not matching. The one site where the unsafe direction was live, and it is closed |
+| `""` (empty host) | `ClientCredentials::anonymous()` / `x509()` (`tcp.rs:2474`, `:2489`); `HostIdentity::Claimed(String::new())` (`epics-ca-rs/.../tcp.rs:798`) | HAG members | **safe** — matches no HAG member; but note a rule with an **empty** `hag` list still applies to it (`access_security.rs:821`, deliberate, C parity, documented at `:730-736`) | n/a |
+
+---
+
+## 5. Upstream comparison summary
+
+**More permissive than upstream (highest severity):**
+- **A1** — PVA ACF host is client-asserted; pvxs derives it from the socket
+  (`ioc/credentials.cpp:27-29`) and has no wire host field at all
+  (`srvcommon.h:36-55`).
+- **A2** — follows from A1; unreachable upstream.
+- **§2.2** — gateway `DENY FROM` evaluated against the CA-claimed host name;
+  ca-gateway explicitly uses `clientAddress.getSockIP()` and left
+  `getClientHostName` commented out (`gateServer.cc:1523-1530`).
+
+**Same as upstream (shared exposure, lower severity):**
+- **A4** — `getpwnam` miss ⇒ `roles = {account}` is verbatim pvxs
+  (`osgroups.cpp:56-60`).
+- **A6** — no ACF ⇒ permissive is verbatim base (`asLib.h:46-49`,
+  `asLibRoutines.c:44`, `:374`).
+- The `unresolved:` sentinel spelling is verbatim base (`asLibRoutines.c:1244`),
+  and `asCheckClientIP` defaulting to off is verbatim base
+  (`asLibRoutines.c:35` — `int asCheckClientIP;` with no initialiser ⇒ 0; our
+  `AtomicBool::new(false)` at `access_security.rs:1462-1463`).
+
+**Stricter than upstream (not defects; listed so a future "parity fix" does not
+undo them):**
+- **S12** — ACF read failure is an `Err`, not a stderr line.
+- **A3's sibling** — an empty/NUL CN is rejected outright rather than
+  propagated.
+- `composite.rs:216` calls `.check(...)` (which passes `&[]` roles,
+  `access_security.rs:293`) while the 11 `tcp.rs` sites and `source.rs:760`
+  call `.check_with_roles(...)`. Under `CompositeSource` a `role/<name>` UAG
+  member therefore cannot match. Fail-closed, so not a security finding, but
+  **it is an inconsistency between two call sites of one policy** — the same
+  shape as §2.2, in the safe direction.
+
+**No upstream to compare against on this machine:** A3 and everything else
+`x509`/`METHOD`/`AUTHORITY` — see §7.C1.
+
+---
+
+## 6. RTEMS reachability
+
+| finding | hosted | additionally on RTEMS |
+|---|---|---|
+| A1 | yes | yes — and `asCheckClientIP`, the only mitigation, was already PVA-blind |
+| A2 | only when `asCheckClientIP=1` | yes, **and more likely**: the `unresolved:` branch is the expected one when DHCP/resolver state is absent (`rtems_init.c:165-188` writes `/etc/dhcpcd.conf` and nothing else) |
+| A3 | yes | **no** — the RTEMS PVA build excludes the TLS surface |
+| A4 | on any unknown account | **always, for every non-root account** — libcsupport's synthesized `/etc/passwd` has only `root`, and our `#[cfg(not(local_account_db))]` arm (`plain.rs:253-265`) reaches the same result independently |
+| A5 | only under `--features cap-tokens` | **no** — `epics-ca-rs/src/server/mod.rs:23` gates on `not(target_os = "rtems")` |
+| A6 | when no ACF is configured | **always** — `rtems-ca-ioc.rs:140` hardcodes `None` and there is no filesystem to load one from and no env to name one with |
+| §2.2 | yes | not evaluated — `epics-bridge-rs` is outside the RTEMS dependency closure (Task M §0.1: only `epics-base-rs`, `epics-ca-rs`, `epics-pva-rs` reach an image) |
+
+---
+
+## 7. What I could not establish from this machine
+
+Stated in the terms the previous two audits used, with what would settle each.
+
+**C1 — the entire x509/TLS upstream comparison (blocks A3, S15, S16, and the
+`METHOD`/`AUTHORITY` parity claims our own doc comments make).**
+The local pvxs checkout at `9348ebc` (`1.5.2-20-g9348ebc`) contains no TLS
+support: `ls src` has no `ossl.cpp`, and `rg 'fill_credentials|X509'` over
+`src/*.cpp src/*.h` returns nothing. Our port cites
+`SSLContext::fill_credentials` and `PeerCredentials` (`auth/x509.rs:16-27`) —
+neither exists in the tree on this machine. I did not reconstruct them from
+memory. **What would settle it:** a pvxs checkout at a revision with
+`PVXS_ENABLE_OPENSSL` / the `tls` work merged, plus the epics-base branches for
+PR #563 / #618 that introduce the `METHOD`/`AUTHORITY` ACF clauses. Until then
+every "mirrors pvxs" claim on the x509 path in this workspace is unverified.
+
+**C2 — whether A1 is exploitable against a *real* pvxs or pvaPy client, or only
+against a crafted one.**
+I established that the server *reads and trusts* a wire `host` field. I did not
+establish which clients populate it, nor with what. `auth/plain.rs:271-276`
+shows our own client sends `EPICS_PVA_AUTH_HOST` or `gethostname()`. Whether
+pvAccessCPP / pvaPy send a `host` field at all is not decidable from a tree
+whose pvxs never reads one. **What would settle it:** a wire capture of a
+`CONNECTION_VALIDATION` reply from pvxs `pvxput` and from pvaPy, or reading the
+`buildCAMethod` equivalent in pvAccessCPP (not present locally). This does not
+change A1's verdict — the server's trust is the defect, not the clients'
+honesty — but it decides whether the fix is a behaviour change for existing
+deployments.
+
+**C3 — the actual ACF outcome on target for any of §1.**
+No RTEMS image has ever run an ACF: `rtems-ca-ioc.rs:140` hardcodes `None`, so
+A1–A4 are unreachable *today* on target and become reachable the moment an ACF
+is compiled in. I cannot say what `compute_rules` does with a real
+`.acf` on RTEMS because nothing has ever loaded one there. **What would settle
+it:** on the bring-up box, an RTEMS image with an ACF compiled into a static
+`&str` and passed to `BlockingCaServer::bind`, then a `caput`/`pvput` from the
+host against a `HAG`-scoped rule, once with a truthful host claim and once with
+a forged one.
+
+**C4 — whether `getpwnam("root")` on RTEMS returns before or after our
+`#[cfg(not(local_account_db))]` arm makes the question moot.**
+The box established the libcsupport synthesis (`pwdgrp.c:201` before the `fopen`
+at `:203`), and our build now selects the no-account-DB arm on RTEMS. Both
+routes give `roles = [account]`, so A4's *outcome* is settled. What is **not**
+settled is whether any other code path in the image still calls `getpwnam`
+directly and would receive the documented POSIX deviation (miss returns `EINVAL`
+rather than not-found). **What would settle it:** `rg 'getpwnam|getpwuid|getgrgid|getgrouplist'` over the RTEMS-reachable crates in a build with
+`local_account_db` off, plus a target run that calls each survivor.
+
+**C5 — whether §2.2's type mismatch is masked in any existing deployment by a
+client that happens to claim its own IP.**
+`is_host_denied` compares case-insensitively for exact string equality
+(`pvlist.rs:308`), so a client whose `HOST_NAME` claim happens to be its dotted
+quad *would* match. Whether any real client does that is not decidable from the
+tree. **What would settle it:** a `.pvlist` with a `DENY FROM` row, a gateway
+run, and a `caput` from a denied host — once with the default
+`CA_PROTO_HOST_NAME` a stock `caput` sends, once with none.
+
+**C6 — the trap/put-logging side.**
+`TrapWriteFields.host` is populated from the same `state.hostname`
+(`epics-ca-rs/src/server/tcp.rs:4343`), so a forged CA host claim also forges
+the *audit record* of the write. I traced the field to its construction but did
+not follow it through the listener chain to whatever consumes a put-log line, so
+I cannot state what a downstream audit consumer does with a forged host.
+**What would settle it:** reading the `TrapWriteListener` implementations and
+whatever `emit_putlog` (`epics-bridge-rs/.../upstream.rs:1761`, called at
+`:1657` and `:1799`) writes, against
+C `asTrapWriteWithData` (`rsrv/camessage.c:768-779`).

--- a/doc/rtems-boot-shim-design.md
+++ b/doc/rtems-boot-shim-design.md
@@ -1,0 +1,427 @@
+# The two artefacts our repo does not have — the RTEMS C boot shim and `.cargo/config.toml`
+
+Read-only investigation. No source file was edited, no commit made.
+
+**Measured at:** worktree `/home/stevek/work/epics-rs/.caucus/worktrees/integration`,
+branch `integration/rtems-scope-b`, HEAD **`69164b67`**, working tree **clean**.
+
+**G1/G2 confirmed closed at this HEAD** (independently re-verified, not taken on
+report): `random_guid` is at `server_native/search_engine.rs:46` with
+`try_fill_secure` at `:61`/`:69`, and `search_engine` is un-gated
+(`mod.rs:55`); `blocking.rs:878` does `config.guid = random_guid();`, there is a
+`guid()` accessor at `:909`, and a test `both_search_paths_advertise_one_guid`
+at `:2708`. G3 (entropy quality on the BSP) remains open and is w1's task.
+
+**Reference tree used (present locally, read):** EPICS base at
+`/home/stevek/work/epics-base` — specifically
+`modules/libcom/RTEMS/posix/rtems_config.c` (read in full),
+`modules/libcom/RTEMS/posix/rtems_init.c:140-1191`,
+`modules/libcom/RTEMS/score/rtems_config.c` (for contrast),
+`modules/libcom/RTEMS/Makefile`, `configure/toolchain.c:29-44`,
+`configure/os/CONFIG.Common.RTEMS`, and
+`configure/os/CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu`.
+
+> **Still not on this machine** (searched again): the RTEMS 6 kernel/BSP tree,
+> rtems-libbsd source, RTEMS headers, `arm-rtems6-gcc`, `qemu-system-arm`. The
+> toolchain now exists **on the remote box**, not here. So every RTEMS
+> *header-level* name below is cited from base's usage of it, and everything
+> that needs a real header or a real link is left as a named hole
+> (`[HOLE-n]`) with a capture instruction — not a guess.
+
+---
+
+## 0. Five decisions this investigation settles
+
+1. **We must use the POSIX arm, not the score arm.** `configure/toolchain.c:31-35`
+   selects `OS_API = posix` for `__RTEMS_MAJOR__ >= 5`. Two independent reasons
+   bind us to it regardless: Rust std threads are pthreads (`libc` declares
+   `pthread_create` for this target at `newlib/rtems/mod.rs:131`), and base's
+   **score** `rtems_config.c` contains no libbsd configuration at all — the
+   score link pulls only `-lnfs` (`CONFIG.Common.RTEMS:148`). Entry symbol is
+   therefore `POSIX_Init`, forced with `-u POSIX_Init`
+   (`CONFIG.Common.RTEMS:154`).
+2. **The 64-fd ceiling is a base *choice*, not an RTEMS limit, and it does not
+   bind us.** Base caps `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS 64`
+   (`posix/rtems_config.c:70`) purely to stay under newlib's `FD_SETSIZE`,
+   and its own comment (`:71-84`) says the cap exists because raising it
+   "will likely cause applications making `select()` calls to fault" —
+   explicitly noting "IOC core components (libca and RSRV) do not make
+   `select()` calls". Base's **score** config sets 150
+   (`score/rtems_config.c:36`). **Measured for us:** `rg 'libc::select|libc::poll|FD_SET|fd_set'`
+   across `epics-base-rs`, `epics-ca-rs`, `epics-pva-rs` returns **zero hits** —
+   every match is Rust's `Future::poll`. We are a blocking thread-per-connection
+   design with no reactor; that is the whole point. **So we may raise the fd
+   ceiling, and we should, because it is the binding constraint on concurrent
+   clients.** §1.2 row F.
+3. **The shim belongs in its own crate with a `build.rs` + `cc`, not prebuilt
+   and not duplicated per IOC crate.** §3.
+4. **`.cargo/config.toml` can carry the whole RTEMS link configuration without
+   touching the host build**, because `[target.<triple>]` sections apply only
+   when that triple is selected. §2.
+5. **Nothing in the shim may be `#[cfg]`-free.** A `.cargo/config.toml` in the
+   repo root is read for *every* invocation; only its `[target.armv7-rtems-eabihf]`
+   table is applied on the RTEMS target. The `[build]` table must stay empty of
+   RTEMS content. §2.3.
+
+---
+
+## 1. Artefact 1 — the C shim
+
+### 1.1 What base's `POSIX_Init` does that we do **not** need
+
+`rtems_init.c:945-1191`, walked. Dropped, with the reason:
+
+| Dropped | base site | Why we don't need it |
+|---|---|---|
+| NFS mount + `nfsMount` iocsh command | `:268-330`, `:594-616`, `:697` | our IOC loads its database from a compiled-in string or argv paths (`rtems-ca-ioc.rs:80-105`); there is no remote filesystem in the acceptance ladder |
+| TFTP / `initialize_remote_filesystem` | `:1126` | same — no remote startup script |
+| iocsh registration, `set_directory`, `IOCSH_PS1`/`IOC_NAME` | `:1160-1163`, `:1131-1141` | the interactive iocsh is host-only (`rustyline` does not build for RTEMS); `rtems-ca-ioc.rs:41-43` states there is no shutdown command by design |
+| telnetd / ftpd / `telnet_pseudoIocsh` | `:797-...`, `rtems_config.c:157-161` | no remote shell in scope; each is a service that adds tasks and fds we would then have to budget |
+| NTP (`epicsNtpGetTime`, `rtemsInit_NTP_server_ip`) | `:1088-1100` | the acceptance ladder asserts values and connections, not timestamps. Base itself prints "Until now no NTP support in RTEMS 5 with rtems-libbsd" (`:1087`) |
+| `setBootConfigFromNVRAM` / bootp NVRAM path | `:987-995` | legacy-stack-only (`#ifdef RTEMS_LEGACY_STACK`), and the zynq BSP config sets `-DMY_DO_BOOTP=NULL` (`CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu:12`) |
+| `fixup_hosts`, `gethostname`-derived prompt | `:1127`, `:1133-1140` | cosmetic |
+| the RTEMS shell and its ~25 `CONFIGURE_SHELL_COMMAND_*` | `rtems_config.c:117-155` | **keep a reduced subset** — see §1.2 row K; the full set is not needed but `netstat`/`ifconfig`/`stackuse` are rungs 2 and 6 of the acceptance ladder |
+| `epicsRtemsInitHookPre/Post` | `:986`, `:993` | base's extension point for site code; we have no site code |
+| `ne2kpci.c`, `QEMU_FIXUPS` e1000 NVM hack | `Makefile:38-40`, `:1017-1024` | both are `__i386__`-only (`#if defined(QEMU_FIXUPS) && defined(__i386__)`); irrelevant on ARM |
+
+### 1.2 The minimal `rtems_config.c` — every directive kept, justified
+
+Each row cites the base line it comes from. Rows **D, E, F, G** are the four
+the brief calls out as load-bearing for us specifically; they are marked ★.
+
+| | Directive | base line | Why we keep it |
+|---|---|---|---|
+| A | `CONFIGURE_POSIX_INIT_THREAD_TABLE` + `..._ENTRY_POINT POSIX_Init` + `..._STACK_SIZE (64*1024)` | `rtems_config.c:26-28` | this **is** the entry contract; without it there is no `POSIX_Init` and `-u POSIX_Init` has nothing to pull |
+| B | `CONFIGURE_APPLICATION_NEEDS_CLOCK_DRIVER` | `:64` | no clock driver ⟹ no ticks ⟹ `rtems_task_wake_after`, every Rust `thread::sleep`, and our delayed-timer band never fire |
+| C | `CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER` | `:65` | the console **is** the acceptance instrument — every rung scrapes `println!` off the serial line |
+| D ★ | `CONFIGURE_MICROSECONDS_PER_TICK 10000` | `:33-35` | keep base's value **and record it**. 10 ms is the quantum for `thread::sleep`, our delayed-timer band, and every latency number the ladder could produce. Base makes it overridable from the build (`:30-32`); we should expose the same override rather than hard-code, so a timing experiment does not need a source edit |
+| E ★ | `CONFIGURE_EXTRA_TASK_STACKS (4000 * RTEMS_MINIMUM_STACK_SIZE)` | `:38` | ≈32 MB of extra task stack. **This matters more to us than to a C IOC**: CA is 1 thread per client and PVA is 3 (`blocking.rs:795-800` states the 3N+2 budget explicitly), and every Rust thread's stack comes out of this pool. Keep base's generous value; shrinking it is an optimisation to make *after* rung 6 measures actual usage |
+| F ★ | `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS` — **raise above base's 64** | `:70`, caveat `:71-84`; contrast `score/rtems_config.c:36` = 150 | this is the real concurrent-client ceiling. Base capped it at 64 only to stay under newlib's `FD_SETSIZE` for `select()` users; **we make no `select`/`poll` call anywhere** (measured, §0 item 2). Each connection is one fd regardless of how many threads serve it, so raising this raises the client ceiling directly. `[HOLE-A]` |
+| G ★ | `CONFIGURE_STACK_CHECKER_ENABLED` | `:92` | the single most valuable debugging directive for a Rust port. Rust's own stack-guard machinery is thin on a tier-3 target; without this a blown thread stack is silent memory corruption. Pair it with base's exit hook: `on_exit(default_network_on_exit, NULL)` (`:1035`) whose body is `rtems_stack_checker_report_usage_with_plugin(&printer)` (`:819-827`) — that is what turns rung 6's "check `stackuse`" into a real measurement |
+| H | `CONFIGURE_UNLIMITED_OBJECTS` + `CONFIGURE_UNLIMITED_ALLOCATION_SIZE 32` | `:88-89` | so RTEMS task/semaphore/mutex counts are not a fixed table. This is what makes thread-per-connection viable at all, and it closes half of design-doc §11's "task-count budget" open item |
+| I | `CONFIGURE_UNIFIED_WORK_AREAS` | `:90` | one heap for RTEMS objects and malloc, so the 32 MB stack pool and the Rust allocator are not two separately-sized pools we must both get right |
+| J | `RTEMS_BSD_CONFIG_BSP_CONFIG` + `RTEMS_BSD_CONFIG_INIT` + `#include <machine/rtems-bsd-config.h>`, under `#ifndef RTEMS_LEGACY_STACK` | `:47-60` | **this is what puts libbsd in the image.** Without it `std::net` links against nothing |
+| K | `CONFIGURE_USE_IMFS_AS_BASE_FILESYSTEM`, `CONFIGURE_FILESYSTEM_IMFS`, `CONFIGURE_FILESYSTEM_DEVFS` | `:48`, `:45`, `:42` | dhcpcd writes `/etc/dhcpcd.conf` (`rtems_init.c:839-873`) so a writable root is required; DEVFS is what gives `/dev/console` and — relevant to G3 — is where `/dev/urandom` would appear if it exists |
+| L | a **reduced** shell: `CONFIGURE_SHELL_COMMANDS_INIT`, `rtems_shell_{NETSTAT,IFCONFIG}_Command`, `CONFIGURE_SHELL_COMMAND_STACKUSE`, `CONFIGURE_SHELL_COMMAND_MALLOC_INFO`, `#include <rtems/shellconfig.h>` | `:117-155` | exactly the four the ladder uses: `netstat -an` is rung 2, `stackuse` + `malloc_info` are rung 6, `ifconfig` is the diagnosis path when rung 3 fails. Everything else in base's list is dropped |
+| M | `CONFIGURE_MAXIMUM_DRIVERS 40` | `:166` | cheap, and libbsd + console + shell register several |
+| N | `CONFIGURE_INIT` then `#include <rtems/confdefs.h>` **last** | `:184-186` | confdefs is a single-translation-unit generator; this must be the final two lines |
+
+**Explicitly not carried over:**
+
+- `CONFIGURE_APPLICATION_NEEDS_RTC_DRIVER` — base guards it out for `__arm__`
+  (`:169-172`), and its own comment says the RTC "seems to be missing with
+  libbsd and qemu" (`rtems_init.c:958-961`). This is also the mechanism behind
+  G3: no RTC ⟹ fixed boot clock ⟹ a time-seeded GUID fallback is deterministic.
+- `RTEMS_BSD_CONFIG_DOMAIN_PAGE_MBUFS_SIZE` — base sets it only for
+  `BSP_pc386`/`pc686`/`qoriq_e500` (`:176-180`), **not** for zynq, which
+  therefore takes libbsd's default. Leave it unset to match base, and revisit
+  only if rung 5/6 shows mbuf exhaustion. Note base defines `BSP_$(RTEMS_BSP)`
+  via `Makefile:41` (`rtems_config_CPPFLAGS += -DBSP_$(RTEMS_BSP)`), so if we
+  ever need a BSP conditional we must pass `-DBSP_xilinx_zynq_a9_qemu`
+  ourselves.
+- NFS / TFTP / libblock / BDBUF (`:41-44`, `:94-97`) — no block devices.
+- `CONFIGURE_MAXIMUM_PERIODS 5`, `CONFIGURE_IMFS_ENABLE_MKFIFO 2`,
+  `CONFIGURE_MAXIMUM_NFS_MOUNTS`, `CONFIGURE_MAXIMUM_USER_EXTENSIONS`
+  (`:30`, `:85-87`) — tied to the dropped facilities.
+
+**`[HOLE-A]` — the fd ceiling value.** Capture on the box: the value of
+`FD_SETSIZE` in this toolchain's `<sys/select.h>`, and whether RTEMS 6's
+confdefs spells it `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS` (base posix) or
+`CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS` (base score, `score/rtems_config.c:36`)
+— base uses both names in different files and I have no RTEMS headers here to
+tell which is current. Then set it to the client ceiling we want (start at 150,
+matching base's own score value) and confirm the image still boots.
+
+### 1.3 The minimal `POSIX_Init`
+
+Ten steps, each citing base. Everything base does that is not in this list is
+in §1.1's dropped table.
+
+| # | Step | base site | Note |
+|---|---|---|---|
+| 1 | `initConsole()` — `tcgetattr`/`tcsetattr` clearing `IXOFF|IXON|IXANY` | `rtems_init.c:711-729`, called `:953` | keep the flow-control clear, drop base's four diagnostic `printf`s at `:715-718` |
+| 2 | `clock_settime(CLOCK_REALTIME, &now)` with a fixed epoch | `:960-970` | base hard-codes `1397460606` because there is no RTC. **Keep it, and make the constant visible**, because it is G3's root cause; a build that later gains real entropy or NTP can drop it |
+| 3 | `epicsThreadSetPriority(self, iocsh)` equivalent — get off POSIX prio 2 | `:1000-1002` | we have no `epicsThreadSetPriority`; the equivalent is a `pthread_setschedparam`/`rtems_task_set_priority` to a **low** priority so our own threads (PVA accept at `Custom(18)`, `blocking.rs:144`) are not starved by the init task |
+| 4 | `rtems_bsd_setlogpriority("debug")` | `:1034` | keep for bring-up; make it a compile-time switch so a quiet image is possible later |
+| 5 | `on_exit(default_network_on_exit, NULL)` → stack-checker report | `:1035`, body `:819-827` | this is directive G's payoff |
+| 6 | `default_network_set_self_prio(RTEMS_MAXIMUM_PRIORITY - 1U)` | `:830-837`, called `:1038` | lower ourselves so libbsd's background work can run during init |
+| 7 | `rtems_bsd_initialize()` + `assert` | `:1040-1041` | **the stack comes up here** |
+| 8 | `rtems_task_wake_after(2)` — let the callout timer allocate | `:1043-1045` | base's comment; keep verbatim |
+| 9 | `rtems_bsd_ifconfig_lo0()` | `:1049` | loopback, and it is what makes `EPICS_CA_ADDR_LIST=127.0.0.1` meaningful inside the guest |
+| 10 | `rtems_dhcpcd_add_hook(&hook)` → `default_network_dhcpcd()` → `epicsEventWaitWithTimeout(dhcpDone, …)` | `:1051-1056`, `:1066`; hook `:742-812`; conf writer `:839-873` | **reduce the hook drastically**: base parses seven dhcp variables (NTP, TFTP, bootfile, cmdline) into globals; we need only `reason == BOUND` to signal, plus `new_host_name` for `sethostname`. Base waits 600 s (`:1066`); use a short timeout and **proceed anyway on timeout**, printing loudly — a dead network should still give us a booting image to diagnose, and rung 1 does not need an address |
+| 11 | `main(argc, argv)` then `epicsExit`/`exit` | `:1180-1190` | this is the contract our Rust `fn main` satisfies |
+
+Keep base's two `ifconfig`/`netstat` dumps (`:1084-1087`) — they cost nothing
+and rung 3's diagnosis depends on knowing the guest's address.
+
+`delayedPanic` (`:145-150`) is worth carrying: two 1-second waits before
+`rtems_panic` so the console actually flushes the message. On a serial-scrape
+acceptance ladder, a panic that loses its own message is a wasted boot.
+
+---
+
+## 2. Artefact 2 — `.cargo/config.toml`
+
+### 2.1 Shape
+
+```toml
+# Repo-root .cargo/config.toml. Read on EVERY cargo invocation; only the
+# [target.armv7-rtems-eabihf] table applies when that triple is selected, so
+# the host build is untouched. Nothing RTEMS may go in [build].
+
+[target.armv7-rtems-eabihf]
+linker    = "<HOLE-1>"          # e.g. $HOME/rtems-bringup/tools/bin/arm-rtems6-gcc
+rustflags = [
+  "-C", "link-arg=<HOLE-2>",    # BSP spec / prefix selection
+  "-C", "link-arg=-L<HOLE-3>",  # BSP lib dir
+  "-C", "link-arg=-u", "-C", "link-arg=POSIX_Init",   # <HOLE-4>: confirm needed
+  # <HOLE-5>: the RTEMS library list, in the order the C link uses
+]
+
+[unstable]
+build-std = ["std", "panic_abort"]     # <HOLE-6>: only if we want it implicit
+```
+
+### 2.2 What belongs here vs in a build script
+
+| Concern | Where | Why |
+|---|---|---|
+| linker binary, link-args, library list | **`.cargo/config.toml`** | they are properties of *the target*, identical for every crate in the workspace. Putting them in a build script would mean every crate that links an RTEMS binary repeats them |
+| compiling the C shim (`rtems_config.c`, `rtems_init.c`) | **`build.rs` + `cc`** | it needs the cross compiler, the BSP include path, and `-DBSP_…`; cargo config cannot compile C |
+| the BSP **prefix path** | **an environment variable read by both** | it appears in the link-args *and* in the shim's include path. Hard-coding a `$HOME`-relative path into a committed config file is wrong — the value differs per machine. Use `RTEMS_BSP_PREFIX` (or reuse base's `RTEMS_BASE` name), read by `build.rs` and injected via `rustc-link-search`/`rustc-link-arg` so `.cargo/config.toml` holds only machine-independent flags |
+| `-Zbuild-std` | **the command line, not the config** | it is nightly-unstable; pinning it in `[unstable]` makes every RTEMS invocation implicitly nightly-only in a way that is easy to forget. Keep it explicit in the documented command (§4) — `[HOLE-6]` is a deliberate maybe, not a recommendation |
+
+**Recommended split**, which shrinks the config file to almost nothing and
+removes the machine-specific hole entirely:
+
+```toml
+[target.armv7-rtems-eabihf]
+linker = "arm-rtems6-gcc"      # found on PATH; the box exports tools/bin
+```
+
+…and everything else emitted by the shim crate's `build.rs` as
+`cargo::rustc-link-search=native=…`, `cargo::rustc-link-lib=…`,
+`cargo::rustc-link-arg=…`, computed from `RTEMS_BSP_PREFIX`. That is the
+structural version: **one owner for the RTEMS link contract**, and it is a
+crate we can test, not a file we hope is right.
+
+### 2.3 Coexistence with the host build — three rules
+
+1. **Never put RTEMS content in `[build]`.** `[build] target = …` would
+   redirect the default host build; `[build] rustflags = …` applies to every
+   target. Both would break `cargo nextest run --workspace`.
+2. **The shim crate must be a target-gated dependency**, not an unconditional
+   one: `[target.'cfg(target_os = "rtems")'.dependencies]` on the IOC crates,
+   the same pattern already used at `epics-pva-rs/Cargo.toml:139`/`:152` and
+   `epics-base-rs`/`epics-ca-rs`. Otherwise a host build tries to run `cc` for
+   a cross target and fails.
+3. **The shim crate's `build.rs` must no-op unless
+   `CARGO_CFG_TARGET_OS == "rtems"`.** Same predicate `epics-base-rs/build.rs`
+   already uses (`build.rs:26`). A `cargo publish`/`cargo package` on a host
+   must not need a cross compiler.
+
+Verify rule 1 holds by running `cargo nextest run --workspace` after adding the
+file — that is the whole regression test for "the host still builds".
+
+### 2.4 The holes, and exactly what to capture
+
+The bring-up panel has a working toolchain now, so each hole is filled by
+**observing a real C link**, not by reading documentation. The single most
+useful capture is: build any RTEMS 6 zynq C example (the BSP ships them) and
+run its link with `make V=1` / `-n`, then `arm-rtems6-gcc -v <that link>`, and
+save the full expanded command.
+
+| Hole | What it is | Capture |
+|---|---|---|
+| **H1** | linker binary | absolute path of `arm-rtems6-gcc`; whether `tools/bin` is on PATH for non-interactive ssh (`BatchMode` shells often skip `.bashrc`) — if not, the config needs the absolute path |
+| **H2** | BSP selection flag(s) | from the expanded C link: everything before `-o` that selects the BSP (linker script, `-B`, `-q…`, `-specs`). Copy verbatim |
+| **H3** | BSP lib dir | the `-L` path(s). Base's zynq config uses `$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/xilinx_zynq_a9_qemu/lib/` (`CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu:19`) — confirm the actual installed path |
+| **H4** | `-u POSIX_Init` | whether it is required when the shim comes from a Rust **staticlib/rlib**. `--gc-sections` is on (`CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu:17`, and rustc adds it too — observed in the §1.3 link line of the acceptance-plan doc), so an unreferenced `POSIX_Init` inside an archive can be dropped. Capture: does `arm-rtems6-nm` find `POSIX_Init` in the linked image without `-u`? |
+| **H5** | library list and order | from base: `-lbsd` (`CONFIG.Common.RTEMS:134`), `-ltftpfs -lz -ltelnetd` (`:145`), `-lrtemsCom -lCom` (`:147`), `-lrtemscpu -lc -lm` (`:151`). We drop `-lrtemsCom -lCom` (those are base's own C libraries — we are not linking EPICS base C) and probably `-ltelnetd`. Capture the minimal set that actually resolves |
+| **H6** | `-Zbuild-std` | decide whether to pin it; see §2.2 |
+| **H7** | static-vs-dynamic | rustc emits `-Wl,-Bdynamic -lc -lm` (observed). RTEMS has no shared libraries. Capture whether that resolves against the static libs anyway or whether an explicit `-static` / reordering is needed |
+| **H8** | shim include path | the `-I` set needed for `<rtems.h>`, `<machine/rtems-bsd-config.h>`, `<rtems/netcmds-config.h>`, `<rtems/shellconfig.h>`. Take it from the C example's *compile* line, not its link line |
+| **H9** | `RTEMS_MINIMUM_STACK_SIZE` | needed to reason about directive E's real byte count. `grep` the toolchain headers |
+| **H10** | `FD_SETSIZE` + the confdefs macro name | `[HOLE-A]` from §1.2 |
+
+Every hole above is a value the panel **measures**. None of them should be
+filled from this document or from a model.
+
+---
+
+## 3. Where the files live, and how the shim is compiled
+
+### 3.1 Layout
+
+```
+crates/epics-rtems-boot/
+    Cargo.toml
+    build.rs            # cc, gated on CARGO_CFG_TARGET_OS == "rtems"
+    src/lib.rs          # empty on host; on RTEMS, the link anchor (§3.3)
+    csrc/rtems_config.c # §1.2
+    csrc/rtems_init.c   # §1.3
+.cargo/config.toml      # §2.1
+```
+
+**One crate, not two copies.** `rtems-ca-ioc` and `rtems-pva-ioc` both need the
+identical boot contract; duplicating a `build.rs` + C sources into
+`epics-ca-rs` and `epics-pva-rs` would be two owners for one invariant, which
+is the shape that produces divergence. Both IOC crates depend on it under
+`[target.'cfg(target_os = "rtems")'.dependencies]`.
+
+### 3.2 `build.rs` + `cc`, not prebuilt
+
+Prebuilt `.o`/`.a` in-tree is rejected for three reasons: it is unreviewable in
+a diff, it is locked to one toolchain build (RSB `5dbc1e08`, Newlib `1b3dcfd`)
+so a toolchain bump silently mismatches, and it cannot pick up the BSP include
+path which differs per machine.
+
+`cc` is not currently a dependency anywhere in the workspace (`rg '^cc = '`
+over all `Cargo.toml` → no hits), so this adds one build-dependency to one
+target-gated crate. `cc` honours `CC_armv7_rtems_eabihf` and
+`CFLAGS_armv7_rtems_eabihf`, which is the same environment the panel will
+already have set. The `build.rs` reads `RTEMS_BSP_PREFIX` and emits the `-I`
+set (`[HOLE-8]`), `-DBSP_xilinx_zynq_a9_qemu` (mirroring base's
+`Makefile:41`), plus the `rustc-link-search`/`rustc-link-lib`/`rustc-link-arg`
+lines from §2.2.
+
+`build.rs` must fail with a **clear message** — not a `cc` panic — when
+`RTEMS_BSP_PREFIX` is unset on an RTEMS target. That message is the first thing
+a new developer will see.
+
+### 3.3 The link-anchor problem
+
+`--gc-sections` is on. If `POSIX_Init` sits in an archive member that nothing
+references, it can be discarded and the image will have no entry task. Base
+solves this with `-u POSIX_Init` (`CONFIG.Common.RTEMS:154`). We should do
+both: emit `cargo::rustc-link-arg=-u` / `=POSIX_Init` from `build.rs`, **and**
+give `src/lib.rs` an `extern "C"` declaration plus a `#[used]` static
+referencing it, so the symbol survives even if the link-arg is ever dropped.
+`[HOLE-4]` decides whether the belt is needed as well as the braces — but
+having both costs nothing and the failure mode without them (an image that
+boots to nothing) is expensive to diagnose over a serial line.
+
+---
+
+## 4. How to invoke the RTEMS build
+
+### 4.1 The commands, with the traps encoded
+
+```bash
+export RTEMS_BSP_PREFIX=$HOME/rtems-bringup/tools        # [HOLE-3]/[HOLE-8]
+export PATH=$RTEMS_BSP_PREFIX/bin:$PATH                  # [HOLE-1]
+
+# CA — epics-ca-rs has `default = []`, so no feature flags are needed.
+cargo +nightly build -p epics-ca-rs --bin rtems-ca-ioc \
+  -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf --release
+
+# PVA — MUST carry --no-default-features and MUST name the bin.
+cargo +nightly build -p epics-pva-rs --bin rtems-pva-ioc \
+  --no-default-features \
+  -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf --release
+```
+
+Two traps, both measured:
+
+1. **`--no-default-features` is mandatory for `epics-pva-rs`.** Its
+   `default = ["tls", "pkcs12", "client"]`, and `tls` pulls `getrandom 0.2`,
+   which the crate's own manifest comment calls "the crate that does not build
+   for RTEMS". `epics-ca-rs` has `default = []` (`Cargo.toml:2`), which is why
+   the CA command needs no flags — the asymmetry is real and easy to trip over.
+2. **Never `--bins`.** `mshim-rs` (`epics-pva-rs/Cargo.toml:228-230`) has **no**
+   `required-features` and imports `server_native::udp::ForwardableDatagram` and
+   `tokio::net::UdpSocket` (`mshim-rs.rs:35-37`), both RTEMS-gated. `--bins`
+   fails on mshim, not on us — a confusing failure that looks like our bug.
+
+### 4.2 The CI shape
+
+Three jobs, in increasing cost, so a regression is attributed precisely:
+
+| Job | Command | Catches |
+|---|---|---|
+| `rtems-check` (no toolchain needed) | the two `cargo check` variants, `-Zbuild-std`, `--target armv7-rtems-eabihf` | Rust-side portability regressions. **This is what we have today** and it must keep running independently — it is the only gate that works without the box |
+| `rtems-link` (toolchain required) | the two `cargo build` commands above | shim/config regressions. Today this is the step that fails at `/usr/bin/ld … EM: 40` |
+| `rtems-boot` (toolchain + qemu) | rungs 1–5 of `doc/rtems-runtime-acceptance-plan.md` | behaviour |
+
+Keep `rtems-check` as a separate job rather than folding it into `rtems-link` —
+otherwise a broken toolchain on the box masks a real portability regression,
+and vice versa. Also keep the warning budget assertion in `rtems-check`: the
+`epics-pva-rs --lib` RTEMS check is currently **exit 0 with 2 warnings**, and
+that number is a measured completion criterion for stage D, not noise.
+
+---
+
+## 5. Corrections owed to `doc/pva-rtems-stage-cd-design.md`
+
+For folding into main, so the next reader is not misled. Both are in **§5.2,
+item 5** of that document.
+
+> **§5.2 item 5, as written:** "A `[[bin]]` target.
+> `crates/epics-pva-rs/Cargo.toml:193-221` declares six binaries, *every one*
+> `required-features = ["client"]`."
+
+**Correction 1 — the count is 8, not 6.** `epics-pva-rs/Cargo.toml` declares
+`pvget-rs` (`:193`), `pvput-rs` (`:198`), `pvmonitor-rs` (`:203`),
+`pvinfo-rs` (`:208`), `pvcall-rs` (`:213`), `pvlist-rs` (`:218`),
+`pvxvct-rs` (`:223`), and `mshim-rs` (`:228`). The cited line range `193-221`
+stops before the last two.
+
+**Correction 2 — "every one" is false; `mshim-rs` has no `required-features`.**
+`Cargo.toml:228-230` is three lines — `name`, `path`, and nothing else. This
+matters operationally, not just editorially: it is why the RTEMS command must
+name the bin and must never use `--bins` (§4.1 trap 2), because `mshim-rs`
+imports `server_native::udp::ForwardableDatagram` and `tokio::net::UdpSocket`
+(`mshim-rs.rs:35-37`), both of which are `#[cfg(not(target_os = "rtems"))]`.
+
+Suggested replacement text for that bullet:
+
+> 5. **A `[[bin]]` target.** `crates/epics-pva-rs/Cargo.toml` declares eight
+>    binaries (`:193`–`:230`). Seven carry `required-features = ["client"]`;
+>    `mshim-rs` (`:228-230`) carries none, and imports RTEMS-gated modules — so
+>    an RTEMS build must always name its bin and never use `--bins`. A
+>    `rtems-pva-ioc` entry must be added with no `client` requirement, and —
+>    unlike `epics-ca-rs`, whose `default = []` — the RTEMS command for this
+>    crate must also carry `--no-default-features`, because `default` includes
+>    `tls` → `getrandom 0.2`.
+
+---
+
+## 6. Report
+
+**Tested:**
+
+- `git rev-parse HEAD` at start and end — pass (`69164b67`, unchanged)
+- `git status --porcelain` at start and end — pass (clean both times)
+- G1/G2 closure independently re-verified — pass (`search_engine.rs:46`/`:61`/`:69`, un-gated at `mod.rs:55`; `blocking.rs:878` stamps the guid; accessor `:909`; test `both_search_paths_advertise_one_guid` `:2708`)
+- Read `epics-base/modules/libcom/RTEMS/posix/rtems_config.c` in full — pass
+- Read `posix/rtems_init.c` `:140-190`, `:705-830`, `:830-1191` — pass
+- Read `posix/rtems_init.c` dhcpcd hook `:742-812` and conf writer `:839-873` — pass
+- Read `score/rtems_config.c:21-44` for contrast — pass (150 fds, 20 ms tick, Classic `Init`, no libbsd)
+- Read `modules/libcom/RTEMS/Makefile` — pass (`SRC_DIRS += ../$(OS_API)`, `-DBSP_$(RTEMS_BSP)` at `:41`, `LIBRARY_RTEMS = rtemsCom`)
+- `configure/toolchain.c:29-35` — pass (`OS_API = posix` for RTEMS ≥ 5)
+- **`select`/`poll`/`fd_set` audit across `epics-base-rs`, `epics-ca-rs`, `epics-pva-rs`** — pass, **zero libc hits** (every match is Rust `Future::poll`). This is the evidence for raising the fd ceiling
+- Existing `build.rs` audit — pass (one file, `epics-base-rs/build.rs`, already uses the `CARGO_CFG_TARGET_OS == "rtems"` predicate)
+- `cc` crate audit — pass (not a dependency anywhere in the workspace)
+- `epics-pva-rs` bin/feature audit re-verified — pass (8 bins; `mshim-rs` `:228-230` has no `required-features`; `default = ["tls","pkcs12","client"]`)
+- `epics-ca-rs` feature audit — pass (`default = []`)
+- Local RTEMS header/BSP/toolchain search — **absent again**, as recorded in the header box; no header-level name asserted without a base citation
+
+**Failed:** none.
+
+**UNFIXED:**
+
+- **Ten named holes (`H1`–`H10`, plus `HOLE-A`)** in the link and shim
+  configuration. Each is left as a hole with a capture instruction (§2.4,
+  §1.2) rather than a guessed value. None can be closed from this machine.
+- **G3** (entropy quality on the BSP) — w1's task; §1.2's dropped-RTC row and
+  §1.3 step 2 document the mechanism that causes it.
+- **The two corrections in §5** are written but not applied —
+  `doc/pva-rtems-stage-cd-design.md` is on `main`, outside this read-only
+  scope.
+- **The fd-ceiling raise is a recommendation, not a measurement.** The
+  no-`select` evidence is solid for our three crates, but I did not audit
+  transitive dependencies compiled into the RTEMS image for `select` use, nor
+  libbsd's own internals. Validate on the box before treating a raised ceiling
+  as safe.
+
+**Fixed:** none — no source file was edited, no commit was made, as instructed.

--- a/doc/rtems-bridge-walls.md
+++ b/doc/rtems-bridge-walls.md
@@ -1,0 +1,227 @@
+# `epics-bridge-rs` RTEMS walls — settling §9's "status undeclared"
+
+Measurement, not a change. No files edited, nothing reverted (nothing was
+modified). Format follows §8.1.1/§8.1.2 of `doc/rtems-runtime-portability-design.md`.
+
+**Provenance.** Integration worktree
+`/home/stevek/work/epics-rs/.caucus/worktrees/integration` @ **`af2d5d16`**,
+branch `integration/rtems-scope-b`. HEAD `af2d5d16` and a **clean** working tree
+at start *and* end — the concurrent panel did not touch the tree during this
+run, so no citation needed re-verification. Toolchain: `nightly-x86_64-unknown-linux-gnu`
+with `rust-src` installed; `armv7-rtems-eabihf` is a known nightly target.
+
+---
+
+## §0 Answer up front
+
+**The bridge does not build for RTEMS, and it is nobody's blocker today.**
+Three runs, all exit 101:
+
+| run | features | failing crates | errors |
+|---|---|---|---|
+| 1 | default (`qsrv`, `qsrv-bin`, `ca-gateway`, `ca-gateway-bin`) | getrandom, signal-hook-registry, socket2, mio | 53 |
+| 2 | `--no-default-features` | signal-hook-registry, socket2, mio | 56 |
+| 3 | `--no-default-features --features qsrv` | getrandom, signal-hook-registry, socket2, mio | 53 |
+
+**Every wall is a dependency wall. Not one is in bridge source.** And the root
+cause is a single line.
+
+---
+
+## §1 The wall table
+
+| Crate (ver) | Error class | Dependency path (from `epics-bridge-rs`) | Remediation class |
+|---|---|---|---|
+| **mio 1.2.0** | 29 errs — `cannot find Selector in sys`, `cannot find event in sys`, `&mut sys::Events` (`mio-1.2.0/src/poll.rs:323`, `src/event/event.rs:24`, `src/event/events.rs:189`) — no epoll/kqueue selector | `mio ← tokio (net) ← ` **`epics-bridge-rs` directly** (`Cargo.toml:93`) | **target-gate the dep** — split `tokio` per-target exactly as base/ca/pva already do |
+| **socket2 0.6.3** | 20 errs — `cannot find IovLen in this scope` (`sys/unix.rs:743`), `recvmsg`/`sendmsg` not in `libc` (`:1128`, `:1181`), `ip_mreqn` missing (`:1405`, `:1407`, `:1412`) | `socket2 ← tokio (net) ←` **`epics-bridge-rs`** (`Cargo.toml:93`) — note this is socket2 **0.6**, pulled by tokio, *not* the 0.5 that base/ca pin directly | **target-gate the dep** — same split; disappears with `net` |
+| **signal-hook-registry 1.4.8** | 4 errs — `unresolved import libc::siginfo_t` (`lib.rs:83`), `cannot find SA_RESTART` (`:187`), plus `:181`, `:267` | `signal-hook-registry ← tokio (signal) ←` **`epics-bridge-rs`** (`Cargo.toml:93`) | **target-gate the dep** — same split; disappears with `signal` |
+| **getrandom 0.2.17** | 1 err — `target is not supported` (`lib.rs:351`, an explicit `compile_error!` for unknown targets) | `getrandom ← {p12, ring} ← {rustls, tokio-rustls} ← epics-pva-rs` **with default features** (`Cargo.toml:102` `epics-pva-rs = { workspace = true, optional = true }` — inherits pva's `default = ["tls", "pkcs12", "client"]`) | **target-gate the dep** — `default-features = false` for pva on RTEMS; identical in kind to phase-6 item 1's TLS gate (`1d5476df`) |
+
+**No in-crate walls.** §8.1.2's bridge-equivalent rows (`getifaddrs`,
+`getgrouplist`) have no counterpart here: the bridge calls no raw libc.
+
+---
+
+## §2 Root cause — one line, proved
+
+`crates/epics-bridge-rs/Cargo.toml:93`:
+
+```toml
+tokio = { version = "1", features = ["full"] }
+```
+
+It sits in the **plain `[dependencies]`** table. Every sibling crate splits the
+same dependency per target:
+
+* `epics-base-rs/Cargo.toml:43-44` host `full`, `:49-` RTEMS `fs, io-util, io-std, macros, parking_lot, rt, …` (no `net`/`signal`/`process`)
+* `epics-ca-rs/Cargo.toml:69-70` / `:74-`
+* `epics-pva-rs/Cargo.toml:139-142` / `:144-`, whose comment states the reason verbatim: *"RTEMS gets tokio without `net`/`signal`/`process`: `net` pulls mio (29 errors …) and `signal` pulls signal-hook-registry (4 errors …)"*
+
+Because **Cargo unions features across the whole graph**, one unconditional
+`features = ["full"]` re-enables `net`, `signal` and `process` for every crate in
+the build — silently undoing `bc7c8f53`'s per-target split.
+
+Proved directly, not inferred (`cargo tree -p epics-bridge-rs
+--no-default-features --target armv7-rtems-eabihf -i tokio -e features`):
+
+```
+├── tokio feature "libc"
+│   ├── tokio feature "net"
+│   │   └── tokio feature "full"
+│   │       └── epics-bridge-rs          ← sole enabler
+│   ├── tokio feature "process" …
+│   └── tokio feature "signal" …
+```
+
+`epics-base-rs` appears in that tree contributing only `io-util`, `fs`,
+`io-std` — the correct RTEMS-safe subset. **`epics-bridge-rs` is the only crate
+in the workspace that enables `tokio/full` unconditionally.**
+
+---
+
+## §3 Is dep-gating alone enough? — measured, and yes
+
+The question §9 could not answer without building. The decisive measurement is
+whether bridge *source* uses the APIs the RTEMS tokio split removes:
+
+| module | `tokio::net` / TcpListener / TcpStream / UdpSocket | `tokio::signal` | `tokio::process` | src lines |
+|---|---|---|---|---|
+| **qsrv** | **0** | **0** | **0** | 20,993 |
+| **pvalink** | **0** | **0** | **0** | 10,664 |
+| **pva_gateway** | **0** | **0** | **0** | 11,032 |
+| **ca_gateway** | 5 | 2 | 0 | 12,838 |
+
+Only `ca_gateway` touches them, at three production sites (test boundaries
+`pvlist.rs:925`, `server.rs:1366` — all three are below theirs, i.e. production):
+
+* `ca_gateway/pvlist.rs:244` `tokio::net::lookup_host(...)`
+* `ca_gateway/server.rs:1219` `tokio::signal::ctrl_c()`
+* `ca_gateway/server.rs:1285` `use tokio::signal::unix::{SignalKind, signal}`
+
+(The other four hits are a doc comment at `upstream.rs:2036` and two test helpers
+at `:2050`-`:2051` using `std::net`, plus a doc comment at `pvlist.rs:179`.)
+
+**And the module gating already exists.** `lib.rs` puts every subsystem behind
+its own feature:
+
+```
+:69  #[cfg(feature = "qsrv")]        pub mod qsrv;
+:72  #[cfg(feature = "ca-gateway")]  pub mod ca_gateway;
+:75  #[cfg(feature = "pvalink")]     pub mod pvalink;
+:82  #[cfg(feature = "pva-gateway")] pub mod pva_gateway;
+```
+
+So excluding the one offending module needs **no new `cfg` work** — only not
+selecting its feature.
+
+**Conclusion: qsrv-on-RTEMS is reachable by dep-gating alone, exactly as
+§8.1.1 was for base.** Three Cargo.toml edits, zero source changes:
+
+1. Split `tokio` per-target in `epics-bridge-rs/Cargo.toml:93`, copying the
+   `epics-pva-rs:139-146` block verbatim.
+2. Give `epics-pva-rs` (`:102`) `default-features = false` on RTEMS — drops
+   `tls`/`pkcs12` (→ getrandom) and `client` (→ the 23,853-line client surface
+   §8.1.2 already measured as feature-gated).
+3. Select `qsrv` without `ca-gateway`/`ca-gateway-bin` for the RTEMS build.
+
+I did **not** verify this reaches exit 0 — that needs the edits, which are out of
+scope here. What is measured is that (a) all four walls are dep-only, (b) the
+qsrv+pvalink path uses none of the removed APIs, and (c) the module gates are
+already in place. The residual risk is a wall that only appears *after* these
+four are cleared, which is exactly how §8.1.2's own walk proceeded.
+
+---
+
+## §4 Minimal RTEMS bridge subset
+
+| keep | why |
+|---|---|
+| `qsrv` (20,993 lines) | the point of the exercise — db-backed PVA with group support; 0 dropped-API uses |
+| `pvalink` (10,664) | `qsrv` pulls it unconditionally (`Cargo.toml:28-29`), and pvxs ties pvalink to QSRV2 the same way; 0 dropped-API uses |
+| `convert`, `error` (root, 1,130) | `#[cfg(any(feature = "qsrv", feature = "pvalink"))]` (`lib.rs:66`) |
+
+| gate | why |
+|---|---|
+| `ca_gateway` (12,838) | the only module using `tokio::net`/`signal`; a CA fan-out gateway on an RTEMS IOC is not a use case |
+| `pva_gateway` (11,032) | same rationale; 8 of §9's locks live here and none has an RTEMS story |
+| `qsrv-bin`, `ca-gateway-bin`, bins (2,723) | `clap`/`tracing-subscriber` daemons; RTEMS uses the `rtems-*-ioc` entry-point shape instead |
+
+**Compile surface:** 32,787 of 59,380 src lines (**55%**) would compile for
+RTEMS — comparable to `epics-pva-rs`'s 46% in §8.1.2, and higher because the
+bridge has no 21k-line protocol engine to gate.
+
+---
+
+## §5 Who needs this, and when — nobody yet
+
+`rg "epics-bridge-rs" --glob 'Cargo.toml'` across the workspace gives every
+inbound edge:
+
+* **examples** — `qsrv-ioc`, `mini-beamline`, `xrt-beamline`, `mqtt-ioc`,
+  `modbus-ioc`, `scope-ioc` (all behind each example's `ioc` feature)
+* **`crates/epics-rs`** — facade, optional `bridge` feature (`Cargo.toml:14`, `:27`)
+* **`crates/ad-plugins-rs`** — optional, `pva` feature (`Cargo.toml:30`, `:40`)
+
+**Not** `epics-base-rs`, **not** `epics-ca-rs`, **not** `epics-pva-rs`.
+
+The only RTEMS binary that exists today is `rtems-ca-ioc`
+(`epics-ca-rs/Cargo.toml:233-234`), and `epics-ca-rs` does not depend on the
+bridge. `rtems-pva-ioc` — item-7 stage G — **does not exist yet**
+(`rg "rtems-pva-ioc" --glob 'Cargo.toml'` → nothing).
+
+So the honest status line, replacing §9's "undeclared":
+
+> `epics-bridge-rs` does not compile for RTEMS and no RTEMS target requires it.
+> It becomes a blocker only if item-7 stage G's `rtems-pva-ioc` chooses
+> **group-aware** db-backed PVA (Q:group, ASG) over plain single-record PVA.
+
+**And stage G may not need it at all.** `epics-pva-rs` already ships db-backed
+PVA without the bridge: `server/native_source.rs` `PvDatabaseSource` +
+`UpstreamMonitor::from_db` (`server_native/source.rs:1912-1921`) serve records
+straight off `epics_base_rs` `DbSubscription`, and `server/` is not RTEMS-gated
+(only `server_native::{accept,peers,runtime,tcp,udp}` are). A first
+`rtems-pva-ioc` can therefore serve records with **zero** bridge dependency; the
+bridge is the increment that adds groups.
+
+---
+
+## §6 Recommendation
+
+1. **Do the three Cargo.toml gates now anyway** (§3). They are cheap, they are
+   pure parity with what base/ca/pva already did, and item 2 in particular
+   (`tokio/full`) is a latent hazard for *any* target-restricted build, not just
+   RTEMS — today the bridge silently re-enables `net`/`signal`/`process` for the
+   entire workspace graph whenever it is in the build.
+2. **Sequence stage G as plain-PVA-first**: `rtems-pva-ioc` on
+   `PvDatabaseSource`, no bridge. That keeps stage G off this dependency
+   entirely and defers the bridge question until groups are actually wanted.
+3. **Close §9's other finding at the same time.** With the bridge declared
+   RTEMS-buildable for the `qsrv` subset, its 40+ raw `tokio::spawn` /
+   `tokio::runtime::Handle` sites (`pvalink/integration.rs` alone: 42, against
+   one `runtime::task` seam use at `qsrv/pva_adapter.rs:1436`) stop being
+   hypothetical and become a real seam audit — and `pvalink` is in the *keep*
+   column, so that audit is on the critical path for a group-aware
+   `rtems-pva-ioc`, not optional.
+
+Ordering: (1) is independent and can land any time; (3) gates (2)'s group-aware
+variant, not its plain variant.
+
+---
+
+## §7 What this measurement does not establish
+
+* **No exit-0 proof.** I measured the walls and the source-level readiness; I did
+  not apply the gates, so "dep-gating alone suffices" is a well-evidenced
+  prediction, not a verified build.
+* **`--lib` only**, per the brief. The bins (`qsrv-rs`, `ca-gateway-rs`) pull
+  `clap` + `tracing-subscriber` and were not probed.
+* **The seam audit (§6 item 3) was not performed** — §9 counted the sites; the
+  question of whether each is reachable on RTEMS is open.
+* **Feature flags that change the outcome, for the record:** `--no-default-features`
+  removes the getrandom wall (drops the `epics-pva-rs` edge entirely);
+  `--features qsrv` restores it (pva returns with default `tls`/`pkcs12`). The
+  mio/socket2/signal-hook-registry trio is present in **all three** runs because
+  `Cargo.toml:93` is unconditional and no feature flag can reach it.
+
+**Logs:** `rtems-default.log`, `rtems-nodefault.log`, `rtems-qsrv.log` in this
+scratchpad directory.

--- a/doc/rtems-cfg-unix-trap-audit.md
+++ b/doc/rtems-cfg-unix-trap-audit.md
@@ -1,0 +1,436 @@
+# The `cfg(unix)` trap — workspace audit
+
+**Measured at** integration worktree `/home/stevek/work/epics-rs/.caucus/worktrees/integration`,
+HEAD **`8660074d`**, working tree **clean** (`git status --porcelain` empty).
+Read-only: no source file was edited, nothing was committed.
+
+**The trap.** `armv7-rtems-eabihf` declares `target-family: ["unix"]`. So
+`#[cfg(unix)]` is **true** on RTEMS. A bare `cfg(unix)` arm therefore hands
+RTEMS a Linux/BSD-shaped path that (a) compiles clean under
+`cargo check --target armv7-rtems-eabihf`, (b) is never executed on the host
+CI, and (c) on target either fails or — worse — succeeds degenerately. The
+GUID defect (`/dev/urandom` under bare `cfg(unix)`) was one instance. This
+document is the population.
+
+---
+
+## 0. Scoping — which crates can reach an RTEMS image
+
+The RTEMS dependency closure is exactly three workspace crates:
+
+| crate | why in scope |
+|---|---|
+| `epics-base-rs` | `epics-ca-rs/Cargo.toml:11`, `epics-pva-rs/Cargo.toml:11` |
+| `epics-ca-rs` | hosts `src/bin/rtems-ca-ioc.rs`, the only RTEMS bin today |
+| `epics-pva-rs` | stage C `BlockingPvaServer`; stage G bin is planned |
+
+`epics-macros-rs` is a proc-macro crate — it runs on the **host** compiler by
+nature and never enters the target image.
+
+**Out of scope by crate (never compiles for RTEMS, so every arm inside is
+DISTINCT):** `ad-core-rs`, `ad-plugins-rs`, `asyn-rs`, `epics-bridge-rs`,
+`epics-rs`, `motor-rs`, `std-rs`, `scaler-rs`, `optics-rs`, `mca-rs`,
+`mqtt-rs`, `modbus-rs`, `epics-tools-rs`, plus `examples/*`,
+`tools/dbd-codegen`, `tools/env-codegen`. (Anchor-4 hits exist in
+`epics-tools-rs/src/procserv/*` and `asyn-rs/src/drivers/serial_port.rs`;
+they are excluded here on that basis, not because they were judged portable.)
+
+### 0.1 Module-level RTEMS gates inside the three in-scope crates
+
+These are the gates that make most hits unreachable. Each was read, not
+inferred:
+
+| gate site | modules cut out on RTEMS |
+|---|---|
+| `epics-ca-rs/src/lib.rs:29,34,37,39,43,45,50,55` | `calink`, `chaos`, `cli`, `client`, `copt`, `discovery`, `hostname`, `repeater` |
+| `epics-ca-rs/src/server/mod.rs:11,14,16,23` | `beacon`, `ca_server`, `introspection`, `signed_beacon` |
+| `epics-base-rs/src/net/mod.rs:28,30,32` | `async_udp_v4`, `iface_map`, `loopback_mcast` |
+| `epics-pva-rs/src/server_native/mod.rs:29,45,64` | `accept`, `runtime`, `udp` |
+| `epics-pva-rs/src/server/mod.rs:8,11` | `iocsh`, `pva_server` |
+| `epics-pva-rs/src/lib.rs:22,24` (feature, **not** target) | `client`, `client_native` |
+
+**Un-gated and therefore live on RTEMS:** all of `epics-base-rs/src/server/*`
+and `epics-base-rs/src/runtime/*`; `epics-ca-rs::server::{addr_list, blocking,
+ioc_app, iocsh, monitor, outbox, tcp, udp, stats, rate_limit, access_token}`;
+`epics-pva-rs::{auth, cli, codec, config, decode, format, log, nt, proto,
+pv_request, pvdata, service, util}`, `server::native_source`,
+`server_native::{blocking, composite, config, monitor_control, op_handle,
+peers, search, search_engine, server_info, shared_pv, source, tcp}`.
+
+**A caveat the reader should weigh.** `client`/`client_native` are cut by a
+**Cargo feature**, not by `target_os`. `client` is a *default* feature
+(`epics-pva-rs/Cargo.toml` `default = ["tls","pkcs12","client"]`), so the
+RTEMS build is only safe because it passes `--no-default-features`. Cargo
+feature unioning means any future workspace member that depends on
+`epics-pva-rs` with `client` on, and is co-built for RTEMS, silently pulls
+those seven arms back into scope. That is weaker protection than a
+`cfg(not(target_os = "rtems"))` and is noted per-hit below.
+
+---
+
+## 1. Findings — SAME DEFECT, ranked SILENT first
+
+Three hits. Two are live on the RTEMS path today.
+
+### S1 — `osd_get_roles` runs the local passwd/group DB on RTEMS, and the arm that says it doesn't is unreachable. **SILENT. LIVE. Security-relevant.**
+
+* **File:line:** `crates/epics-pva-rs/src/auth/plain.rs:202` (the bare
+  `#[cfg(unix)]` arm) and `:261-265` (the `#[cfg(not(unix))]` arm).
+* **What the arm does:** `:202` opens `#[cfg(unix)] { ... }` around
+  `libc::getpwnam(account)` (`:219`), then `getgrouplist_ids` (`:240`), then
+  `libc::getgrgid(gid)` (`:248`) per gid, returning the account's POSIX group
+  **names**. RTEMS takes this arm.
+* **Why it is the defect, in the code's own words.** The `#[cfg(not(unix))]`
+  arm at `:261` carries this comment verbatim:
+
+  > `// No local group DB available (Windows LANMAN handled elsewhere;`
+  > `// RTEMS / vxWorks): pvxs reports the account as its only role.`
+  > `vec![account.to_string()]`
+
+  The author intended RTEMS to land there. RTEMS is `cfg(unix)`, so it never
+  can. This is the trap with a written record of the intent it violates.
+* **The asymmetry that proves it was an oversight, not a decision.** The
+  helper this very function calls **does** carve RTEMS out, 100 lines above:
+  `getgrouplist_ids` exists twice, `#[cfg(all(unix, not(target_os = "rtems")))]`
+  at `:53` and `#[cfg(all(unix, target_os = "rtems"))]` at `:103`, with a doc
+  at `:97` that opens *"RTEMS is `cfg(unix)` but its newlib has no
+  `getgrouplist(3)`"*. So the supplementary-group call is RTEMS-aware while
+  its two callers are not.
+* **Why LIVE, and why it matters.** `osd_get_roles` has exactly one production
+  caller: `crates/epics-pva-rs/src/server_native/tcp.rs:2466`,
+  `ClientCredentials::with_server_roles()` — described at `:2459-2463` as
+  *"The single funnel every constructor / parse path passes through, so
+  `roles` is server-derived by construction."* `server_native::tcp` is
+  **un-gated** (`server_native/mod.rs:63`) and is the module stage C's
+  `serve_connection_blocking` drives, so **every accepted PVA connection on
+  RTEMS runs this**. The resulting `roles` is then passed to the ACF gate at
+  `tcp.rs:1993, 4381, 4406, 4704, 5071, 6441, 6697, 6845, …` (`&ctx.roles`),
+  i.e. it decides whether a PUT/GET is authorized against `member group:`
+  rules.
+* **Why SILENT.** Three outcomes, none of which logs or errors:
+  1. RTEMS `getpwnam` misses → the fallback at `:212-215` returns
+     `vec![account]` — which is coincidentally the *right* answer, so the
+     defect is invisible when it is harmless.
+  2. RTEMS `getpwnam` hits a synthetic/default passwd entry → roles are
+     whatever that entry's `pw_gid` maps to. An ACF rule
+     `member group:<that name>` then matches **every** client.
+  3. `getgrgid` returns NULL for the gid → the group is skipped, roles come
+     back shorter than intended, and a legitimate client is denied with an
+     ordinary authorization refusal indistinguishable from a correct one.
+* **What is not established here.** Which of 1/2/3 RTEMS actually does depends
+  on RTEMS libcsupport's passwd/group behaviour when `/etc/passwd` is absent
+  from the IMFS image. **The RTEMS kernel source is not on this machine**
+  (searched; per `rtems-qemu-box` it lives on the remote build box), so I am
+  not stating what it does — that is the target-run question. What *is*
+  established without it: the arm selection is wrong relative to its own
+  documented intent, and all three possible outcomes are silent.
+
+### S2 — `thread_sleep_quantum()` hardcodes 100 Hz on RTEMS, decoupled from the tick the boot shim actually configures. **SILENT. LIVE.**
+
+* **File:line:** `crates/epics-base-rs/src/runtime/time.rs:43-52`.
+* **What the arm does:** `#[cfg(target_os = "linux")]` calls
+  `libc::sysconf(libc::_SC_CLK_TCK)` and returns `1.0/hz`; the
+  `#[cfg(not(target_os = "linux"))]` else at `:49-51` returns the literal
+  `0.01`. RTEMS falls into the else. This is the anchor shape *"an else that
+  was written as 'some other unix'"* — the doc at `:38-40` states the premise
+  as *"the 0.01 s fallback on the targets where `libc` is not linked (it is a
+  Linux-only dependency of this crate)"*.
+* **The premise is half true and that is the problem.** `libc` really is
+  Linux-only for this crate — `epics-base-rs/Cargo.toml:66-67` is
+  `[target.'cfg(target_os = "linux")'.dependencies] libc = "0.2"` — so the
+  `sysconf` call genuinely cannot be made on RTEMS from here. But the chosen
+  constant is a *Linux* value (`_SC_CLK_TCK == 100`), while on RTEMS the tick
+  is a build-time confdefs choice: `CONFIGURE_MICROSECONDS_PER_TICK`.
+* **Why LIVE.** `quantize_to_sleep_quantum` (`time.rs:83`) is called from
+  `epics-base-rs/src/server/records/sseq.rs:1052` and `:1231`; `records::sseq`
+  is un-gated (`server/records/mod.rs:110`), so it is compiled into the RTEMS
+  image and runs for any `sseq` record in the loaded database.
+* **Why SILENT.** It is a numeric quantization of `DLYn`, C parity
+  `sseqRecord.c:197-200`. A wrong quantum produces delays rounded to the wrong
+  grid — no error, no log, and no acceptance rung asserts sub-second timing.
+* **Current status: correct by coincidence, and that coincidence is ours to
+  break.** EPICS base's RTEMS posix config sets
+  `CONFIGURE_MICROSECONDS_PER_TICK 10000` (`epics-base/modules/libcom/RTEMS/
+  posix/rtems_config.c:33-35`) = 100 Hz = 0.01 s, and the boot-shim design
+  (`doc/rtems-boot-shim-design.md`) keeps that directive. So today the literal
+  matches. Base's **score** config uses 20 ms
+  (`score/rtems_config.c:40`) — proof the value is a choice, not a constant.
+  The moment our shim picks a different tick, `time.rs:50` is silently wrong
+  with nothing tying the two together.
+
+### S3 — `posix_groups` has the same defect as S1, currently unreachable on RTEMS only because a *feature* is off. **SILENT. LATENT.**
+
+* **File:line:** `crates/epics-pva-rs/src/auth/plain.rs:119` (bare
+  `#[cfg(unix)]`) and `:175` (the `#[cfg(not(unix))]` arm returning
+  `Vec::new()`).
+* **What the arm does:** `libc::getuid()` → `libc::getpwuid` (`:131`) →
+  `getgrouplist_ids` (`:156`) → `libc::getgrgid` (`:161`), returning the
+  *current process's* group names. RTEMS takes it, exactly as in S1.
+* **Why LATENT not LIVE:** the only production caller is
+  `crates/epics-pva-rs/src/client_native/server_conn.rs:1534`, and
+  `client_native` is `#[cfg(feature = "client")]` (`lib.rs:24-25`) which the
+  RTEMS build turns off via `--no-default-features`. That is a feature gate,
+  not a target gate — see the caveat in §0.1. If any RTEMS-co-built crate ever
+  unions `client` back on, S3 becomes live with the same three silent
+  outcomes as S1.
+
+---
+
+## 2. UNKNOWN-NEEDS-TARGET-RUN — all fail LOUDLY
+
+These are deliberate, RTEMS-aware arms whose *runtime* behaviour on
+RTEMS/libbsd I cannot establish from this machine. They are listed separately
+from §1 because their failure mode is an error return, not a wrong answer.
+
+### U1 — `SO_REUSEPORT` before bind, CA blocking driver
+
+* `crates/epics-ca-rs/src/server/blocking.rs:281` (`set_reuse_opt`) and `:301`
+  (`bind_udp_search_socket`). Raw `libc::socket` + two `libc::setsockopt`
+  (`SO_REUSEADDR`, `SO_REUSEPORT`) + `libc::bind`, only when the port is
+  non-zero (`:311`). Compiles for RTEMS, so the `libc` crate does define both
+  constants for `armv7-rtems-eabihf`.
+* **Open question for the target run:** does RTEMS libbsd's `setsockopt`
+  accept `SO_REUSEPORT` on an `AF_INET`/`SOCK_DGRAM` socket? libbsd is
+  FreeBSD-derived, where it exists — but I have not read the libbsd tree
+  (**not on this machine**) and will not assert it.
+* **LOUD:** a rejected option returns `Err(last_os_error())` from
+  `set_reuse_opt`, propagated by `?` out of `bind_udp_search` → the server's
+  `bind()` fails → rung 2 of the acceptance ladder ("binds 5064") fails with
+  an errno. Nothing degrades quietly.
+* The sibling `#[cfg(not(unix))]` arm at `:340` is DISTINCT and says so:
+  *"RTEMS is Unix-family, so the shared-port path above is the one that
+  matters for the target."*
+
+### U2 — same, PVA blocking driver
+
+* `crates/epics-pva-rs/src/server_native/blocking.rs:1092`, `:1112`.
+  Byte-for-byte the same construction as U1 (the doc at `:1075-1077` states it
+  is hand-rolled for the same reason: `socket2` does not cross to RTEMS,
+  `Cargo.toml:139-141`). Same open question, same LOUD failure. `:1151` is the
+  `#[cfg(not(unix))]` twin — DISTINCT.
+
+### U3 — the RTEMS `FIONREAD` request value
+
+* `crates/epics-ca-rs/src/server/blocking.rs:373` supplies
+  `FIONREAD_REQUEST = 0x4004_667F` under `#[cfg(target_os = "rtems")]`,
+  because the `libc` crate omits `FIONREAD` for this target. The value is
+  derived in the doc at `:346-368` from newlib's `sys/filio.h` +
+  `sys/ioccom.h` encoding.
+* **Already handled correctly, and safe by construction:** the doc states, and
+  `pending_bytes` (`:376`) implements, that any `ioctl` error returns `Err`
+  and every caller treats that as "flush now" (C's own `status < 0` branch).
+  So a wrong constant costs batching, never correctness. Listed here only
+  because the *value* is unverified on target; the *design* is not a defect.
+
+---
+
+## 3. DISTINCT — full enumeration with the reason for each
+
+Grouped by why they cannot bite. Every one was opened and read.
+
+### 3.1 Unreachable on RTEMS — module cut by `cfg(not(target_os = "rtems"))`
+
+| file:line | what the arm does | gate |
+|---|---|---|
+| `epics-ca-rs/src/hostname.rs:66` | `#[cfg(unix)] resolve_ptr` — `getnameinfo(NI_NAMEREQD)` reverse lookup | `lib.rs:50` |
+| `epics-ca-rs/src/hostname.rs:199` | `#[cfg(unix)] #[tokio::test]` warm-cache test; comment relies on `/etc/hosts` loopback PTR | `lib.rs:50` + test |
+| `epics-ca-rs/src/hostname.rs:226` | `#[cfg(unix)] #[test]` loopback-resolves-to-a-name | `lib.rs:50` + test |
+| `epics-ca-rs/src/client/transport.rs:106` | `#[cfg(unix)] fd_recv_queue_probe` — `libc::ioctl(FIONREAD)` occupancy probe | `lib.rs:39` |
+| `epics-ca-rs/src/client/transport.rs:118` | `#[cfg(not(unix))]` twin returning "always drained" | `lib.rs:39` |
+| `epics-ca-rs/src/client/transport.rs:1003` | `#[cfg(unix)]` capture `as_raw_fd()` before the stream split | `lib.rs:39` |
+| `epics-ca-rs/src/client/transport.rs:1008` | `#[cfg(not(unix))]` twin passing fd `0` | `lib.rs:39` |
+| `epics-ca-rs/src/server/ca_server.rs:1095` | `#[cfg(unix)]` SIGTERM drain task via `tokio::signal::unix` | `server/mod.rs:14` |
+| `epics-ca-rs/src/server/ca_server.rs:1119` | `#[cfg(not(unix))]` twin: `signal_handle = None` | `server/mod.rs:14` |
+| `epics-ca-rs/src/repeater.rs:135` | `#[cfg(not(windows))] set_reuse_address` after exclusive bind | `lib.rs:55` |
+| `epics-base-rs/src/net/loopback_mcast.rs:73` | `#[cfg(unix)] sock.set_reuse_port(true)` | `net/mod.rs:32` |
+| `epics-base-rs/src/net/loopback_mcast.rs:79` | `#[cfg(target_os = "linux")]` `IP_MULTICAST_ALL` clear | `net/mod.rs:32` |
+| `epics-base-rs/src/net/loopback_mcast.rs:152` | `#[cfg(unix)] #[tokio::test]` two-listeners test | `net/mod.rs:32` + test |
+| `epics-base-rs/src/net/async_udp_v4.rs:215` | `#[cfg(not(target_os = "windows"))]` extra per-NIC broadcast bind | `net/mod.rs:28` |
+| `epics-base-rs/src/net/async_udp_v4.rs:1257` | `#[cfg(unix)] set_reuse_port` on a fixed port | `net/mod.rs:28` |
+
+### 3.2 Unreachable on RTEMS — enclosing **function** is RTEMS-gated
+
+| file:line | what the arm does | enclosing gate |
+|---|---|---|
+| `epics-ca-rs/src/server/udp.rs:360` | `#[cfg(unix)] sock.set_reuse_port(true)` for a fixed port | `bind_responder_socket` is `#[cfg(not(target_os = "rtems"))]` at `:329` |
+| `epics-ca-rs/src/server/udp.rs:367` | `#[cfg(target_os = "linux")] set_multicast_all_v4(false)` | same, `:329` |
+| `epics-ca-rs/src/server/addr_list.rs:480` | `#[cfg(unix)]` `ifa_dstaddr` walk for point-to-point links | `broadcast_for_ip` is `#[cfg(not(target_os = "rtems"))]` at `:453`; RTEMS stub at `:493` returns `None` |
+| `epics-ca-rs/src/server/addr_list.rs:538,540` | `#[cfg(target_os="linux")]` / `#[cfg(not(...))]` `sa_family` width split | `ifa_dstaddr_for_ipv4` is `#[cfg(all(unix, not(target_os = "rtems")))]` at `:507` |
+
+Note the sibling stubs in this file are the correct pattern and worth citing
+as such: `discover_broadcast_addrs` (`:395`, returns `Vec::new()`) and
+`osi_local_addr` (`:431`, returns `Ipv4Addr::LOCALHOST`) both have explicit
+`#[cfg(target_os = "rtems")]` bodies with a documented C-parity rationale.
+
+### 3.3 Unreachable on RTEMS — feature-gated (`client`, `tls`)
+
+`epics-pva-rs/src/client_native/udp.rs:273, 416, 500, 592, 610, 668`;
+`client_native/udp.rs:423, 634` (`#[cfg(any(target_os="linux", target_os="android"))]`);
+`client_native/search_engine.rs:820`; `auth/tls.rs:1561, 1628`
+(`std::process::Command::new("openssl")`, `#[cfg(feature = "tls")]`).
+
+Weaker than a target gate — see §0.1 caveat.
+
+### 3.4 Unreachable on RTEMS — the binary cannot compile for the target
+
+`cargo` will attempt these under `--bins`, which is why the RTEMS build
+command must name its bin (`--bin rtems-ca-ioc`). All fail at *compile*, so
+they are loud by construction.
+
+| bin | hits | why it cannot compile for RTEMS |
+|---|---|---|
+| `epics-ca-rs/src/bin/ca-repeater-rs.rs` | `:30` `#[cfg(unix)] detach_stdio` (`libc::open("/dev/null")` + `dup2` onto 0/1/2), `:36` the `/dev/null` literal, `:53` `#[cfg(not(unix))]` twin | imports `epics_ca_rs::repeater`, RTEMS-gated at `lib.rs:55` |
+| `epics-ca-rs/src/bin/softioc-rs.rs` | `:419` `std::fs::read_to_string("/etc/hostname")` | imports `epics_ca_rs::discovery::TsigKey` (`:427`), RTEMS-gated at `lib.rs:45`. The read is also un-cfg'd and already falls back to `"localhost"` |
+| `epics-pva-rs/src/bin/mshim-rs.rs` | `:140` `#[cfg(unix)] set_reuse_port` | uses `socket2` (`Cargo.toml:139-140`, `cfg(not(rtems))`) and `tokio::net::UdpSocket` |
+| `epics-pva-rs/src/bin/pvxvct-rs.rs` | `:648` `#[cfg(unix)] #[test]` iface-name test | test code; bin also uses the `cli` iface resolver |
+
+**One latent comment-lie worth recording** (not a defect today, because the
+bin cannot build for RTEMS): `ca-repeater-rs.rs:53-56` says
+*"C `caRepeater` skips detach on Windows / RTEMS / VxWorks via
+`CAN_DETACH_STDINOUT`. Match that — leave stdio inherited."* — placed on the
+`#[cfg(not(unix))]` arm RTEMS can never reach. Identical in shape to S1. If
+the repeater is ever ported to RTEMS, that comment is already wrong.
+
+### 3.5 Test-only arms in otherwise-live modules
+
+`epics-pva-rs/src/auth/plain.rs:324, 355` (`#[cfg(unix)] #[test]`, inside
+`#[cfg(test)] mod tests` at `:279`); `epics-pva-rs/src/cli.rs:730`
+(`#[cfg(unix)]` inside a `#[test]`); `epics-ca-rs/src/server/udp.rs:1146,
+1184` (inside `#[cfg(test)]` at `:1119`).
+
+### 3.6 Already carved out for RTEMS — the correct pattern
+
+These are the exemplars. A reviewer checking a new arm should compare against
+these, not against §3.1.
+
+| file:line | how RTEMS is excluded |
+|---|---|
+| `epics-pva-rs/src/server_native/search_engine.rs:86` | `#[cfg(target_os = "rtems")] fill_entropy` → `libc::getentropy` (chosen over `arc4random_buf` **because it can report failure**); `/dev/urandom` arm is `#[cfg(all(unix, not(target_os = "rtems")))]` at `:99`. The GUID fix. |
+| `epics-pva-rs/src/server_native/search_engine.rs:565-588` | source-guard test `rtems_selects_entropy_by_target_not_by_family` — asserts the RTEMS arm exists, calls `getentropy`, and that `#[cfg(unix)]` appears **zero** times in production scope. This is the only mechanical defence against the family in the whole workspace. |
+| `epics-pva-rs/src/auth/plain.rs:53,103` | dual `getgrouplist_ids`, `cfg(all(unix, not(rtems)))` / `cfg(all(unix, rtems))`, doc at `:97` names the trap |
+| `epics-pva-rs/src/cli.rs:410,414` | `resolve_iface_ipv4`: `cfg(all(unix, not(rtems)))` → `getifaddrs`; `cfg(any(not(unix), target_os="rtems"))` → **`Err` naming the workaround**. Loud, not degenerate. |
+| `epics-base-rs/src/server/ioc_app.rs:1088-1099` | comment states the rule outright — *"RTEMS is `cfg(unix)` too, so the guard is `all(unix, not(target_os = "rtems"))`, not `unix` alone"* — then applies it to the SIGTERM arm |
+| `epics-ca-rs/src/server/blocking.rs:373` | `#[cfg(target_os = "rtems")] FIONREAD_REQUEST` (see U3) |
+| `epics-ca-rs/src/bin/rtems-ca-ioc.rs:61,197` | `#[cfg(any(target_os = "rtems", feature = "rtems-exec-model"))]` — the pattern that makes the RTEMS path *host-testable*, which is what let rung −1 run at all |
+
+### 3.7 Portable degradation, no RTEMS-specific arm needed
+
+`epics-base-rs/src/server/iocsh/commands.rs:956` — `#[cfg(target_os="linux")]`
+around `read_to_string("/proc/self/status")` for the `iocStats` RSS line. RTEMS
+is not linux, the block is skipped, and the command simply prints no `RSS:`
+line. `:966` `available_parallelism().unwrap_or(1)` degrades to 1 on any target
+that cannot answer.
+
+---
+
+## 4. Two anchors the brief's `rg` patterns cannot see
+
+Both were found by widening past `#[cfg(unix)]` in `src/`. Neither is a defect
+today; both are places a future one would hide.
+
+### 4.1 `cfg(unix)` in a **Cargo dependency table**
+
+`crates/epics-pva-rs/Cargo.toml:168-169`:
+
+```toml
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+```
+
+Correct as written — RTEMS is unix and genuinely needs `libc` (used by
+`auth/plain.rs`, `server_native/blocking.rs`). But it is the same predicate,
+in a file no `src/` grep reaches. Contrast `epics-base-rs/Cargo.toml:66-67`,
+which gates `libc` to `cfg(target_os = "linux")` — that asymmetry is precisely
+what forces `time.rs`'s else-arm (S2). `epics-ca-rs/Cargo.toml:14` takes a
+third position: `libc` unconditional.
+
+Three crates, three different answers to "when do we have libc". None is
+wrong; nobody reading one would predict the others.
+
+### 4.2 Host-shaped crates that are **un-gated** in the RTEMS closure
+
+`hostname = "0.4"` is a plain dependency in both `epics-base-rs/Cargo.toml:15`
+and `epics-pva-rs/Cargo.toml:19` — no target gate — so it is compiled into the
+RTEMS image. Its two call sites:
+
+* `epics-base-rs/src/runtime/env.rs:348` `pub fn hostname()` — falls back to
+  `"localhost"`. Its three callers (`epics-ca-rs` `discovery/mdns.rs:188`,
+  `client/search.rs:775`, `client/types.rs:532`) are **all** in RTEMS-gated
+  modules, so it is dead on target today.
+* `epics-pva-rs/src/auth/plain.rs:276` `authnz_default_host()` — callers are
+  `client_native/context.rs:341,344`, feature-gated off.
+
+**Classification: DISTINCT (no live RTEMS caller), latent.** Recorded because
+the *dependency* crossing to RTEMS un-gated is what would make a future caller
+silently degrade rather than fail to compile — `host_or_ca_fallback` turns a
+failed `gethostname` into the literal `"invalidhost."` (`plain.rs:14`, pvxs
+`buildCAMethod` parity), which then flows into PVA ACF **host** matching with
+no log line.
+
+---
+
+## 5. Counts
+
+| classification | count | of which SILENT |
+|---|---|---|
+| SAME DEFECT | **3** (S1, S2, S3) | **3** |
+| UNKNOWN-NEEDS-TARGET-RUN | 3 (U1, U2, U3) | 0 — all LOUD |
+| DISTINCT | 43 | — |
+
+DISTINCT breakdown: 15 module-gated, 4 function-gated, 9 feature-gated,
+7 in non-compiling bins, 6 test-only, 2 portable-degradation
+(+ the §3.6 exemplars, counted where their gate places them).
+
+Anchor totals swept at `8660074d`, in-scope crates only:
+`cfg(unix)`/`cfg(not(unix))` — 49 hits across 18 files;
+`target_family = "unix"` — 1 (a comment in the GUID guard);
+`cfg(not(windows))`-family — 2;
+`cfg(any(target_os = …))` — 4;
+Linux-shaped literal paths (`/dev`, `/proc`, `/sys`, `/etc`) — 4;
+newlib-questionable syscalls (`getifaddrs`, `getgrouplist`, `getpwnam`,
+`getpwuid`, `getgrgid`, `sysconf`) — all resolved into the rows above.
+
+---
+
+## 6. What this audit says about the acceptance ladder
+
+The lesson from the GUID, applied rather than restated:
+
+* **The ladder in `doc/rtems-runtime-acceptance-plan.md` catches U1, U2 and
+  every §3.4 bin — none of S1, S2, S3.** U1/U2 fail rung 2 ("binds 5064") with
+  an errno; §3.4 fails before rung 0 (link). S1 produces an authorization
+  decision, S2 produces a rounded number, S3 produces nothing at all until a
+  feature flips. A fully green ladder is compatible with all three being
+  wrong.
+* **The only mechanical defence that exists in the tree is
+  `search_engine.rs:565` — one source-guard test, in one module.** It asserts
+  that module has zero bare `#[cfg(unix)]`. Nothing asserts that for
+  `auth/plain.rs`, which is where S1 lives.
+* **Cheapest host-side catch for S1** (in the spirit of "a host test beats a
+  reboot rung"): `osd_get_roles` is target-neutral in signature, so a test
+  under a `rtems-exec-model`-style feature that forces the RTEMS arm — or, far
+  cheaper, a source guard on `auth/plain.rs` mirroring
+  `search_engine.rs:565` — would fail *today*, on Linux, with no toolchain.
+  The `#[cfg(not(unix))]` arm at `:261` already contains the intended RTEMS
+  answer; the fix is arm selection, not new logic.
+* **S2 has no test that can catch it** without knowing the shim's tick, which
+  is the point: it is a cross-language coupling between `time.rs:50` and a C
+  `#define` in a file that does not exist yet
+  (`doc/rtems-boot-shim-design.md`). The place to close it is the shim's
+  authoring, while both halves are being written.
+
+## 7. What I did not establish
+
+Stated plainly rather than inferred:
+
+* **RTEMS libcsupport's passwd/group behaviour** when `/etc/passwd` is absent
+  from the image — decides which of S1's three silent outcomes occurs. RTEMS
+  kernel source is not on this machine.
+* **RTEMS libbsd's `SO_REUSEPORT` support** (U1, U2). libbsd source is not on
+  this machine.
+* **The RTEMS `FIONREAD` value** (U3) — derived from newlib header encoding in
+  the code's own doc, not verified against a newlib tree here.
+* **Whether `hostname::get()` succeeds on RTEMS** (§4.2) — no live caller
+  today, so it was not chased further.
+
+No source file was edited. No commit was made. HEAD is `8660074d`, tree clean.

--- a/doc/rtems-first-link-and-boot.md
+++ b/doc/rtems-first-link-and-boot.md
@@ -1,0 +1,143 @@
+# It links, it boots, and it stops at an upstream `libc` defect
+
+The first cross-toolchain link and boot of `rtems-ca-ioc`. Measured on the
+bring-up box against `684e5508`; the fixes it produced landed as `8a8c3071` and
+`51cef3f2`.
+
+| Rung (`doc/rtems-runtime-acceptance-plan.md`) | Result |
+|---|---|
+| 0 — it links | **PASS** |
+| 1 — it boots and prints | **PASS** |
+| 2 — it holds port 5064 | **FAIL** — upstream `libc`, §3 |
+| 3–6 — search, caget, camonitor, endurance | **BLOCKED** by rung 2 |
+
+## 1. Rung 0 — the link, and the fifth cause
+
+Four things were flagged as likely to break the link. None of them did. The
+cause was a fifth, and it is in `8a8c3071`: `CONFIGURE_APPLICATION_NEEDS_LIBBLOCK`
+is not optional on a BSP whose nexus device set contains a block device, because
+omitting the directive drops libblock's *configuration* rather than libblock.
+
+With it: exit 0, a 7,285,116-byte image.
+
+```
+Class: ELF32   Machine: ARM   Type: EXEC   Flags: 0x5000400, Version5 EABI, hard-float ABI
+0016c390 T POSIX_Init      001696f0 T main      0048f300 T rtems_bsd_initialize
+```
+
+### The four flagged items, all settled by measurement
+
+1. **`bsp_include_dir` — the guess was right.** The method was wrong, though: a
+   BSP *sample's* compile line is not evidence about the installed layout,
+   because the kernel's waf build compiles out of its own source tree. libbsd is
+   the right analogue.
+2. **`-Bdynamic` is harmless** — no `-static` and no reordering needed. rustc
+   emits `-Wl,-Bdynamic "-lbsd" "-lm" "-lz"`, but RTEMS ships only `.a`, so ld
+   resolves from archives. Proof: `rtems_bsd_initialize` is in the image at
+   `0x0048f300`, and `readelf -d` reports no dynamic section at all.
+3. **`CONFIGURE_MAXIMUM_FILE_DESCRIPTORS` is the RTEMS 6 spelling, and 150
+   stands.** `FD_SETSIZE` is **256** on RTEMS (newlib `sys/select.h:33-34`,
+   `__rtems__` arm), not the 64 that base's own caveat assumes.
+4. **`CONFIGURE_MAXIMUM_USER_EXTENSIONS 1` is enough** — the stack checker is an
+   *initial* extension from the static table and never draws on the
+   runtime-created pool. The hypothesis that it would was wrong.
+
+## 2. Rung 1 — it boots
+
+Console verbatim. Every `rtems-boot:` marker appeared, in order:
+
+```
+rtems-boot: POSIX_Init entered (RTEMS rtems-6.0.0 (ARM/ARMv4/xilinx_zynq_a9_qemu))
+rtems-boot: initializing libbsd
+rtems-boot: dhcp BOUND          (cgem0: offered 10.0.2.15 from 10.0.2.2)
+rtems-boot: -------- ifconfig --------
+rtems-boot: -------- netstat -rn --------
+rtems-boot: main() reached
+rtems-ca-ioc: cannot bind CA TCP port 5064: invalid argument
+rtems-boot: IOC terminated with 1
+```
+
+## 3. Rung 2 — the blocker is upstream, and `bind` is not what failed
+
+The IOC's message names the wrong operation. From a standalone RTEMS Rust probe
+built outside the workspace:
+
+```
+rustprobe: TcpListener 0.0.0.0:5064   -> ok
+rustprobe: UdpSocket   0.0.0.0:5064   -> ok
+rustprobe: bound 5065
+rustprobe: local_addr() on 5065       -> ERR kind=InvalidInput os=None msg=invalid argument
+```
+
+`os=None` means **no syscall failed**. A C probe replaying std's exact sequence
+confirms the kernel is fine: `socket`, `fcntl(F_GETFD)`, `fcntl(F_SETFD)`,
+`setsockopt(SO_REUSEADDR)`, `bind(0.0.0.0:5064)` and `listen(128)` all return 0.
+
+It is a struct-layout mismatch, measured in the guest:
+
+```
+probe2: sizeof(sockaddr_in)=16 offsetof(sin_len)=0 offsetof(sin_family)=1
+probe2: sizeof(sockaddr_storage)=128 offsetof(ss_family)=1 AF_INET=2
+probe2: getsockname len=16 bytes: 10 02 00 00 00 00 00 00
+```
+
+RTEMS is FreeBSD-derived, so byte 0 is `ss_len` = 16 and byte 1 is `ss_family`
+= 2. But `libc-0.2.185/src/unix/newlib/arm/mod.rs:20,27` declares `sockaddr_in`
+and `sockaddr_storage` **without the length byte**, and `newlib/mod.rs:36-42`
+sets `sa_family_t = u8`. So std's `socket_addr_from_c`
+(`sys/net/connection/socket/mod.rs:194`) reads offset 0, gets **16**, matches
+neither `AF_INET` nor `AF_INET6`, and returns the `InvalidInput` at `:208`.
+
+**The `aarch64` sibling is correct** — `newlib/aarch64/mod.rs:22-28` has
+`sin_len`. `arm` is the outlier. A second defect in the same declaration:
+`sockaddr_storage` should be 128 bytes, not the ~28 the arm definition implies.
+
+### Why there is no worthwhile workaround in our code
+
+The blast radius is every caller of `socket_addr_from_c`: `local_addr`,
+`peer_addr`, **`accept` (`mod.rs:609`)**, `UdpSocket::recv_from`
+(`unix.rs:350`), and `lookup_host` (`mod.rs:324`). Even if `BlockingCaServer::bind`
+skipped `local_addr()`, every accepted CA connection would still fail. The fix
+belongs upstream in `libc`, mirroring what aarch64 already does.
+
+## 4. `getpwnam` with no `/etc/passwd` synthesizes a root entry
+
+This is the answer `doc/rtems-cfg-unix-trap-audit.md` §7 left open, and it is
+the dangerous one of the three outcomes it listed.
+
+`cpukit/libcsupport/src/pwdgrp.c`: `getpw_r` calls `_libcsupport_pwdgrp_init()`
+at **line 201**, *before* `fopen("/etc/passwd")` at line 203. That runs
+`pwdgrp_init()` once, which `mkdir("/etc")` and then `init_file` with these
+literals:
+
+- line 77 — `init_file("/etc/passwd", "root::0:0::::\n");`
+- line 82 — `init_file("/etc/group",  "root::0:\n");`
+
+Confirmed at runtime in the guest:
+
+```
+probe3: stat(/etc/passwd) before any call -> -1 (errno=2 No such file or directory)
+probe3: getpwnam(root)   HIT  name=root uid=0 gid=0 dir=[] shell=[]
+probe3: getgrgid(0)      HIT  gr_name=root gr_gid=0 gr_mem[0]=(none)
+probe3: getpwnam(nobody) MISS errno=22 (Invalid argument)
+probe3: stat(/etc/passwd) after -> 0
+```
+
+Two things a PVA authorization decision must not miss. **Only `root` is
+synthesized** — every other name misses. And the miss is a **POSIX deviation**:
+`getpw_r` returns -1 with `errno=EINVAL` (line 222) where POSIX specifies return
+0 with `*result=NULL`, so on RTEMS an unknown user looks like `EINVAL`, not
+not-found.
+
+So an unconfigured RTEMS image would have resolved the account `root` to uid 0 /
+gid 0 and handed the ACF gate the role `root`, silently. That is finding S1 of
+the `cfg(unix)` audit, and `2b7f7154` closed it before this measurement existed
+— the measurement confirms the fix was necessary rather than precautionary.
+
+## 5. Open
+
+- **The `libc` `sin_len`/`ss_len` omission on `armv7-rtems-eabihf`** blocks rungs
+  2–6. Not patched locally: patching a registry crate in place would have hidden
+  the defect rather than closed it.
+- **`rtems-ca-ioc` attributes a `local_addr()` failure to "cannot bind".** A
+  reporting defect, not the blocker.

--- a/doc/rtems-hosted-assumptions-and-ceilings.md
+++ b/doc/rtems-hosted-assumptions-and-ceilings.md
@@ -1,5 +1,31 @@
 # Unguarded hosted assumptions, and the static-configuration ceiling
 
+> **CORRECTION (2026-07-22, after `b594b18a`).** §B.3's parity premise is
+> **wrong** and the projection built on it is wrong with it. This document says
+> *"`epicsThreadStackSmall` is what C `rsrv` uses for its per-client tasks, so
+> this is also the parity answer"*. Read from the C source: the per-client
+> `CAS-client` task uses **`epicsThreadStackBig`** (`caservertask.c:109-111`);
+> `epicsThreadStackSmall` is what **`CAS-beacon`** uses
+> (`caservertask.c:758-760`). Small would have been 4× *cheaper* than parity,
+> not equal to it.
+>
+> Which C table governs also had to be established rather than assumed: RTEMS 6
+> sets `OS_API = posix`, and `osdThread.c` exists only under `os/posix` and
+> `os/RTEMS-score`, so the **POSIX** size table applies — not RTEMS-score's
+> 5000/8000/11000 bytes.
+>
+> Consequence for §B.3's table: the ceiling after the fix is **~17 CA clients /
+> ~17 PVA connections**, not the ~44 / ~29 projected here. That is still 3.4×
+> and 5.7× better than the ~5 / ~3 measured before, and descriptors (~140)
+> remain ~8× further out, so **the ranking and the remedy in §B.3 both stand** —
+> only the projected magnitude was too optimistic.
+>
+> Everything else in this document was re-verified and holds. The correction is
+> recorded here rather than edited into §B.3 because the reasoning that produced
+> the wrong number is worth seeing: the audit inferred the parity class from the
+> *name* `epicsThreadStackSmall` matching "small per-client thread" instead of
+> reading which task actually passes it.
+
 **Measured at** integration worktree
 `/home/stevek/work/epics-rs/.caucus/worktrees/integration`, HEAD
 **`684e550878afa284884eaefa6a3d9064e7733976`** (`684e5508`, *"feat(rtems): the

--- a/doc/rtems-hosted-assumptions-and-ceilings.md
+++ b/doc/rtems-hosted-assumptions-and-ceilings.md
@@ -1,0 +1,449 @@
+# Unguarded hosted assumptions, and the static-configuration ceiling
+
+**Measured at** integration worktree
+`/home/stevek/work/epics-rs/.caucus/worktrees/integration`, HEAD
+**`684e550878afa284884eaefa6a3d9064e7733976`** (`684e5508`, *"feat(rtems): the
+boot shim and the link contract, in one crate"*). Read-only: no file was created
+in the repo, nothing edited, nothing committed.
+
+**Tree state.** `git status --porcelain` was **empty** for the whole
+investigation and went dirty only while this document was being written: the
+sibling panel's S1 fix appeared as ` M crates/epics-pva-rs/src/auth/plain.rs`
+plus a new untracked `crates/epics-pva-rs/build.rs` (it emits a
+`local_account_db` cfg, splitting `cfg(unix)`'s two meanings — "libc is linked",
+true on RTEMS, from "there is a passwd/group database", false there). **Every
+citation below was taken from the `684e5508` blobs.** The one citation that
+touches an edited file is A3's count of five `env::var` sites in
+`auth/plain.rs`; re-verified after the edit landed — `git show
+684e5508:…/auth/plain.rs` and the working tree both report 5, so that number
+holds under both. Nothing else in this document reads a file the panel is
+editing.
+
+Part A is the surface no predicate audit can reach: live-on-RTEMS code with no
+`cfg` anywhere that assumes a hosted OS. Part B is the arithmetic — what our
+code can demand versus what `crates/epics-rtems-boot/csrc/rtems_config.c`
+actually reserves.
+
+Scope is §0.1 of `doc/rtems-cfg-unix-trap-audit.md`: the un-gated surface of
+`epics-base-rs`, `epics-ca-rs`, `epics-pva-rs`, plus the shim.
+
+---
+
+# Part A — hosted assumptions with no guard
+
+Ranked silent-first, because the silent ones are what a green ladder cannot
+catch.
+
+## A1 — SILENT. Every thread priority in the port is inert on RTEMS, twice over.
+
+The design work behind priorities is real and cited: PVA at 18 / UDP at 16
+(pvxs `server.cpp:388`, `udp_collector.cpp:93`), CA receiver at
+`CaServerLow` = 20 and CA sender at 19
+(`epics-ca-rs/src/server/blocking.rs:200`, `:669`). None of it takes effect on
+the target, for two independent reasons, either of which alone is sufficient:
+
+1. **The switch cannot be turned on.** `apply_to_current_thread`
+   (`epics-base-rs/src/runtime/task.rs:583`) delegates to
+   `apply_to_current_thread_under(RtPolicy::current(), …)`, and
+   `RtPolicy::current()` (`:550`) reads `RT_PRIORITY_ENV` =
+   `"EPICS_RS_ALLOW_RT_PRIORITY"` (`:511`), defaulting to `RtPolicy::Disabled`
+   when unset (`:533-535`). `POSIX_Init`
+   (`crates/epics-rtems-boot/csrc/rtems_init.c:190-292`) calls `setenv` **zero
+   times** — see A3 — and there is no shell in the image to set it. So the
+   policy is `Disabled` on every boot, and `apply_to_current_thread_under`
+   returns `PriorityApplied::Disabled` at `:598` before any scheduler call is
+   reachable.
+2. **Even switched on, the call is not wired for this target.**
+   `apply_priority_impl` has two arms; the non-Linux one
+   (`task.rs:769-773`) returns `PriorityApplied::Unsupported` with the comment
+   *"The crate links `libc` only on Linux"* — confirmed by
+   `epics-base-rs/Cargo.toml:66-67`,
+   `[target.'cfg(target_os = "linux")'.dependencies] libc = "0.2"`.
+
+**What the threads actually run at instead.** `POSIX_Init` deliberately lowers
+the init task to `RTEMS_MAXIMUM_PRIORITY - 1U` — *just above idle* —
+(`rtems_init.c:222-223`), and `main()` runs on that task (`:286`). Every IOC
+thread is created from it. What priority a pthread created there receives is an
+RTEMS pthread-attribute-default question; **I cannot establish that from this
+machine** (see Part C, C1).
+
+**Why SILENT.** Nothing logs. `sched_calls_made()` (`task.rs:783`) staying at
+`0` is the *documented correct* observation for the switch being off
+(`:775-781`), so the one counter that could reveal this reads as healthy. Every
+acceptance rung — bind, search, caget, camonitor — passes at any priority.
+
+**Not proposing a fix here** (read-only inventory), but naming the shape: the
+priority intent is expressed as a call that is a no-op on the only target that
+has no other way to set priorities, and the target does have an API
+(`rtems_task_set_priority`, which the shim itself uses at `rtems_init.c:222`).
+
+## A2 — SILENT. Every timestamp the IOC serves is 2014-04-14 plus uptime.
+
+`rtems_init.c:206-211` sets `CLOCK_REALTIME` from
+`EPICS_RTEMS_BOOT_EPOCH`, default `1397460606` (`:69`), and the file says why
+in its own words at `:57-64`: no RTC on this BSP, so *"the clock starts from a
+compile-time constant and is identical on every boot of every board"*. The shim
+drops NTP (its `:8` note, and `doc/rtems-boot-shim-design.md` §1.1), so nothing
+ever corrects it — `general_time::notify_clock_sync`
+(`epics-base-rs/src/runtime/general_time.rs:237`) is never called.
+
+That clock reaches the wire through one funnel with seven live call sites:
+`general_time::get_current()` (`general_time.rs:256`) is called from
+`server/recgbl.rs:428`, `server/record/record_instance.rs:3315`, `:3891`,
+`:3968`, `server/database/field_io.rs:980`, `server/records/bi.rs:202`,
+`server/records/mbbi.rs:554`. It becomes the CA wire stamp at
+`types/codec.rs:47-53` (`epics_timestamp_parts`).
+
+**Why SILENT.** A client sees a well-formed timestamp twelve years stale. `caget
+-t` prints it without complaint; `camonitor` deltas are correct because the
+monotonic part advances. The golden capture in `doc/rtems-acceptance-golden.txt`
+was taken on Linux, so a guest run's stamps differ from it by construction and
+the difference reads as expected, not as a finding.
+
+**One sharp edge nearby.** `codec.rs:49-52` computes
+`unix.as_secs().saturating_sub(EPICS_UNIX_EPOCH_OFFSET_SECS)` where the offset
+is `631_152_000` (1990-01-01, `:11`). The default boot epoch is safely above
+that. But `EPICS_RTEMS_BOOT_EPOCH` is a build-time override
+(`rtems_init.c:68-70`), and any value below 1990 makes **every** timestamp
+saturate to EPICS second 0 — silently, because `saturating_sub` cannot fail.
+
+## A3 — SILENT. The environment is empty, so every `EPICS_*` setting is its compiled-in default and none is reachable.
+
+`POSIX_Init` never calls `setenv`/`putenv` (read in full, 292 lines), the shim
+drops the iocsh and the startup script (`rtems_init.c:8`), and the reduced shell
+(`rtems_config.c:143-159`) offers `netstat`, `ifconfig`, `stackuse`,
+`malloc_info` — none of which sets a variable in the IOC's environment.
+
+`runtime/env.rs` reads no files (verified: zero `std::fs`/`Path` hits), so there
+is no `envPaths`-style fallback either. The env-var read surface that goes
+compiled-in-default on this target, by file:
+`epics-pva-rs/src/config/env.rs` (68 sites), `epics-ca-rs/src/server/addr_list.rs`
+(10), `epics-ca-rs/src/server/tcp.rs` (5), `epics-ca-rs/src/protocol.rs` (5),
+`epics-pva-rs/src/auth/plain.rs` (5), `epics-base-rs/src/runtime/env.rs` (4).
+
+Consequences that matter, beyond A1: `EPICS_CA_ADDR_LIST` /
+`EPICS_PVA_ADDR_LIST` / `EPICS_PVA_NAME_SERVERS` cannot be set on the guest, so
+every discovery test must be driven from the host side; `EPICS_CAS_BEACON_*`,
+queue sizes and every log-level switch are fixed at compile time.
+
+**The one loud exception, worth recording as the contrast:** the `getenv` device
+support (`epics-base-rs/src/server/builtin_devices/getenv.rs`) turns an unset
+variable into *"an empty VAL with a UDF_ALARM"* (its `:18-20`). A `.db` using
+`DTYP "getenv"` therefore fails visibly on RTEMS rather than silently — which is
+what the rest of this list does not do.
+
+## A4 — SILENT. `argv` is hard-coded to one element, so `rtems-ca-ioc` can only ever serve `DEMO_DB`.
+
+`rtems_init.c:195` declares `char *argv[] = {"rtems-ioc", NULL};` and `:286`
+calls `main(1, argv)`. `rtems-ca-ioc` builds its database list from
+`std::env::args().skip(1)` (`crates/epics-ca-rs/src/bin/rtems-ca-ioc.rs:124`),
+which is therefore **always empty**, so `load_database` always takes the
+`db_string(DEMO_DB, …)` branch (`:96`). The three demo records are the only
+records this target can serve today.
+
+**Why SILENT.** The IOC boots, prints its three record names, answers `caget`,
+and every ladder rung passes. Nothing distinguishes "serving the database you
+asked for" from "serving the built-in fallback because the argument vector is a
+constant" — the fallback is the designed behaviour for an empty argv, and argv
+is empty by construction rather than by choice.
+
+This also makes the `db_loader` filesystem surface
+(`epics-base-rs/src/server/db_loader/mod.rs`, 24 `std::fs` sites,
+`db_loader/include.rs`, `db_loader/substitution.rs`) unreachable on the target
+as it stands — which is why it is not in the SILENT list, but is the first thing
+that becomes reachable the moment argv is made configurable.
+
+## A5 — SILENT. Two live DNS paths degrade into an authorization answer and a dropped address, both behind a log line no ladder reads.
+
+`std::net::ToSocketAddrs` calls `getaddrinfo`, which on RTEMS needs libbsd's
+resolver and a resolver configuration. `POSIX_Init` writes `/etc/dhcpcd.conf`
+(`rtems_init.c:165-188`) but nothing in the shim writes or reads
+`/etc/resolv.conf`; **whether dhcpcd populates it on this BSP is not
+establishable from this machine** (Part C, C3).
+
+Two live call sites, both read in full:
+
+* `epics-base-rs/src/server/access_security.rs:1499-1526`, `hag_members` —
+  resolves ACF host-group members when `as_check_client_ip()` is on. A resolve
+  failure logs `tracing::warn!` *"ACF: Unable to resolve host"* and stores the
+  member as `format!("unresolved:{m}")` (`:1516`), an entry no IPv4 peer can
+  ever match. On a resolver-less guest **every named HAG member becomes a
+  non-matching sentinel**, so a rule intended to grant access denies it — or, in
+  a `DENY FROM` rule, fails to deny. The log is `warn`, the effect is an access
+  decision.
+* `epics-pva-rs/src/config/env.rs:367-390`, `resolve_token_addr` — a token that
+  will not resolve is dropped with `tracing::debug!` and `None` (`:385-388`).
+  The doc comment right above it (`:355-365`) records that this exact "silently
+  dropping every DNS hostname" behaviour was a previous defect (P-6). It
+  reappears on RTEMS not as a parser bug but as an environment property.
+
+## A6 — SILENT on host, and it is the binding ceiling on target: 10 of 12 thread spawns set no stack size.
+
+Full enumeration of `thread::Builder::new()` in the three crates:
+
+| site | `.stack_size()`? |
+|---|---|
+| `epics-base-rs/src/runtime/background/scan_once.rs:172` | **yes** — `StackSizeClass::Big` (`:176`) |
+| `epics-base-rs/src/runtime/background/callback_executor.rs:293` | **yes** — `Big` (`:296`) |
+| `epics-base-rs/src/runtime/background/delayed_timer.rs:226` (`cbTimer`) | no |
+| `epics-base-rs/src/runtime/task.rs:887` (`spawn_dedicated_thread`, tokio arm) | no |
+| `epics-base-rs/src/runtime/task.rs:908` (`spawn_dedicated_thread`, **exec arm — the RTEMS one**) | no |
+| `epics-base-rs/src/runtime/task.rs:651` (RT-range probe) | no |
+| `epics-base-rs/src/server/ioc_app.rs:694`, `:1029` | no |
+| `epics-ca-rs/src/server/blocking.rs:192` (**per client**) | no |
+| `epics-ca-rs/src/server/blocking.rs:659` (**per client**) | no |
+| `epics-ca-rs/src/bin/rtems-ca-ioc.rs:157` (`CAS-TCP`), `:168` (`CAS-UDP`) | no |
+
+`StackSizeClass` (`task.rs:442-459`) exists precisely for this, is documented as
+matching *"the POSIX `stackSizeTable` in `osdThread.c`"*, and is applied at two
+sites out of twelve. **Every thread that scales with connection count is in the
+"no" column.** Why that is silent on the host and decisive on the target is
+Part B.
+
+## A7 — LOUD, or unreachable. Recorded so the reader can see they were checked.
+
+* `std::env::current_exe()` — on RTEMS, std reads the literal path `"sys:exe"`
+  (`std/src/sys/paths/unix.rs:363-366`), which does not exist in our IMFS, so it
+  returns `Err`. Sole caller is `epics-ca-rs/src/repeater.rs:599`, an
+  RTEMS-gated module. **Not live.**
+* Autosave — `create_dir_all` (`server/autosave/startup.rs:246`) and
+  `canonicalize` (`autosave/request.rs:207`) would fail loudly, but autosave is
+  opt-in (`ioc_builder.rs:42`, `:72` default `None`; `:401` only acts when
+  configured) and `rtems-ca-ioc` never calls `.autosave(…)`. **Not live**,
+  latent for stage G and any real IOC.
+* `iocsh` — `epics-base-rs/src/server/iocsh/mod.rs` has 32 `std::fs` sites and
+  `commands.rs:956` reads `/proc/self/status` under `cfg(target_os = "linux")`;
+  `rtems-ca-ioc` never starts the shell, and the RSS branch is correctly
+  linux-gated. `available_parallelism()` at `commands.rs:966` already degrades
+  via `.unwrap_or(1)`.
+* `std::process::Command` — two sites, both in `epics-pva-rs/src/auth/tls.rs`
+  (`:1561`, `:1628`) invoking `openssl`, inside `cfg(feature = "tls")` which the
+  RTEMS build turns off. `std::env::temp_dir()` and `tempfile` — test code only
+  (`ioc_app.rs:1522`, `autosave/*.rs`, `replay.rs:286`).
+* `std::random` — on RTEMS std selects the `arc4random` backend
+  (`std/src/sys/random/mod.rs:23`). That is what `HashMap`'s `RandomState` draws
+  on. It is *not* what the server GUID uses: `search_engine.rs:86` deliberately
+  calls `libc::getentropy` instead, because arc4random returns `void` and cannot
+  report failure. Consistent, and worth knowing the two paths differ.
+
+---
+
+# Part B — the static-configuration ceiling
+
+## B.0 What the shim reserves
+
+From `crates/epics-rtems-boot/csrc/rtems_config.c`, read in full:
+
+| directive | value | line |
+|---|---|---|
+| `CONFIGURE_POSIX_INIT_THREAD_STACK_SIZE` | 64 KiB | `:35` |
+| `CONFIGURE_MICROSECONDS_PER_TICK` | 10000 (10 ms) | `:44` |
+| `CONFIGURE_EXTRA_TASK_STACKS` | `4000 * RTEMS_MINIMUM_STACK_SIZE` | `:54` |
+| `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS` | 150 | `:104` |
+| `CONFIGURE_MAXIMUM_USER_EXTENSIONS` | 1 | `:121` |
+| `CONFIGURE_UNLIMITED_ALLOCATION_SIZE` | 32 | `:130` |
+| `CONFIGURE_UNLIMITED_OBJECTS` | — | `:131` |
+| `CONFIGURE_UNIFIED_WORK_AREAS` | — | `:132` |
+| `CONFIGURE_STACK_CHECKER_ENABLED` | — | `:141` |
+| `CONFIGURE_MAXIMUM_DRIVERS` | 40 | `:165` |
+
+Base's own comment gives the stack unit: *"MINIMUM_STACK_SIZE == 8K"*
+(`epics-base/modules/libcom/RTEMS/posix/rtems_config.c:38`), so
+`CONFIGURE_EXTRA_TASK_STACKS` ≈ **32 MiB**.
+
+## B.1 The per-thread cost, from rust-src on this machine
+
+`rust-src` is installed under the local `nightly` toolchain, so these are read
+from the actual standard library rather than recalled. **Version caveat:** the
+local nightly is `rustc 1.99.0-nightly (af3d95584 2026-07-09)`; the bring-up box
+runs `(87e5904f5 2026-07-20)` per `rtems-qemu-box`. Eleven days apart, different
+commits — the box should re-check these three facts against its own `rust-src`
+before anything is sized on them.
+
+1. **Default thread stack = 2 MiB on RTEMS.**
+   `std/src/sys/thread/unix.rs:25-31` gates `DEFAULT_MIN_STACK_SIZE = 2 * 1024 *
+   1024` on `not(any(l4re, vxworks, espidf, nuttx))`. VxWorks got a 256 KiB
+   carve-out at `:34-35`; **RTEMS did not**, so it takes the generic 2 MiB. This
+   is the previous audit's family — an else-arm written for hosted unix that
+   RTEMS falls into — living inside std itself.
+2. **`std::sync::Mutex` and `Condvar` are pthread-backed on RTEMS, not futex.**
+   `std/src/sys/sync/mutex/mod.rs` lists the futex arm by explicit `target_os`
+   (linux, android, freebsd, openbsd, dragonfly, …); RTEMS is absent, so it
+   falls to `any(target_family = "unix", …)` → `pthread::Mutex`. Identical
+   selection in `std/src/sys/sync/condvar/mod.rs`.
+3. **Each `std::thread` carries a pthread mutex + condvar for its parker.**
+   `std/src/sys/sync/thread_parking/mod.rs` — same shape, RTEMS falls to the
+   `target_family = "unix"` arm → `pthread::Parker`.
+
+Together: **on RTEMS one `std::thread` costs 1 pthread + 1 pthread\_mutex + 1
+pthread\_cond, where on our Linux CI host it costs 1 pthread + 0.** Our
+per-thread OS-object demand is three times what every host test exercises, and
+nothing on the host can observe the difference.
+
+## B.2 The demand census
+
+`StackSizeClass::bytes()` (`task.rs:451-459`) is
+`f * 0x10000 * size_of::<usize>()`. On `armv7-rtems-eabihf` `size_of::<usize>()`
+is 4, so Small = 256 KiB, Medium = 512 KiB, **Big = 1 MiB** (on the x86-64 host
+the same code yields 512 KiB / 1 MiB / 2 MiB — the classes are half as large on
+the target).
+
+**Fixed, before the first client** (`rtems-ca-ioc` as it stands):
+
+| thread | n | stack |
+|---|---|---|
+| `POSIX_Init` / `main` | 1 | 64 KiB (confdefs) |
+| callback pool — `NUM_CALLBACK_PRIORITIES` 3 × `DEFAULT_THREADS_PER_PRIORITY` 1 (`callback_executor.rs:44`, `:51`) | 3 | 3 × 1 MiB (Big) |
+| `cbTimer` (`delayed_timer.rs:226`) | 1 | 2 MiB (default) |
+| `scanOnce` (`scan_once.rs:172`) | 1 | 1 MiB (Big) |
+| `CAS-TCP` (`rtems-ca-ioc.rs:157`) | 1 | 2 MiB (default) |
+| `CAS-UDP` (`rtems-ca-ioc.rs:168`) | 1 | 2 MiB (default) |
+| **total** | **8** | **≈ 10 MiB** |
+
+Plus libbsd's own threads, whose count is not establishable here (Part C, C4).
+
+**Per connection:**
+
+| | threads | stack | fds | `std::sync` objects beyond parkers |
+|---|---|---|---|---|
+| CA client (`blocking.rs:192` + `:659`) | 2 | **4 MiB** | 1 | 1 — `send_lock: Arc<Mutex<TcpStream>>` (`:634`, `std::sync::Mutex` per `:102`) |
+| PVA connection (reader + writer + connection thread, `blocking.rs:770-792`) | 3 | **6 MiB** | 1 | 0 (both queues are `tokio::sync::mpsc`, pure-Rust) |
+
+In OS objects, one PVA connection is 3 pthreads + 3 mutexes + 3 condvars; one CA
+client is 2 pthreads + 3 mutexes + 2 condvars.
+
+## B.3 The first ceiling, and where it bites
+
+Against the 32 MiB `CONFIGURE_EXTRA_TASK_STACKS` reserve, minus ≈10 MiB fixed,
+**≈22 MiB is left**:
+
+| load | consumes | verdict |
+|---|---|---|
+| 5 CA clients | 20 MiB | fits |
+| **6 CA clients** | 24 MiB | **over** |
+| 3 PVA connections | 18 MiB | fits |
+| **4 PVA connections** | 24 MiB | **over** |
+
+**The first ceiling is task-stack memory, and it is hit at roughly 5 concurrent
+CA clients or 3 concurrent PVA connections.** It is not the file descriptors:
+150 descriptors is ~140 clients, about **28×** further out. It is not any object
+table: those are `CONFIGURE_UNLIMITED_OBJECTS` (B.4).
+
+The cause is A6, not the shim. Every one of those threads takes 2 MiB because no
+`.stack_size()` is set, while the two threads that *do* set one take 1 MiB. Had
+the per-connection threads used `StackSizeClass::Small` (256 KiB), the same 22
+MiB would hold **~44 CA clients or ~29 PVA connections** — at which point the
+descriptor ceiling and the shim's reserve are finally in the same order of
+magnitude, which is what a coherent configuration looks like. `epicsThreadStackSmall`
+is what C `rsrv` uses for its per-client tasks, so this is also the parity
+answer, not merely the cheap one.
+
+**A second reading, which I cannot rule out.** `CONFIGURE_UNIFIED_WORK_AREAS`
+(`rtems_config.c:132`) merges the RTEMS workspace and the C heap into one pool,
+and the shim's own comment says that is the point (`:127-128`). If pthread
+stacks are `malloc`ed from that unified pool rather than drawn against the
+`CONFIGURE_EXTRA_TASK_STACKS` reserve, the ceiling is instead **total BSP RAM
+divided by 2 MiB**, and `EXTRA_TASK_STACKS` is only an addend to the initial
+size estimate. Which of the two readings holds is a confdefs question (Part C,
+C2), and the BSP's default RAM size is a QEMU question (C4). **The remedy is the
+same under both readings, and so is the ranking**: 2 MiB per connection thread
+is 8× the class the code already defines for this purpose, on the only target
+where it is scarce.
+
+## B.4 What `CONFIGURE_UNLIMITED_OBJECTS` covers — what I can and cannot establish
+
+**I cannot establish the confdefs semantics from this machine.** Searched:
+`/opt/rtems`, `/usr/local/rtems`, `$HOME/rtems*`, `/usr/include/rtems`, and a
+whole-filesystem `find` for `confdefs.h`, `rtems-bsd-config.h`, `shellconfig.h`
+— **zero hits**; no `arm-rtems6-gcc` on `PATH`; the only `rtems*` files in the
+repo are the two we wrote. Per the reference-source rule I am not reconstructing
+`<rtems/confdefs.h>` from memory.
+
+**What local evidence does establish** — an *exception list by base's own
+practice*, not by reading confdefs. EPICS base sets `CONFIGURE_UNLIMITED_OBJECTS`
+(`posix/rtems_config.c:90`) and *still* explicitly configures six other maxima
+alongside it:
+
+| directive base still sets | line | our shim |
+|---|---|---|
+| `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS` 64 | `:83` | set, 150 (`:104`) |
+| `CONFIGURE_MAXIMUM_USER_EXTENSIONS` 5 | `:87` | set, 1 (`:121`) — **already proven necessary**: the shim's `:110-113` records that libbsd dies with *"cannot create extension"* without it |
+| `CONFIGURE_MAXIMUM_DRIVERS` 40 | `:173` | set, 40 (`:165`) |
+| `CONFIGURE_MAXIMUM_PERIODS` 5 | `:28` | not set — we create no rate-monotonic periods |
+| `CONFIGURE_IMFS_ENABLE_MKFIFO` 2 | `:84` | not set — we create no FIFOs |
+| `CONFIGURE_MAXIMUM_NFS_MOUNTS` 3 | `:86` | not set — NFS is dropped |
+
+So for the facilities the shim keeps, its exception coverage matches base's.
+Two honest qualifications: base's `CONFIGURE_MAXIMUM_PERIODS` line predates
+`CONFIGURE_UNLIMITED_OBJECTS` in the same file and may simply be legacy, so
+inferring "periods are outside the unlimited set" from it is weak; and file
+descriptors are a libio limit rather than an object class at all, so their
+presence on this list proves nothing about object coverage.
+
+**The question this leaves open is worth more to us than to base, and that is
+the point.** By B.1(2) and B.1(3), every `std::sync::Mutex`, every `Condvar`,
+and every thread's parker becomes a POSIX synchronization object on RTEMS. At 32
+PVA connections that is 8 + 96 = 104 threads and on the order of 300 POSIX mutex
+and condition-variable objects — created by Rust's standard library, invisibly,
+where the equivalent C IOC creates a handful. If `CONFIGURE_UNLIMITED_OBJECTS`
+does **not** extend to `CONFIGURE_MAXIMUM_POSIX_THREADS`,
+`…_POSIX_MUTEXES`, `…_POSIX_CONDITION_VARIABLES` and `…_POSIX_KEYS`, the failure
+will look exactly like the user-extension failure the panel already hit: a
+creation error during early init or at the Nth connection, not a graceful
+refusal. That is the first thing to check on the box, and B.5 says how.
+
+## B.5 Ceilings the image can hit, ordered by how close they are
+
+| # | ceiling | reserve | our demand | first hit at | loud? |
+|---|---|---|---|---|---|
+| 1 | **task-stack memory** | ≈22 MiB after fixed | 4 MiB/CA client, 6 MiB/PVA conn | **~5 CA / ~3 PVA** | thread spawn returns `Err`; CA logs `warn!` *"failed to spawn blocking CA client thread"* (`blocking.rs:207-211`) and **drops the client silently from the client's point of view** — it sees a TCP connect that dies |
+| 2 | POSIX object classes (threads/mutexes/condvars/keys) | `UNLIMITED_OBJECTS` **if it covers them** | 1 pthread + 1 mutex + 1 cond per thread | unknown — see B.4 | loud (creation error), like the user-extension one |
+| 3 | file descriptors | 150 (`:104`) | 1 per connection + listeners | ~140 clients | loud (`accept` returns `EMFILE`) |
+| 4 | user extensions | 1 (`:121`) | libbsd 1 + stack checker ? | boot, if the checker also claims one | loud — the shim's `:116-118` already flags this |
+| 5 | drivers | 40 (`:165`) | libbsd + console + shell | not close | loud |
+
+Ceiling 1 is both the nearest and the only one on the list that does **not**
+announce itself to the operator — the server logs a warning and keeps running,
+the client just fails to connect. That combination is what makes it the one to
+close first.
+
+---
+
+# Part C — what I cannot establish from this machine
+
+Stated in those words, with what would settle each.
+
+* **C1 — the priority a pthread created from `POSIX_Init` inherits.** A1 shows
+  our code never sets one, and the shim lowers the init task to
+  `RTEMS_MAXIMUM_PRIORITY - 1U`. Whether RTEMS's default pthread attribute is
+  inherit-from-creator or an explicit default is an RTEMS POSIX-API question.
+  **Settled by:** reading `cpukit/posix/src/pthreadcreate.c` and
+  `pthread_attr_init` on the box, or by running `stackuse`/`rtems task` on a
+  booted guest and reading the priority column.
+* **C2 — whether pthread stacks are drawn against
+  `CONFIGURE_EXTRA_TASK_STACKS` or `malloc`ed from the unified work area.**
+  This selects between the two readings in B.3. **Settled by:** reading
+  `<rtems/confdefs.h>` (`_CONFIGURE_STACK_SPACE_SIZE`) plus
+  `cpukit/posix/src/pthreadcreate.c` on the box; or empirically, by booting with
+  a client-count ramp and watching where thread creation starts failing.
+* **C3 — whether a DNS resolver exists on the guest.** A5 depends on it. The
+  shim writes `/etc/dhcpcd.conf` but nothing writes or reads
+  `/etc/resolv.conf`. **Settled by:** `cat /etc/resolv.conf` from the guest
+  shell after DHCP binds, or a `getaddrinfo` probe record.
+* **C4 — libbsd's own thread and object count, and the BSP's default RAM.**
+  Both are addends to every number in B.2/B.3. **Settled by:** the `stackuse`
+  and `malloc_info` shell commands the shim already configures
+  (`rtems_config.c:156-157`) on a booted guest — which is precisely the rung
+  `doc/rtems-runtime-acceptance-plan.md` calls the resource rung.
+* **C5 — whether `CONFIGURE_UNLIMITED_OBJECTS` covers the POSIX object
+  classes.** B.4. **Settled by:** reading `<rtems/confdefs.h>` on the box —
+  specifically which `CONFIGURE_MAXIMUM_POSIX_*` macros the unlimited branch
+  assigns — which is a single grep once the toolchain tree is in hand, and is
+  the same read that closes the `CONFIGURE_MAXIMUM_PERIODS` doubt in B.4.
+* **C6 — the three rust-src facts in B.1 against the box's own toolchain.** Read
+  here from `nightly (af3d95584 2026-07-09)`; the box runs
+  `(87e5904f5 2026-07-20)`. **Settled by:** the same three greps in the box's
+  `lib/rustlib/src/rust/library/std/src`.
+
+No source file was edited, no commit was made. HEAD `684e5508`, tree clean at
+both ends of this investigation.

--- a/doc/rtems-link-contract.md
+++ b/doc/rtems-link-contract.md
@@ -1,0 +1,133 @@
+# The RTEMS link contract — measured, not designed
+
+`doc/rtems-boot-shim-design.md` assumed one crate could own the whole link
+contract and emit it from a single `build.rs`. **It cannot.** This document
+records the measurement that changed the design, so nobody re-derives it.
+
+Landed as `crates/epics-rtems-boot` on `integration/rtems-scope-b`
+(`684e5508`). Nothing in that commit has ever been linked — there is no
+`arm-rtems6` toolchain on the development machine. §4 lists exactly what the
+box must run to close that.
+
+## 1. What a build script's link output actually reaches
+
+Probed with a real dependent binary, not read from documentation:
+
+| `cargo::` instruction | reaches a dependent binary? |
+|---|---|
+| `rustc-link-search` | **yes** — lands on the dependent's own rustc line |
+| `rustc-link-lib` | **yes, indirectly** — rustc forwards it from the rlib's metadata to the linker, *but only if the binary actually references the crate* |
+| `rustc-link-arg` | **no** — applies to the emitting package's own targets, and an rlib performs no link |
+
+The middle row was proved twice over: `rust-lld: error: unable to find library
+-lPROBE_LINK_LIB` appeared while the reference existed, and **disappeared when
+the reference was removed**.
+
+### Consequences
+
+1. `-u POSIX_Init`, `-B<bsp>/lib` and the five ABI selectors **cannot** be
+   pushed from the shim crate into the IOC's link.
+2. An **unreferenced rlib is not linked at all**. Without a live reference the
+   shim archive, `-lbsd -lm -lz` and `POSIX_Init` all silently vanish. Hence
+   `epics_rtems_boot::link_anchor()` is called from `rtems-ca-ioc`'s `main` —
+   it is load-bearing, not decorative.
+
+So the contract is delivered in **two halves with one owner**: search paths and
+libraries from `epics-rtems-boot/build.rs`; link arguments from a three-line
+`epics-ca-rs/build.rs` calling `epics_rtems_boot::contract::emit_link_args()`.
+The flag list is written once.
+
+### The split buys the ordering constraint for free
+
+`doc/rtems-qemu-bringup-artefacts.md` §(b) requires `-lbsd -lm -lz` to precede
+the `-qrtems` group rather than land inside it. Measured on rustc's own line:
+the dependency's `-l` at **arg 36**, the `-C link-arg` at **arg 60**. The
+ordering is a consequence of the delivery split, not a flag anyone tuned.
+
+`-B<bsp>/lib` supplies both the BSP `-L` and the `-T linkcmds`, so the linker
+script is never named — a test fails if any emitted arg contains `-T` or
+`linkcmds`.
+
+## 2. Making Rust agree with the `thumb/armv7-a+simd/hard` multilib
+
+The multilib string is the compiler's own answer, not inferred from `-L` paths:
+
+```
+$ arm-rtems6-gcc -print-multi-directory \
+    -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9
+thumb/armv7-a+simd/hard
+```
+
+`rustc --print target-spec-json --target armv7-rtems-eabihf` (needs
+`-Z unstable-options`; the bare form prints nothing) gives `abi = "eabihf"`,
+`llvm-floatabi = "hard"`, `features = "+thumb2,+neon,+vfp3"`. **Every
+ABI-significant axis already matches.**
+
+The axis that differs is not an ABI axis: rustc emits **A32**, not Thumb (no
+`thumb-mode` feature; the triple is `armv7-`, not `thumbv7-`). Armv7-A
+interworks and AAPCS is identical for both instruction sets, so `-mthumb` is a
+multilib *selector* for the C side, not a constraint on Rust's output. This is
+reasoned, not observed — only a real link proves the veneers resolve.
+
+What *is* load-bearing: the five selectors must reach the **link**, because gcc
+picks the multilib from its link-time flags. Omit them and it takes the default
+and dies about VFP register arguments. They are emitted both as link args and
+as the shim's `cc` compile flags, and `contract::check_abi` turns the rustc half
+into a build-time assertion against `CARGO_CFG_TARGET_ABI` / `TARGET_FEATURE`.
+
+## 3. One deliberate deviation from the design, and why
+
+Design §3.2 says `build.rs` must hard-fail when `RTEMS_BSP_PREFIX` is unset.
+**It does not.** Cargo resolves dependencies identically for `check` and
+`build`, so that hard failure would delete the `rtems-check` gate — which §4.2
+of the same document calls *"the only gate that works without the box"*. The
+two requirements conflict; this resolved toward §4.2.
+
+Instead the crate leaves **one undefined symbol whose name is the diagnosis**.
+Verified on real artefacts:
+
+- check-mode RTEMS rlib → `U epics_rtems_boot__RTEMS_BSP_PREFIX_was_not_set_at_build_time`
+- linked-mode RTEMS rlib → `U POSIX_Init` (the `#[used]` static produced a
+  genuine relocation, which is what pulls the shim archive in and survives
+  `--gc-sections`)
+
+`CONFIGURE_MAXIMUM_USER_EXTENSIONS 1` is present with a host test that fails if
+it is removed, and a comment recording the exact boot failure it fixes
+(`emerg: rtems_bsd_threads_init_early: cannot create extension`) and that base
+reserves 5.
+
+## 4. Unproven — what only the box can answer
+
+The 17 host tests guard **structure** — entry-point agreement across
+configuration / C / link, `confdefs` last, the user-extension reservation, no
+dropped facility creeping back. They do not guard syntax, and they cannot link.
+
+1. **Neither C file has been through a compiler.** →
+   `cargo build -p epics-ca-rs --bin rtems-ca-ioc -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf --release`
+   with `RTEMS_BSP_PREFIX` set and `$RTEMS_BSP_PREFIX/bin` on `PATH`.
+2. **The include path is a guess.** `bsp_include_dir` assumes
+   `<prefix>/arm-rtems6/<bsp>/lib/include`. → take the real `-I` set from a BSP
+   sample's *compile* line.
+3. **`-lbsd -lm -lz` resolution.** Order is right by measurement, but rustc also
+   emits `-Bdynamic` and RTEMS has no shared libraries. → does the link need
+   `-static`, or reordering?
+4. **The fd ceiling of 150.** Base's own score-arm value, and our three crates
+   make no `select`/`poll` call — but libbsd's internals were not audited and
+   RTEMS 6 may spell the macro `CONFIGURE_LIBIO_MAXIMUM_FILE_DESCRIPTORS`. →
+   grep the toolchain headers for it and for `FD_SETSIZE`.
+5. **`CONFIGURE_MAXIMUM_USER_EXTENSIONS 1` may be one too few** now that
+   `CONFIGURE_STACK_CHECKER_ENABLED` is also on. → if the boot dies creating an
+   extension, raise toward base's 5; it is `#ifndef`-overridable.
+6. **Interworking is reasoned, not observed** (§2).
+7. **`arm-rtems6-gcc` must be on `PATH` for non-interactive ssh.**
+   `.cargo/config.toml` names it unqualified deliberately. → confirm a
+   `BatchMode` shell sees it.
+8. **Boot behaviour of the reduced `POSIX_Init`** — the DHCP timeout path,
+   loopback bring-up, the stack-usage report on exit. → rungs 1–3 of
+   `doc/rtems-runtime-acceptance-plan.md`; console markers are prefixed
+   `rtems-boot:`.
+
+`rtems-pva-ioc` does not exist yet, so `epics-pva-rs` was left untouched — its
+measured 2-warning RTEMS budget stays usable as an instrument. When the stage-G
+bin lands it needs exactly the two manifest lines and the one-line `build.rs`
+that `epics-ca-rs` now has.

--- a/doc/rtems-qemu-bringup-artefacts.md
+++ b/doc/rtems-qemu-bringup-artefacts.md
@@ -1,0 +1,150 @@
+# RTEMS 6 / QEMU bring-up — measured artefacts
+
+Everything here was **measured on a real toolchain**, not taken from
+documentation. `doc/rtems-runtime-acceptance-plan.md` marked exactly two items
+`[VERIFY-ON-BOX]` because neither the RTEMS tree nor `qemu-system-arm` existed
+on the development machine; both are recorded below, plus the boot evidence
+that makes them trustworthy.
+
+**Where.** Remote box `192.168.2.128` (`gv100`, Ubuntu 24.04, 12 cores), all
+artefacts under `$HOME/rtems-bringup/` — see the `rtems-qemu-box` memory for
+the access and sudo limits that apply there.
+
+## Toolchain
+
+| Component | Version |
+|---|---|
+| `arm-rtems6-gcc` | GCC 13.3.0 20240521 (RTEMS 6, RSB `5dbc1e08`, Newlib `1b3dcfd`) |
+| `arm-rtems6-ld` | GNU Binutils 2.43 |
+| `arm-rtems6-gdb` | GDB 17.2 |
+| RTEMS kernel + BSP | 6.0.2 `2faafecb7f9df8400fd78a1e6d9b3cf3df0eeccc`, BSP `arm/xilinx_zynq_a9_qemu` |
+| rtems-libbsd | branch `6-freebsd-12`, `libbsd.a` 89.9 MB, `rtems_bsd_initialize` present |
+
+## Artefact (a) — the QEMU command line
+
+```
+qemu-system-arm -no-reboot -nographic \
+  -serial null -serial mon:stdio \
+  -M xilinx-zynq-a9 -m 256M \
+  -nic user,hostfwd=tcp::5064-:5064,hostfwd=udp::5064-:5064,hostfwd=tcp::5075-:5075,hostfwd=udp::5076-:5076 \
+  -kernel <app>.exe
+```
+
+Three details that are not guessable and each cost a debugging cycle:
+
+- **`-serial null -serial mon:stdio`, in that order.** The BSP's
+  `ZYNQ_UART_KERNEL_IO_BASE_ADDR` defaults to `ZYNQ_UART_1_BASE_ADDR` — the
+  *second* UART. A single `-serial mon:stdio` prints nothing at all, which
+  looks exactly like a boot failure.
+- **The NIC must be `-nic user,...`.** The GEMs are SoC-onboard, so
+  `-nic netdev=net0` fails with `Invalid parameter 'netdev'` and
+  `-device cadence_gem` would add a *third* NIC. The
+  `warning: nic cadence_gem.1 has no peer` line is the harmless second GEM.
+- **No `restrict=yes`.** EPICS base's i386 QEMU line carries it
+  (`rtems_init.c:1027-1030`); it blocks guest-initiated outbound traffic and is
+  wrong for an IOC.
+
+## Artefact (b) — the link command
+
+Driver flags are `-B<BSP>/lib -qrtems -Wl,--gc-sections` plus the ABI flags.
+`-qrtems` expands via `collect2` to (`$RB` = `~/rtems-bringup`):
+
+```
+-u POSIX_Init
+crti.o crtbegin.o
+-L$RB/tools/lib/gcc/arm-rtems6/13.3.0/thumb/armv7-a+simd/hard
+-L$RB/tools/lib/gcc/arm-rtems6/13.3.0/../../../../arm-rtems6/lib/thumb/armv7-a+simd/hard
+-L$RB/tools/arm-rtems6/xilinx_zynq_a9_qemu/lib
+-L$RB/tools/lib/gcc/arm-rtems6/13.3.0
+-L$RB/tools/lib/gcc/arm-rtems6/13.3.0/../../../../arm-rtems6/lib
+--gc-sections <objs> -lbsd -lm -lz
+--start-group -lgcc
+  --start-group -lrtemsbsp -lrtemscpu -latomic -lc -lgcc --end-group
+--end-group
+crtend.o crtn.o
+-T $RB/tools/arm-rtems6/xilinx_zynq_a9_qemu/lib/linkcmds
+```
+
+Three consequences for `.cargo/config.toml` / the shim crate's `build.rs`:
+
+1. `-lbsd -lm -lz` sit **before** the `-qrtems` group, not inside it.
+2. `-B<BSP>/lib` is what supplies both the BSP `-L` and the `-T linkcmds`, so
+   the linker script is never named explicitly.
+3. The multilib is **`thumb/armv7-a+simd/hard`**, selected by
+   `-march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard -mtune=cortex-a9`.
+   Rust must emit a matching ABI or its objects land in the wrong multilib.
+
+## Boot evidence
+
+Stock samples, console verbatim:
+
+```
+*** BEGIN OF TEST HELLO WORLD ***
+*** TEST VERSION: 6.0.0.2faafecb7f9df8400fd78a1e6d9b3cf3df0eeccc
+*** TEST BUILD: RTEMS_POSIX_API
+*** TEST TOOLS: 13.3.0 20240521 (RTEMS 6, RSB 5dbc1e08…, Newlib 1b3dcfd)
+Hello World
+*** END OF TEST HELLO WORLD ***
+[ RTEMS shutdown ]
+```
+
+A hand-written `POSIX_Init` + libbsd shim — the C-side contract our
+`rtems-ca-ioc` needs — boots and reaches `main`:
+
+```
+SHIM: POSIX_Init entered
+nexus0: <RTEMS Nexus device>
+SHIM: rtems_bsd_initialize -> 0 (RTEMS_SUCCESSFUL)
+SHIM: main() reached
+[ RTEMS shutdown ]
+```
+
+**It did not boot the first time**, and the failure is worth keeping:
+`emerg: rtems_bsd_threads_init_early: cannot create extension`. Cause:
+`CONFIGURE_UNLIMITED_OBJECTS` does **not** cover user extensions. Fixed by
+adding `CONFIGURE_MAXIMUM_USER_EXTENSIONS 1` per libbsd's own
+`testsuite/include/rtems/bsd/test/default-init.h`.
+
+## Networking, proven rather than assumed
+
+DHCP over SLIRP works:
+
+```
+cgem0: <Cadence CGEM Gigabit Ethernet Interface> on nexus0
+info: cgem0: offered 10.0.2.15 from 10.0.2.2 … acknowledged 10.0.2.15
+```
+
+`hostfwd` was proven **byte-level, with a negative control** — not by a
+successful connect, because SLIRP completes the host-side accept before the
+guest answers, so "connection succeeded" is not evidence:
+
+```
+=== bytes from guest port 23 via hostfwd 2323 ===
+00000000  ff fb 01 0d 0a 52 54 45  4d 53 20 53 68 65 6c 6c  |.....RTEMS Shell|
+00000010  20 6f 6e 20 2f 64 65 76                           | on /dev|
+=== NEGATIVE CONTROL 2399 -> guest:99 (nothing listening) ===
+(no output)
+```
+
+This closes `doc/rtems-runtime-acceptance-plan.md` §3's open question: SLIRP
+plus port-preserving `hostfwd` is sufficient, and **no tap device and no sudo
+widening are needed**.
+
+## Known rough edges
+
+- **libbsd's `waf install` is not parallel-safe.** `-j12` dies in
+  `fix_perms → os.chmod` with `FileNotFoundError` on
+  `lib/include/machine/cpufunc.h` — a copy-then-chmod race, not a build error
+  (the compile phase logged zero errors). `./waf install -j1` succeeds.
+  Upstream waf was not patched; the install is serialised.
+- **libbsd's `NET_CFG_SELF_IP` stays at its default `192.168.0.10`.** Not a
+  defect for us — our IOC will use DHCP (`10.0.2.15`), where the plain
+  `hostfwd=tcp::5064-:5064` form applies. It matters only to anyone reusing
+  libbsd's *test* binaries, which must be targeted at `192.168.0.10` or
+  reconfigured with `--net-test-config`.
+
+## What is still not done
+
+No Rust has been built or linked on the box — `cargo`/`rustc` are still absent
+there. The shim proves the **C** side of the contract; wiring
+`.cargo/config.toml` and linking `rtems-ca-ioc` is the next step.

--- a/doc/rtems-runtime-acceptance-plan.md
+++ b/doc/rtems-runtime-acceptance-plan.md
@@ -1,0 +1,653 @@
+# §10 Runtime acceptance plan — QEMU `xilinx_zynq_a9_qemu`, RTEMS 6
+
+Read-only investigation. No source file was edited. `cargo check` / `cargo
+build` were run (they mutate only `target/`).
+
+**Measured at:** worktree `/home/stevek/work/epics-rs/.caucus/worktrees/integration`,
+branch `integration/rtems-scope-b`, HEAD **`ab97461f`** at start **and** end.
+Working tree was clean at start; at end **one file is dirty** —
+`crates/epics-base-rs/src/runtime/task.rs`, modified by the concurrent panel.
+No claim below cites that file, so nothing needed re-verification.
+
+**Reference trees used (all present locally, all read):**
+
+- EPICS base C — `/home/stevek/work/epics-base`
+- pvxs C++ — `/home/stevek/work/epics-modules/pvxs` @ `9348ebc`
+- Rust `library/std` source — `~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library`
+- `libc` crate 0.2.188 — `~/.cargo/registry/src/index.crates.io-*/libc-0.2.188`
+
+> ### ⛔ What is NOT on this machine — stated, not reconstructed
+>
+> Per the reference-source rule, I searched and found **nothing**, so I am
+> naming the gap instead of writing from memory:
+>
+> | Missing | Searched | Result |
+> |---|---|---|
+> | RTEMS 6 kernel/BSP source tree | `/home/stevek/work/rtems*`, `/home/stevek/rtems*`, `/opt/rtems*`, `/home/stevek/codes/rtems*`, `find /home/stevek -maxdepth 3 -iname '*rtems*'` | **absent** |
+> | `arm-rtems6-gcc` toolchain | `which arm-rtems6-gcc` | **absent** |
+> | `qemu-system-arm` | `which qemu-system-arm` | **absent** |
+> | RTEMS BSP documentation for `xilinx_zynq_a9_qemu` | as above | **absent** |
+> | rtems-libbsd source | as above | **absent** |
+>
+> Consequence: **every claim in this doc about the RTEMS/BSP side is grounded
+> in EPICS base's own RTEMS build files, which ARE present**, or is marked
+> **`[VERIFY-ON-BOX]`** — a thing the bring-up panel must confirm against the
+> real toolchain rather than take from me. There is exactly one exception I
+> call out inline: the concrete `qemu-system-arm` command line for this BSP.
+> Base's tree contains a QEMU line only for the **i386** BSP
+> (`modules/libcom/RTEMS/posix/rtems_init.c:1027-1030`); it has **no** ARM/zynq
+> equivalent, and `RTEMS_QEMU_FIXUPS = YES` appears only for `pc386`/`pc686`
+> (`configure/os/CONFIG.Common.RTEMS-pc386-qemu:12`,
+> `CONFIG.Common.RTEMS-pc686-qemu:11`) — **not** for
+> `CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu`, which I read in full (19 lines, no
+> run rule). So base builds this BSP but does not itself run it under QEMU.
+
+---
+
+## 0. The four findings that decide the plan
+
+1. **The Rust side already compiles all the way through codegen for
+   `armv7-rtems-eabihf`; only the link fails, and it fails on the *host*
+   linker.** Measured below (§1.3). This means the bring-up is a
+   toolchain/link/boot exercise, not a porting exercise.
+2. **We have no RTEMS `main` contract wired.** EPICS base's RTEMS entry is
+   `POSIX_Init` (`configure/os/CONFIG.Common.RTEMS:154`, `-u POSIX_Init`),
+   defined at `modules/libcom/RTEMS/posix/rtems_init.c:945`, which brings up
+   libbsd + dhcpcd and **then calls `main(argc, argv)`**
+   (`rtems_init.c:1180`). Our `rtems-ca-ioc` provides `main` and nothing else.
+   A small C shim (confdefs + `POSIX_Init`) is the missing piece — §1.2.
+3. **`std::net` on RTEMS is plain BSD sockets and needs libbsd underneath.**
+   Rust's std has no RTEMS special-casing in the socket layer (§1.4), and
+   `libc`'s newlib constants are FreeBSD-valued (`SO_REUSEPORT = 0x0200`,
+   `SO_RCVTIMEO = 0x1006`, `newlib/mod.rs:623`,`:632`) — i.e. the bindings
+   already assume the libbsd stack. libbsd is a **separate RTEMS package and a
+   second bring-up**: base links it as `-lbsd` with `-DRTEMS_LIBBSD_STACK`
+   (`CONFIG.Common.RTEMS:134-135`) and initialises it explicitly via
+   `rtems_bsd_initialize()` (`rtems_init.c:1040`). Answer to the brief's
+   question: **no, our `std::net` path does not have a stack by default; the
+   stack is a deliberate second build+init step.**
+4. **QEMU user-mode networking is very likely sufficient for BOTH CA and PVA —
+   no tap device, no sudo.** Both protocols delegate the server IP to the
+   datagram source: CA sets `cid = u32::MAX` "use UDP source address"
+   (`epics-ca-rs/src/server/udp.rs:661`, C parity `camessage.c:2193-2207`) and
+   PVA encodes `Ipv4Addr::UNSPECIFIED` as the server address
+   (`epics-pva-rs/src/server_native/search.rs:236`). So a NAT'd reply through
+   `hostfwd` still points the client at a reachable endpoint. §3. **This
+   removes the sudo decision from the critical path** — which matters more than
+   it first looks, because the sudo limits already set on the bring-up box
+   (apt-get install only, no `/etc` edits, no `systemctl`) make a tap device
+   *unavailable* today, not merely expensive. §3.3.
+
+---
+
+## 1. `rtems-ca-ioc` as it stands, and what it needs to become an image
+
+### 1.1 What it does today
+
+Whole file read: `crates/epics-ca-rs/src/bin/rtems-ca-ioc.rs` (245 lines).
+Manifest entry `crates/epics-ca-rs/Cargo.toml:232-234`, deliberately **without**
+`required-features` (`:226-231` explains: a `required-features` gate would make
+cargo silently skip the target and turn the RTEMS gate vacuous).
+
+Gate: `#[cfg(any(target_os = "rtems", feature = "rtems-exec-model"))]` on the
+`ioc` module (`:60`) and on the real `main` (`:197-200`). The host default
+build compiles a stub `main` that prints a refusal and returns
+`ExitCode::FAILURE` (`:202-211`) — it does not silently start a runtime.
+
+Execution, in order:
+
+| Step | Line | What |
+|---|---|---|
+| 1 | `:112` | `background_init()` — callback pool (`cbLow`/`cbMedium`/`cbHigh`), delayed timer, scanOnce worker. C `callbackInit`, `callback.c:286` |
+| 2 | `:92-105`, `:115` | `load_database()` — every argv entry is a `.db` path; with none, the built-in `DEMO_DB` (`:80-84`). Driven by `block_on_sync(builder.build())` |
+| 3 | `:122-124` | `db.all_record_names()`, sorted |
+| 4 | `:129-137` | `cas_server_port()` (`EPICS_CAS_SERVER_PORT` > `EPICS_CA_SERVER_PORT` > 5064, `epics-base-rs/src/runtime/net.rs:56-62`), then `BlockingCaServer::bind((0.0.0.0, port), db, acf)`. ACF is `None` → permissive |
+| 5 | `:138-144` | `bind_udp_search(0.0.0.0:port)` — same port as TCP, C parity `caservertask.c:491-499` |
+| 6 | `:146-155` | thread `CAS-TCP` → `server.serve()` |
+| 7 | `:157-166` | thread `CAS-UDP` → `server.serve_udp_search(udp)` |
+| 8 | `:168-176` | the banner + one line per record |
+| 9 | `:182-194` | `tcp_thread.join()` then `udp_thread.join()` — **runs until killed**; there is no shutdown path (`:41-43`) |
+
+`DEMO_DB` (`:80-84`) is exactly three records:
+
+```
+record(ao,        "RTEMS:AO")  { field(VAL,"1.5") field(PREC,"3") field(EGU,"V") }
+record(longout,   "RTEMS:LO")  { field(VAL,"7")   field(EGU,"counts") }
+record(stringout, "RTEMS:MSG") { field(VAL,"rtems-ca-ioc") }
+```
+
+There is a source-inspection guard test (`:214-245`) asserting this file never
+references `tokio::main`/`tokio::net`/`tokio::time`/`tokio::spawn`/
+`Runtime::new`/`Builder::new_multi_thread`/`block_in_place`/`block_on(` —
+because tokio's `rt` features survive on the RTEMS target, so `cargo check`
+alone cannot catch a runtime constructor.
+
+### 1.2 What it needs to become a bootable image
+
+**(a) An RTEMS configuration + Init task.** Base's is
+`modules/libcom/RTEMS/posix/rtems_config.c` (read in full). The load-bearing
+parts we must reproduce:
+
+| Directive | base line | Why it matters to us |
+|---|---|---|
+| `CONFIGURE_POSIX_INIT_THREAD_ENTRY_POINT POSIX_Init`, stack `64*1024` | `rtems_config.c:26-28` | the entry symbol; linked via `-u POSIX_Init` (`CONFIG.Common.RTEMS:154`) |
+| `RTEMS_BSD_CONFIG_INIT` + `#include <machine/rtems-bsd-config.h>`, guarded `#ifndef RTEMS_LEGACY_STACK` | `rtems_config.c:47-60` | this is what pulls libbsd into the image |
+| `CONFIGURE_UNLIMITED_OBJECTS`, `CONFIGURE_UNLIMITED_ALLOCATION_SIZE 32` | `rtems_config.c:88-89` | **directly answers design-doc §11's open "RTEMS task-count budget"**: base does not cap tasks; objects are allocated unlimited, 32 at a time. Our thread-per-connection model is not fighting a fixed task table under base's own config |
+| `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS 64` + the `select()`/`FD_SETSIZE` warning | `rtems_config.c:70-84` | **this IS a hard cap for us.** 3 threads per connection is a thread cost, but each connection is 1 fd. 64 fds total, minus console/IMFS/libbsd internals, is the real concurrent-client ceiling to measure |
+| `CONFIGURE_EXTRA_TASK_STACKS (4000 * RTEMS_MINIMUM_STACK_SIZE)` | `rtems_config.c:38` | ≈32 MB of extra task stack budget — relevant because we spawn far more threads than a C IOC |
+| `CONFIGURE_MICROSECONDS_PER_TICK 10000` (default) | `rtems_config.c:33-35` | **10 ms tick.** Any timing assertion finer than 10 ms is meaningless without overriding this |
+| `CONFIGURE_APPLICATION_NEEDS_CLOCK_DRIVER` / `CONSOLE_DRIVER` | `rtems_config.c:64-65` | console driver is what makes `printf`/Rust `println!` reach the serial port we scrape |
+| `CONFIGURE_STACK_CHECKER_ENABLED` | `rtems_config.c:92` | keep it on for bring-up; it is how a Rust thread stack overflow becomes a diagnosable message rather than a silent corruption |
+
+**(b) A `POSIX_Init` that calls our `main`.** Base's (`rtems_init.c:945-1191`)
+does far more than we need (NFS, iocsh registration, telnetd, NTP, TFTP). The
+minimal shim, grounded on the same file, is:
+
+1. `initConsole()` equivalent / rely on the BSP console (`rtems_init.c:951`)
+2. optional `clock_settime` so timestamps are not 1970 (`rtems_init.c:966`)
+3. `epicsThreadSetPriority(self, iocsh)` — base drops the Init task off POSIX
+   prio 2 (`rtems_init.c:1000-1002`); our equivalent is to leave the Init task
+   at a *low* priority so our own threads are not starved
+4. `rtems_bsd_setlogpriority("debug")` (`rtems_init.c:1034`)
+5. `default_network_set_self_prio(RTEMS_MAXIMUM_PRIORITY - 1U)`
+   (`rtems_init.c:1038`) — base lowers itself so libbsd's background work runs
+6. `rtems_bsd_initialize()` (`rtems_init.c:1040`) — **the stack comes up here**
+7. `rtems_task_wake_after(2)` for the callout timer (`rtems_init.c:1044`)
+8. `rtems_bsd_ifconfig_lo0()` (`rtems_init.c:1049`)
+9. `rtems_dhcpcd_add_hook(...)` + `rtems_dhcpcd_start(NULL)`
+   (`rtems_init.c:1053`,`:874`), then wait on the hook event with a timeout
+   (`rtems_init.c:1066`, base waits 600 s)
+10. `main(argc, argv)` (`rtems_init.c:1180`)
+
+Note base writes a default `/etc/dhcpcd.conf` if missing
+(`rtems_init.c:839-873`) containing `nodhcp6 / ipv4only / timeout 0` — under
+QEMU SLIRP the built-in DHCP server answers, so this path is what gives the
+guest its address. `[VERIFY-ON-BOX]` that SLIRP's DHCP satisfies this dhcpcd
+config.
+
+**(c) A linker configuration.** There is **no `.cargo/config.toml` in the
+repo** (verified: `ls -a` of the worktree root shows `.config`, `.github`,
+`.git`, `.gitattributes`, `.gitignore` — no `.cargo`), and **no script or CI
+file in the workspace references rtems** outside `doc/` and `archaeology/`
+(`rg -ln rtems --glob '!doc/**' --glob '!crates/**'`). So this does not exist
+yet at all.
+
+### 1.3 The link failure, measured
+
+`cargo +nightly check -p epics-ca-rs --bin rtems-ca-ioc -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf`
+→ **exit 0**.
+
+`cargo +nightly build` (same flags) → **exit 101, and the failure is
+instructive**: every crate compiled — including `tokio`, `clap`, `serde_json`,
+`chrono`, `dashmap`, `parking_lot` — producing **124 ARM object files**. The
+error is:
+
+```
+error: linking with `cc` failed: exit status: 1
+  /usr/bin/ld: ...rcgu.o: relocations in generic ELF (EM: 40)
+  /usr/bin/ld: ...rcgu.o: error adding symbols: file in wrong format
+```
+
+`EM: 40` is ARM; `/usr/bin/ld` is the x86-64 host linker. The observed link
+line was:
+
+```
+"cc" <124 objects> -Wl,--as-needed -Wl,-Bstatic <58 rlibs> -Wl,-Bdynamic
+  -lc -lm -L .../raw-dylibs -Wl,-z,noexecstack -o rtems_ca_ioc-...
+  -Wl,--gc-sections -no-pie
+```
+
+Diffing that against base's grounded RTEMS link settings, **everything RTEMS is
+missing**:
+
+| Present in base | base line | In our link line? |
+|---|---|---|
+| cross linker `arm-rtems6-gcc` | `CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu:11-13` (`GNU_TARGET = arm-rtems`) | **no** — plain host `cc` |
+| `-L $(RTEMS_BASE)/arm-rtems6/xilinx_zynq_a9_qemu/lib/` | `CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu:19` | **no** |
+| `-lbsd` (+ `-DRTEMS_LIBBSD_STACK`) | `CONFIG.Common.RTEMS:134-135` | **no** |
+| `-lrtemscpu -lc -lm`, `-lrtemsCom -lCom`, `-ltftpfs -lz -ltelnetd` | `CONFIG.Common.RTEMS:145-152` | only `-lc -lm`, and *dynamically* |
+| `-u POSIX_Init` | `CONFIG.Common.RTEMS:154` | **no** |
+| `-Wl,--gc-sections` | `CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu:17` | **yes** (rustc adds it anyway) |
+
+So the concrete deliverable is a `.cargo/config.toml`:
+
+```toml
+[target.armv7-rtems-eabihf]
+linker = "arm-rtems6-gcc"
+rustflags = ["-C", "link-arg=-B<RTEMS_BSP_LIB_DIR>", "-C", "link-arg=-u", ...]
+```
+
+`[VERIFY-ON-BOX]` — I will not invent the exact flag set. The authoritative
+list is what `arm-rtems6-gcc` needs for this BSP (BSP linker script selection,
+`-B`/`-qrtems`-style spec flags, whether `-lbsd` ordering matters against
+`-lrtemscpu`). Take the flags from a working C link of any RTEMS 6 zynq
+example on the remote box and mirror them; do not take them from this doc.
+
+### 1.4 Does `std::net` work? Grounded answer
+
+- The Rust target is real and tier 3: `os: rtems`, `env: newlib`,
+  `target-family: ["unix"]`, `std: true`, `host_tools: false`
+  (`rustc --print target-spec-json --target armv7-rtems-eabihf`).
+- `rg rtems` across `library/std/src` returns hits only in `os/rtems/{mod,raw,fs}.rs`,
+  `sys/pal/unix/mod.rs:87` (excluded from the `poll()` fast path for stdio fd
+  sanity), `sys/random/mod.rs:23`, `sys/process/unix/unix.rs:1187-1194`
+  (three missing signals). **No RTEMS gating anywhere in the socket layer** —
+  `std::net` is compiled as ordinary unix sockets.
+- `libc` provides the socket surface via `unix/newlib` (e.g. `bind` at
+  `newlib/mod.rs:861`, `recvfrom` at `:870`) with **BSD-valued** constants
+  (`SO_REUSEADDR 0x0004` `:616`, `SO_REUSEPORT 0x0200` `:623`,
+  `SO_SNDTIMEO 0x1005` `:631`, `SO_RCVTIMEO 0x1006` `:632`). Those are FreeBSD
+  numbers — the bindings presuppose libbsd.
+- `libc`'s `unix/newlib/rtems/mod.rs` additionally declares `getentropy`
+  (`:143`) and `arc4random_buf` (`:145`) — relevant because PVA's
+  `random_guid()` needs an entropy source (`epics-pva-rs/src/server_native/udp.rs:47`,
+  `try_fill_secure` `:62`/`:70`).
+- `PTHREAD_STACK_MIN = 0` (`newlib/rtems/mod.rs:80`) — Rust's
+  `thread::Builder::stack_size` therefore has no libc-side floor; the RTEMS
+  floor comes from `CONFIGURE_*_STACK_SIZE`. `[VERIFY-ON-BOX]`: confirm our
+  spawned threads get a usable default stack, because CA/PVA frames are not
+  small.
+
+**Conclusion:** `std::net` will *compile* regardless. It will only *work* if
+the image links `-lbsd` and calls `rtems_bsd_initialize()`. Design-doc §11
+already recorded the matching measurement — "std built for RTEMS **with no BSP
+present**" (`doc/rtems-runtime-portability-design.md:583-598`) — which is
+exactly the state my `cargo check` reproduces and my `cargo build` exposes.
+
+### 1.5 Expected console output if it worked
+
+From `:168-176`, with no argv (built-in `DEMO_DB`) and default port:
+
+```
+rtems-ca-ioc: serving 3 records on CA port 5064 (TCP + UDP search), RTEMS execution model, no tokio runtime
+rtems-ca-ioc: RTEMS:AO
+rtems-ca-ioc: RTEMS:LO
+rtems-ca-ioc: RTEMS:MSG
+```
+
+(Names are `sort`ed at `:124`; `RTEMS:AO` < `RTEMS:LO` < `RTEMS:MSG` by byte
+order.) Preceded by whatever our `POSIX_Init` shim prints; if the shim mirrors
+base's, that includes `***** RTEMS Version: … *****`
+(`rtems_init.c:1013-1014`), `***** Initializing network (libbsd, dhcpcd) *****`
+(`:1033`), `***** ifconfig lo0 *****` (`:1048`), and the `IFCONFIG`/`NETSTAT`
+dumps (`:1084-1087`) — those dumps are worth keeping, because rung 2's
+diagnosis depends on knowing the guest's address.
+
+---
+
+## 2. The acceptance ladder
+
+Each rung: the command, the exact line that constitutes proof, and — where the
+rung can pass for the wrong reason — the negative control that closes it.
+
+Two conventions that make this executable:
+
+- **`$IOC` = the ELF image**, `$QEMU` = the invocation from §3.
+- **Rung −1 first.** Establish the golden host output before trusting any guest
+  output (below). Without it, rung 4/5's expected text is my prediction, not a
+  measurement.
+
+### Rung −1 — golden output on Linux (no QEMU, no toolchain)
+
+The same binary runs on a host under the exec-model feature
+(`epics-ca-rs/Cargo.toml:106` → `epics-base-rs/Cargo.toml:92`). Use a
+non-standard port: never bind 5064 in a test.
+
+```
+EPICS_CAS_SERVER_PORT=15064 \
+  cargo run -p epics-ca-rs --bin rtems-ca-ioc --features rtems-exec-model
+# in another shell:
+EPICS_CA_AUTO_ADDR_LIST=NO EPICS_CA_ADDR_LIST=127.0.0.1:15064 caget RTEMS:AO RTEMS:LO RTEMS:MSG
+```
+
+**Proof:** capture both outputs verbatim into
+`doc/rtems-acceptance-golden.txt`. Every later rung asserts *equality with this
+file*, modulo the port number. This converts "expected output" from prediction
+into measurement and is the single highest-value cheap step in the plan.
+
+### Rung 0 — it links
+
+```
+cargo +nightly build -p epics-ca-rs --bin rtems-ca-ioc \
+  -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf --release
+```
+
+**Proof:** exit 0 **and** `arm-rtems6-readelf -h $IOC` reports
+`Machine: ARM`, `Type: EXEC`, and `arm-rtems6-nm $IOC | grep POSIX_Init`
+resolves. **Negative control:** today this rung fails at
+`/usr/bin/ld ... EM: 40` (§1.3) — that is the *current* measured state, so a
+pass here is a real state change, not a tautology.
+
+### Rung 1 — it boots and prints
+
+```
+$QEMU -kernel $IOC ... | tee boot.log
+```
+
+**Proof:** `boot.log` contains, in order:
+`***** RTEMS Version:` … then
+`rtems-ca-ioc: serving 3 records on CA port 5064 (TCP + UDP search), RTEMS execution model, no tokio runtime`
+followed by the three `rtems-ca-ioc: RTEMS:…` lines (§1.5).
+**Negative control:** the banner is printed at `:168` — *after* `bind()` at
+`:131` and `:138` succeeded and both threads spawned at `:147`/`:158`. So the
+banner appearing already proves the sockets bound. If any bind failed the log
+shows instead `rtems-ca-ioc: cannot bind CA TCP port 5064: …` (`:134`) or
+`… cannot bind CA UDP search port 5064: …` (`:141`) and the process exits
+FAILURE. **This makes rung 2 partly redundant with rung 1 — deliberately, and
+it is the strongest single line in the ladder.**
+
+### Rung 2 — it holds port 5064, independently confirmed
+
+From the guest side, via the RTEMS shell if the shim configures it
+(base does: `CONFIGURE_SHELL_COMMAND_*`, `rtems_config.c:119-155`, incl.
+`rtems_shell_NETSTAT_Command`):
+
+```
+netstat -an
+```
+
+**Proof:** a `tcp4 … *.5064 … LISTEN` row and a `udp4 … *.5064` row.
+**Why it is not redundant with rung 1:** rung 1 proves *our* code thought the
+bind succeeded; this proves the *stack* agrees, which is the thing libbsd
+bring-up can get wrong.
+
+### Rung 3 — it answers a CA search from the host
+
+```
+EPICS_CA_AUTO_ADDR_LIST=NO EPICS_CA_ADDR_LIST=127.0.0.1:5064 \
+  cainfo RTEMS:AO
+```
+
+**Proof:** `cainfo` prints `State:            connected` and a
+`Host: <addr>:5064`. **Negative control that this rung genuinely needs:** run
+the identical command with the IOC killed and confirm
+`Channel "RTEMS:AO" not found.` — otherwise a stale host-side CA repeater or a
+second IOC on the LAN can make this rung pass with nothing running in the
+guest. **Run this control every time**; it is the single most likely false
+pass in the whole ladder.
+
+### Rung 4 — it serves a real `caget`
+
+```
+EPICS_CA_AUTO_ADDR_LIST=NO EPICS_CA_ADDR_LIST=127.0.0.1:5064 \
+  caget -t RTEMS:AO RTEMS:LO RTEMS:MSG
+```
+
+**Proof:** byte-identical to the rung −1 golden capture. With `-t` (terse) and
+the `DEMO_DB` values at `:81-83` the three values are `1.5`, `7`,
+`rtems-ca-ioc` — but **assert against the golden file, not against this
+sentence**: default `caget` field width and float formatting are host-tool
+behaviour I have not measured, and `PREC=3` on `RTEMS:AO` may or may not apply
+to the default `DBR_DOUBLE` request. Rung −1 settles it; I will not guess.
+
+### Rung 5 — it survives a `camonitor`, and a write propagates
+
+```
+EPICS_CA_AUTO_ADDR_LIST=NO EPICS_CA_ADDR_LIST=127.0.0.1:5064 \
+  camonitor RTEMS:LO &
+sleep 2
+EPICS_CA_AUTO_ADDR_LIST=NO EPICS_CA_ADDR_LIST=127.0.0.1:5064 caput RTEMS:LO 42
+```
+
+**Proof:** the monitor prints an initial update with value `7`, then a second
+update with value `42`, then keeps the connection open for ≥60 s with no
+`Disconnected` line. This is the rung that exercises the parts nothing else
+does: the per-connection thread (`server/blocking.rs:190-207`), the event
+thread at `Custom(CaServerLow-1)` (`:669`), and the `background_init` callback
+bands that carry the monitor tail (`rtems-ca-ioc.rs:112`).
+**Negative control:** `caput` a value, confirm `caget` reads it back — proving
+the update came from record processing and not from a cached client-side value.
+
+### Rung 6 — the honest endurance rung
+
+Leave rung 5's `camonitor` running while looping `caget`/`caput` for ≥10
+minutes; then check the RTEMS shell's `stackuse` and `malloc_info` (both
+configured in base at `rtems_config.c:130`,`:154`).
+
+**Proof:** no stack-checker report of a blown thread stack, and no monotonic
+heap growth across the window. **Why this rung exists:** rungs 0–5 all pass in
+seconds and prove *function*. Thread-per-connection on a target with a 64-fd
+cap and finite task stacks fails on *accumulation*, not on the first request,
+and nothing above would catch it.
+
+---
+
+## 3. QEMU network plumbing
+
+### 3.1 The problem the brief names, and why it does not bite
+
+CA discovery is a UDP broadcast to the search port. Under QEMU user-mode
+networking (SLIRP) the guest sits on a private NAT (`10.0.2.0/24` in the
+default configuration); the host cannot broadcast into it, and `hostfwd` only
+forwards specific host ports inward. So "host broadcasts, guest hears" is
+indeed impossible.
+
+**But CA does not require broadcast.** The client will unicast its search to
+every entry in `EPICS_CA_ADDR_LIST` when `EPICS_CA_AUTO_ADDR_LIST=NO`. That is
+what every rung above uses. The remaining question is whether the *reply* is
+usable, and this is where the measured code settles it:
+
+- **CA:** the search reply sets `cid = u32::MAX` — "use the UDP packet's source
+  address as the server IP" — and carries the TCP port in `data_type`
+  (`epics-ca-rs/src/server/udp.rs:658-665`; C parity `rsrv/camessage.c:2193-2207`,
+  quoted in the comment at `:642-659`). The client therefore connects TCP to
+  *wherever the reply appeared to come from*, which under SLIRP is the host-side
+  forwarded endpoint — reachable by construction.
+- Because the reply advertises the guest's TCP **port number** verbatim, the
+  forward must preserve the number: `hostfwd=tcp::5064-:5064`, not a remapped
+  host port. Our IOC uses the same value for TCP and UDP (`rtems-ca-ioc.rs:129`
+  feeds both `:131` and `:138`), so both forwards use 5064.
+
+### 3.2 The working configuration
+
+```
+-netdev user,id=net0,hostfwd=udp:127.0.0.1:5064-:5064,hostfwd=tcp:127.0.0.1:5064-:5064
+-device <BSP NIC>,netdev=net0
+```
+
+`[VERIFY-ON-BOX]` — three things I am explicitly not asserting:
+
+1. **The full `qemu-system-arm` command line for `xilinx_zynq_a9_qemu`** (the
+   `-M` machine name, the NIC device name, the serial/console flags). Base has
+   an i386 line only (`rtems_init.c:1027-1030`:
+   `qemu-system-i386 -m 64 -no-reboot -serial stdio -display none -net nic,model=e1000 -net user,restrict=yes -append "--video=off --console=/dev/com1" -kernel libComTestHarness`)
+   and **no ARM equivalent anywhere in the tree**. Take the ARM line from the
+   RTEMS BSP documentation on the remote box.
+2. **Do not copy base's `restrict=yes`** — it blocks guest-initiated outbound
+   traffic. It is fine for a self-contained test harness; it is wrong here.
+3. Whether SLIRP's UDP forwarding keeps the NAT binding alive long enough for
+   CA's search/beacon cadence. UDP hostfwd mappings are timed out by SLIRP;
+   long-idle monitors are TCP so they are unaffected, but a *reconnect* after a
+   long idle re-searches over UDP.
+
+### 3.3 What user-mode networking will NOT give you — and the tap fallback
+
+| Lost under SLIRP | Consequence |
+|---|---|
+| CA beacons (`CA_PROTO_RSRV_IS_UP`) broadcast guest→host | host clients never learn "server came up"; they still connect via search, so rungs 3–5 are unaffected, but a *beacon-anomaly reconnect* test is impossible |
+| Host-broadcast search (`EPICS_CA_AUTO_ADDR_LIST=YES`) | must be `NO` in every rung — that is why every command above sets it |
+| Guest→host connection initiation to arbitrary host ports | irrelevant for an IOC; relevant if we later test CA *client* code on the guest |
+| Realistic packet loss / MTU / multi-NIC behaviour | out of scope for functional acceptance either way |
+
+**The decision to put to the user, not assume:** if beacon behaviour or
+auto-address-list discovery must be in scope, the plumbing becomes a **tap
+device** (`-netdev tap,...` with a host bridge), which requires either
+`CAP_NET_ADMIN` on the qemu binary or a `sudo`-installed `qemu-bridge-helper`
+with an `/etc/qemu/bridge.conf` entry — **a root-scoped change to the user's own
+desktop.** I am flagging it, not assuming it.
+
+**And note it is currently out of bounds anyway.** The recorded sudo limits on
+the bring-up box (`gv100` / `192.168.2.128`, the user's own desktop) are: sudo
+for `apt-get install` only, **no `/etc` edits**, no `systemctl`, nothing under
+`/home/stevek`. A tap device needs exactly the two things that list forbids —
+an `/etc/qemu/bridge.conf` entry and interface/bridge administration. So tap is
+not a cheaper-or-costlier alternative today; it is **unavailable without the
+user first widening those limits**, which is a separate conversation.
+
+My recommendation: **run the whole ladder on SLIRP.** It costs nothing, needs
+no privilege, stays inside the granted limits, and by §0 finding 4 it covers
+rungs 0–6 in full. Raise tap only if a specific test demands broadcast, and
+raise it as a request to widen the sudo scope — not as a plumbing detail.
+
+---
+
+## 4. The same ladder for PVA (after stage C + G)
+
+Prerequisites, from `doc/pva-rtems-stage-cd-design.md` (my previous round,
+preserved on main as `e6db56f9`): stage C (`BlockingPvaServer`), stage D (the
+socket-free SEARCH core extracted out of the RTEMS-gated `udp.rs`, plus the
+blocking responder), and stage G (an `rtems-pva-ioc` binary — which does not
+exist: all six `epics-pva-rs` bins are `required-features = ["client"]`,
+`Cargo.toml:193-221`).
+
+### 4.1 What is the same
+
+Rungs −1, 0, 1, 2, 6 transfer verbatim with `pvxinfo`/`pvxget`/`pvxmonitor` (or
+`pvinfo-rs`/`pvget-rs`/`pvmonitor-rs`) substituted, and `5075`/`5076`
+substituted for `5064`.
+
+### 4.2 What differs — four things
+
+1. **The unicast escape hatch exists and works the same way.** PVA's search
+   response encodes the server address as `Ipv4Addr::UNSPECIFIED`
+   (`epics-pva-rs/src/server_native/search.rs:236`) — the spec's "use the
+   datagram source" sentinel, exactly parallel to CA's `u32::MAX`. So
+   `EPICS_PVA_AUTO_ADDR_LIST=NO EPICS_PVA_ADDR_LIST=127.0.0.1:5076` over
+   `hostfwd` should work for the same reason CA does. **This is the single most
+   important thing to check early**, because if it were false the whole PVA
+   ladder would need tap.
+2. **Two ports, not one.** PVA uses a UDP broadcast/search port and a separate
+   TCP server port (5076 / 5075 conventionally), so the forward set is larger
+   and the "preserve the port number" constraint applies to the TCP port the
+   SEARCH reply advertises (`build_search_response_proto`'s `tcp_port`,
+   `search.rs:223`,`:238`).
+3. **The GUID.** `random_guid()` lives in the RTEMS-gated `udp.rs:47` and its
+   entropy helper `try_fill_secure` (`:62`/`:70`) must resolve on RTEMS —
+   `libc` declares `getentropy` and `arc4random_buf` for RTEMS
+   (`newlib/rtems/mod.rs:143`,`:145`), so the symbols exist, but **whether they
+   return real entropy on this BSP is `[VERIFY-ON-BOX]`**. A degenerate GUID
+   (all zeros, or identical across boots) is a *silent* failure: clients would
+   treat two different servers as one. **Add a PVA-specific rung**: reboot the
+   guest and assert `pvxinfo` reports a *different* GUID than the previous boot.
+   Nothing in the CA ladder has an analogue, and no functional test would catch
+   it.
+4. **Beacons.** My stage-C/D doc recommended leaving PVA beacons gated for the
+   minimal RTEMS IOC (a recorded deviation). Under SLIRP that recommendation
+   costs nothing — beacons could not cross the NAT anyway. Under tap it would
+   become visible. Keep the deviation, and note that it makes the SLIRP-vs-tap
+   choice *less* consequential for PVA than for CA.
+
+### 4.3 One extra PVA rung worth having
+
+`pvxinfo RTEMS:AO` (or `-F tree`) to assert the **top-level NT type id**. Per
+[[pvxget-delta-omits-top-struct-id]] the default Delta output drops it, so this
+must use `-F tree`/`pvxinfo` — a trap that would otherwise produce a
+false-negative on the guest and cost a day chasing a non-bug.
+
+---
+
+## 5. What this acceptance can NOT prove
+
+Stated plainly, because a green ladder will be read as "RTEMS works".
+
+1. **Nothing about real-time scheduling.** QEMU emulates a Cortex-A9
+   functionally, not temporally. Instruction timing, cache, interrupt latency
+   and preemption points bear no defensible relation to hardware. **Every
+   priority-related conclusion — the 18/16 pvxs-parity assignment, the
+   `CaServerLow`/`CaServerLow-1` CA values, the entire PI-lock evaluation in
+   `doc/pi-lock-evaluation.md` — is untestable here.** A green ladder is
+   evidence of *functional* correctness on RTEMS and of nothing else. It must
+   not be cited in support of any hard-RT claim.
+2. **Nothing about priority inheritance.** Additionally moot by construction:
+   RT priority application is opt-in via `EPICS_RS_ALLOW_RT_PRIORITY` and on
+   RTEMS `apply_priority_impl` is the non-Linux arm returning `Unsupported`
+   ([[pi-locks-park-on-invisible]]). So the guest is not even applying
+   priorities. Do not conclude "no inversion observed."
+3. **Nothing about the 10 ms tick boundary.**
+   `CONFIGURE_MICROSECONDS_PER_TICK 10000` (`rtems_config.c:33-35`) means any
+   observed latency below 10 ms is quantisation, not measurement.
+4. **Nothing about the task-count budget at scale.** Rungs 3–5 use one or two
+   clients. The `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS 64` cap
+   (`rtems_config.c:70`) and 3-threads-per-PVA-connection are a *concurrency*
+   risk; only a many-client soak (rung 6 extended) touches it, and QEMU's
+   emulated NIC is a poor place to generate that load.
+5. **Nothing about the real BSP.** `xilinx_zynq_a9_qemu` is a QEMU-targeted BSP.
+   Driver behaviour, DMA, cache coherency and NIC errata on a physical Zynq are
+   a different bring-up. Base itself distinguishes these
+   (`xilinx_zynq_a9_qemu` vs `xilinx_zynq_zedboard` vs `xilinx_zynq_microzed`
+   are three separate config files in `configure/os/`).
+6. **Nothing about libbsd behaviour under stress.** We would be exercising a
+   handful of sockets on a NAT'd virtual NIC.
+7. **Nothing about the code paths still gated out.** The RTEMS build excludes
+   `iocsh`, the async server, `pva_server`, `accept`, `runtime`, `udp` — a green
+   ladder says the *included* subset runs, not that the crate runs.
+8. **`cargo check` green ≠ links ≠ boots ≠ serves.** §1.3 is the proof: check
+   is exit 0 today while build is exit 101. Each rung is a genuinely
+   independent claim; do not let rung 0 stand in for rung 1.
+
+---
+
+## 6. Recommended execution order
+
+1. **Rung −1 on Linux** — no toolchain needed, do it today, produces
+   `doc/rtems-acceptance-golden.txt` that every later rung asserts against.
+2. Write the C shim (`rtems_config.c` + minimal `POSIX_Init`) and the
+   `.cargo/config.toml`, cribbing flags from a working C link on the remote box
+   (§1.2, §1.3).
+3. Rung 0 → 1 → 2. If rung 1 prints the banner, §1.2's whole libbsd chain is
+   proven at once.
+4. Rungs 3–5 on SLIRP with `EPICS_CA_AUTO_ADDR_LIST=NO`, **each with its
+   negative control**.
+5. Rung 6 before declaring §10's CA criterion met.
+6. Only then revisit tap-vs-SLIRP, and only if a specific test demands
+   broadcast (§3.3) — as a decision put to the user, not an assumption.
+
+---
+
+## 7. Report
+
+**Tested:**
+
+- `git rev-parse HEAD` at start and end — pass (`ab97461f`, unchanged)
+- `git status --porcelain` at start — pass (clean)
+- `git status --porcelain` at end — **dirty**: `crates/epics-base-rs/src/runtime/task.rs` (concurrent panel). No cited claim depends on that file
+- `cargo +nightly check -p epics-ca-rs --bin rtems-ca-ioc -Zbuild-std=std,panic_abort --target armv7-rtems-eabihf` — **pass, exit 0**
+- `cargo +nightly build` (same flags) — **fail, exit 101**, host `ld`, `EM: 40`, `file in wrong format`. This is the expected and informative result (§1.3), not a regression
+- Locate RTEMS toolchain / kernel / BSP docs / qemu locally — **all absent**, enumerated in the ⛔ box; no claim reconstructed from memory
+- `rustc --print target-spec-json --target armv7-rtems-eabihf` — pass (tier 3, `std: true`, `target-family: unix`, `env: newlib`)
+- `rg rtems` over `library/std/src` — pass (no socket-layer gating; 5 hits, all listed §1.4)
+- `libc` newlib socket surface + RTEMS submodule — pass (`bind` `:861`, `recvfrom` `:870`, BSD-valued SO_* `:616-632`, `getentropy`/`arc4random_buf` `rtems/mod.rs:143`/`:145`)
+- Read `crates/epics-ca-rs/src/bin/rtems-ca-ioc.rs` in full (245 lines) — pass
+- Read `epics-base/modules/libcom/RTEMS/posix/rtems_config.c` in full — pass
+- Read `epics-base/modules/libcom/RTEMS/posix/rtems_init.c` `POSIX_Init` path (`:945-1191`) — pass
+- Read `configure/os/CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu` in full (19 lines) — pass; **no qemu run rule for this BSP**
+- Read `configure/os/CONFIG.Common.RTEMS:110-175` (libbsd/link wiring) — pass
+- CA search-reply address encoding — pass (`server/udp.rs:658-665`, `cid = u32::MAX`)
+- PVA search-response address encoding — pass (`server_native/search.rs:236`, `Ipv4Addr::UNSPECIFIED`)
+- Workspace audit for existing RTEMS build tooling — pass (**none**: no `.cargo/config.toml`, no script or CI reference outside `doc/`/`archaeology/`)
+- `rtems-exec-model` feature exists on both crates — pass (`epics-ca-rs/Cargo.toml:106`, `epics-base-rs/Cargo.toml:92`)
+
+**Failed:** none as an investigation result. The one red command
+(`cargo build` → 101) is a measured property of the current state, reported as
+such in §1.3 and used as rung 0's negative control.
+
+**UNFIXED:**
+
+- The exact `qemu-system-arm` command line for `xilinx_zynq_a9_qemu`, and the
+  exact `arm-rtems6-gcc` link flags, are **not determined** — the sources that
+  would ground them are not on this machine. Marked `[VERIFY-ON-BOX]` in §1.3
+  and §3.2 rather than reconstructed.
+- Rung 4/5's exact expected `caget` text is **not determined** — default field
+  width and float formatting are host-tool behaviour I did not measure. Rung −1
+  is the prescribed fix; the ladder asserts against a captured golden file, not
+  against my prose.
+- Whether SLIRP's UDP hostfwd NAT binding survives CA's search cadence — open,
+  §3.2 item 3.
+- Whether `getentropy`/`arc4random_buf` return real entropy on this BSP — open,
+  §4.2 item 3, with a proposed reboot-GUID rung to catch it.
+- Design-doc §11's "RTEMS task-count budget" is **partly closed, not closed**:
+  base configures `CONFIGURE_UNLIMITED_OBJECTS` (`rtems_config.c:88-89`), so
+  tasks are not the binding constraint, but `CONFIGURE_MAXIMUM_FILE_DESCRIPTORS 64`
+  (`:70`) is a hard concurrent-connection ceiling nobody has measured against.
+
+**Fixed:** none — no source file was edited, no commit was made, as instructed.

--- a/doc/rtems-runtime-portability-design.md
+++ b/doc/rtems-runtime-portability-design.md
@@ -481,6 +481,38 @@ branch. Phase-6 items 5/8/9 likewise depend on that branch's primitives
 `caucus/WG0SFREHPX/ca-sans-io-1962c8be-1` into main is the user's decision, but
 until it lands, no PVA RTEMS milestone can be *committed* green.
 
+### 8.1.3 Measured, not applied — `epics-bridge-rs` (2026-07-21)
+
+`doc/rtems-bridge-walls.md` settles the status this document and the PI-lock
+evaluation §9 both left undeclared. Measured on `integration/rtems-scope-b`
+@ `af2d5d16`, three `cargo check --target armv7-rtems-eabihf` runs (default /
+`--no-default-features` / `--features qsrv`), all exit 101:
+
+- **Every wall is a dependency wall; not one is in bridge source** — mio 1.2.0
+  (29), socket2 0.6 (20), signal-hook-registry 1.4.8 (4), getrandom 0.2.17 (1).
+- **Root cause is one line**, `epics-bridge-rs/Cargo.toml:93`
+  `tokio = { version = "1", features = ["full"] }` in the *plain*
+  `[dependencies]` table while `epics-base-rs:43-44`, `epics-ca-rs:69-70` and
+  `epics-pva-rs:139-142` all split the same dep per target. Cargo **unions**
+  features across the graph, so that one line silently re-enables
+  `net`/`signal`/`process` for every crate in any build containing the bridge —
+  a latent hazard for *any* target-restricted build, not only RTEMS. Proved by
+  `cargo tree -i tokio -e features`: the bridge is the sole enabler of `full`.
+- **Dep-gating alone is predicted sufficient for the `qsrv` subset** (3
+  Cargo.toml edits, 0 source changes): `qsrv`/`pvalink`/`pva_gateway` use
+  `tokio::net`/`signal`/`process` **0** times; only `ca_gateway` does, at 3
+  production sites (`pvlist.rs:244`, `server.rs:1219`, `:1285`), and every
+  module already sits behind its own feature (`lib.rs:69,72,75,82`). Compile
+  surface would be 32,787 / 59,380 src lines (55%). **Not verified to exit 0** —
+  the gates were not applied; this is a well-evidenced prediction.
+- **Nobody's blocker today.** No inbound edge from base/ca/pva; the only RTEMS
+  binary that exists (`rtems-ca-ioc`) does not depend on the bridge, and
+  `rtems-pva-ioc` does not exist yet. It becomes a blocker only if item-7 stage G
+  chooses *group-aware* db-backed PVA — and stage G can avoid it entirely, since
+  `epics-pva-rs` already serves records off `DbSubscription` via
+  `PvDatabaseSource` + `UpstreamMonitor::from_db` (`server_native/source.rs:1912-1921`)
+  in a `server/` module that is **not** RTEMS-gated.
+
 ### 8.2 Gateable — excluded from the RTEMS build
 
 - **ring / rustls / tokio-rustls (TLS)** — `optional = true` in **epics-ca-rs

--- a/doc/rtems-runtime-portability-design.md
+++ b/doc/rtems-runtime-portability-design.md
@@ -596,11 +596,26 @@ libm, chrono, flate2, lz4_flex — and, importantly, hashing via **RustCrypto**
    `--lib` RTEMS checks exit 0 for epics-base-rs, epics-ca-rs **and
    epics-pva-rs** — the committed-green pva RTEMS check that items 5, 7 and
    10 were waiting on. Item-5 stages 3–5, item-7 stages C–G, and items 8–9
-   are unblocked on this branch. Next owed there: extract `PvaServerConfig`
+   are unblocked on this branch. ~~Next owed there: extract `PvaServerConfig`
    out of the host-gated `runtime.rs` — 8 production `tcp.rs` signatures
    name it (`tcp.rs:45`), so the gate re-point is **not** the "4 cfg lines"
    named in `4c75e766` until that lands — then the `tcp`/`peers` gate
-   re-point and the `AbortOnDrop` → `TaskAbortHandle` rename.
+   re-point and the `AbortOnDrop` → `TaskAbortHandle` rename.~~
+   **LANDED 2026-07-21** (`42a42abf` config → `server_native/config.rs` ·
+   `4da1e04a` SEARCH protocol → `server_native/search.rs`, byte-identical
+   moves diff-proved · `04cdf6fa` tcp.rs's 3 handle annotations → seam
+   aliases · `5ff20f4a` exec `AbortHandle` gains the `Debug` its tokio
+   mirror has · `ab2d48e2` gate re-point: `tcp`/`peers`/`config`/`search`
+   target-neutral, `accept`/`runtime`/`udp` stay gated · `af2d5d16` rustdoc
+   links). RTEMS `--lib` exit 0 with `tcp.rs` **type-checked into the
+   build** (deliberate-type-error probe), workspace 9839 unchanged.
+   Known residue: **116 dead-code warnings on the RTEMS check** — with the
+   pre-split `run_tcp_server*` re-exports gated, RTEMS has no entry point
+   into `tcp` yet, so the whole module is unreachable until the blocking
+   thread-per-client driver (item 7 stage C) roots it; the count is the
+   honest measure of unwired surface, deliberately not `#[allow]`-ed.
+   Still owed: the crate-wide item-9 handle rename (~87 sites), item-5
+   stages 3–5, item-7 stages C–G.
 
    **RT-Linux track (separate from RTEMS, user-ordered 2026-07-21).**
    Item 4 landed as `c065fe28` on the CA branch: SCHED_FIFO application is

--- a/doc/rtems-runtime-portability-design.md
+++ b/doc/rtems-runtime-portability-design.md
@@ -578,6 +578,48 @@ libm, chrono, flate2, lz4_flex — and, importantly, hashing via **RustCrypto**
    connect-time seed preserved), and mapped-of-mapped is unrepresentable by
    type, which is what keeps the default monitor path allocation-free.
 
+   **Merge ordering resolved 2026-07-21 — local branch
+   `integration/rtems-scope-b`** (off `main@5241145f`; main itself untouched,
+   nothing pushed). All three branches on item 7's critical path are merged
+   there: the dep gate (`7f0f9d3e`), the CA sans-io branch through `c065fe28`
+   (which adds the opt-in SCHED_FIFO wiring, below), and
+   `phase6/pva-channelsource-ring` (`aa1af842`). Conflict resolutions of
+   record: `iocsh/commands.rs` (main's `install_record_defs` structure +
+   the CA branch's sync record API, data-lock guard scoped per field before
+   `update_scan_index(..).await`); `runtime/task.rs` (a cfg-forked
+   `runtime::task::timeout` seam — the exec arm races a pinned `sleep`
+   against the future and returns a local `Elapsed`, since tokio's `Elapsed`
+   has no public constructor); the dep gate's TLS feature gates re-applied to
+   the split-out `accept.rs`. Verified at the branch tip (`2ce9bd11`): clippy
+   `--workspace --all-targets -D warnings` clean; nextest workspace
+   **9839/9839**; `rtems-exec-model` feature-ON suite **593/593**; and
+   `--lib` RTEMS checks exit 0 for epics-base-rs, epics-ca-rs **and
+   epics-pva-rs** — the committed-green pva RTEMS check that items 5, 7 and
+   10 were waiting on. Item-5 stages 3–5, item-7 stages C–G, and items 8–9
+   are unblocked on this branch. Next owed there: extract `PvaServerConfig`
+   out of the host-gated `runtime.rs` — 8 production `tcp.rs` signatures
+   name it (`tcp.rs:45`), so the gate re-point is **not** the "4 cfg lines"
+   named in `4c75e766` until that lands — then the `tcp`/`peers` gate
+   re-point and the `AbortOnDrop` → `TaskAbortHandle` rename.
+
+   **RT-Linux track (separate from RTEMS, user-ordered 2026-07-21).**
+   Item 4 landed as `c065fe28` on the CA branch: SCHED_FIFO application is
+   now opt-in behind `EPICS_RS_ALLOW_RT_PRIORITY` (default **off**;
+   deliberately not C's `EPICS_ALLOW_POSIX_THREAD_PRIORITY_SCHEDULING`,
+   whose default is YES), the policy is a parameter of
+   `apply_to_current_thread_under` so "switch off ⟹ no scheduler call"
+   holds by call graph, the permitted FIFO range is probed once (C's
+   `find_pri_range`, `osdThread.c:259-334`), and `cbTimer` /
+   `CAS-client-blocking` / `CAS-event-blocking` now carry their C
+   priorities. Item 4b's evaluation is at **`doc/pi-lock-evaluation.md`** —
+   headline: 14 of the 25 shared locks are tokio primitives that no PI
+   mutex can reach (blocking threads wait in `std::thread::park()`,
+   invisible to the kernel's PI chain), and L1, the `dbScanLock` analogue,
+   holds that property *by contract* (`OwnedMutexGuard` across await) — the
+   design decision gating any hard-RT claim. On RTEMS `apply_priority_impl`
+   still returns `Unsupported` (`task.rs:715-719`); target-side priority
+   belongs with BSP bring-up (§10).
+
    Items 1/2/4 are **desktop-neutral** — they improve the hosted build too and
    can land before any RTEMS wiring. Item 4 alone deletes 6 tasks: today a
    single MONITOR on a db-backed PVA IOC costs 2–3 tasks because


### PR DESCRIPTION
These 13 files were written on a local `main` that ran 19 commits ahead of origin while falling ~131k lines behind it, so they never reached the remote and are not derivable from code — they carry the RTEMS bring-up measurements, the workspace-wide `cfg(unix)` audit, the link contract, the hosted-assumption ceilings, and the PI-lock evaluation the RT measurements cite. Two existing docs also gain content the remote lacked: §8.1.3 of the portability design (the `epics-bridge-rs` dependency-wall measurement) and item-7 decision 5 (PVAS thread priorities, with the pvxs 18/16 correction). The roadmap table in `rtems-runtime-portability-design.md` is deliberately left at origin's version and is not reconciled here — both copies are stale against shipped reality (`realtime-pva-ioc` exists on main), which is a separate task.