### PR TITLE
fix(histogram): alarm on inverted limits only, not on an empty range

### DIFF
--- a/crates/epics-base-rs/src/server/records/histogram.rs
+++ b/crates/epics-base-rs/src/server/records/histogram.rs
@@ -263,8 +263,8 @@ impl Record for HistogramRecord {
     ///         prec->sevr = INVALID_ALARM;
     /// ```
     ///
-    /// **DEVIATION from C, deliberate — CBUG-F12 refused.** An inverted-limits
-    /// histogram (`LLIM >= ULIM`) cannot bin anything: it is genuinely
+    /// **DEVIATION from C, deliberate — CBUG-F12 refused.** An *inverted*-limits
+    /// histogram (`LLIM > ULIM`) cannot bin anything: it is genuinely
     /// misconfigured, and the record's *intent* — the C code literally tries to
     /// set `SOFT_ALARM`/`INVALID_ALARM` — is to flag it. C's *mechanism* is
     /// broken: it writes `stat`/`sevr` DIRECTLY instead of `nsta`/`nsev` via
@@ -289,9 +289,26 @@ impl Record for HistogramRecord {
     /// C's `nsev < INVALID_ALARM` guard (it only raises when strictly higher).
     /// Gated on `csta` because C's `add_count` returns before the limits test
     /// when counting is stopped.
+    ///
+    /// # Why the alarm test is `>` where C's counting test is `>=`
+    ///
+    /// The deviation flags an *inversion* — a limit pair only an operator can
+    /// create. It must not flag an *empty* range, because `LLIM == ULIM` is the
+    /// state every histogram is in before anyone configures it: neither field
+    /// carries an `initial(...)` in `histogramRecord.dbd`, so a freshly loaded
+    /// record has `LLIM == ULIM == 0` and `CSTA == 1`. Testing `>=` here made
+    /// the port raise SOFT/INVALID on the first process of *every* unconfigured
+    /// histogram, where C shows NO_ALARM — measured by the differential oracle
+    /// as 14 defects across `SCAN`/`PROC`/`UDF`, all of them a bare
+    /// `record(histogram, "…") {}`. Refusing C's broken *mechanism* was never a
+    /// licence to alarm on C's default state.
+    ///
+    /// [`Self::add_count`]'s guard stays `>=`, and is not the same test: an
+    /// empty range bins nothing, which is arithmetic rather than a judgement
+    /// about configuration, and C's `add_count` returns there too.
     fn check_alarms(&mut self, common: &mut crate::server::record::CommonFields) {
         use crate::server::record::AlarmSeverity;
-        if self.csta && self.llim >= self.ulim {
+        if self.csta && self.llim > self.ulim {
             crate::server::recgbl::rec_gbl_set_sevr(
                 common,
                 crate::server::recgbl::alarm_status::SOFT_ALARM,

--- a/crates/epics-base-rs/tests/histogram_invalid_limits_alarm.rs
+++ b/crates/epics-base-rs/tests/histogram_invalid_limits_alarm.rs
@@ -1,4 +1,4 @@
-//! CBUG-F12 REFUSED — a histogram with `LLIM >= ULIM` and its invalid-limits
+//! CBUG-F12 REFUSED — a histogram with `LLIM > ULIM` and its inverted-limits
 //! alarm.
 //!
 //! C's `add_count` (histogramRecord.c:329-334) refuses to count when the limits
@@ -22,6 +22,15 @@
 //! `recGblResetAlarms`. (This is a Tier-2 deviation from a compiled C IOC on the
 //! process path, where C erases the alarm; recorded as a CBUG-F12 allowlist
 //! row.)
+//!
+//! The refusal covers an INVERSION (`LLIM > ULIM`) and stops there. C's counting
+//! test is `>=`, but `LLIM == ULIM` is the state every histogram is in before
+//! anyone configures it — neither field carries an `initial(...)` in
+//! `histogramRecord.dbd`, so a bare `record(histogram, "…") {}` loads with
+//! `LLIM == ULIM == 0` and `CSTA == 1`. Alarming there made every unconfigured
+//! histogram publish SOFT/INVALID on its first process against C's NO_ALARM,
+//! which the differential oracle measured as 14 defects. Refusing C's broken
+//! mechanism is not a licence to alarm on C's default state.
 
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::recgbl::alarm_status;
@@ -89,10 +98,12 @@ async fn process_path_alarms_while_inverted_clears_when_valid() {
     );
 }
 
-/// Equal limits are inverted limits (C's test is `>=`); they too raise
-/// SOFT/INVALID on the process path.
+/// Equal limits are an EMPTY range, not an inverted one, and they are what an
+/// unconfigured record has. They bin nothing (C's counting test is `>=`) but
+/// they raise no alarm, because no operator has expressed anything to be wrong
+/// about.
 #[epics_macros_rs::epics_test]
-async fn equal_limits_alarm_on_process_too() {
+async fn equal_limits_do_not_alarm() {
     let db = PvDatabase::new();
     db.add_record("H3", Box::new(HistogramRecord::new(16, 5.0, 5.0)))
         .await
@@ -102,8 +113,28 @@ async fn equal_limits_alarm_on_process_too() {
 
     assert_eq!(
         alarm(&db, "H3").await,
-        (AlarmSeverity::Invalid, alarm_status::SOFT_ALARM),
-        "LLIM == ULIM is the `>=` boundary — still a misconfiguration, raised"
+        (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
+        "LLIM == ULIM is an empty range, not an inversion — nothing is raised"
+    );
+}
+
+/// The oracle's 14 defects, as one in-process case: a record loaded with no
+/// `field(LLIM,…)` / `field(ULIM,…)` at all. `histogramRecord.dbd` gives neither
+/// an `initial(...)`, so both are 0 and `CSTA` is 1 — and C publishes NO_ALARM
+/// after a `caput .PROC 1` on exactly this record.
+#[epics_macros_rs::epics_test]
+async fn a_freshly_loaded_histogram_does_not_alarm() {
+    let db = PvDatabase::new();
+    db.add_record("H6", Box::new(HistogramRecord::new(16, 0.0, 0.0)))
+        .await
+        .unwrap();
+
+    process(&db, "H6").await;
+
+    assert_eq!(
+        alarm(&db, "H6").await,
+        (AlarmSeverity::NoAlarm, alarm_status::NO_ALARM),
+        "an unconfigured histogram is not a misconfigured one — C shows NO_ALARM here"
     );
 }
 

--- a/crates/epics-oracle-rs/allowlist/expected-deviations.toml
+++ b/crates/epics-oracle-rs/allowlist/expected-deviations.toml
@@ -301,13 +301,13 @@ port serves the same menu minus that one instrument-only choice.
 [[deviation]]
 id = "CBUG-F12"
 bucket = "NOT-REPRODUCED"
-enabled = false
+enabled = true
 upstream = "epics-base / histogram"
 record_types = ["histogram"]
-fields = ["STAT", "SEVR"]
-surface = ["value_string"]
+fields = ["SGNL"]
+surface = ["stat", "sevr"]
 why = """
-An inverted-limits histogram (LLIM >= ULIM) cannot bin anything, so the record is
+An INVERTED-limits histogram (LLIM > ULIM) cannot bin anything, so the record is
 genuinely misconfigured. C's add_count tries to raise SOFT/INVALID but writes
 stat/sevr DIRECTLY instead of nsta/nsev, so recGblResetAlarms erases it on the
 process path (dead code -> NO_ALARM) while it sticks on the .SGNL special path.
@@ -317,10 +317,26 @@ histogram reports SOFT/INVALID CONSISTENTLY on both the process and the .SGNL
 special paths (port fix landed 2026-07-20, CBUG-F12 REPRODUCED -> NOT-REPRODUCED;
 covered by epics-base-rs `histogram_invalid_limits_alarm` unit tests).
 
-Kept `enabled = false`: the deviation is only observable on an inverted-limits
-histogram, and the put-phase harness never drives LLIM >= ULIM (no such case in
-cases.rs), so its scope agrees at NO_ALARM and enabling this row would report a
-FALSE STALE. Flip `enabled = true` once cases.rs grows an inverted-limits case
-that reads STAT/SEVR after a process — then the port's SOFT/INVALID vs C's
-NO_ALARM on the process path becomes the EXPECTED deviation this row allowlists.
+ENABLED 2026-08-03, and the scope corrected, after the first full `--phase all`
+run since the port fix landed. Two things were wrong here:
+
+1. The row claimed the harness "never drives LLIM >= ULIM (no such case in
+   cases.rs)". False. Neither LLIM nor ULIM carries an `initial(...)` in
+   histogramRecord.dbd, so every bare `record(histogram, "…") {}` the harness
+   loads already satisfies `LLIM >= ULIM` at 0 == 0 — C's condition holds on the
+   DEFAULT record, not only on a configured-inverted one.
+2. `fields` named STAT/SEVR and `surface` named value_string. `fields` is matched
+   against the case's own field and `surface` against the compared surface, so
+   this row could not have matched any case even enabled.
+
+What the run measured: C's behaviour is path-dependent on the one condition, so
+NO single port test agrees with C on both paths. With `>=` the port alarmed on
+the process path where C erases (14 DEFECTs on SCAN/PROC/UDF, every case a bare
+histogram); narrowed to `>` the port is quiet on the default record's SGNL path
+where C's sticky direct write shows SOFT/INVALID (10 DEFECTs on SGNL). The `>`
+form was taken: the port's rule is then uniform — an INVERSION an operator
+created alarms on both paths, an EMPTY range (which is what an unconfigured
+record has) alarms on neither — and the residue is exactly C's dead-code/sticky
+split, which is what this row exists to allowlist. Those 10 SGNL cases are its
+live scope.
 """

--- a/doc/upstream-c-bugs.md
+++ b/doc/upstream-c-bugs.md
@@ -1530,7 +1530,7 @@ decisive code path is quoted.
 | CBUG-F9 | pvxs | process-only blocking PUT selects a `requestType` dbNotify never matches — silent no-op success | Medium | NOT-REPRODUCED |
 | CBUG-F10 | pvxs | UnionArray encode omits the selector its own decoder requires — a decoded UnionA cannot be re-serialized | Medium | NOT-REPRODUCED |
 | CBUG-F11 | asyn | `caput REC.TSIZ -1` suspends the put thread forever inside `callocMustSucceed`, holding the global trace mutex | High | NOT-REPRODUCED |
-| CBUG-F12 | base histogram | the `LLIM >= ULIM` alarm writes `stat`/`sevr` directly — erased on the process path (NO_ALARM) but STICKS on the `.SGNL` special path (SOFT); port now refuses — raises SOFT/INVALID consistently on both paths via `nsta`/`nsev` (`9a51ba4c`) | Low | NOT-REPRODUCED |
+| CBUG-F12 | base histogram | the `LLIM >= ULIM` alarm writes `stat`/`sevr` directly — erased on the process path (NO_ALARM) but STICKS on the `.SGNL` special path (SOFT); port now refuses — raises SOFT/INVALID consistently on both paths via `nsta`/`nsev` (`9a51ba4c`), on `LLIM > ULIM` only, so an unconfigured `0 == 0` record stays quiet | Low | NOT-REPRODUCED |
 
 ### CBUG-F1: aCalc's `INC` bounds check admits writes two elements past the runtime stack — SIGSEGV at legal compile depth
 Bucket: NOT-REPRODUCED · Severity: High
@@ -1845,6 +1845,24 @@ on both the C IOC and the port.
 Proof (compiled softIoc, this host, and differential oracle):
 `LLIM=10 ULIM=5`, process → C and port both `STAT=NO_ALARM`; `caput .SGNL`
 with inverted limits → C and port both `STAT=SOFT SEVR=INVALID`.
+
+**Reconciliation 2026-08-03 — the refusal's condition narrowed to `>`.** The
+`9a51ba4c` refusal took C's condition verbatim (`llim >= ulim`), and the first
+full `--phase all` run since it landed showed what that costs: LLIM and ULIM
+carry no `initial(...)`, so a bare `record(histogram, "…") {}` already satisfies
+`>=` at `0 == 0`, and the port alarmed on the process path of every UNCONFIGURED
+histogram against C's NO_ALARM — 14 defects on `SCAN`/`PROC`/`UDF`. The alarm
+test is now `llim > ulim`: an INVERSION is a pair only an operator can create,
+an EMPTY range is the state every histogram loads in. C's path-dependence means
+no single condition agrees with C on both paths, so the residue moved rather
+than vanished — with `>` the port is quiet on a default record's `.SGNL` path
+where C's sticky write shows SOFT/INVALID (10 cases). That residue is C's bug
+showing through, is what the CBUG-F12 allowlist row now covers
+(`fields = ["SGNL"]`, `surface = ["stat","sevr"]`, `enabled = true`; the row had
+been unmatchable — its `fields` named the compared surfaces, not the case
+field), and histogram reconciles at 417 ran / 406 agreed / 11 expected /
+0 defect. A genuinely inverted histogram still alarms on BOTH paths, which is
+the consistency the refusal was for.
 
 ## Batch G — filed 2026-07-17 (PVA differential-oracle campaign, pvxs QSRV2 metadata)
 


### PR DESCRIPTION
LLIM and ULIM carry no `initial(...)` in histogramRecord.dbd, so every freshly loaded histogram sits at LLIM == ULIM == 0; the port's `>=` alarm test therefore raised SOFT/INVALID on records nobody had configured, which the differential oracle measured as 14 defects across SCAN/PROC/UDF. Narrowing to `>` leaves the SGNL special path as the sole surviving CBUG-F12 deviation — and its allowlist row could never have fired even when enabled, because it named compared surfaces (STAT/SEVR) in `fields`, where the matcher expects the case's field; that is corrected here too.

Re-measured after the change: `--phase all --record-types histogram` is 417 ran / 406 agreed / 11 expected deviation / 0 DEFECT / 0 ERROR.