### PR TITLE
feat(net): bind the IPv6 SEARCH socket on every backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+### The IPv6 SEARCH socket binds on every backend too
+
+v0.25.3 left the IPv6 half out of the embedded targets, on the reading that
+`socket2` and `tokio::net` were required to build it. They were an
+implementation choice, not a platform limit: `std` covers the bind, the group
+join and the loop-back option, and `IPV6_V6ONLY` / `IPV6_MULTICAST_HOPS` are
+plain `setsockopt` calls whose constants both target `libc`s carry.
+
+- **`epics_base_rs::net::search_udp::SearchUdpSocketV6`** is a sibling type
+  rather than a variant of `SearchUdpSocket`, because the two families differ
+  in what a socket *is* here and not only in the address it carries: the v4
+  host arm is a per-NIC bundle with `IP_PKTINFO` attribution and a
+  `255.255.255.255` fanout, and v6 has none of the three. Folding them into one
+  type would give four of its methods a second meaning, "unsupported for this
+  variant". The `exec_backend` receive pump, its stop flag and its joining
+  `Drop` are address-family neutral and are shared as code.
+
+- `IPV6_V6ONLY` is set on an **unbound** socket, the same ordering constraint
+  `SO_REUSEADDR` / `SO_REUSEPORT` have, which is why neither family can go
+  through `std::net::UdpSocket::bind` — it binds as it constructs.
+
+- `epics-pva-rs`'s `V6Socket` is gone (153 lines), along with the uninhabited
+  `enum V6Socket {}` whose `exec_backend` methods were `match *self {}`.
+
+- Both cross-compile ratchets still read **zero** target errors, now covering
+  both address families. Compiling is not running: whether an RTEMS BSP or the
+  VxWorks stack has IPv6 enabled is an on-target question, and a failed bind
+  degrades the client to IPv4-only by design.
+
 ## v0.25.3 — 2026-07-30
 
 Patch release. The CA and PVA *clients* now bind a UDP SEARCH socket on the

--- a/crates/epics-libcom-rs/src/net/mod.rs
+++ b/crates/epics-libcom-rs/src/net/mod.rs
@@ -60,7 +60,7 @@ pub mod search_udp;
 pub const ORIGIN_TAG_MCAST_GROUP: Ipv4Addr = Ipv4Addr::new(224, 0, 0, 128);
 
 pub use iface_v4::{IfaceV4, broadcast_addrs, local_addr};
-pub use search_udp::{SearchDatagram, SearchUdpSocket};
+pub use search_udp::{SearchDatagram, SearchUdpSocket, SearchUdpSocketV6};
 
 #[cfg(not(epics_embedded_target))]
 pub use async_udp_v4::{

--- a/crates/epics-libcom-rs/src/net/search_udp.rs
+++ b/crates/epics-libcom-rs/src/net/search_udp.rs
@@ -39,7 +39,7 @@
 //! One thread per search engine, and a CA client has one.
 
 use std::io;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 /// One received SEARCH datagram, and what the receiving path knows about it.
 ///
@@ -170,6 +170,87 @@ impl SearchUdpSocket {
     }
 }
 
+/// A client's IPv6 UDP SEARCH or beacon socket, on **every** target.
+///
+/// Separate from [`SearchUdpSocket`] rather than a variant of it, because the
+/// two families differ in what a socket *is* here and not only in the address
+/// it carries: the v4 host arm is a per-NIC bundle with `IP_PKTINFO` receive
+/// attribution and a `255.255.255.255` fanout, and v6 has none of the three —
+/// no broadcast at all, one socket, and a multicast group that is the same
+/// destination on every NIC. Folding them into one type would give four of its
+/// methods a second meaning ("unsupported for this variant"), which is the
+/// dual meaning both types exist to avoid. What they do share — the
+/// `exec_backend` receive pump, its stop flag and its joining `Drop` — is
+/// shared as code, not duplicated.
+///
+/// Both arms bind `IPV6_V6ONLY`, so this socket never sees the v4-mapped
+/// traffic [`SearchUdpSocket`] already handles and the two never answer the
+/// same datagram.
+pub struct SearchUdpSocketV6(sys::SockV6);
+
+impl SearchUdpSocketV6 {
+    /// Bind an ephemeral v6 SEARCH socket.
+    ///
+    /// `pump_name`/`pump_priority` describe the `exec_backend` receive thread,
+    /// exactly as on [`SearchUdpSocket::bind_ephemeral`]; the host arm has no
+    /// thread and ignores them.
+    ///
+    /// A host with no IPv6 stack fails here — `EAFNOSUPPORT` from `socket()`,
+    /// or `EADDRNOTAVAIL` from the bind. That is a normal condition and not an
+    /// engine error: the caller drops to IPv4-only, which is why this returns
+    /// the error rather than deciding the policy itself.
+    pub fn bind_search(
+        pump_name: &str,
+        pump_priority: crate::runtime::task::ThreadPriority,
+    ) -> io::Result<Self> {
+        sys::SockV6::bind_search(pump_name, pump_priority).map(Self)
+    }
+
+    /// Bind a v6 beacon listener on `[::]:port`, sharing the port with
+    /// whatever server already holds it (`SO_REUSEADDR` + `SO_REUSEPORT`).
+    ///
+    /// The v6 counterpart of [`SearchUdpSocket::bind_beacon`], and shared for
+    /// the same reason: pvxs puts every UDP socket through
+    /// `epicsSocketEnableAddressUseForDatagramFanout`
+    /// (`udp_collector.cpp:136`), which has no `_WIN32` carve-out.
+    pub fn bind_beacon(
+        port: u16,
+        pump_name: &str,
+        pump_priority: crate::runtime::task::ThreadPriority,
+    ) -> io::Result<Self> {
+        sys::SockV6::bind_beacon(port, pump_name, pump_priority).map(Self)
+    }
+
+    /// Join an IPv6 multicast group (`IPV6_JOIN_GROUP`).
+    ///
+    /// `iface` is a scope index; `0` lets the routing table choose, which is
+    /// what a single wildcard socket has to do.
+    pub fn join_multicast_v6(&self, group: Ipv6Addr, iface: u32) -> io::Result<()> {
+        self.0.join_multicast_v6(group, iface)
+    }
+
+    /// `IPV6_MULTICAST_HOPS`. The v6 spelling of the v4 multicast TTL; pvxs
+    /// sends its v6 multicast at hop limit 1 (link-local only).
+    pub fn set_multicast_hops_v6(&self, hops: u32) -> io::Result<()> {
+        self.0.set_multicast_hops_v6(hops)
+    }
+
+    /// Every local address this socket bound — one entry, both arms.
+    pub fn local_addrs(&self) -> Vec<SocketAddr> {
+        self.0.local_addrs()
+    }
+
+    /// The next datagram.
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<SearchDatagram> {
+        self.0.recv(buf).await
+    }
+
+    /// Send one datagram to one destination.
+    pub async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+        self.0.send_to(buf, dest).await
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Host: the per-NIC bundle, unchanged.
 // ---------------------------------------------------------------------------
@@ -289,6 +370,100 @@ mod sys {
             }
             Ok(ok)
         }
+    }
+
+    pub(super) struct SockV6(std::sync::Arc<tokio::net::UdpSocket>);
+
+    impl SockV6 {
+        pub(super) fn bind_search(
+            pump_name: &str,
+            pump_priority: crate::runtime::task::ThreadPriority,
+        ) -> io::Result<Self> {
+            // No pump: the reactor is the pump.
+            let _ = (pump_name, pump_priority);
+            let sock = new_v6_socket()?;
+            // Link-local hop limit, matching pvxs's v6 send path
+            // (`udp_collector.cpp`). Best-effort: a stack that refuses it still
+            // reaches the link.
+            let _ = sock.set_multicast_hops_v6(1);
+            sock.bind(&v6_bind_addr(0).into())?;
+            Self::adopt(sock)
+        }
+
+        pub(super) fn bind_beacon(
+            port: u16,
+            pump_name: &str,
+            pump_priority: crate::runtime::task::ThreadPriority,
+        ) -> io::Result<Self> {
+            let _ = (pump_name, pump_priority);
+            let sock = new_v6_socket()?;
+            sock.set_reuse_address(true)?;
+            #[cfg(unix)]
+            sock.set_reuse_port(true)?;
+            sock.bind(&v6_bind_addr(port).into())?;
+            Self::adopt(sock)
+        }
+
+        fn adopt(sock: socket2::Socket) -> io::Result<Self> {
+            sock.set_nonblocking(true)?;
+            let std_sock: std::net::UdpSocket = sock.into();
+            tokio::net::UdpSocket::from_std(std_sock).map(|s| Self(std::sync::Arc::new(s)))
+        }
+
+        pub(super) fn join_multicast_v6(
+            &self,
+            group: std::net::Ipv6Addr,
+            iface: u32,
+        ) -> io::Result<()> {
+            self.0.join_multicast_v6(&group, iface)
+        }
+
+        pub(super) fn set_multicast_hops_v6(&self, hops: u32) -> io::Result<()> {
+            socket2::SockRef::from(&*self.0).set_multicast_hops_v6(hops)
+        }
+
+        pub(super) fn local_addrs(&self) -> Vec<SocketAddr> {
+            self.0.local_addr().into_iter().collect()
+        }
+
+        pub(super) async fn recv(&self, buf: &mut [u8]) -> io::Result<SearchDatagram> {
+            let (n, src) = self.0.recv_from(buf).await?;
+            Ok(SearchDatagram {
+                n,
+                src,
+                // `IP_PKTINFO` attribution is the v4 bundle's; a single v6
+                // socket reports no receiving NIC, the same `None` the exec
+                // arm reports for the same reason.
+                iface_ip: None,
+                drops: 0,
+            })
+        }
+
+        pub(super) async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+            self.0.send_to(buf, dest).await
+        }
+    }
+
+    /// An unbound `AF_INET6` datagram socket with `IPV6_V6ONLY` already set.
+    ///
+    /// Unbound, because `IPV6_V6ONLY` only takes effect before the bind — the
+    /// same ordering constraint the v4 arm's shared-port bind has, and the
+    /// reason neither family can use `std::net::UdpSocket::bind`, which binds
+    /// as it constructs.
+    fn new_v6_socket() -> io::Result<socket2::Socket> {
+        use socket2::{Domain, Protocol, Socket, Type};
+        let sock = Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP))?;
+        sock.set_only_v6(true)?;
+        Ok(sock)
+    }
+
+    fn v6_bind_addr(port: u16) -> SocketAddr {
+        SocketAddr::V6(std::net::SocketAddrV6::new(
+            std::net::Ipv6Addr::UNSPECIFIED,
+            port,
+            0,
+            0,
+        ))
     }
 }
 
@@ -537,6 +712,120 @@ mod sys {
         }
     }
 
+    /// The IPv6 socket, over the same pump.
+    ///
+    /// A newtype over [`Sock`] rather than a second struct: the pump thread,
+    /// its stop flag, the unbounded channel and the joining `Drop` are
+    /// address-family neutral, and duplicating them would give the port-release
+    /// invariant two implementations to hold. Only the bind and the two
+    /// multicast options differ, and those are what this type adds.
+    pub(super) struct SockV6(Sock);
+
+    impl SockV6 {
+        pub(super) fn bind_search(
+            pump_name: &str,
+            pump_priority: ThreadPriority,
+        ) -> io::Result<Self> {
+            let socket = bind_v6(0, false)?;
+            let sock = Sock::with_pump(socket, pump_name, pump_priority)?;
+            let this = Self(sock);
+            // Link-local hop limit, as pvxs sends v6 multicast. Best-effort:
+            // a stack that refuses the option still reaches the link.
+            let _ = this.set_multicast_hops_v6(1);
+            Ok(this)
+        }
+
+        pub(super) fn bind_beacon(
+            port: u16,
+            pump_name: &str,
+            pump_priority: ThreadPriority,
+        ) -> io::Result<Self> {
+            let socket = bind_v6(port, true)?;
+            Sock::with_pump(socket, pump_name, pump_priority).map(Self)
+        }
+
+        pub(super) fn join_multicast_v6(
+            &self,
+            group: std::net::Ipv6Addr,
+            iface: u32,
+        ) -> io::Result<()> {
+            self.0.socket.join_multicast_v6(&group, iface)
+        }
+
+        pub(super) fn set_multicast_hops_v6(&self, hops: u32) -> io::Result<()> {
+            set_int_opt(
+                &self.0.socket,
+                sockopt::IPPROTO_IPV6,
+                sockopt::IPV6_MULTICAST_HOPS,
+                hops as _,
+            )
+        }
+
+        pub(super) fn local_addrs(&self) -> Vec<SocketAddr> {
+            self.0.local_addrs()
+        }
+
+        pub(super) async fn recv(&self, buf: &mut [u8]) -> io::Result<SearchDatagram> {
+            self.0.recv(buf).await
+        }
+
+        pub(super) async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> io::Result<usize> {
+            self.0.send_to(buf, dest).await
+        }
+    }
+
+    /// An `AF_INET6` datagram socket bound to `[::]:port`, with `IPV6_V6ONLY`
+    /// — and, for a shared listener, `SO_REUSEADDR`/`SO_REUSEPORT` — set
+    /// **before** the bind, which is the only point at which they take effect.
+    ///
+    /// Hand-rolled for that ordering, the same reason and the same sequence as
+    /// [`bind_shared_port`]. `IPV6_V6ONLY` is not optional here: without it a
+    /// dual-stack bind would take the v4-mapped copy of traffic the v4 SEARCH
+    /// socket is already receiving, and the engine would see every reply twice.
+    #[cfg(unix)]
+    fn bind_v6(port: u16, share: bool) -> io::Result<UdpSocket> {
+        use std::os::fd::FromRawFd;
+        // SAFETY: `socket()` returns a fresh owned fd or -1.
+        let fd = unsafe { libc::socket(libc::AF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // Owned immediately, so every early return below closes it via `Drop`.
+        // SAFETY: `fd` is a valid, exclusively-owned socket fd just returned.
+        let socket = unsafe { UdpSocket::from_raw_fd(fd) };
+        set_int_opt(&socket, sockopt::IPPROTO_IPV6, sockopt::IPV6_V6ONLY, 1)?;
+        if share {
+            set_int_opt(&socket, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1)?;
+            set_int_opt(&socket, libc::SOL_SOCKET, libc::SO_REUSEPORT, 1)?;
+        }
+        // Zeroed rather than field-by-field: `sin6_len` exists on the BSD
+        // targets and not on Linux, and all-zero is valid for both.
+        // SAFETY: `sockaddr_in6` is plain-old-data.
+        let mut sin6: libc::sockaddr_in6 = unsafe { std::mem::zeroed() };
+        sin6.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+        sin6.sin6_port = port.to_be();
+        // SAFETY: `sin6` is fully initialized and the length is exact.
+        let rc = unsafe {
+            libc::bind(
+                fd,
+                std::ptr::addr_of!(sin6).cast(),
+                std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t,
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(socket)
+    }
+
+    #[cfg(not(unix))]
+    fn bind_v6(_port: u16, _share: bool) -> io::Result<UdpSocket> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "IPv6 bind on a non-Unix exec-backend socket",
+        ))
+    }
+
     /// The directed broadcast of every eligible interface, narrowed to
     /// `ifaces` when that list is non-empty.
     ///
@@ -622,6 +911,9 @@ mod sys {
         pub(super) const SO_RCVBUF: libc::c_int = libc::SO_RCVBUF;
         pub(super) const IPPROTO_IP: libc::c_int = libc::IPPROTO_IP;
         pub(super) const IP_MULTICAST_TTL: libc::c_int = libc::IP_MULTICAST_TTL;
+        pub(super) const IPPROTO_IPV6: libc::c_int = libc::IPPROTO_IPV6;
+        pub(super) const IPV6_V6ONLY: libc::c_int = libc::IPV6_V6ONLY;
+        pub(super) const IPV6_MULTICAST_HOPS: libc::c_int = libc::IPV6_MULTICAST_HOPS;
     }
 
     /// Bind the wildcard address on a well-known port that a server on this
@@ -709,6 +1001,9 @@ mod sys {
         pub(super) const SO_RCVBUF: i32 = 0;
         pub(super) const IPPROTO_IP: i32 = 0;
         pub(super) const IP_MULTICAST_TTL: i32 = 0;
+        pub(super) const IPPROTO_IPV6: i32 = 0;
+        pub(super) const IPV6_V6ONLY: i32 = 0;
+        pub(super) const IPV6_MULTICAST_HOPS: i32 = 0;
     }
 
     #[cfg(not(unix))]
@@ -790,5 +1085,115 @@ mod tests {
                 .expect("recv");
         assert_eq!(&buf[..dg.n], b"CA-SEARCH");
         assert_eq!(dg.drops, 0, "a single quiet datagram overflows nothing");
+    }
+
+    // ── IPv6 ────────────────────────────────────────────────────────────
+
+    /// A machine with no IPv6 stack is a normal machine, and a CI runner is
+    /// often one. Every v6 case below skips on that machine rather than
+    /// failing, so the suite asserts about v6 exactly where v6 exists.
+    fn bind_v6_or_skip() -> Option<SearchUdpSocketV6> {
+        match SearchUdpSocketV6::bind_search("test-PVAC-UDP6", ThreadPriority::Medium) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                eprintln!("skipping: no usable IPv6 stack here ({e})");
+                None
+            }
+        }
+    }
+
+    /// The v6 counterpart of [`binds_and_reports_a_local_address`], and the
+    /// property this whole type was added for: on `exec_backend` the answer
+    /// used to be "no socket exists", by construction.
+    #[epics_macros_rs::epics_test]
+    async fn v6_binds_and_reports_a_local_address() {
+        let Some(sock) = bind_v6_or_skip() else {
+            return;
+        };
+        let addrs = sock.local_addrs();
+        assert!(!addrs.is_empty(), "a bound v6 SEARCH socket has an address");
+        for a in &addrs {
+            assert!(a.is_ipv6(), "an AF_INET6 bind reports a v6 address: {a}");
+            assert_ne!(a.port(), 0, "ephemeral bind assigns a real port: {a}");
+        }
+    }
+
+    /// Round-trip over `::1`, through whichever receive path this build
+    /// selected — the reactor on one arm, the shared pump thread on the other.
+    #[epics_macros_rs::epics_test]
+    async fn v6_round_trips_a_datagram_to_itself() {
+        let Some(sock) = bind_v6_or_skip() else {
+            return;
+        };
+        let port = sock.local_addrs()[0].port();
+        let dest = SocketAddr::from((Ipv6Addr::LOCALHOST, port));
+
+        if let Err(e) = sock.send_to(b"PVA-SEARCH6", dest).await {
+            // A v6 socket can bind while `::1` is unroutable (a container with
+            // IPv6 compiled in and no loopback route). That is the same "no
+            // usable v6 here" condition the binder reports, one step later.
+            eprintln!("skipping: v6 loopback is not routable here ({e})");
+            return;
+        }
+        let mut buf = [0u8; 64];
+        let dg =
+            crate::runtime::task::timeout(std::time::Duration::from_secs(5), sock.recv(&mut buf))
+                .await
+                .expect("a datagram sent to ourselves arrives")
+                .expect("recv");
+        assert_eq!(&buf[..dg.n], b"PVA-SEARCH6");
+        assert_eq!(
+            dg.iface_ip, None,
+            "a single v6 socket attributes no receiving NIC"
+        );
+    }
+
+    /// `IPV6_V6ONLY` holds, which is what keeps the v6 SEARCH socket out of
+    /// the v4 port space the v4 SEARCH socket owns.
+    ///
+    /// Asserted through behaviour rather than by reading the option back, and
+    /// twice, because either witness alone can pass vacuously: the same port
+    /// must still be *bindable* in the v4 family (a dual-stack `[::]` bind
+    /// reserves both, so this is `EADDRINUSE` when the option is lost), and a
+    /// v4 datagram delivered to it must leave the v6 socket silent.
+    ///
+    /// The v4 side is a plain `std` socket rather than a [`SearchUdpSocket`]
+    /// because [`SearchUdpSocket::bind_beacon`] deliberately skips the
+    /// loopback NIC, so nothing sent to `127.0.0.1` can reach it.
+    #[epics_macros_rs::epics_test]
+    async fn v6_socket_does_not_take_v4_mapped_traffic() {
+        let Some(v6) = bind_v6_or_skip() else {
+            return;
+        };
+        let port = v6.local_addrs()[0].port();
+
+        let v4 = std::net::UdpSocket::bind((std::net::Ipv4Addr::LOCALHOST, port)).expect(
+            "IPV6_V6ONLY leaves the v4 half of the port free; EADDRINUSE here means the v6 \
+             SEARCH socket bound dual-stack",
+        );
+        v4.set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .expect("read timeout");
+
+        let dest = SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port));
+        v4.send_to(b"V4-ONLY", dest).expect("v4 send_to");
+
+        // Blocking, but the datagram is already queued by the send above, so
+        // this returns without parking anything.
+        let mut buf = [0u8; 64];
+        let (n, _) = v4
+            .recv_from(&mut buf)
+            .expect("the v4 socket receives its own datagram");
+        assert_eq!(&buf[..n], b"V4-ONLY");
+
+        let mut v6buf = [0u8; 64];
+        let leaked = crate::runtime::task::timeout(
+            std::time::Duration::from_millis(300),
+            v6.recv(&mut v6buf),
+        )
+        .await;
+        assert!(
+            leaked.is_err(),
+            "IPV6_V6ONLY must keep the v4-mapped copy off the v6 socket"
+        );
     }
 }

--- a/crates/epics-pva-rs/build.rs
+++ b/crates/epics-pva-rs/build.rs
@@ -106,12 +106,13 @@ const LOCAL_ACCOUNT_DB_TARGETS: &[&str] = &[
 // exists", so every arm that needs one takes that predicate — the target's
 // shape, now reached by the host build that models the target.
 //
-// The v4 SEARCH socket is no longer one of those arms. It binds on both
-// backends through `epics_base_rs::net::search_udp::SearchUdpSocket`, whose
-// `exec_backend` arm is a `std::net::UdpSocket` and a receive-pump thread and
-// names no reactor. `tokio_backend` still selects the IPv6 half, which is
-// `socket2` and `tokio::net` throughout, and `SearchTransport` still reduces
-// to `NameServersOnly` when the configuration asks for no UDP.
+// Neither SEARCH socket is one of those arms any longer. Both bind on both
+// backends, through `epics_base_rs::net::search_udp`'s `SearchUdpSocket` and
+// `SearchUdpSocketV6`, whose `exec_backend` arms are a `std::net::UdpSocket` /
+// a raw `libc` `AF_INET6` bind and a receive-pump thread, naming no reactor.
+// `tokio_backend` still selects the PVA *server*'s UDP responder, and
+// `SearchTransport` still reduces to `NameServersOnly` when the configuration
+// asks for no UDP.
 //
 // This is a third copy of a four-line rule, so it is pinned rather than
 // trusted: a `const` assertion in `src/lib.rs` checks it against

--- a/crates/epics-pva-rs/src/client_native/search_engine.rs
+++ b/crates/epics-pva-rs/src/client_native/search_engine.rs
@@ -52,8 +52,9 @@ use std::time::Duration;
 // on RTEMS 6 now reports its port — MEASURED on target, `UDPSEARCH
 // bound=[0.0.0.0:55153]`.
 //
-// What remains target-shaped is the IPv6 half alone; see [`V6Socket`].
-use epics_base_rs::net::search_udp::SearchUdpSocket;
+// The IPv6 half is no longer target-shaped either: it binds through
+// `SearchUdpSocketV6` on both backends, over the same receive pump.
+use epics_base_rs::net::search_udp::{SearchUdpSocket, SearchUdpSocketV6};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 // The periodic/one-shot timers come from the `runtime::task` seam, NOT from
@@ -368,14 +369,16 @@ struct UdpTransport {
     /// [`Self::response_port`] advertises.
     search_socket: SearchUdpSocket,
     /// PR #205 IPv6 Stage 4: optional v6 SEARCH socket. `None` when the
-    /// host has no usable IPv6 stack, and always `None` on `exec_backend`,
-    /// where [`V6Socket`] is uninhabited.
-    search_socket_v6: Option<V6Socket>,
+    /// target has no usable IPv6 stack — which is a runtime fact on every
+    /// backend now, not a compile-time one: the socket is
+    /// [`SearchUdpSocketV6`], which binds on the embedded targets through the
+    /// same receive pump the v4 socket uses.
+    search_socket_v6: Option<SearchUdpSocketV6>,
     /// Beacon listener on [`Self::broadcast_port`]. `None` when the bind
     /// failed — beacon-driven fast reconnect is best-effort.
     beacon_socket: Option<SearchUdpSocket>,
     /// PR #205 IPv6 Stage 6: optional v6 multicast beacon listener.
-    beacon_socket_v6: Option<V6Socket>,
+    beacon_socket_v6: Option<SearchUdpSocketV6>,
     /// Explicit `addr_list` UDP SEARCH targets (already merged with any
     /// programmatic extras) — every datagram is sent to each of these.
     extra_targets: Vec<SocketAddr>,
@@ -460,7 +463,7 @@ impl SearchTransport {
         // PR #205 IPv6 Stage 4: optional v6 send/recv socket. Used
         // alongside the v4 socket — graceful degradation when the
         // host has no usable IPv6 stack.
-        let search_socket_v6 = V6Socket::bind_search();
+        let search_socket_v6 = bind_search_udp_v6();
         // Beacon receive uses the per-client UDP port and joins the
         // per-client address-list multicast groups (pvxs `udp_port`).
         let beacon_socket = bind_beacon_udp(config.broadcast_port, &config.addr_list); // Optional.
@@ -468,7 +471,7 @@ impl SearchTransport {
         // `[::]:5076` joined to `ff0e::400`. Receives v6 multicast
         // beacons emitted by the server's Stage 5 path. None when the
         // host has no v6.
-        let beacon_socket_v6 = V6Socket::bind_beacon(config.broadcast_port);
+        let beacon_socket_v6 = bind_beacon_udp_v6(config.broadcast_port);
 
         // Merge the per-client address-list UDP SEARCH targets into
         // `extra_targets`. The list was parsed once (DNS-resolved,
@@ -524,7 +527,7 @@ impl SearchTransport {
             .unwrap_or(0);
         let response_port_v6 = search_socket_v6
             .as_ref()
-            .and_then(|s| s.local_port())
+            .and_then(local_port_v6)
             .unwrap_or(response_port);
 
         Ok(Self::Udp(Box::new(UdpTransport {
@@ -567,7 +570,7 @@ impl SearchTransport {
             Self::Udp(u) => {
                 let mut addrs = u.search_socket.local_addrs();
                 if let Some(s) = &u.search_socket_v6 {
-                    addrs.extend(s.local_port().map(|p| {
+                    addrs.extend(local_port_v6(s).map(|p| {
                         SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, p, 0, 0))
                     }));
                 }
@@ -575,7 +578,7 @@ impl SearchTransport {
                     addrs.extend(s.local_addrs());
                 }
                 if let Some(s) = &u.beacon_socket_v6 {
-                    addrs.extend(s.local_port().map(|p| {
+                    addrs.extend(local_port_v6(s).map(|p| {
                         SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, p, 0, 0))
                     }));
                 }
@@ -983,178 +986,55 @@ impl SearchEngine {
 
 // ── The IPv6 half ───────────────────────────────────────────────────────
 
-/// The client's IPv6 SEARCH or beacon socket, where one can exist at all.
+/// Bind the client's ephemeral IPv6 SEARCH socket, or report why not.
 ///
-/// This is the one part of the UDP transport that does not cross to the
-/// embedded targets, and the reason is the dependency graph rather than a
-/// design choice: both binders are `socket2` (newlib has no `msghdr` /
-/// `recvmsg` / `ip_mreqn`, and neither does VxWorks's `libc` module) and the
-/// receive is `tokio::net::UdpSocket`, whose `net` feature is not enabled on
-/// either target because mio has no selector there.
-///
-/// So on `exec_backend` the type is **uninhabited**. `Option<V6Socket>` is
-/// then `None` by construction rather than by a runtime check that a build
-/// could get wrong, every method below reduces to `match *self {}`, and the
-/// `socket2`/`tokio::net` surface leaves the target's compiled unit entirely.
-/// That is the shape the whole transport used to have as a `SearchTransport`
-/// variant, kept for the half that is genuinely unreachable.
-#[cfg(tokio_backend)]
-struct V6Socket(Arc<tokio::net::UdpSocket>);
-
-#[cfg(exec_backend)]
-enum V6Socket {}
-
-#[cfg(tokio_backend)]
-impl V6Socket {
-    /// PR #205 IPv6 Stage 4: a v6-only ephemeral socket used to send SEARCH
-    /// to IPv6 destinations (unicast servers from `EPICS_PVA_ADDR_LIST` and
-    /// the v6 multicast group). `None` when the host lacks IPv6 — the engine
-    /// keeps running IPv4-only.
-    ///
-    /// Sets `IPV6_V6ONLY=true` explicitly so the v6 socket cannot accept
-    /// v4-mapped traffic that would otherwise duplicate what the v4 SEARCH
-    /// socket already handles.
-    fn bind_search() -> Option<Self> {
-        use socket2::{Domain, Protocol, Socket, Type};
-
-        let sock = match Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)) {
-            Ok(s) => s,
-            Err(e) => {
-                debug!("IPv6 SEARCH socket: socket() failed: {e}; v6 disabled");
-                return None;
-            }
-        };
-        if let Err(e) = sock.set_only_v6(true) {
-            debug!("IPv6 SEARCH socket: set_only_v6 failed: {e}");
+/// `None` is the ordinary answer on a host or target with no usable IPv6
+/// stack; the engine then runs IPv4-only. It is no longer the *only* answer
+/// on `exec_backend`: this used to be a `V6Socket` that was an uninhabited
+/// enum there, because both binders were `socket2` and the receive was
+/// `tokio::net::UdpSocket`. [`SearchUdpSocketV6`] owes neither — it binds
+/// `AF_INET6` through `libc` for the `IPV6_V6ONLY`-before-bind ordering and
+/// receives on the same pump thread the v4 SEARCH socket already uses — so
+/// the embedded targets reach this path like any other.
+fn bind_search_udp_v6() -> Option<SearchUdpSocketV6> {
+    match SearchUdpSocketV6::bind_search("PVAC-UDP6", PVA_SEARCH_UDP_PRIORITY) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            debug!("IPv6 SEARCH socket: {e}; v6 disabled");
+            None
         }
-        if let Err(e) = sock.set_nonblocking(true) {
-            debug!("IPv6 SEARCH socket: set_nonblocking failed: {e}");
-            return None;
-        }
-        // Multicast TTL=1 (link-local only) is the safe default — matches
-        // pvxs `udp_collector.cpp` v6 send path.
-        if let Err(e) = sock.set_multicast_hops_v6(1) {
-            debug!("IPv6 SEARCH socket: set_multicast_hops_v6 failed: {e}");
-        }
-        let bind =
-            std::net::SocketAddr::V6(std::net::SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 0, 0, 0));
-        if let Err(e) = sock.bind(&bind.into()) {
-            debug!("IPv6 SEARCH socket: bind {bind} failed: {e}; v6 disabled");
-            return None;
-        }
-        Self::adopt(sock, "IPv6 SEARCH socket")
-    }
-
-    /// PR #205 IPv6 Stage 6: a v6 beacon listener on `[::]:port` with
-    /// `SO_REUSEADDR`/`SO_REUSEPORT` + `IPV6_V6ONLY=1`, joined to the default
-    /// v6 PVA multicast group `ff0e::400`. `None` when the host lacks v6 or
-    /// the bind fails — fast-reconnect via v6 beacons is best-effort and the
-    /// v4 beacon socket keeps doing its job.
-    fn bind_beacon(port: u16) -> Option<Self> {
-        use socket2::{Domain, Protocol, Socket, Type};
-
-        let sock = match Socket::new(Domain::IPV6, Type::DGRAM, Some(Protocol::UDP)) {
-            Ok(s) => s,
-            Err(e) => {
-                debug!("v6 beacon socket: socket() failed: {e}; v6 beacon recv disabled");
-                return None;
-            }
-        };
-        if let Err(e) = sock.set_only_v6(true) {
-            debug!("v6 beacon socket: set_only_v6 failed: {e}");
-        }
-        // Mirror the v4 beacon socket setup: SO_REUSEADDR + SO_REUSEPORT so
-        // a server v6 SEARCH listener on `[::]:port` and a client v6 beacon
-        // listener can coexist. The server emits beacons FROM a separate
-        // ephemeral socket, so this REUSEPORT-shared listener only receives.
-        //
-        // SO_REUSEADDR on every platform, Windows included: pvxs puts its UDP
-        // sockets through `epicsSocketEnableAddressUseForDatagramFanout`
-        // (udp_collector.cpp:136), and that libcom helper has no `#ifdef
-        // _WIN32` — the Windows carve-out belongs to the TCP time-wait helper,
-        // not this one. Skipping it here would stop a second PVA process on a
-        // Windows host from co-binding the beacon port.
-        if let Err(e) = sock.set_reuse_address(true) {
-            debug!("v6 beacon socket: set_reuse_address failed: {e}");
-        }
-        #[cfg(unix)]
-        if let Err(e) = sock.set_reuse_port(true) {
-            debug!("v6 beacon socket: set_reuse_port failed: {e}");
-        }
-        if let Err(e) = sock.set_nonblocking(true) {
-            debug!("v6 beacon socket: set_nonblocking failed: {e}");
-            return None;
-        }
-
-        let bind = SocketAddr::V6(std::net::SocketAddrV6::new(
-            Ipv6Addr::UNSPECIFIED,
-            port,
-            0,
-            0,
-        ));
-        if let Err(e) = sock.bind(&bind.into()) {
-            debug!("v6 beacon socket: bind {bind} failed: {e}; v6 beacon recv disabled");
-            return None;
-        }
-
-        let adopted = Self::adopt(sock, "v6 beacon socket")?;
-        // Join the default PVA v6 multicast group on the unspecified
-        // interface (let the OS pick). Additional groups from
-        // EPICS_PVA_ADDR_LIST are joined separately.
-        if let Err(e) = adopted.0.join_multicast_v6(&DEFAULT_V6_MULTICAST_GROUP, 0) {
-            debug!(
-                "v6 beacon socket: join_multicast_v6 ff0e::400 failed: {e}; \
-                 v6 multicast beacons will not be received"
-            );
-        }
-        Some(adopted)
-    }
-
-    fn adopt(sock: socket2::Socket, what: &str) -> Option<Self> {
-        let std_sock: std::net::UdpSocket = sock.into();
-        match tokio::net::UdpSocket::from_std(std_sock) {
-            Ok(s) => Some(Self(Arc::new(s))),
-            Err(e) => {
-                debug!("{what}: tokio adoption failed: {e}");
-                None
-            }
-        }
-    }
-
-    fn local_port(&self) -> Option<u16> {
-        self.0.local_addr().ok().map(|a| a.port())
-    }
-
-    async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
-        self.0.recv_from(buf).await
-    }
-
-    async fn send_to(&self, buf: &[u8], dest: SocketAddr) -> std::io::Result<usize> {
-        self.0.send_to(buf, dest).await
     }
 }
 
-#[cfg(exec_backend)]
-impl V6Socket {
-    fn bind_search() -> Option<Self> {
-        None
+/// Bind the v6 beacon listener on `[::]:port` and join the default PVA v6
+/// multicast group.
+///
+/// Best-effort in both steps, as the v4 beacon listener is: a failed bind
+/// leaves fast-reconnect to the v4 socket, and a failed group join leaves the
+/// socket receiving unicast only.
+fn bind_beacon_udp_v6(port: u16) -> Option<SearchUdpSocketV6> {
+    let sock = match SearchUdpSocketV6::bind_beacon(port, "PVAC-BEACON6", PVA_SEARCH_UDP_PRIORITY) {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("v6 beacon socket: {e}; v6 beacon recv disabled");
+            return None;
+        }
+    };
+    // Interface index 0: let the OS pick. Additional groups from
+    // EPICS_PVA_ADDR_LIST are joined separately.
+    if let Err(e) = sock.join_multicast_v6(DEFAULT_V6_MULTICAST_GROUP, 0) {
+        debug!(
+            "v6 beacon socket: join_multicast_v6 ff0e::400 failed: {e}; \
+             v6 multicast beacons will not be received"
+        );
     }
+    Some(sock)
+}
 
-    fn bind_beacon(_port: u16) -> Option<Self> {
-        None
-    }
-
-    fn local_port(&self) -> Option<u16> {
-        match *self {}
-    }
-
-    async fn recv_from(&self, _buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
-        match *self {}
-    }
-
-    async fn send_to(&self, _buf: &[u8], _dest: SocketAddr) -> std::io::Result<usize> {
-        match *self {}
-    }
+/// The ephemeral port a bound v6 socket holds, for the SEARCH frame's
+/// advertised `response_port`.
+fn local_port_v6(sock: &SearchUdpSocketV6) -> Option<u16> {
+    sock.local_addrs().first().map(|a| a.port())
 }
 
 // ── UDP socket helpers ──────────────────────────────────────────────────
@@ -1194,11 +1074,11 @@ fn bind_ephemeral_udp() -> PvaResult<SearchUdpSocket> {
 /// optional v6 socket, or parks forever when v6 is disabled. Shared by the
 /// v6 search and v6 beacon arms of [`SearchTransport`].
 async fn recv_from_v6(
-    sock: Option<&V6Socket>,
+    sock: Option<&SearchUdpSocketV6>,
     buf: &mut [u8],
 ) -> std::io::Result<(usize, SocketAddr)> {
     match sock {
-        Some(s) => s.recv_from(buf).await,
+        Some(s) => s.recv(buf).await.map(|dg| (dg.n, dg.src)),
         None => std::future::pending().await,
     }
 }
@@ -5107,10 +4987,10 @@ mod tests {
     /// `extra_targets`, and verifies `find()` resolves to the server's
     /// TCP endpoint. Regression guard against the v6 send path being
     /// dropped or the v6 recv arm losing the SEARCH_RESPONSE.
-    // Gated to `tokio_backend`, and not because of the reactor: the subject is
-    // the IPv6 half, and `V6Socket` is uninhabited on `exec_backend` (both its
-    // binders are `socket2`, its receive is `tokio::net`). A v6 assertion there
-    // would be asserting about a socket that cannot exist.
+    // Gated to `tokio_backend` because this arm drives a whole PVA *server*
+    // over the reactor, not because the client's v6 socket is unavailable:
+    // `SearchUdpSocketV6` binds on both backends now. The exec arm's v6 socket
+    // is covered at the primitive instead, by `search_udp`'s own tests.
     #[cfg(tokio_backend)]
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -5203,10 +5083,10 @@ mod tests {
     /// port, and the advertised `response_port` inside the frame must
     /// equal it. Before the fix the v6 frame carried the v4 socket port
     /// (≠ source) and this assertion fails.
-    // Gated to `tokio_backend`, and not because of the reactor: the subject is
-    // the IPv6 half, and `V6Socket` is uninhabited on `exec_backend` (both its
-    // binders are `socket2`, its receive is `tokio::net`). A v6 assertion there
-    // would be asserting about a socket that cannot exist.
+    // Gated to `tokio_backend` because this arm drives a whole PVA *server*
+    // over the reactor, not because the client's v6 socket is unavailable:
+    // `SearchUdpSocketV6` binds on both backends now. The exec arm's v6 socket
+    // is covered at the primitive instead, by `search_udp`'s own tests.
     #[cfg(tokio_backend)]
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5277,7 +5157,7 @@ mod tests {
         // Use a unique broadcast port for this test so we don't fight
         // a parallel test or a local pva-rs IOC for the well-known
         // 5076 socket. Picks via OS-coordinated probe, drops, then
-        // passes the port directly to `V6Socket::bind_beacon`.
+        // passes the port directly to `bind_beacon_udp_v6`.
         let pick_port = || {
             let s = std::net::UdpSocket::bind("[::1]:0").expect("v6 probe bind");
             let p = s.local_addr().unwrap().port();
@@ -5286,10 +5166,10 @@ mod tests {
         };
         let port = pick_port();
 
-        let sock = V6Socket::bind_beacon(port)
+        let sock = bind_beacon_udp_v6(port)
             .expect("v6 beacon socket must bind on a host with IPv6 enabled");
         assert_eq!(
-            sock.local_port(),
+            local_port_v6(&sock),
             Some(port),
             "beacon socket must bind the EPICS_PVA_BROADCAST_PORT we set"
         );
@@ -5302,10 +5182,10 @@ mod tests {
     /// recv arm decodes the beacon, the BeaconTracker observes the
     /// (server_addr, guid) pair, and `beacon_guid_for(addr)` returns
     /// the GUID we sent. Guards the full recv-decode-track chain.
-    // Gated to `tokio_backend`, and not because of the reactor: the subject is
-    // the IPv6 half, and `V6Socket` is uninhabited on `exec_backend` (both its
-    // binders are `socket2`, its receive is `tokio::net`). A v6 assertion there
-    // would be asserting about a socket that cannot exist.
+    // Gated to `tokio_backend` because this arm drives a whole PVA *server*
+    // over the reactor, not because the client's v6 socket is unavailable:
+    // `SearchUdpSocketV6` binds on both backends now. The exec arm's v6 socket
+    // is covered at the primitive instead, by `search_udp`'s own tests.
     #[cfg(tokio_backend)]
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/doc/pvalink-rtems-design.md
+++ b/doc/pvalink-rtems-design.md
@@ -535,9 +535,11 @@ Any future "pvalink compiles for RTEMS" green must not be read as
 > now, through `epics_base_rs::net::search_udp::SearchUdpSocket`. Fact 3
 > below was the `sin_len` libc defect (§3.2), fixed in the pinned `libc`
 > patch: `local_addr()` reads back on RTEMS 6, MEASURED. Fact 1 stays true
-> and is why TCP-only came first; fact 2 stays true. What is still absent
-> is the IPv6 half alone — both its binders are `socket2` and its receive
-> is `tokio::net`, so `V6Socket` is an uninhabited enum on `exec_backend`.
+> and is why TCP-only came first; fact 2 stays true. The IPv6 half followed
+> on 2026-08-03 through `SearchUdpSocketV6`, whose `exec_backend` arm is a
+> raw `libc` `AF_INET6` bind on the same pump — CROSS-COMPILED for both
+> RTOS targets, not yet exercised on one, so whether the BSP's stack
+> answers the bind is still open.
 > Measured on target: `UDPSEARCH reply pv=RTEMS:PVA:AO
 > server=10.0.2.15:5075 proto=tcp version=2`, resolved by broadcast with no
 > name server configured.

--- a/scripts/rtems-check.sh
+++ b/scripts/rtems-check.sh
@@ -479,18 +479,25 @@ fi
 #     28  after server_conn's unconditional tokio::net import was removed
 #      0  after stage 4         UDP transport cfg-gated out of the target build
 #      0  after the v4 SEARCH socket landed — transport compiled IN, still 0
+#      0  after the v6 SEARCH socket landed — BOTH families in, still 0
 #
 # Stage 4 closed the remaining 28 (§5) by gating the whole UDP SEARCH/beacon
-# transport out of the target build. The v4 half is now compiled back IN and the
-# count is still zero: `search_engine.rs` binds through `SearchUdpSocket`, whose
-# `exec_backend` arm is one `std::net::UdpSocket` plus a receive-pump thread, and
+# transport out of the target build. Both halves are now compiled back IN and
+# the count is still zero: `search_engine.rs` binds through `SearchUdpSocket`
+# and `SearchUdpSocketV6`, whose `exec_backend` arms are `std::net::UdpSocket` /
+# a raw `libc` `AF_INET6` bind plus a shared receive-pump thread, and
 # `config::env`'s interface enumeration goes through
-# `epics_base_rs::net::iface_v4` instead of `if-addrs`. What stays absent is the
-# IPv6 half alone: `V6Socket` is an uninhabited enum there, so `socket2` and
-# `tokio::net` leave the target's compiled unit entirely — which is what keeps
-# this number at zero while the `epics-bridge-rs:realtime-pva-ioc --features
-# qsrv-core,pvalink` bin above pulls `epics-pva-rs/client` and still compiles
-# for the target.
+# `epics_base_rs::net::iface_v4` instead of `if-addrs`. `socket2` and
+# `tokio::net` are named only on the hosted arm of each, so neither reaches the
+# target's compiled unit — which is what keeps this number at zero while the
+# `epics-bridge-rs:realtime-pva-ioc --features qsrv-core,pvalink` bin above
+# pulls `epics-pva-rs/client` and still compiles for the target.
+#
+# Zero after the v6 half is a stronger statement than zero before it, and the
+# reason to keep the ratchet at an unchanged number rather than retire it: the
+# same 0 now covers twice the surface. Compiling is not running — whether the
+# BSP's stack answers an `AF_INET6` bind is an on-target question this script
+# cannot ask.
 #
 # The count stays pinned even at zero: a probe that regressed the client back
 # off the target would raise it, and this comparison is what turns that into a
@@ -589,5 +596,5 @@ else
     log "crate and target binary compiles for the generated native-TLS spec, in"
     log "both the portability and the image configuration."
 fi
-log "PVA client (--features client): $PVA_CLIENT_TARGET_ERRORS target errors (v4 UDP transport compiled in; only the IPv6 half is absent)."
+log "PVA client (--features client): $PVA_CLIENT_TARGET_ERRORS target errors (both the v4 and the v6 UDP transport compiled in)."
 log "CA client: built, not probed (CRATE_FEATURES[epics-ca-rs]=client-core)."

--- a/scripts/vxworks-check.sh
+++ b/scripts/vxworks-check.sh
@@ -549,8 +549,8 @@ fi
 #
 # Zero is MEASURED on the box against the merged tree, not carried over from
 # the RTEMS gate's identical-looking zero. The two zeroes have the same cause —
-# the v4 SEARCH transport binds through `SearchUdpSocket`, whose `exec_backend`
-# arm names no tokio and no `socket2`, and only the IPv6 half is left out — but
+# both SEARCH transports bind through `SearchUdpSocket` / `SearchUdpSocketV6`,
+# whose `exec_backend` arms name no tokio and no `socket2` — but
 # the arms that reach that shape used to be spelled `cfg(target_os = "rtems")`,
 # which is FALSE for `target_os = "vxworks"`. A gate that assumed the RTEMS
 # zero would have been asking cargo to compile the hosted tokio/UDP path for a
@@ -593,7 +593,7 @@ log "VxWorks gate (toolchain $TOOLCHAIN): every crate and target binary compiles
 log "for $TARGET, in the portability configuration — which is the only"
 log "configuration this target has, permanently: there is no C of ours to link,"
 log "so there is no image-closure cfg for a second one to name."
-log "PVA client (--features client): $VXWORKS_PVA_CLIENT_TARGET_ERRORS target errors (v4 UDP transport compiled in; only the IPv6 half is absent)."
+log "PVA client (--features client): $VXWORKS_PVA_CLIENT_TARGET_ERRORS target errors (both the v4 and the v6 UDP transport compiled in)."
 log "CA client: built, not probed (CRATE_FEATURES[epics-ca-rs]=client-core)."
 # Repeated at the end, not only at the top: a green summary is what gets pasted
 # into a report, and it must say which resolution the rows measured — the


### PR DESCRIPTION
v0.25.3 left the v6 half out on the reading that socket2 and tokio::net were required; std covers the bind and the group join, and IPV6_V6ONLY / IPV6_MULTICAST_HOPS are setsockopt constants both target libcs carry. Both cross-compile ratchets still read zero with twice the surface compiled in — but compiling is not running, and whether an RTEMS BSP or the VxWorks stack has IPv6 enabled is still an on-target question (a failed bind degrades to IPv4-only by design).