### PR TITLE
release: v0.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## v0.25.4 — 2026-08-04
+
+Patch release. The IPv6 SEARCH socket now builds on the embedded targets too,
+completing the half v0.25.3 left out. On the CA server, an out-of-buffers burst
+no longer disconnects every client it is serving, and a subscriber that stops
+reading no longer grows the server without bound. A default `histogram` record
+no longer alarms on its first process. Workspace version 0.25.3 -> 0.25.4.
 
 ### The IPv6 SEARCH socket binds on every backend too
 
@@ -30,6 +36,49 @@ plain `setsockopt` calls whose constants both target `libc`s carry.
   both address families. Compiling is not running: whether an RTEMS BSP or the
   VxWorks stack has IPv6 enabled is an on-target question, and a failed bind
   degrades the client to IPv4-only by design.
+
+### The CA server rides out an out-of-buffers burst instead of dropping clients
+
+C's `cas_send_bs_msg` (`rsrv/caserverio.c:65-101`) continues its send loop on
+both `SOCK_EINTR` and `SOCK_ENOBUFS`, sleeping 15 s for the latter. Both port
+drivers wrote frames with `write_all`, whose contract is the opposite — any
+`Err` ends the call — so an ENOBUFS burst that C rides out disconnected every
+CA client the IOC was serving.
+
+- The policy lives *under* every writer rather than at each call site: the
+  hosted driver has three write sites and the blocking driver two, and a retry
+  bolted onto the drain would have left the unsolicited `CA_PROTO_VERSION`
+  greeting and the out-of-band monitor frame exactly as they were. Resumption
+  is exact for the same reason C's is — the adapter sits at the `write` /
+  `poll_write` level, where a retry re-offers only the bytes the kernel did not
+  take.
+
+### A CA subscriber that stops reading no longer grows the server without bound
+
+The hosted driver's monitor producer pushed into an unbounded `mpsc` decoupled
+from the socket, so a subscriber that stopped reading grew the server at a
+measured 9.34 kB/s — 32.8 MB/hour — per 100 Hz subscription, with no knee. The
+blocking driver that the embedded targets run was never exposed: its event
+thread writes the socket directly under the send lock, so back-pressure reaches
+the bounded `EvQue` ring and the ring coalesces, which is what C gets from
+`event_task` blocking on `SEND_LOCK`.
+
+- Bounding the channel instead would deadlock, because the connection loop is
+  both a producer (reply handlers) and the sole drain. A credit rides inside
+  the queued frame and is released by the drain owner's `Drop` once the bytes
+  are in the socket writer, so the producer stops dequeuing and the backlog
+  coalesces in the ring. In-loop reply handlers are exempt and unaffected.
+  Re-measured at 0.000 kB/s with the drain still provably parked; the harness
+  and all five run logs are in `doc/ca-stuck-reader-measurement.md`.
+
+### A default `histogram` record no longer alarms on its first process
+
+`LLIM` and `ULIM` carry no `initial(...)` in `histogramRecord.dbd`, so a bare
+`record(histogram)` loads at `0 == 0` and satisfies C's `llim >= ulim`. Taking
+that condition verbatim into the CBUG-F12 refusal made `check_alarms` raise
+SOFT/INVALID on the first process of every unconfigured histogram where C
+raises NO_ALARM — 14 oracle defects on SCAN/PROC/UDF. `add_count` keeps `>=`:
+binning nothing into an empty range is arithmetic, not a judgement.
 
 ## v0.25.3 — 2026-07-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "bitflags",
  "chrono",
@@ -994,7 +994,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "cc",
  "libc",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "chrono",
  "clap",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2241,7 +2241,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3209,7 +3209,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3828,7 +3828,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"


### PR DESCRIPTION
Patch level: the loose `-i --grep=BREAKING` scan over v0.25.3..main is empty, and the only removed `pub` line is `epics-libcom-rs/src/net/mod.rs`'s re-export, which gained `SearchUdpSocketV6` rather than losing anything — `epics-pva-rs`'s deleted `V6Socket` was private. The `[workspace.dependencies]` pins stay at 0.25.0, caret requirements this patch satisfies.

The Unreleased section carried only the IPv6 entry, so #70 and #71 are written up here for the first time.