### PR TITLE
perf(qsrv): make the PUT path cheaper per op than pvxs

### DIFF
--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -1273,13 +1273,30 @@ fn asg_change_broadcast() -> &'static tokio::sync::broadcast::Sender<()> {
     })
 }
 
+/// Monotonic count of ASG-field changes, for pull-style consumers
+/// (see [`asg_change_generation`]) that cannot hold a broadcast
+/// receiver — e.g. a sync access-check cache that must know whether
+/// a cached (channel → ASG) resolution is still current.
+static ASG_CHANGE_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Fire from the field-I/O layer when a record's `ASG` field is
 /// successfully written. Idempotent: if no subscriber exists yet
 /// the send is a no-op (lagged subscribers also tolerated — the
 /// wire re-eval is coarse and one missed beat is recovered by the
 /// downstream `oldaccess != access` filter).
 pub fn notify_asg_field_changed() {
+    ASG_CHANGE_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Release);
     let _ = asg_change_broadcast().send(());
+}
+
+/// Current ASG-field-change generation. A consumer that caches
+/// anything derived from a record's `ASG` field snapshots this before
+/// resolving and treats its entry as stale once the value moves —
+/// the pull-side counterpart of [`subscribe_asg_changes`]. C's
+/// equivalent invalidation is `asChangeGroup` re-running
+/// `asComputePvt` for every `ASGCLIENT` on `dbPut record.ASG`.
+pub fn asg_change_generation() -> u64 {
+    ASG_CHANGE_GENERATION.load(std::sync::atomic::Ordering::Acquire)
 }
 
 /// Subscribe to ASG-field-change notifications. Called once at

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -376,16 +376,13 @@ impl AccessGate {
                                 }
                             }
                         };
-                        let calc_ok = |expr: &str| -> bool {
+                        let calc_ok = |compiled: &crate::calc::CompiledExpr| -> bool {
                             let Some(ref inputs) = inp_values else {
                                 return false;
                             };
-                            match crate::calc::compile(expr) {
-                                Ok(c) => crate::calc::eval(&c, &mut inputs.clone())
-                                    .map(|r| r != 0.0)
-                                    .unwrap_or(false),
-                                Err(_) => false,
-                            }
+                            crate::calc::eval(compiled, &mut inputs.clone())
+                                .map(|r| r != 0.0)
+                                .unwrap_or(false)
                         };
                         cfg.compute_for_name(
                             &asg, host, user, roles, asl, method, authority, &calc_ok,
@@ -502,6 +499,13 @@ pub struct AccessRule {
     /// rule. When `Some`, the rule only grants access while the
     /// expression evaluates to 1 against the ASG's `INP*` link values.
     pub calc: Option<String>,
+    /// The expression compiled at ACF parse — C compiles a RULE's CALC
+    /// once at load (`asAsgRuleCalc` runs `postfix()`), then every
+    /// `asComputePvt` evaluates the stored RPN. `parse_acf` upholds
+    /// `calc.is_some() ⟹ calc_compiled.is_some()`; a hand-built rule
+    /// that carries `calc` text without the compiled form fails closed
+    /// in `compute_rules`.
+    pub calc_compiled: Option<crate::calc::CompiledExpr>,
     /// True when the rule must be treated as inert by `asComputePvt`.
     /// C `asAsgRuleDisable` (`asLib.y:300-306`) sets `pasgrule->ignore`
     /// for a RULE that contains an unsupported keyword. This port also
@@ -703,7 +707,7 @@ impl AccessSecurityConfig {
         record_asl: u8,
         method: &str,
         authority: &str,
-        calc_ok: &dyn Fn(&str) -> bool,
+        calc_ok: &dyn Fn(&crate::calc::CompiledExpr) -> bool,
     ) -> (AccessLevel, bool) {
         let asg = match self.asg.get(asg_name) {
             Some(a) => a,
@@ -784,7 +788,7 @@ impl AccessSecurityConfig {
         record_asl: u8,
         method: &str,
         authority: &str,
-        calc_ok: &dyn Fn(&str) -> bool,
+        calc_ok: &dyn Fn(&crate::calc::CompiledExpr) -> bool,
     ) -> (AccessLevel, bool) {
         let mut access = AccessLevel::NoAccess;
         let mut trap = false;
@@ -869,10 +873,14 @@ impl AccessSecurityConfig {
             // `asLibRoutines.c:957-1042` evaluates `calcPerform()` and
             // grants on a true result with good inputs. `calc_ok` returns
             // false when the expression is false, an input is bad, or no
-            // INP* resolver is installed (fail closed).
-            if let Some(ref expr) = rule.calc {
-                if !calc_ok(expr) {
-                    continue;
+            // INP* resolver is installed (fail closed). The program was
+            // compiled once at ACF parse; a rule holding `calc` text with
+            // no compiled form (hand-built, bypassing `parse_acf`) fails
+            // closed here.
+            if rule.calc.is_some() {
+                match rule.calc_compiled {
+                    Some(ref compiled) if calc_ok(compiled) => {}
+                    _ => continue,
                 }
             }
             // C `asLibRoutines.c:1041-1042`: a matching rule sets
@@ -1979,21 +1987,21 @@ fn parse_rule(chars: &mut std::iter::Peekable<std::str::Chars>) -> CaResult<Acce
     // unconditional grant. The expression is still validated (compiled)
     // here so a syntactically broken CALC is rejected exactly as C's
     // `postfix()` rejects it in `asAsgRuleCalc`.
-    if let Some(ref expr) = calc {
-        // validate the CALC expression at parse (C `postfix()`
-        // rejects a broken one in `asAsgRuleCalc`). The rule is NOT
-        // forced inert anymore: it is conditionally active and gated at
-        // access-check time by `compute_rules`'s `calc_ok`, which
-        // resolves the ASG's INP* links and evaluates the expression.
-        // When no INP* resolver is installed the evaluator returns false
-        // (fail closed), preserving the previous deny behaviour without
-        // hard-disabling the rule.
-        if let Err(e) = crate::calc::compile(expr) {
-            return Err(CaError::Protocol(format!(
-                "ACF: bad CALC expression '{expr}': {e}"
-            )));
-        }
-    }
+    // compile the CALC expression at parse (C `postfix()` rejects a
+    // broken one in `asAsgRuleCalc` and stores the RPN for every later
+    // `asComputePvt`). The rule is conditionally active and gated at
+    // access-check time by `compute_rules`'s `calc_ok`, which resolves
+    // the ASG's INP* links and evaluates the stored program. When no
+    // INP* resolver is installed the evaluator returns false (fail
+    // closed), preserving the previous deny behaviour without
+    // hard-disabling the rule.
+    let calc_compiled =
+        match calc {
+            Some(ref expr) => Some(crate::calc::compile(expr).map_err(|e| {
+                CaError::Protocol(format!("ACF: bad CALC expression '{expr}': {e}"))
+            })?),
+            None => None,
+        };
 
     Ok(AccessRule {
         level,
@@ -2004,6 +2012,7 @@ fn parse_rule(chars: &mut std::iter::Peekable<std::str::Chars>) -> CaResult<Acce
         authority,
         trap,
         calc,
+        calc_compiled,
         ignore,
     })
 }

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -128,7 +128,49 @@ pub struct AccessGate {
     /// when absent, CALC rules fail closed (deny). Installed by the
     /// owning server via [`Self::with_inp_resolver`].
     inp_resolver: Option<InpResolver>,
+    /// C `asAddClient` computes a client's access once per channel and
+    /// every operation is a bit test; the Rust op layer called
+    /// [`Self::check_with_roles`] — resolver + full rule walk — on every
+    /// EXEC. The walk result is deterministic in (policy snapshot,
+    /// pv name, credential identity) whenever no [`InpResolver`] is
+    /// installed (CALC rules then fail closed, reading no live values),
+    /// so those checks are cached here, shared across gate clones.
+    /// An entry is valid only while all three of its stamps hold: the
+    /// `acl_version` generation, the ASG-field-change generation
+    /// ([`asg_change_generation`] — the resolver reads `record.ASG`),
+    /// and the identity of the ACF config `Arc` it was computed against
+    /// (so a cell swap that forgot to bump the version still misses).
+    /// `Open` gates and unattached cells bypass the cache: their checks
+    /// are already walk-free, and an unattached-cell result would
+    /// otherwise survive the ACF being attached.
+    check_cache: std::sync::Arc<parking_lot::RwLock<HashMap<CheckKey, CachedCheck>>>,
 }
+
+/// Full identity a cached [`AccessGate`] check depends on. `roles` is
+/// part of the key — a re-auth that only changes role claims must miss.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct CheckKey {
+    pv_name: String,
+    host: String,
+    user: String,
+    method: String,
+    authority: String,
+    roles: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+struct CachedCheck {
+    acl_version: u64,
+    asg_generation: u64,
+    /// `Arc::as_ptr` of the ACF config the entry was computed against.
+    cfg_ident: usize,
+    level: AccessLevel,
+    rule_was_trap: bool,
+}
+
+/// Bound on distinct (pv × credential) entries; overflow flushes the
+/// map (a re-walk per entry is exactly the pre-cache behaviour).
+const CHECK_CACHE_CAP: usize = 4096;
 
 #[derive(Clone)]
 enum AclVersionSource {
@@ -230,6 +272,7 @@ impl AccessGate {
             inner: AccessGateInner::Required { acf, resolver },
             acl_version: AclVersionSource::Atomic(acl_version),
             inp_resolver: None,
+            check_cache: std::sync::Arc::new(parking_lot::RwLock::new(HashMap::new())),
         }
     }
 
@@ -252,6 +295,7 @@ impl AccessGate {
                 std::sync::atomic::AtomicU64::new(0),
             )),
             inp_resolver: None,
+            check_cache: std::sync::Arc::new(parking_lot::RwLock::new(HashMap::new())),
         }
     }
 
@@ -276,6 +320,7 @@ impl AccessGate {
             inner: AccessGateInner::Open,
             acl_version: AclVersionSource::Aggregator(f),
             inp_resolver: None,
+            check_cache: std::sync::Arc::new(parking_lot::RwLock::new(HashMap::new())),
         }
     }
 
@@ -341,6 +386,35 @@ impl AccessGate {
                 match acf.load_full() {
                     None => (AccessLevel::ReadWrite, false),
                     Some(cfg) => {
+                        // See the [`Self::check_cache`] field doc: cache
+                        // only walk results that read no live values, and
+                        // snapshot every stamp BEFORE the compute so a
+                        // change racing it invalidates the entry instead
+                        // of being lost.
+                        let acl_version = self.acl_version();
+                        let asg_generation = asg_change_generation();
+                        let cfg_ident = std::sync::Arc::as_ptr(&cfg) as usize;
+                        let key = self.inp_resolver.is_none().then(|| CheckKey {
+                            pv_name: pv_name.clone(),
+                            host: host.to_string(),
+                            user: user.to_string(),
+                            method: method.to_string(),
+                            authority: authority.to_string(),
+                            roles: roles.to_vec(),
+                        });
+                        if let Some(ref key) = key
+                            && let Some(hit) = self.check_cache.read().get(key)
+                            && hit.acl_version == acl_version
+                            && hit.asg_generation == asg_generation
+                            && hit.cfg_ident == cfg_ident
+                        {
+                            return AccessChecked {
+                                pv_name,
+                                level: hit.level,
+                                rule_was_trap: hit.rule_was_trap,
+                                _seal: AccessSeal,
+                            };
+                        }
                         let (asg, asl) = resolver(pv_name.clone()).await;
                         // pre-resolve the ASG's INP* links up
                         // front — the resolver is async (it reads the
@@ -384,9 +458,26 @@ impl AccessGate {
                                 .map(|r| r != 0.0)
                                 .unwrap_or(false)
                         };
-                        cfg.compute_for_name(
+                        let (level, rule_was_trap) = cfg.compute_for_name(
                             &asg, host, user, roles, asl, method, authority, &calc_ok,
-                        )
+                        );
+                        if let Some(key) = key {
+                            let mut cache = self.check_cache.write();
+                            if cache.len() >= CHECK_CACHE_CAP {
+                                cache.clear();
+                            }
+                            cache.insert(
+                                key,
+                                CachedCheck {
+                                    acl_version,
+                                    asg_generation,
+                                    cfg_ident,
+                                    level,
+                                    rule_was_trap,
+                                },
+                            );
+                        }
+                        (level, rule_was_trap)
                     }
                 }
             }
@@ -448,6 +539,56 @@ ASG(DEFAULT) {
         let denied = gate.check("x", "h", "intruder", "anonymous", "").await;
         assert_eq!(denied.level(), AccessLevel::NoAccess);
         assert!(!denied.allows_read());
+    }
+
+    /// The gate's check cache must not outlive its policy: a cell swap
+    /// (ACF reload) has to miss even when the caller forgets the
+    /// `bump_acl_version` convention — the config-`Arc` identity stamp
+    /// is what closes that path. The pre-swap repeat exercises the hit
+    /// path against the same policy.
+    #[epics_macros_rs::epics_test]
+    async fn check_cache_misses_on_acf_swap_without_version_bump() {
+        let cfg_deny = parse_acf(
+            r#"
+ASG(DEFAULT) {
+}
+"#,
+        )
+        .unwrap();
+        let cfg_allow = parse_acf(
+            r#"
+ASG(DEFAULT) {
+    RULE(1, WRITE)
+}
+"#,
+        )
+        .unwrap();
+        let cell = crate::server::access_security::new_acf_cell(Some(cfg_deny));
+        let resolver: AsgAslResolver =
+            Arc::new(|_pv| Box::pin(async { ("DEFAULT".to_string(), 0u8) }));
+        let gate = AccessGate::required(cell.clone(), resolver);
+
+        assert!(
+            !gate
+                .check("x", "h", "u", "anonymous", "")
+                .await
+                .allows_write()
+        );
+        // Cache-hit path, same policy.
+        assert!(
+            !gate
+                .check("x", "h", "u", "anonymous", "")
+                .await
+                .allows_write()
+        );
+
+        // Swap the policy WITHOUT bumping acl_version.
+        cell.store(Some(Arc::new(cfg_allow)));
+        assert!(
+            gate.check("x", "h", "u", "anonymous", "")
+                .await
+                .allows_write()
+        );
     }
 }
 

--- a/crates/epics-bridge-rs/src/bin/ca_gateway_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/ca_gateway_rs.rs
@@ -340,7 +340,13 @@ fn main() -> ExitCode {
         }
     }
 
+    // One worker, reactor-style — see qsrv_rs.rs: the default per-CPU
+    // pool migrates the mostly-serial serving work across idle workers,
+    // costing ~35 µs of extra CPU per op on a 96-core host
+    // (doc/qsrv-put-perf.md). Multi-thread flavor is kept so
+    // `block_on_sync` works from runtime tasks.
     let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
         .enable_all()
         .build()
     {

--- a/crates/epics-bridge-rs/src/bin/dual_gateway_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/dual_gateway_rs.rs
@@ -727,7 +727,13 @@ fn main() -> ExitCode {
         }
     }
 
+    // One worker, reactor-style — see qsrv_rs.rs: the default per-CPU
+    // pool migrates the mostly-serial serving work across idle workers,
+    // costing ~35 µs of extra CPU per op on a 96-core host
+    // (doc/qsrv-put-perf.md). Multi-thread flavor is kept so
+    // `block_on_sync` works from runtime tasks.
     let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
         .enable_all()
         .build()
     {

--- a/crates/epics-bridge-rs/src/bin/dual_ioc_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/dual_ioc_rs.rs
@@ -112,7 +112,11 @@ fn parse_pv(def: &str) -> CaResult<(String, EpicsValue)> {
     Ok((name, value))
 }
 
-#[tokio::main]
+// One worker, reactor-style — see qsrv_rs.rs: the default per-CPU pool
+// migrates the mostly-serial serving work across idle workers, costing
+// ~35 µs of extra CPU per put on a 96-core host (doc/qsrv-put-perf.md).
+// Multi-thread flavor is kept so `block_on_sync` works from runtime tasks.
+#[tokio::main(worker_threads = 1)]
 async fn main() -> ExitCode {
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/crates/epics-bridge-rs/src/bin/pva_gateway_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/pva_gateway_rs.rs
@@ -606,7 +606,12 @@ impl ResolvedConfig {
     }
 }
 
-#[tokio::main]
+// One worker, reactor-style — the shape pva2pva forwards from (a single
+// event loop). The default per-CPU pool migrates the mostly-serial
+// serving work across idle workers, costing ~35 µs of extra CPU per op
+// on a 96-core host (doc/qsrv-put-perf.md). Multi-thread flavor is kept
+// so `block_on_sync` works from runtime tasks.
+#[tokio::main(worker_threads = 1)]
 async fn main() -> ExitCode {
     let args = Args::parse();
     init_tracing(args.verbose);

--- a/crates/epics-bridge-rs/src/bin/qsrv_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/qsrv_rs.rs
@@ -55,7 +55,12 @@ fn parse_macro(raw: &str) -> Result<(String, String), String> {
     Ok((k.to_string(), v.to_string()))
 }
 
-#[tokio::main]
+// One worker, reactor-style — the shape pvxs serves from (a single event
+// loop). With the default per-CPU pool, the mostly-serial serving work
+// migrates across idle workers, costing ~35 µs of extra CPU per put on a
+// 96-core host (doc/qsrv-put-perf.md). Multi-thread flavor is kept:
+// current_thread would refuse `block_on_sync` from runtime tasks.
+#[tokio::main(worker_threads = 1)]
 async fn main() -> ExitCode {
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/crates/epics-bridge-rs/src/pva_gateway/control.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/control.rs
@@ -600,11 +600,11 @@ impl ChannelSource for ControlSource {
             Some(gate) => gate
                 .check_with_roles(
                     name.clone(),
-                    &ctx.host,
-                    &ctx.account,
-                    &ctx.roles,
-                    &ctx.method,
-                    &ctx.authority,
+                    &ctx.creds.host,
+                    &ctx.creds.account,
+                    &ctx.creds.roles,
+                    &ctx.creds.method,
+                    &ctx.creds.authority,
                 )
                 .await
                 .allows_write(),
@@ -612,17 +612,17 @@ impl ChannelSource for ControlSource {
         if !granted {
             tracing::warn!(
                 gateway_control = %name,
-                account = %ctx.account,
-                method = %ctx.method,
-                host = %ctx.host,
+                account = %ctx.creds.account,
+                method = %ctx.creds.method,
+                host = %ctx.creds.host,
                 "pva-gateway: control RPC denied — no WRITE grant under the control ACF"
             );
             return Err(OpError::denied(format!(
                 "control RPC '{name}' denied: {account}/{method} from {host} \
                  holds no WRITE grant under the gateway control ACF",
-                account = ctx.account,
-                method = ctx.method,
-                host = ctx.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
+                host = ctx.creds.host,
             )));
         }
         // run_control_rpc validates arguments and executes the admin
@@ -713,11 +713,13 @@ mod tests {
     fn ctx(account: &str, method: &str) -> ChannelContext {
         ChannelContext {
             peer: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5075),
-            account: account.into(),
-            method: method.into(),
-            host: "localhost".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: account.into(),
+                method: method.into(),
+                host: "localhost".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }

--- a/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
@@ -1455,8 +1455,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.put_value_checked(checked, value, ctx).await;
         self.sink
             .record(make_audit_event(&pv, &user, &host, &result));
@@ -1479,8 +1479,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .put_delta_checked(checked, desc, changed, delta, ctx)
@@ -1505,8 +1505,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<Option<SourceRead>, OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .put_get_checked(checked, desc, changed, delta, ctx)
@@ -1538,8 +1538,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.process_checked(checked, ctx).await;
         let mut ev = make_audit_event(&pv, &user, &host, &result);
         ev.event = AuditEventKind::Process;
@@ -1552,8 +1552,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Option<PvField> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.get_value_checked(checked, ctx).await;
         if self.audit_get {
             // GET returns Option, which cannot distinguish "not found"
@@ -1583,8 +1583,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Option<SourceRead> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.read_checked(checked, ctx).await;
         if self.audit_get {
             let outcome: Result<(), OpError> = if result.is_some() {
@@ -1604,8 +1604,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Option<MonitorStream<PvField>> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.subscribe_checked(checked, ctx).await;
         if self.audit_subscribe {
             let outcome: Result<(), OpError> = if result.is_some() {
@@ -1664,8 +1664,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: epics_pva_rs::server_native::source::ChannelContext,
     ) -> Option<MonitorStream<RawMonitorEvent>> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.subscribe_raw_checked(checked, ctx).await;
         if self.audit_subscribe {
             let outcome: Result<(), OpError> = if result.is_some() {
@@ -1691,8 +1691,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         opts: epics_pva_rs::server_native::MonitorOptions,
     ) -> Option<MonitorStream<epics_pva_rs::server_native::MonitorUpdate>> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .subscribe_checked_opts_marked(checked, ctx, opts)
@@ -1716,8 +1716,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         opts: epics_pva_rs::server_native::MonitorOptions,
     ) -> Option<MonitorStream<RawMonitorEvent>> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .subscribe_raw_checked_opts(checked, ctx, opts)
@@ -1750,8 +1750,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         >,
     > {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.subscribe_seeded(checked, ctx, opts).await;
         if self.audit_subscribe {
             let outcome: Result<(), OpError> = if result.is_some() {
@@ -1772,8 +1772,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         opts: epics_pva_rs::server_native::MonitorOptions,
     ) -> Option<epics_pva_rs::server_native::source::SubscriptionSeed<RawMonitorEvent>> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.subscribe_raw_seeded(checked, ctx, opts).await;
         if self.audit_subscribe {
             let outcome: Result<(), OpError> = if result.is_some() {
@@ -1816,8 +1816,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: epics_pva_rs::server_native::source::ChannelContext,
     ) -> Result<RpcReply, OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .rpc_checked(checked, request_desc, request_value, ctx)
@@ -1859,8 +1859,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<PvField, OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .channel_array_get(checked, offset, count, stride, ctx)
@@ -1879,8 +1879,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<u32, OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.channel_array_get_length(checked, ctx).await;
         if self.audit_get {
             let outcome: Result<(), OpError> = result.as_ref().map(|_| ()).map_err(|e| e.clone());
@@ -1899,8 +1899,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .channel_array_put(checked, offset, stride, value, ctx)
@@ -1917,8 +1917,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self
             .inner
             .channel_array_set_length(checked, length, ctx)
@@ -2014,8 +2014,8 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         opts: epics_pva_rs::server_native::MonitorOptions,
     ) -> Option<MonitorStream<PvField>> {
         let pv = checked.pv_name().to_string();
-        let user = ctx.account.clone();
-        let host = ctx.host.clone();
+        let user = ctx.creds.account.clone();
+        let host = ctx.creds.host.clone();
         let result = self.inner.subscribe_checked_opts(checked, ctx, opts).await;
         if self.audit_subscribe {
             let outcome: Result<(), OpError> = if result.is_some() {
@@ -2453,11 +2453,13 @@ mod tests {
     fn test_ctx() -> ChannelContext {
         ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "alice".into(),
-            method: "anonymous".into(),
-            host: "host1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "alice".into(),
+                method: "anonymous".into(),
+                host: "host1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }
@@ -2648,7 +2650,7 @@ mod tests {
             true
         }
         async fn has_pv_checked(&self, _name: &str, ctx: ChannelContext) -> bool {
-            *self.checked_has_pv_account.lock().unwrap() = Some(ctx.account);
+            *self.checked_has_pv_account.lock().unwrap() = Some(ctx.creds.account.clone());
             true
         }
         async fn get_introspection(&self, _name: &str) -> Option<FieldDesc> {
@@ -2660,7 +2662,7 @@ mod tests {
             _name: &str,
             ctx: ChannelContext,
         ) -> Option<FieldDesc> {
-            *self.checked_intro_account.lock().unwrap() = Some(ctx.account);
+            *self.checked_intro_account.lock().unwrap() = Some(ctx.creds.account.clone());
             Some(FieldDesc::Scalar(ScalarType::Double))
         }
         async fn get_value(&self, _name: &str) -> Option<PvField> {
@@ -2713,12 +2715,12 @@ mod tests {
         assert_eq!(
             checked_has_pv_account.lock().unwrap().as_deref(),
             Some("alice"),
-            "has_pv_checked must reach the inner carrying ctx.account through every wrapper"
+            "has_pv_checked must reach the inner carrying ctx.creds.account through every wrapper"
         );
         assert_eq!(
             checked_intro_account.lock().unwrap().as_deref(),
             Some("alice"),
-            "get_introspection_checked must reach the inner carrying ctx.account"
+            "get_introspection_checked must reach the inner carrying ctx.creds.account"
         );
         assert!(
             !plain_has_pv.load(Ordering::SeqCst),

--- a/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
@@ -2488,7 +2488,7 @@ mod tests {
         let res = acl
             .put_delta_checked(
                 checked_for("X").await,
-                FieldDesc::Scalar(ScalarType::Double),
+                std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
                 PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
@@ -2524,7 +2524,7 @@ mod tests {
         let err = acl
             .put_delta_checked(
                 checked_for("SECRET:KEY").await,
-                FieldDesc::Scalar(ScalarType::Double),
+                std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
                 PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
@@ -2566,7 +2566,7 @@ mod tests {
         let res = audited
             .put_delta_checked(
                 checked_for("X").await,
-                FieldDesc::Scalar(ScalarType::Double),
+                std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
                 PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
@@ -2608,7 +2608,7 @@ mod tests {
         let err = ro
             .put_delta_checked(
                 checked_for("X").await,
-                FieldDesc::Scalar(ScalarType::Double),
+                std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
                 PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),

--- a/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
@@ -120,7 +120,7 @@ impl<S: ChannelSource> ChannelSource for ReadOnly<S> {
     async fn put_delta_checked(
         &self,
         _checked: epics_pva_rs::server_native::source::AccessChecked,
-        _desc: FieldDesc,
+        _desc: std::sync::Arc<FieldDesc>,
         _changed: epics_pva_rs::proto::BitSet,
         _delta: PvField,
         _ctx: ChannelContext,
@@ -134,7 +134,7 @@ impl<S: ChannelSource> ChannelSource for ReadOnly<S> {
     async fn put_get_checked(
         &self,
         _checked: epics_pva_rs::server_native::source::AccessChecked,
-        _desc: FieldDesc,
+        _desc: std::sync::Arc<FieldDesc>,
         _changed: epics_pva_rs::proto::BitSet,
         _delta: PvField,
         _ctx: ChannelContext,
@@ -740,7 +740,7 @@ impl<S: ChannelSource> ChannelSource for Acl<S> {
     async fn put_delta_checked(
         &self,
         checked: epics_pva_rs::server_native::source::AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -764,7 +764,7 @@ impl<S: ChannelSource> ChannelSource for Acl<S> {
     async fn put_get_checked(
         &self,
         checked: epics_pva_rs::server_native::source::AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -1473,7 +1473,7 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
     async fn put_delta_checked(
         &self,
         checked: epics_pva_rs::server_native::source::AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -1499,7 +1499,7 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
     async fn put_get_checked(
         &self,
         checked: epics_pva_rs::server_native::source::AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -2426,7 +2426,7 @@ mod tests {
         async fn put_delta_checked(
             &self,
             _checked: AccessChecked,
-            _desc: FieldDesc,
+            _desc: std::sync::Arc<FieldDesc>,
             _changed: epics_pva_rs::proto::BitSet,
             _delta: PvField,
             _ctx: ChannelContext,

--- a/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/middleware.rs
@@ -122,7 +122,7 @@ impl<S: ChannelSource> ChannelSource for ReadOnly<S> {
         _checked: epics_pva_rs::server_native::source::AccessChecked,
         _desc: std::sync::Arc<FieldDesc>,
         _changed: epics_pva_rs::proto::BitSet,
-        _delta: PvField,
+        _delta: &PvField,
         _ctx: ChannelContext,
     ) -> Result<(), OpError> {
         Err(OpError::denied("read-only mode: PUT rejected"))
@@ -136,7 +136,7 @@ impl<S: ChannelSource> ChannelSource for ReadOnly<S> {
         _checked: epics_pva_rs::server_native::source::AccessChecked,
         _desc: std::sync::Arc<FieldDesc>,
         _changed: epics_pva_rs::proto::BitSet,
-        _delta: PvField,
+        _delta: &PvField,
         _ctx: ChannelContext,
     ) -> Result<Option<SourceRead>, OpError> {
         Err(OpError::denied("read-only mode: PUT rejected"))
@@ -742,7 +742,7 @@ impl<S: ChannelSource> ChannelSource for Acl<S> {
         checked: epics_pva_rs::server_native::source::AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         if !self.config.allowed(checked.pv_name()) {
@@ -766,7 +766,7 @@ impl<S: ChannelSource> ChannelSource for Acl<S> {
         checked: epics_pva_rs::server_native::source::AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> Result<Option<SourceRead>, OpError> {
         if !self.config.allowed(checked.pv_name()) {
@@ -1475,7 +1475,7 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         checked: epics_pva_rs::server_native::source::AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> Result<(), OpError> {
         let pv = checked.pv_name().to_string();
@@ -1501,7 +1501,7 @@ impl<S: ChannelSource, A: AuditSink> ChannelSource for Audited<S, A> {
         checked: epics_pva_rs::server_native::source::AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> Result<Option<SourceRead>, OpError> {
         let pv = checked.pv_name().to_string();
@@ -2428,7 +2428,7 @@ mod tests {
             _checked: AccessChecked,
             _desc: std::sync::Arc<FieldDesc>,
             _changed: epics_pva_rs::proto::BitSet,
-            _delta: PvField,
+            _delta: &PvField,
             _ctx: ChannelContext,
         ) -> Result<(), OpError> {
             self.delta_reached.store(true, Ordering::SeqCst);
@@ -2490,7 +2490,7 @@ mod tests {
                 checked_for("X").await,
                 std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
-                PvField::Scalar(ScalarValue::Double(1.0)),
+                &PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
             )
             .await;
@@ -2526,7 +2526,7 @@ mod tests {
                 checked_for("SECRET:KEY").await,
                 std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
-                PvField::Scalar(ScalarValue::Double(1.0)),
+                &PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
             )
             .await
@@ -2568,7 +2568,7 @@ mod tests {
                 checked_for("X").await,
                 std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
-                PvField::Scalar(ScalarValue::Double(1.0)),
+                &PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
             )
             .await;
@@ -2610,7 +2610,7 @@ mod tests {
                 checked_for("X").await,
                 std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Double)),
                 changed,
-                PvField::Scalar(ScalarValue::Double(1.0)),
+                &PvField::Scalar(ScalarValue::Double(1.0)),
                 test_ctx(),
             )
             .await

--- a/crates/epics-bridge-rs/src/pva_gateway/source.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/source.rs
@@ -1304,7 +1304,7 @@ impl ChannelSource for GatewayChannelSource {
         checked: AccessChecked,
         _desc: std::sync::Arc<FieldDesc>,
         _changed: epics_pva_rs::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> Result<Option<SourceRead>, OpError> {
         if !checked.allows_write() {
@@ -1344,10 +1344,10 @@ impl ChannelSource for GatewayChannelSource {
         let read = match ctx.pv_request.as_ref() {
             Some(req) => {
                 client
-                    .pvput_get_pv_field_with_request_value_marked(name, req, &delta)
+                    .pvput_get_pv_field_with_request_value_marked(name, req, delta)
                     .await
             }
-            None => client.pvput_get_pv_field_marked(name, &delta).await,
+            None => client.pvput_get_pv_field_marked(name, delta).await,
         };
         read.map(|r| Some(upstream_read(r)))
             .map_err(upstream_op_error)

--- a/crates/epics-bridge-rs/src/pva_gateway/source.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/source.rs
@@ -205,10 +205,10 @@ struct UpstreamIdentityKey {
 impl UpstreamIdentityKey {
     fn from_ctx(ctx: &ChannelContext) -> Self {
         Self {
-            account: ctx.account.clone(),
-            method: ctx.method.clone(),
-            host: ctx.host.clone(),
-            authority: ctx.authority.clone(),
+            account: ctx.creds.account.clone(),
+            method: ctx.creds.method.clone(),
+            host: ctx.creds.host.clone(),
+            authority: ctx.creds.authority.clone(),
         }
     }
 }
@@ -521,7 +521,14 @@ impl GatewayChannelSource {
                 // documents this.
                 let resolver = self.asg_resolver.read().await;
                 let asg = (resolver)(pv);
-                cfg.check_access_method(&asg, &ctx.host, &ctx.account, 0, &ctx.method, "")
+                cfg.check_access_method(
+                    &asg,
+                    &ctx.creds.host,
+                    &ctx.creds.account,
+                    0,
+                    &ctx.creds.method,
+                    "",
+                )
             }
         }
     }
@@ -550,7 +557,7 @@ impl GatewayChannelSource {
     /// downstream method is logged at `info` so the gateway's
     /// identity-assertion trust boundary is visible in audit output.
     fn upstream_client_for(&self, ctx: &ChannelContext) -> Arc<PvaClient> {
-        if ctx.account.is_empty() || ctx.method == "anonymous" {
+        if ctx.creds.account.is_empty() || ctx.creds.method == "anonymous" {
             return self.cache.client().clone();
         }
         let key = UpstreamIdentityKey::from_ctx(ctx);
@@ -561,12 +568,12 @@ impl GatewayChannelSource {
         // a downstream method other than `ca` cannot be
         // forwarded verbatim — the upstream `ca` credential is a
         // gateway assertion. Make that explicit in audit output.
-        if ctx.method != "ca" {
+        if ctx.creds.method != "ca" {
             tracing::info!(
-                downstream_account = %ctx.account,
-                downstream_method = %ctx.method,
-                downstream_authority = %ctx.authority,
-                downstream_host = %ctx.host,
+                downstream_account = %ctx.creds.account,
+                downstream_method = %ctx.creds.method,
+                downstream_authority = %ctx.creds.authority,
+                downstream_host = %ctx.creds.host,
                 "PVA gateway asserting downstream identity upstream as CA-style \
                  credentials: the pvAccess wire cannot forward this auth method/authority",
             );
@@ -578,11 +585,11 @@ impl GatewayChannelSource {
         // `server_addr` and the client would fall back to UDP search,
         // never reaching a pinned or discovery-isolated upstream.
         let client = Arc::new(self.cache.client().with_asserted_identity(
-            ctx.account.clone(),
-            ctx.host.clone(),
+            ctx.creds.account.clone(),
+            ctx.creds.host.clone(),
             AssertedIdentity {
-                downstream_method: ctx.method.clone(),
-                downstream_authority: ctx.authority.clone(),
+                downstream_method: ctx.creds.method.clone(),
+                downstream_authority: ctx.creds.authority.clone(),
             },
         ));
         pool.insert(key, client.clone());
@@ -595,7 +602,7 @@ impl GatewayChannelSource {
     /// `cache`. Parallels `upstream_client_for` which does the same for
     /// PUT/RPC/PROCESS.
     fn upstream_cache_for(&self, ctx: &ChannelContext) -> Arc<ChannelCache> {
-        if ctx.account.is_empty() || ctx.method == "anonymous" {
+        if ctx.creds.account.is_empty() || ctx.creds.method == "anonymous" {
             return self.cache.clone();
         }
         let key = UpstreamIdentityKey::from_ctx(ctx);
@@ -1229,17 +1236,17 @@ impl ChannelSource for GatewayChannelSource {
         if !checked.allows_write() {
             tracing::debug!(
                 pv = %checked.pv_name(),
-                account = %ctx.account,
-                method = %ctx.method,
+                account = %ctx.creds.account,
+                method = %ctx.creds.method,
                 "pva-gateway: PUT denied by gateway ACF"
             );
             return Err(OpError::denied(format!(
                 "PUT denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
 
@@ -1256,8 +1263,8 @@ impl ChannelSource for GatewayChannelSource {
         let client = self.upstream_client_for(&ctx);
         tracing::debug!(
             pv = %name,
-            account = %ctx.account,
-            method = %ctx.method,
+            account = %ctx.creds.account,
+            method = %ctx.creds.method,
             "pva-gateway: forwarding PUT with downstream credentials"
         );
         // Forward the downstream PUT INIT pvRequest — preserved into
@@ -1310,17 +1317,17 @@ impl ChannelSource for GatewayChannelSource {
         if !checked.allows_write() {
             tracing::debug!(
                 pv = %checked.pv_name(),
-                account = %ctx.account,
-                method = %ctx.method,
+                account = %ctx.creds.account,
+                method = %ctx.creds.method,
                 "pva-gateway: PUT_GET denied by gateway ACF"
             );
             return Err(OpError::denied(format!(
                 "PUT_GET denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
 
@@ -1328,8 +1335,8 @@ impl ChannelSource for GatewayChannelSource {
         let client = self.upstream_client_for(&ctx);
         tracing::debug!(
             pv = %name,
-            account = %ctx.account,
-            method = %ctx.method,
+            account = %ctx.creds.account,
+            method = %ctx.creds.method,
             "pva-gateway: forwarding PUT_GET with downstream credentials"
         );
         // One upstream PUT_GET carrying the downstream's preserved INIT
@@ -1431,17 +1438,17 @@ impl ChannelSource for GatewayChannelSource {
         if !checked.allows_write() {
             tracing::debug!(
                 pv = %checked.pv_name(),
-                account = %ctx.account,
-                method = %ctx.method,
+                account = %ctx.creds.account,
+                method = %ctx.creds.method,
                 "pva-gateway: RPC denied by gateway ACF"
             );
             return Err(OpError::denied(format!(
                 "RPC denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
         let name = checked.pv_name();
@@ -1508,17 +1515,17 @@ impl ChannelSource for GatewayChannelSource {
         if !checked.allows_write() {
             tracing::debug!(
                 pv = %checked.pv_name(),
-                account = %ctx.account,
-                method = %ctx.method,
+                account = %ctx.creds.account,
+                method = %ctx.creds.method,
                 "pva-gateway: PROCESS denied by gateway ACF"
             );
             return Err(OpError::denied(format!(
                 "PROCESS denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
         let name = checked.pv_name();
@@ -1586,9 +1593,9 @@ impl ChannelSource for GatewayChannelSource {
                 "ARRAY getArray denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
         let name = checked.pv_name();
@@ -1619,9 +1626,9 @@ impl ChannelSource for GatewayChannelSource {
                 "ARRAY putArray denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
         let name = checked.pv_name();
@@ -1648,9 +1655,9 @@ impl ChannelSource for GatewayChannelSource {
                 "ARRAY setLength denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
         let name = checked.pv_name();
@@ -1676,9 +1683,9 @@ impl ChannelSource for GatewayChannelSource {
                 "ARRAY getLength denied by gateway access security: \
                  PV '{pv}' from {host}/{account}/{method}",
                 pv = checked.pv_name(),
-                host = ctx.host,
-                account = ctx.account,
-                method = ctx.method,
+                host = ctx.creds.host,
+                account = ctx.creds.account,
+                method = ctx.creds.method,
             )));
         }
         let name = checked.pv_name();
@@ -1997,11 +2004,13 @@ mod tests {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         ChannelContext {
             peer: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-            account: account.to_string(),
-            method: method.to_string(),
-            host: host.to_string(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: account.to_string(),
+                method: method.to_string(),
+                host: host.to_string(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }
@@ -2020,7 +2029,13 @@ mod tests {
     /// folded into the `_checked` family.
     async fn check(src: &GatewayChannelSource, pv: &str, ctx: &ChannelContext) -> AccessChecked {
         src.access()
-            .check(pv, &ctx.host, &ctx.account, &ctx.method, "")
+            .check(
+                pv,
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.method,
+                "",
+            )
             .await
     }
 
@@ -2576,11 +2591,13 @@ ASG(DEFAULT) {
         let src = make_source();
         let ctx = ChannelContext {
             peer: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-            account: "alice".to_string(),
-            method: "x509".to_string(),
-            host: "ws01.lab".to_string(),
-            authority: "Lab Root CA".to_string(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "alice".to_string(),
+                method: "x509".to_string(),
+                host: "ws01.lab".to_string(),
+                authority: "Lab Root CA".to_string(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };
@@ -2697,7 +2714,7 @@ ASG(DEFAULT) {
         // `make_ctx` helper always leaves authority empty.
         fn ctx_with(host: &str, account: &str, method: &str, authority: &str) -> ChannelContext {
             let mut c = make_ctx(host, account, method);
-            c.authority = authority.to_string();
+            std::sync::Arc::make_mut(&mut c.creds).authority = authority.to_string();
             c
         }
 

--- a/crates/epics-bridge-rs/src/pva_gateway/source.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/source.rs
@@ -1302,7 +1302,7 @@ impl ChannelSource for GatewayChannelSource {
     async fn put_get_checked(
         &self,
         checked: AccessChecked,
-        _desc: FieldDesc,
+        _desc: std::sync::Arc<FieldDesc>,
         _changed: epics_pva_rs::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,

--- a/crates/epics-bridge-rs/src/qsrv/channel.rs
+++ b/crates/epics-bridge-rs/src/qsrv/channel.rs
@@ -723,7 +723,7 @@ impl BridgeChannel {
             // carries "Put not permitted"; identity goes to the log.
             return Err(super::put_status::put_not_permitted(&format!(
                 "write denied for {} (user='{}' host='{}')",
-                self.pv_name, self.access.user, self.access.host
+                self.pv_name, self.access.creds.user, self.access.creds.host
             )));
         }
 
@@ -811,9 +811,9 @@ impl BridgeChannel {
         // rendered from the value inside the helper.
         let meta = super::trap_write::TrapWriteMeta {
             pv_name: &self.pv_name,
-            user: &self.access.user,
-            host: &self.access.host,
-            peer: &self.access.host,
+            user: &self.access.creds.user,
+            host: &self.access.creds.host,
+            peer: &self.access.creds.host,
             dbr_type: self.value_dbf as u16,
         };
         super::trap_write::put_with_trap(grant, meta, epics_val, |value| async move {
@@ -920,7 +920,7 @@ impl Channel for BridgeChannel {
         if !self.access.can_read(&self.pv_name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for {} (user='{}' host='{}')",
-                self.pv_name, self.access.user, self.access.host
+                self.pv_name, self.access.creds.user, self.access.creds.host
             )));
         }
 
@@ -999,7 +999,7 @@ impl BridgeChannel {
         if !self.access.can_read(&self.pv_name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor create denied for {} (user='{}' host='{}')",
-                self.pv_name, self.access.user, self.access.host
+                self.pv_name, self.access.creds.user, self.access.creds.host
             )));
         }
         let mut monitor = BridgeMonitor::new(

--- a/crates/epics-bridge-rs/src/qsrv/group.rs
+++ b/crates/epics-bridge-rs/src/qsrv/group.rs
@@ -837,7 +837,7 @@ impl GroupChannel {
         if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for group {} (user='{}' host='{}')",
-                self.def.name, self.access.user, self.access.host
+                self.def.name, self.access.creds.user, self.access.creds.host
             )));
         }
 
@@ -966,7 +966,7 @@ impl GroupChannel {
         if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for group {} (user='{}' host='{}')",
-                self.def.name, self.access.user, self.access.host
+                self.def.name, self.access.creds.user, self.access.creds.host
             )));
         }
 
@@ -1495,9 +1495,9 @@ impl GroupChannel {
         let pv_name = format!("{record_name}.{field_name}");
         let meta = super::trap_write::TrapWriteMeta {
             pv_name: &pv_name,
-            user: &self.access.user,
-            host: &self.access.host,
-            peer: &self.access.host,
+            user: &self.access.creds.user,
+            host: &self.access.creds.host,
+            peer: &self.access.creds.host,
             dbr_type: value.dbr_type() as u16,
         };
         // Synchronous bracket: after H6 every `_already_locked` callee below
@@ -1554,9 +1554,9 @@ impl GroupChannel {
         let pv_name = format!("{record_name}.{field_name}");
         let meta = super::trap_write::TrapWriteMeta {
             pv_name: &pv_name,
-            user: &self.access.user,
-            host: &self.access.host,
-            peer: &self.access.host,
+            user: &self.access.creds.user,
+            host: &self.access.creds.host,
+            peer: &self.access.creds.host,
             dbr_type: value.dbr_type() as u16,
         };
         super::trap_write::put_with_trap(grant, meta, value, |value| async move {
@@ -1618,7 +1618,7 @@ impl GroupChannel {
             // carry pvxs's `doFieldPreProcessing` text (iocsource.cpp:385).
             return Err(super::put_status::put_not_permitted(&format!(
                 "write denied for group {} (user='{}' host='{}')",
-                self.def.name, self.access.user, self.access.host
+                self.def.name, self.access.creds.user, self.access.creds.host
             )));
         }
 
@@ -1774,7 +1774,11 @@ impl GroupChannel {
                 return Err(super::put_status::put_not_permitted(&format!(
                     "group {} PUT: member '{}' field '{}' write denied for \
                      user='{}' host='{}' (per-member ACF)",
-                    self.def.name, m.field_name, m.channel, self.access.user, self.access.host
+                    self.def.name,
+                    m.field_name,
+                    m.channel,
+                    self.access.creds.user,
+                    self.access.creds.host
                 )));
             }
             member_grants.insert(m.channel.clone(), grant);
@@ -2027,7 +2031,7 @@ impl super::provider::Channel for GroupChannel {
         if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "read denied for group {} (user='{}' host='{}')",
-                self.def.name, self.access.user, self.access.host
+                self.def.name, self.access.creds.user, self.access.creds.host
             )));
         }
         // pvRequest can override the group default atomicity.
@@ -2139,7 +2143,7 @@ impl super::provider::Channel for GroupChannel {
         if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor create denied for group {} (user='{}' host='{}')",
-                self.def.name, self.access.user, self.access.host
+                self.def.name, self.access.creds.user, self.access.creds.host
             )));
         }
         Ok(AnyMonitor::Group(Box::new(
@@ -2473,7 +2477,7 @@ impl super::provider::PvaMonitor for GroupMonitor {
         if !self.access.can_read(&self.def.name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor read denied for group {} (user='{}' host='{}')",
-                self.def.name, self.access.user, self.access.host
+                self.def.name, self.access.creds.user, self.access.creds.host
             )));
         }
 

--- a/crates/epics-bridge-rs/src/qsrv/monitor.rs
+++ b/crates/epics-bridge-rs/src/qsrv/monitor.rs
@@ -227,7 +227,7 @@ impl PvaMonitor for BridgeMonitor {
         if !self.access.can_read(&self.record_name).await {
             return Err(BridgeError::PutRejected(format!(
                 "monitor read denied for {} (user='{}' host='{}')",
-                self.record_name, self.access.user, self.access.host
+                self.record_name, self.access.creds.user, self.access.creds.host
             )));
         }
 

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -149,7 +149,64 @@ impl AccessControl for AllowAllAccess {}
 pub struct AcfAccessControl {
     db: Arc<epics_base_rs::server::database::PvDatabase>,
     cfg: Arc<epics_base_rs::server::access_security::AccessSecurityConfig>,
+    /// C `asAddClient` keeps one computed ASGCLIENT per channel and every
+    /// put is a bit test; pvxs caches the client's computed access on the
+    /// channel at the first PUT (pvxs 3c0154b, issue #176). The Rust QSRV
+    /// channel object is rebuilt per operation, so the computed
+    /// (level, trap) is cached here on the policy owner instead, keyed by
+    /// (channel, full credential identity). Invalidation is by
+    /// construction: an ACF reload swaps in a whole new
+    /// `AcfAccessControl` (`set_access_control`), and a `dbPut
+    /// record.ASG` moves [`asg_change_generation`] which every entry
+    /// snapshots. The rule walk here never evaluates CALC against live
+    /// INP* values (`check_access_method_trap` fails those closed), so an
+    /// entry cannot go stale through a DB value change.
+    grant_cache: parking_lot::RwLock<HashMap<GrantKey, CachedAccess>>,
 }
+
+/// Full identity a cached access computation depends on. `roles` is part
+/// of the key — a re-auth that only changes role claims must miss.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct GrantKey {
+    channel: String,
+    user: String,
+    host: String,
+    method: String,
+    authority: String,
+    roles: Vec<String>,
+}
+
+impl GrantKey {
+    fn new(channel: &str, creds: &ClientCreds) -> Self {
+        Self {
+            channel: channel.to_string(),
+            user: creds.user.clone(),
+            host: creds.host.clone(),
+            method: creds.method.clone(),
+            authority: creds.authority.clone(),
+            roles: creds.roles.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CachedAccess {
+    /// [`asg_change_generation`] snapshot taken BEFORE the (ASG, ASL)
+    /// resolve, so a change racing the compute invalidates the entry on
+    /// its next read instead of being lost.
+    asg_generation: u64,
+    level: AccessLevelLite,
+    /// `TRAPWRITE` flag of the first credential's granting rule; only
+    /// meaningful when `level` is `ReadWrite`.
+    write_trap: bool,
+}
+
+/// Bound on distinct (channel × credential) cache entries. C's ASGCLIENT
+/// list is bounded by live channels; this cache is name-keyed, so a
+/// client cycling names/identities could otherwise grow it without
+/// limit. Overflow flushes the whole map — crude, but a full re-walk per
+/// entry is exactly the pre-cache behaviour.
+const GRANT_CACHE_CAP: usize = 4096;
 
 impl AcfAccessControl {
     pub fn new(
@@ -159,6 +216,7 @@ impl AcfAccessControl {
         Self {
             db,
             cfg: Arc::new(cfg),
+            grant_cache: parking_lot::RwLock::new(HashMap::new()),
         }
     }
 
@@ -173,13 +231,22 @@ impl AcfAccessControl {
     /// must never stand in for an ASG the code failed to look up: doing so
     /// evaluates the wrong access group, which for a record in a read-only
     /// group means granting a write the ACF denies.
-    async fn resolve_asg_and_asl(&self, channel: &str) -> (String, u8) {
+    /// The third element is whether the channel resolved to a known
+    /// record. Only a known-record resolution may be cached: an unknown
+    /// name's `DEFAULT` fallback would otherwise keep serving `DEFAULT`
+    /// after the record appears (post-init `dbLoadRecords`), with no
+    /// ASG-field put to move the invalidation generation.
+    async fn resolve_asg_and_asl(&self, channel: &str) -> (String, u8, bool) {
         let (record_name, _field) = epics_base_rs::server::database::parse_pv_name(channel);
         if let Some(rec) = self.db.get_record(record_name) {
             let inst = rec.read();
-            return (inst.common.access_group().to_string(), inst.common.asl);
+            return (
+                inst.common.access_group().to_string(),
+                inst.common.asl,
+                true,
+            );
         }
-        ("DEFAULT".to_string(), 0u8)
+        ("DEFAULT".to_string(), 0u8, false)
     }
 
     /// Build pvxs-style credential strings from `ClientCreds`.
@@ -210,8 +277,23 @@ impl AcfAccessControl {
     /// maximum level across all credentials — mirrors `SecurityClient::canWrite`
     /// `any_of` semantics (`pvxs/ioc/securityclient.cpp:42-45`).
     async fn level_for_creds(&self, channel: &str, creds: &ClientCreds) -> AccessLevelLite {
+        self.computed_access(channel, creds).await.level
+    }
+
+    /// The single rule evaluation every check on this policy routes
+    /// through, cached per (channel, credential identity) — see the
+    /// [`Self::grant_cache`] field doc for the C/pvxs model and the
+    /// invalidation reasoning.
+    async fn computed_access(&self, channel: &str, creds: &ClientCreds) -> CachedAccess {
         use epics_base_rs::server::access_security::AccessLevel;
-        let (asg, asl) = self.resolve_asg_and_asl(channel).await;
+        let generation = epics_base_rs::server::access_security::asg_change_generation();
+        let key = GrantKey::new(channel, creds);
+        if let Some(hit) = self.grant_cache.read().get(&key)
+            && hit.asg_generation == generation
+        {
+            return *hit;
+        }
+        let (asg, asl, record_known) = self.resolve_asg_and_asl(channel).await;
         let cred_strings = Self::credential_strings(creds);
         // a QSRV access context built through the legacy
         // no-method constructors (`AccessContext::anonymous`,
@@ -235,51 +317,18 @@ impl AcfAccessControl {
         } else {
             creds.method.as_str()
         };
-        let mut best = AccessLevelLite::None;
-        for cred_user in &cred_strings {
-            let lvl = self.cfg.check_access_method(
-                &asg,
-                &creds.host,
-                cred_user,
-                asl,
-                method,
-                &creds.authority,
-            );
-            let lit = match lvl {
-                AccessLevel::ReadWrite => AccessLevelLite::ReadWrite,
-                AccessLevel::Read => AccessLevelLite::Read,
-                _ => AccessLevelLite::None,
-            };
-            if lit == AccessLevelLite::ReadWrite {
-                return lit;
-            }
-            if lit == AccessLevelLite::Read && best == AccessLevelLite::None {
-                best = lit;
-            }
-        }
-        best
-    }
-
-    /// Write authorization plus the matched (granting) rule's
-    /// `TRAPWRITE` flag, in one pass.
-    ///
-    /// pvxs `SecurityClient::canWrite` is `any_of` over the credential
-    /// list (`pvxs/ioc/securityclient.cpp:42-45`): the first credential
-    /// that grants `ReadWrite` wins, and that rule's `trapMask` is the
-    /// grant's trap flag — C `asComputePvt` copies `trapMask` from the
-    /// rule that set the granted access (`asLibRoutines.c:1041-1048`).
-    /// A denied write carries `rule_was_trap = false` (`asComputePvt`
-    /// leaves `trapMask = 0` on a `NoAccess` outcome).
-    async fn grant_for_creds(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
-        use epics_base_rs::server::access_security::AccessLevel;
-        let (asg, asl) = self.resolve_asg_and_asl(channel).await;
-        let cred_strings = Self::credential_strings(creds);
-        // Same empty-method → "anonymous" normalization as
-        // `level_for_creds` (see that method for the rationale).
-        let method = if creds.method.is_empty() {
-            "anonymous"
-        } else {
-            creds.method.as_str()
+        // pvxs `SecurityClient::canWrite` is `any_of` over the credential
+        // list (`pvxs/ioc/securityclient.cpp:42-45`): the first
+        // credential that grants `ReadWrite` wins, and that rule's
+        // `trapMask` is the grant's trap flag — C `asComputePvt` copies
+        // `trapMask` from the rule that set the granted access
+        // (`asLibRoutines.c:1041-1048`). A denied write carries
+        // `rule_was_trap = false` (`asComputePvt` leaves `trapMask = 0`
+        // on a `NoAccess` outcome).
+        let mut entry = CachedAccess {
+            asg_generation: generation,
+            level: AccessLevelLite::None,
+            write_trap: false,
         };
         for cred_user in &cred_strings {
             let (lvl, trap) = self.cfg.check_access_method_trap(
@@ -290,16 +339,34 @@ impl AcfAccessControl {
                 method,
                 &creds.authority,
             );
-            if lvl == AccessLevel::ReadWrite {
-                return WriteGrant {
-                    allowed: true,
-                    rule_was_trap: trap,
-                };
+            match lvl {
+                AccessLevel::ReadWrite => {
+                    entry.level = AccessLevelLite::ReadWrite;
+                    entry.write_trap = trap;
+                    break;
+                }
+                AccessLevel::Read => entry.level = AccessLevelLite::Read,
+                _ => {}
             }
         }
+        if record_known {
+            let mut cache = self.grant_cache.write();
+            if cache.len() >= GRANT_CACHE_CAP {
+                cache.clear();
+            }
+            cache.insert(key, entry);
+        }
+        entry
+    }
+
+    /// Write authorization plus the matched (granting) rule's
+    /// `TRAPWRITE` flag, from the same cached evaluation every other
+    /// check uses (see [`Self::computed_access`]).
+    async fn grant_for_creds(&self, channel: &str, creds: &ClientCreds) -> WriteGrant {
+        let computed = self.computed_access(channel, creds).await;
         WriteGrant {
-            allowed: false,
-            rule_was_trap: false,
+            allowed: computed.level == AccessLevelLite::ReadWrite,
+            rule_was_trap: computed.write_trap,
         }
     }
 }
@@ -1949,6 +2016,45 @@ ASG(SECURE) {
         // Only admin can write.
         assert!(acl.can_write("AI:SEC", "admin", "anywhere").await);
         assert!(!acl.can_write("AI:SEC", "guest", "anywhere").await);
+    }
+
+    /// The grant cache must repoint when the record's ASG changes
+    /// (C `asChangeGroup` re-runs `asComputePvt` for every ASGCLIENT
+    /// on `dbPut record.ASG`). The first check populates the cache
+    /// under the record's initial group; moving the record into a
+    /// deny-all group and firing the ASG-change notifier must flip
+    /// the cached decision, not serve the stale grant.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acf_grant_cache_invalidated_by_asg_field_change() {
+        use epics_base_rs::server::access_security::{notify_asg_field_changed, parse_acf};
+        use epics_base_rs::server::database::PvDatabase;
+        use epics_base_rs::server::records::ai::AiRecord;
+
+        let acf_text = r#"
+ASG(OPEN) {
+    RULE(1, WRITE)
+}
+ASG(LOCKED) {
+}
+"#;
+        let cfg = parse_acf(acf_text).unwrap();
+        let db = Arc::new(PvDatabase::new());
+        db.add_record("AI:MOVE", Box::new(AiRecord::new(0.0)))
+            .await
+            .unwrap();
+        let rec = db.get_record("AI:MOVE").unwrap();
+        rec.write().common.asg = "OPEN".to_string();
+
+        let acl = AcfAccessControl::new(db.clone(), cfg);
+        // Twice: the second call is the cache-hit path.
+        assert!(acl.can_write("AI:MOVE", "guest", "anywhere").await);
+        assert!(acl.can_write("AI:MOVE", "guest", "anywhere").await);
+
+        // The field-I/O layer's `dbPut record.ASG` sequence: mutate,
+        // then notify.
+        rec.write().common.asg = "LOCKED".to_string();
+        notify_asg_field_changed();
+        assert!(!acl.can_write("AI:MOVE", "guest", "anywhere").await);
     }
 
     /// Regression: AcfAccessControl must honor method, authority,

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -5,7 +5,7 @@
 //! The trait definitions here are temporary — they will move to `epics-pva-rs`
 //! once that crate's native PVA server exposes them directly.
 
-// RTEMS-EXEC-MODEL-ALLOW(20): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(21): checked - these run and pass in the feature-ON suite.
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -157,7 +157,9 @@ pub struct AcfAccessControl {
     /// (channel, full credential identity). Invalidation is by
     /// construction: an ACF reload swaps in a whole new
     /// `AcfAccessControl` (`set_access_control`), and a `dbPut
-    /// record.ASG` moves [`asg_change_generation`] which every entry
+    /// record.ASG` moves
+    /// [`asg_change_generation`](epics_base_rs::server::access_security::asg_change_generation)
+    /// which every entry
     /// snapshots. The rule walk here never evaluates CALC against live
     /// INP* values (`check_access_method_trap` fails those closed), so an
     /// entry cannot go stale through a DB value change.
@@ -191,7 +193,8 @@ impl GrantKey {
 
 #[derive(Clone, Copy)]
 struct CachedAccess {
-    /// [`asg_change_generation`] snapshot taken BEFORE the (ASG, ASL)
+    /// [`asg_change_generation`](epics_base_rs::server::access_security::asg_change_generation)
+    /// snapshot taken BEFORE the (ASG, ASL)
     /// resolve, so a change racing the compute invalidates the entry on
     /// its next read instead of being lost.
     asg_generation: u64,

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -720,6 +720,12 @@ pub struct BridgeProvider {
     /// would drop fields contributed to the same group name by other files
     /// or `info(Q:group)` tags.
     group_files: parking_lot::RwLock<Vec<GroupFileEntry>>,
+    /// Bumped on every rewrite of the live [`Self::groups`] map
+    /// (`rebuild_groups` / `reset_groups`). Lets a caller that caches a
+    /// resolved [`AnyChannel`] (the PVA adapter's per-peer channel
+    /// cache) detect that group name→definition bindings may have
+    /// changed and re-resolve, without re-checking the map per op.
+    group_generation: std::sync::atomic::AtomicU64,
     /// QSRV2 serving gate. pvxs adds the single-record and group sources
     /// to the PVA server only when `enable2()` returns true
     /// (`ioc/iochooks.cpp:461-496`, gated by `PVXS_QSRV_ENABLE` /
@@ -806,6 +812,7 @@ impl BridgeProvider {
             ops_subscribe: std::sync::atomic::AtomicU64::new(0),
             base_group_defs: parking_lot::RwLock::new(Vec::new()),
             group_files: parking_lot::RwLock::new(Vec::new()),
+            group_generation: std::sync::atomic::AtomicU64::new(0),
             enabled,
         }
     }
@@ -915,6 +922,13 @@ impl BridgeProvider {
         // immutable receiver is correct — `&mut self` blocked
         // hot-reload through `Arc<BridgeProvider>`.
         *self.access_cell.write() = access;
+    }
+
+    /// Current group-registry generation (see the field doc). A cached
+    /// channel resolution is valid only while this value is unchanged.
+    pub fn group_generation(&self) -> u64 {
+        self.group_generation
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Get a clone of the current access control policy.
@@ -1064,6 +1078,8 @@ impl BridgeProvider {
             }
         }
         *self.groups.write() = merged;
+        self.group_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 
     /// Load group definitions from a record's info(Q:group, ...) tag.
@@ -1255,6 +1271,8 @@ impl BridgeProvider {
         self.base_group_defs.write().clear();
         self.group_files.write().clear();
         self.groups.write().clear();
+        self.group_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
         n
     }
 

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -430,16 +430,11 @@ impl AccessControl for AcfAccessControl {
 #[derive(Clone)]
 pub struct AccessContext {
     pub access: Arc<dyn AccessControl>,
-    pub user: String,
-    pub host: String,
-    /// Auth method. pvxs `ClientCredentials::method`
-    /// (pvxs/include/pvxs/srvcommon.h:43).
-    pub method: String,
-    /// Root CA subject CN for the x509 method; empty for others.
-    pub authority: String,
-    /// Role claims for UAG `role/…` entries.
-    /// pvxs `ClientCredentials::roles()` (pvxs/include/pvxs/srvcommon.h:55).
-    pub roles: Vec<String>,
+    /// Full credential set of the downstream client (pvxs
+    /// `ClientCredentials`, srvcommon.h:36-56). Shared by refcount so
+    /// per-op access checks hand `&self.creds` to the policy instead
+    /// of re-cloning five strings per check.
+    pub creds: Arc<ClientCreds>,
 }
 
 impl AccessContext {
@@ -447,11 +442,7 @@ impl AccessContext {
     pub fn anonymous(access: Arc<dyn AccessControl>) -> Self {
         Self {
             access,
-            user: String::new(),
-            host: String::new(),
-            method: String::new(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: Arc::new(ClientCreds::default()),
         }
     }
 
@@ -459,11 +450,11 @@ impl AccessContext {
     pub fn with_identity(access: Arc<dyn AccessControl>, user: String, host: String) -> Self {
         Self {
             access,
-            user,
-            host,
-            method: String::new(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: Arc::new(ClientCreds {
+                user,
+                host,
+                ..Default::default()
+            }),
         }
     }
 
@@ -471,11 +462,7 @@ impl AccessContext {
     pub fn with_creds(access: Arc<dyn AccessControl>, creds: ClientCreds) -> Self {
         Self {
             access,
-            user: creds.user,
-            host: creds.host,
-            method: creds.method,
-            authority: creds.authority,
-            roles: creds.roles,
+            creds: Arc::new(creds),
         }
     }
 
@@ -485,15 +472,11 @@ impl AccessContext {
     }
 
     pub async fn can_read(&self, channel: &str) -> bool {
-        self.access
-            .can_read_creds(channel, &self.to_client_creds())
-            .await
+        self.access.can_read_creds(channel, &self.creds).await
     }
 
     pub async fn can_write(&self, channel: &str) -> bool {
-        self.access
-            .can_write_creds(channel, &self.to_client_creds())
-            .await
+        self.access.can_write_creds(channel, &self.creds).await
     }
 
     /// Authorize a write to `channel` and surface the matched rule's
@@ -502,19 +485,7 @@ impl AccessContext {
     /// `asTrapWrite` put-logging — the grant is the single source of the
     /// trap decision.
     pub async fn write_grant(&self, channel: &str) -> WriteGrant {
-        self.access
-            .write_grant(channel, &self.to_client_creds())
-            .await
-    }
-
-    fn to_client_creds(&self) -> ClientCreds {
-        ClientCreds {
-            user: self.user.clone(),
-            host: self.host.clone(),
-            method: self.method.clone(),
-            authority: self.authority.clone(),
-            roles: self.roles.clone(),
-        }
+        self.access.write_grant(channel, &self.creds).await
     }
 }
 
@@ -2239,8 +2210,8 @@ ASG(ROLE_GATED) {
     async fn access_context_with_identity() {
         let ctx =
             AccessContext::with_identity(Arc::new(AllowAllAccess), "alice".into(), "host1".into());
-        assert_eq!(ctx.user, "alice");
-        assert_eq!(ctx.host, "host1");
+        assert_eq!(ctx.creds.user, "alice");
+        assert_eq!(ctx.creds.host, "host1");
     }
 
     #[tokio::test]

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -173,15 +173,15 @@ pub fn take_registered_pva_pvs() -> std::collections::HashMap<String, PvaPvHandl
 /// defect where these were hardcoded to `"anonymous"` / `""`.
 fn ctx_to_creds(ctx: &epics_pva_rs::server_native::source::ChannelContext) -> ClientCreds {
     ClientCreds {
-        user: ctx.account.clone(),
-        host: ctx.host.clone(),
-        method: ctx.method.clone(),
-        authority: ctx.authority.clone(),
+        user: ctx.creds.account.clone(),
+        host: ctx.creds.host.clone(),
+        method: ctx.creds.method.clone(),
+        authority: ctx.creds.authority.clone(),
         // forward the native PVA peer's parsed role/group
         // claims so `AcfAccessControl` can evaluate role-based UAG
         // entries (`R member group:ops`). Previously hardcoded empty,
         // so role-scoped ACF rules denied real over-the-wire clients.
-        roles: ctx.roles.clone(),
+        roles: ctx.creds.roles.clone(),
     }
 }
 
@@ -564,9 +564,9 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                 Err(e) => {
                     tracing::debug!(
                         "qsrv get_value_checked({name}) {} from {}@{}: {e}",
-                        ctx.account,
-                        ctx.method,
-                        ctx.host
+                        ctx.creds.account,
+                        ctx.creds.method,
+                        ctx.creds.host
                     );
                     None
                 }
@@ -607,8 +607,8 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                 return Err(OpError::denied(format!(
                     "PUT denied by access security: '{}' from {}@{}",
                     checked.pv_name(),
-                    ctx.account,
-                    ctx.host
+                    ctx.creds.account,
+                    ctx.creds.host
                 )));
             }
             let name = checked.pv_name().to_string();
@@ -702,8 +702,8 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                 return Err(OpError::denied(format!(
                     "PUT denied by access security: '{}' from {}@{}",
                     checked.pv_name(),
-                    ctx.account,
-                    ctx.host
+                    ctx.creds.account,
+                    ctx.creds.host
                 )));
             }
             let name = checked.pv_name().to_string();
@@ -2277,11 +2277,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "127.0.0.1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "127.0.0.1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: Some(PvField::Structure(req)),
             log: Default::default(),
         };
@@ -2358,11 +2360,13 @@ mod tests {
             .await;
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "127.0.0.1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "127.0.0.1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: Some(PvField::Structure(req)),
             log: Default::default(),
         };
@@ -2400,11 +2404,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "alice".into(),
-            method: "ca".into(),
-            host: "ws01".into(),
-            authority: String::new(),
-            roles: vec!["operators".into(), "experts".into()],
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "alice".into(),
+                method: "ca".into(),
+                host: "ws01".into(),
+                authority: String::new(),
+                roles: vec!["operators".into(), "experts".into()],
+            }),
             pv_request: None,
             log: Default::default(),
         };
@@ -2531,11 +2537,13 @@ mod tests {
             .push(("record".into(), PvField::Structure(record)));
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "127.0.0.1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "127.0.0.1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: Some(PvField::Structure(req)),
             log: Default::default(),
         };
@@ -2717,11 +2725,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "127.0.0.1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "127.0.0.1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: Some(PvField::Structure(req)),
             log: Default::default(),
         };
@@ -2821,11 +2831,15 @@ mod tests {
                 .push(("record".into(), PvField::Structure(record)));
             let ctx = ChannelContext {
                 peer: "127.0.0.1:5075".parse().unwrap(),
-                account: "anonymous".into(),
-                method: "anonymous".into(),
-                host: "127.0.0.1".into(),
-                authority: String::new(),
-                roles: Vec::new(),
+                creds: std::sync::Arc::new(
+                    epics_pva_rs::server_native::config::ClientCredentials {
+                        account: "anonymous".into(),
+                        method: "anonymous".into(),
+                        host: "127.0.0.1".into(),
+                        authority: String::new(),
+                        roles: Vec::new(),
+                    },
+                ),
                 pv_request: Some(PvField::Structure(req)),
                 log: Default::default(),
             };
@@ -2961,11 +2975,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "127.0.0.1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "127.0.0.1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };
@@ -3076,11 +3092,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "127.0.0.1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "127.0.0.1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -691,7 +691,7 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
     fn put_delta_checked(
         &self,
         checked: epics_pva_rs::server_native::source::AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
         delta: PvField,
         ctx: epics_pva_rs::server_native::source::ChannelContext,
@@ -2963,7 +2963,13 @@ mod tests {
             .await;
 
         store
-            .put_delta_checked(checked, desc, changed, PvField::Structure(delta), ctx)
+            .put_delta_checked(
+                checked,
+                std::sync::Arc::new(desc),
+                changed,
+                PvField::Structure(delta),
+                ctx,
+            )
             .await
             .expect("partial group PUT must succeed");
 
@@ -3072,7 +3078,13 @@ mod tests {
             .await;
 
         store
-            .put_delta_checked(checked, desc, changed, PvField::Structure(delta), ctx)
+            .put_delta_checked(
+                checked,
+                std::sync::Arc::new(desc),
+                changed,
+                PvField::Structure(delta),
+                ctx,
+            )
             .await
             .expect("empty-marked group PUT is a silent no-op");
 

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -693,7 +693,7 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
         checked: epics_pva_rs::server_native::source::AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: epics_pva_rs::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: epics_pva_rs::server_native::source::ChannelContext,
     ) -> impl std::future::Future<Output = Result<(), OpError>> + Send {
         let provider = self.provider.clone();
@@ -762,15 +762,26 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                         || desc
                             .bit_for_path("value.index")
                             .is_some_and(|b| changed.get(b));
-                    let merged = if value_sent {
+                    // Borrow the wire delta directly on the hot path; the
+                    // rare metadata-only PUT owns its merged copy locally.
+                    let merged_owned;
+                    let merged: &PvField = if value_sent {
                         delta
                     } else {
-                        match self.get_value_checked(checked.clone(), ctx.clone()).await {
+                        merged_owned = match self
+                            .get_value_checked(checked.clone(), ctx.clone())
+                            .await
+                        {
                             Some(prior) => epics_pva_rs::pvdata::encode::fill_unmarked_from_prior(
-                                &desc, &changed, 0, delta, &prior,
+                                &desc,
+                                &changed,
+                                0,
+                                delta.clone(),
+                                &prior,
                             ),
-                            None => delta,
-                        }
+                            None => delta.clone(),
+                        };
+                        &merged_owned
                     };
                     let pv = match merged {
                         PvField::Structure(s) => s,
@@ -784,10 +795,10 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                         Some(req) => {
                             crate::qsrv::channel::PutOptions::from_pv_request(req, &ctx.log)
                         }
-                        None => crate::qsrv::channel::PutOptions::from_pv_request(&pv, &ctx.log),
+                        None => crate::qsrv::channel::PutOptions::from_pv_request(pv, &ctx.log),
                     };
                     single
-                        .put_with_options(&pv, opts)
+                        .put_with_options(pv, opts)
                         .await
                         .map_err(|e| OpError::failed(crate::qsrv::put_status::wire_message(&e)))
                 }
@@ -2967,7 +2978,7 @@ mod tests {
                 checked,
                 std::sync::Arc::new(desc),
                 changed,
-                PvField::Structure(delta),
+                &PvField::Structure(delta),
                 ctx,
             )
             .await
@@ -3082,7 +3093,7 @@ mod tests {
                 checked,
                 std::sync::Arc::new(desc),
                 changed,
-                PvField::Structure(delta),
+                &PvField::Structure(delta),
                 ctx,
             )
             .await

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -748,14 +748,29 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                         .map_err(|e| OpError::failed(crate::qsrv::put_status::wire_message(&e)))
                 }
                 crate::qsrv::AnyChannel::Single(single) => {
-                    // Single-record: generic read-merge-write under the
-                    // same identity (the record put consumes only the
-                    // value leaf, so the whole-structure write is fine).
-                    let merged = match self.get_value_checked(checked.clone(), ctx.clone()).await {
-                        Some(prior) => epics_pva_rs::pvdata::encode::fill_unmarked_from_prior(
-                            &desc, &changed, 0, delta, &prior,
-                        ),
-                        None => delta,
+                    // Single-record: the record put consumes only the `value`
+                    // subtree (`pv_structure_to_epics` — scalar/array `value`,
+                    // NTEnum `value.index`), so the prior-read merge exists
+                    // solely to supply `value` when the client's marks did
+                    // not cover it. When they do (bit 0 = whole structure,
+                    // the `value` bit, or NTEnum's `value.index` bit), hand
+                    // the delta over as-is: unmarked leaves are never read
+                    // by the put, and skipping the readback removes a full
+                    // structure build per PUT.
+                    let value_sent = changed.get(0)
+                        || desc.bit_for_path("value").is_some_and(|b| changed.get(b))
+                        || desc
+                            .bit_for_path("value.index")
+                            .is_some_and(|b| changed.get(b));
+                    let merged = if value_sent {
+                        delta
+                    } else {
+                        match self.get_value_checked(checked.clone(), ctx.clone()).await {
+                            Some(prior) => epics_pva_rs::pvdata::encode::fill_unmarked_from_prior(
+                                &desc, &changed, 0, delta, &prior,
+                            ),
+                            None => delta,
+                        }
                     };
                     let pv = match merged {
                         PvField::Structure(s) => s,

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -10,6 +10,7 @@
 
 use epics_pva_rs::server_native::MonitorStream;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 
 use tokio::sync::mpsc;
@@ -203,6 +204,72 @@ pub struct QsrvPvStore {
     /// `impl Future<..> + Send`, so holding one across an `.await` is a
     /// compile error rather than a review finding.
     pva_pvs: Arc<parking_lot::RwLock<HashMap<String, PvaPvHandle>>>,
+    /// Per-peer cache of resolved channels, keyed `(peer, pv name)`.
+    /// A pvput client mints a fresh op per put, and every op used to
+    /// re-run the full name→record/group resolution plus a fresh
+    /// `AccessContext`. An entry is served only while BOTH guards hold:
+    ///
+    /// - the op's `ctx.creds` is the SAME `Arc` the entry was built
+    ///   from (`Arc::ptr_eq`) — a re-auth mints a new credentials Arc,
+    ///   so a stale identity can never leak into another peer's (or the
+    ///   re-authed peer's own) channel, which is the defect a name-only
+    ///   channel cache had here before; holding the Arc in the entry
+    ///   also makes the pointer comparison ABA-safe, and
+    /// - the provider's [`BridgeProvider::group_generation`] is
+    ///   unchanged, so `dbLoadGroup`-style registry rewrites force
+    ///   re-resolution.
+    ///
+    /// ACF hot-reload needs no guard: the cached `AccessContext` holds
+    /// the provider's live access proxy, so `set_access_control` swaps
+    /// are observed by cached channels on their next check. Entries are
+    /// evicted on `notify_channel_close`, which the wire layer fires
+    /// for explicit DESTROY_CHANNEL and on connection teardown alike.
+    channel_cache: ChannelCache,
+}
+
+/// See [`QsrvPvStore::channel_cache`].
+type ChannelCache = Arc<parking_lot::Mutex<HashMap<SocketAddr, HashMap<String, CachedChannel>>>>;
+
+struct CachedChannel {
+    creds: Arc<epics_pva_rs::server_native::config::ClientCredentials>,
+    generation: u64,
+    channel: Arc<AnyChannel>,
+}
+
+/// Resolve `name` through the per-peer cache (see
+/// [`QsrvPvStore::channel_cache`] for the freshness guards). A free fn
+/// over the captured `Arc`s so the `impl Future + Send` trait methods
+/// and the free monitor path can both call it.
+async fn cached_channel(
+    provider: &Arc<BridgeProvider>,
+    cache: &ChannelCache,
+    name: &str,
+    ctx: &epics_pva_rs::server_native::source::ChannelContext,
+) -> crate::BridgeResult<Arc<AnyChannel>> {
+    let generation = provider.group_generation();
+    if let Some(hit) = cache
+        .lock()
+        .get(&ctx.peer)
+        .and_then(|m| m.get(name))
+        .filter(|e| Arc::ptr_eq(&e.creds, &ctx.creds) && e.generation == generation)
+        .map(|e| e.channel.clone())
+    {
+        return Ok(hit);
+    }
+    let channel = Arc::new(
+        provider
+            .create_channel_with_creds(name, ctx_to_creds(ctx))
+            .await?,
+    );
+    cache.lock().entry(ctx.peer).or_default().insert(
+        name.to_string(),
+        CachedChannel {
+            creds: ctx.creds.clone(),
+            generation,
+            channel: channel.clone(),
+        },
+    );
+    Ok(channel)
 }
 
 impl QsrvPvStore {
@@ -210,6 +277,7 @@ impl QsrvPvStore {
         Self {
             provider,
             pva_pvs: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            channel_cache: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         }
     }
 
@@ -239,13 +307,16 @@ impl QsrvPvStore {
         self.channel_for(name, "", "").await
     }
 
-    /// create a channel for the supplied identity. No
-    /// `channels` cache — caching an `AnyChannel` keyed by PV
-    /// name only reused one peer's `AccessContext` for every
-    /// subsequent peer and silently bypassed any ACF policy the
-    /// IOC runner installed. Metadata is still cached inside the
-    /// `BridgeProvider` (record_cache) so the per-call cost
-    /// stays low.
+    /// create a channel for the supplied identity, uncached. A
+    /// name-only `AnyChannel` cache here once reused one peer's
+    /// `AccessContext` for every subsequent peer and silently
+    /// bypassed any ACF policy the IOC runner installed; the
+    /// ctx-bearing `_checked` paths now cache through
+    /// [`QsrvPvStore::channel_cache`], whose peer + creds-Arc
+    /// keying is what makes caching safe. This ctx-less path has
+    /// no peer to key by, so it stays uncached — metadata is
+    /// still cached inside the `BridgeProvider` (record_cache)
+    /// so the per-call cost stays low.
     async fn channel_for(&self, name: &str, user: &str, host: &str) -> Option<AnyChannel> {
         self.provider
             .create_channel_for(name, user, host)
@@ -456,6 +527,24 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
     // `_checked` overrides so every wire op runs against the
     // ACF policy with the correct user/host.
 
+    /// Evict this peer's cached resolution of `name` (see
+    /// [`QsrvPvStore::channel_cache`]). The wire layer fires this once
+    /// per opened channel, for explicit DESTROY_CHANNEL and connection
+    /// teardown alike, so entries never outlive their channel.
+    fn notify_channel_close(
+        &self,
+        name: &str,
+        ctx: &epics_pva_rs::server_native::source::ChannelContext,
+    ) {
+        let mut cache = self.channel_cache.lock();
+        if let Some(by_name) = cache.get_mut(&ctx.peer) {
+            by_name.remove(name);
+            if by_name.is_empty() {
+                cache.remove(&ctx.peer);
+            }
+        }
+    }
+
     /// pvxs `SingleSource::onSubscribe` (`ioc/singlesource.cpp:114-140`) reads
     /// `record._options.DBE` with the THROWING `as<T>()`, before `connect()`
     /// emits the INIT reply. An array-typed DBE of integer, real or string
@@ -531,6 +620,7 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
     ) -> impl std::future::Future<Output = Option<PvField>> + Send {
         let pva_pvs = self.pva_pvs.clone();
         let provider = self.provider.clone();
+        let cache = self.channel_cache.clone();
         async move {
             if !checked.allows_read() {
                 return None;
@@ -545,10 +635,7 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
             {
                 return Some(value);
             }
-            let channel = provider
-                .create_channel_with_creds(&name, ctx_to_creds(&ctx))
-                .await
-                .ok()?;
+            let channel = cached_channel(&provider, &cache, &name, &ctx).await.ok()?;
             // forward the decoded INIT pvRequest so QSRV group
             // GET honors `record._options` (e.g. `atomic`). The native
             // wire layer now threads `init_pv_request` into the GET /
@@ -602,6 +689,7 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
         ctx: epics_pva_rs::server_native::source::ChannelContext,
     ) -> impl std::future::Future<Output = Result<(), OpError>> + Send {
         let provider = self.provider.clone();
+        let cache = self.channel_cache.clone();
         async move {
             if !checked.allows_write() {
                 return Err(OpError::denied(format!(
@@ -642,11 +730,10 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                 Some(req) => crate::qsrv::channel::PutOptions::from_pv_request(req, &ctx.log),
                 None => crate::qsrv::channel::PutOptions::from_pv_request(&pv, &ctx.log),
             };
-            let channel = provider
-                .create_channel_with_creds(&name, ctx_to_creds(&ctx))
+            let channel = cached_channel(&provider, &cache, &name, &ctx)
                 .await
                 .map_err(|e| OpError::failed(e.to_string()))?;
-            match channel {
+            match &*channel {
                 crate::qsrv::AnyChannel::Single(single) => single
                     .put_with_options(&pv, opts)
                     .await
@@ -697,6 +784,7 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
         ctx: epics_pva_rs::server_native::source::ChannelContext,
     ) -> impl std::future::Future<Output = Result<(), OpError>> + Send {
         let provider = self.provider.clone();
+        let cache = self.channel_cache.clone();
         async move {
             if !checked.allows_write() {
                 return Err(OpError::denied(format!(
@@ -711,11 +799,10 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
                 Some(PvField::Structure(ref req)) => Some(req),
                 _ => None,
             };
-            let channel = provider
-                .create_channel_with_creds(&name, ctx_to_creds(&ctx))
+            let channel = cached_channel(&provider, &cache, &name, &ctx)
                 .await
                 .map_err(|e| OpError::failed(e.to_string()))?;
-            match channel {
+            match &*channel {
                 crate::qsrv::AnyChannel::Group(group) => {
                     // Prune to the client's marked members (presence ==
                     // marked). Nothing marked → empty apply, which the

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -527,10 +527,11 @@ impl epics_pva_rs::server_native::ChannelSource for QsrvPvStore {
     // `_checked` overrides so every wire op runs against the
     // ACF policy with the correct user/host.
 
-    /// Evict this peer's cached resolution of `name` (see
-    /// [`QsrvPvStore::channel_cache`]). The wire layer fires this once
-    /// per opened channel, for explicit DESTROY_CHANNEL and connection
-    /// teardown alike, so entries never outlive their channel.
+    /// Evict this peer's cached resolution of `name` (see the private
+    /// `QsrvPvStore::channel_cache` field docs). The wire layer fires
+    /// this once per opened channel, for explicit DESTROY_CHANNEL and
+    /// connection teardown alike, so entries never outlive their
+    /// channel.
     fn notify_channel_close(
         &self,
         name: &str,

--- a/crates/epics-bridge-rs/tests/pva_gateway.rs
+++ b/crates/epics-bridge-rs/tests/pva_gateway.rs
@@ -2486,11 +2486,13 @@ async fn r18_28_gateway_monitor_seed_declares_whole_structure() {
 
     let ctx = ChannelContext {
         peer: "127.0.0.1:1234".parse().unwrap(),
-        account: "tester".to_string(),
-        method: "anonymous".to_string(),
-        host: "localhost".to_string(),
-        authority: String::new(),
-        roles: Vec::new(),
+        creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+            account: "tester".to_string(),
+            method: "anonymous".to_string(),
+            host: "localhost".to_string(),
+            authority: String::new(),
+            roles: Vec::new(),
+        }),
         pv_request: None,
         log: Default::default(),
     };

--- a/crates/epics-bridge-rs/tests/pva_gateway.rs
+++ b/crates/epics-bridge-rs/tests/pva_gateway.rs
@@ -2052,7 +2052,7 @@ impl ChannelSource for RecordingDoublingSource {
         checked: AccessChecked,
         _desc: std::sync::Arc<FieldDesc>,
         _changed: BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> impl std::future::Future<Output = Result<Option<SourceRead>, OpError>> + Send {
         let store = self.value.clone();
@@ -2065,7 +2065,7 @@ impl ChannelSource for RecordingDoublingSource {
                 return Err(OpError::denied("write denied"));
             }
             let incoming =
-                double_of(&delta).ok_or_else(|| OpError::failed("no double .value field"))?;
+                double_of(delta).ok_or_else(|| OpError::failed("no double .value field"))?;
             let doubled = incoming * 2.0;
             *store.lock().unwrap() = doubled;
             Ok(Some(SourceRead::from(nt_double_value(doubled))))

--- a/crates/epics-bridge-rs/tests/pva_gateway.rs
+++ b/crates/epics-bridge-rs/tests/pva_gateway.rs
@@ -2050,7 +2050,7 @@ impl ChannelSource for RecordingDoublingSource {
     fn put_get_checked(
         &self,
         checked: AccessChecked,
-        _desc: FieldDesc,
+        _desc: std::sync::Arc<FieldDesc>,
         _changed: BitSet,
         delta: PvField,
         ctx: ChannelContext,

--- a/crates/epics-bridge-rs/tests/testqgroup.rs
+++ b/crates/epics-bridge-rs/tests/testqgroup.rs
@@ -618,11 +618,13 @@ async fn br_r10_33_group_monitor_stamps_the_servers_negotiated_queue_size() {
             .push(("record".into(), PvField::Structure(record)));
         ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "alice".into(),
-            method: "anonymous".into(),
-            host: "host1".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(epics_pva_rs::server_native::config::ClientCredentials {
+                account: "alice".into(),
+                method: "anonymous".into(),
+                host: "host1".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: Some(PvField::Structure(req)),
             log: Default::default(),
         }

--- a/crates/epics-ca-rs/src/bin/softioc-rs.rs
+++ b/crates/epics-ca-rs/src/bin/softioc-rs.rs
@@ -301,7 +301,12 @@ fn parse_macros(macro_strs: &[String]) -> HashMap<String, String> {
     macros
 }
 
-#[tokio::main]
+// One worker, reactor-style: the default per-CPU pool migrates the
+// mostly-serial serving work across idle workers, costing ~35 µs of
+// extra CPU per put on a 96-core host (doc/qsrv-put-perf.md in the
+// workspace root). Multi-thread flavor is kept so `block_on_sync`
+// works from runtime tasks.
+#[tokio::main(worker_threads = 1)]
 async fn main() -> CaResult<()> {
     let args = Args::parse();
 

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -936,14 +936,11 @@ impl ClientState {
         asl: u8,
     ) -> (AccessLevel, bool) {
         let calc_inputs = self.calc_inputs(cfg, asg_name);
-        let calc_ok = |expr: &str| -> bool {
+        let calc_ok = |compiled: &epics_base_rs::calc::CompiledExpr| -> bool {
             match calc_inputs {
-                Some(ref i) => match epics_base_rs::calc::compile(expr) {
-                    Ok(c) => epics_base_rs::calc::eval(&c, &mut i.clone())
-                        .map(|r| r != 0.0)
-                        .unwrap_or(false),
-                    Err(_) => false,
-                },
+                Some(ref i) => epics_base_rs::calc::eval(compiled, &mut i.clone())
+                    .map(|r| r != 0.0)
+                    .unwrap_or(false),
                 None => false,
             }
         };

--- a/crates/epics-pva-rs/src/pvdata/encode.rs
+++ b/crates/epics-pva-rs/src/pvdata/encode.rs
@@ -1756,6 +1756,88 @@ pub fn decode_pv_field_with_bitset_cached(
     }
 }
 
+/// In-place variant of [`decode_pv_field_with_bitset_cached`]: overwrite
+/// exactly the marked fields of `dst`, leaving unmarked slots untouched.
+/// The wire cursor consumes the same bytes as the allocating variant.
+///
+/// `dst` must be shaped like `desc` (a [`default_value_for`] tree or a
+/// previous decode against the same descriptor); a shape mismatch falls
+/// back to the allocating decoder for that subtree, so the call is total
+/// either way.
+///
+/// This exists for the server PUT hot path: a PUT delta usually marks a
+/// couple of leaves of a many-field NT structure, and rebuilding the
+/// unmarked remainder per EXEC (`default_value_for` — a full tree of
+/// field-name Strings) was ~10% of server CPU under a scalar-PUT load.
+/// After this decode, unmarked slots hold values from an earlier EXEC
+/// rather than type defaults; both are semantically dead to the
+/// `put_delta_checked` contract, which reads marked fields only.
+pub fn decode_pv_field_with_bitset_into(
+    dst: &mut PvField,
+    desc: &FieldDesc,
+    bitset: &crate::proto::BitSet,
+    bit_offset: usize,
+    cur: &mut Cursor<&[u8]>,
+    order: ByteOrder,
+    cache: &mut TypeCache,
+) -> Result<(), DecodeError> {
+    fn any_descendant_set(
+        bitset: &crate::proto::BitSet,
+        pos: usize,
+        desc_local: &FieldDesc,
+    ) -> bool {
+        let total = desc_local.total_bits();
+        for i in 0..total {
+            if bitset.get(pos + i) {
+                return true;
+            }
+        }
+        false
+    }
+
+    match desc {
+        FieldDesc::Scalar(_)
+        | FieldDesc::ScalarArray(_)
+        | FieldDesc::Variant
+        | FieldDesc::VariantArray
+        | FieldDesc::Union { .. }
+        | FieldDesc::UnionArray { .. }
+        | FieldDesc::StructureArray { .. } => {
+            if bitset.get(bit_offset) {
+                *dst = decode_pv_field_cached(desc, cur, order, cache)?;
+            }
+            Ok(())
+        }
+        FieldDesc::Structure { fields, .. } => {
+            if bitset.get(bit_offset) {
+                *dst = decode_pv_field_cached(desc, cur, order, cache)?;
+                return Ok(());
+            }
+            if !any_descendant_set(bitset, bit_offset, desc) {
+                return Ok(());
+            }
+            match dst {
+                PvField::Structure(s) if s.fields.len() == fields.len() => {
+                    let mut child_bit = bit_offset + 1;
+                    for ((_, slot), (_, child_desc)) in s.fields.iter_mut().zip(fields) {
+                        decode_pv_field_with_bitset_into(
+                            slot, child_desc, bitset, child_bit, cur, order, cache,
+                        )?;
+                        child_bit += child_desc.total_bits();
+                    }
+                    Ok(())
+                }
+                _ => {
+                    *dst = decode_pv_field_with_bitset_cached(
+                        desc, bitset, bit_offset, cur, order, cache,
+                    )?;
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
 // ── Value-region type-cache marker flattening (reader-task owned) ─────────
 //
 // Used by the connection reader to rewrite 0xFD/0xFE type-cache markers that
@@ -2235,7 +2317,7 @@ pub fn prune_to_marked(
     desc: &FieldDesc,
     bitset: &crate::proto::BitSet,
     bit_offset: usize,
-    decoded: PvField,
+    decoded: &PvField,
 ) -> Option<PvField> {
     match desc {
         FieldDesc::Scalar(_)
@@ -2246,7 +2328,7 @@ pub fn prune_to_marked(
         | FieldDesc::UnionArray { .. }
         | FieldDesc::StructureArray { .. } => {
             if bitset.get(bit_offset) {
-                Some(decoded)
+                Some(decoded.clone())
             } else {
                 None
             }
@@ -2254,21 +2336,30 @@ pub fn prune_to_marked(
         FieldDesc::Structure { .. } if bitset.get(bit_offset) => {
             // Own bit set → the whole subtree was sent fresh (pvxs
             // BitSet compression); every descendant is marked.
-            Some(decoded)
+            Some(decoded.clone())
         }
         FieldDesc::Structure { struct_id, fields } => {
-            let mut decoded_children: Vec<(String, PvField)> = match decoded {
-                PvField::Structure(s) => s.fields,
-                _ => Vec::new(),
+            let decoded_struct = match decoded {
+                PvField::Structure(s) => Some(s),
+                _ => None,
             };
             let mut out = PvStructure::new(struct_id);
             let mut child_bit = bit_offset + 1;
             for (name, child_desc) in fields {
-                let decoded_child = decoded_children
-                    .iter()
-                    .position(|(n, _)| n == name)
-                    .map(|idx| decoded_children.swap_remove(idx).1)
-                    .unwrap_or_else(|| default_value_for(child_desc));
+                // Borrow this child's decoded value; only marked leaves
+                // below are cloned into the pruned output, so the cost is
+                // proportional to what the client actually sent. The
+                // default fill is defensive — the decoder emits every
+                // field — and cheap here because an unmarked default is
+                // pruned without cloning.
+                let default_child;
+                let decoded_child = match decoded_struct.and_then(|s| s.get_field(name)) {
+                    Some(c) => c,
+                    None => {
+                        default_child = default_value_for(child_desc);
+                        &default_child
+                    }
+                };
                 if let Some(kept) = prune_to_marked(child_desc, bitset, child_bit, decoded_child) {
                     out.fields.push((name.clone(), kept));
                 }
@@ -4315,7 +4406,7 @@ mod tests {
         let desc = two_member_group_desc();
         let mut changed = crate::proto::BitSet::new();
         changed.set(1); // member `a` only
-        let pruned = prune_to_marked(&desc, &changed, 0, two_member_delta());
+        let pruned = prune_to_marked(&desc, &changed, 0, &two_member_delta());
         let s = match pruned {
             Some(PvField::Structure(s)) => s,
             other => panic!("expected a structure, got {other:?}"),
@@ -4335,7 +4426,7 @@ mod tests {
         let desc = two_member_group_desc();
         let changed = crate::proto::BitSet::new(); // nothing set
         assert!(
-            prune_to_marked(&desc, &changed, 0, two_member_delta()).is_none(),
+            prune_to_marked(&desc, &changed, 0, &two_member_delta()).is_none(),
             "an unmarked delta prunes to None (nothing to apply)"
         );
     }
@@ -4347,12 +4438,137 @@ mod tests {
         let desc = two_member_group_desc();
         let mut changed = crate::proto::BitSet::new();
         changed.set(0);
-        let pruned = prune_to_marked(&desc, &changed, 0, two_member_delta());
+        let pruned = prune_to_marked(&desc, &changed, 0, &two_member_delta());
         let s = match pruned {
             Some(PvField::Structure(s)) => s,
             other => panic!("expected a structure, got {other:?}"),
         };
         assert!(s.get_field("a").is_some() && s.get_field("b").is_some());
+    }
+
+    // ---- decode_pv_field_with_bitset_into: scratch-reuse decode ----
+
+    /// Boundary: marked leaf overwritten, unmarked leaf untouched. The
+    /// unmarked slot deliberately holds a non-default sentinel (99) to
+    /// prove the in-place decode does not rebuild it.
+    #[test]
+    fn decode_into_overwrites_marked_and_keeps_unmarked() {
+        let desc = two_member_group_desc();
+        let mut changed = crate::proto::BitSet::new();
+        changed.set(1); // member `a` only
+        // Wire bytes: just the marked `a` leaf (Long 42).
+        let mut wire = Vec::new();
+        encode_scalar_value(&ScalarValue::Long(42), ByteOrder::Little, &mut wire);
+
+        let mut dst = two_member_delta(); // a=11, b=0
+        if let PvField::Structure(s) = &mut dst {
+            s.fields[1].1 = PvField::Scalar(ScalarValue::Long(99)); // stale sentinel
+        }
+        let mut cur = Cursor::new(wire.as_slice());
+        let mut cache = TypeCache::new();
+        decode_pv_field_with_bitset_into(
+            &mut dst,
+            &desc,
+            &changed,
+            0,
+            &mut cur,
+            ByteOrder::Little,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(
+            cur.remaining(),
+            0,
+            "cursor must consume exactly the marked leaf"
+        );
+        let s = match &dst {
+            PvField::Structure(s) => s,
+            other => panic!("expected structure, got {other:?}"),
+        };
+        assert_eq!(
+            s.get_field("a"),
+            Some(&PvField::Scalar(ScalarValue::Long(42))),
+            "marked leaf must carry the decoded value"
+        );
+        assert_eq!(
+            s.get_field("b"),
+            Some(&PvField::Scalar(ScalarValue::Long(99))),
+            "unmarked leaf must keep its previous (stale) value untouched"
+        );
+    }
+
+    /// Boundary: nothing marked → dst untouched, no bytes consumed.
+    #[test]
+    fn decode_into_nothing_marked_leaves_dst_and_cursor() {
+        let desc = two_member_group_desc();
+        let changed = crate::proto::BitSet::new();
+        let mut dst = two_member_delta();
+        let before = dst.clone();
+        let wire: [u8; 0] = [];
+        let mut cur = Cursor::new(&wire[..]);
+        let mut cache = TypeCache::new();
+        decode_pv_field_with_bitset_into(
+            &mut dst,
+            &desc,
+            &changed,
+            0,
+            &mut cur,
+            ByteOrder::Little,
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(dst, before);
+    }
+
+    /// Boundary: root bit set (pvxs BitSet compression) and shape-mismatch
+    /// fallback must both yield exactly what the allocating decoder yields
+    /// from the same bytes.
+    #[test]
+    fn decode_into_matches_allocating_decoder() {
+        let desc = two_member_group_desc();
+        for (mark_root, dst_seed) in [
+            (true, two_member_delta()),
+            (false, PvField::Null), // shape mismatch → fallback path
+        ] {
+            let mut changed = crate::proto::BitSet::new();
+            if mark_root {
+                changed.set(0);
+            } else {
+                changed.set(1);
+                changed.set(2);
+            }
+            let mut wire = Vec::new();
+            encode_scalar_value(&ScalarValue::Long(7), ByteOrder::Little, &mut wire);
+            encode_scalar_value(&ScalarValue::Long(8), ByteOrder::Little, &mut wire);
+
+            let mut dst = dst_seed;
+            let mut cur = Cursor::new(wire.as_slice());
+            let mut cache = TypeCache::new();
+            decode_pv_field_with_bitset_into(
+                &mut dst,
+                &desc,
+                &changed,
+                0,
+                &mut cur,
+                ByteOrder::Little,
+                &mut cache,
+            )
+            .unwrap();
+
+            let mut cur2 = Cursor::new(wire.as_slice());
+            let mut cache2 = TypeCache::new();
+            let allocated = decode_pv_field_with_bitset_cached(
+                &desc,
+                &changed,
+                0,
+                &mut cur2,
+                ByteOrder::Little,
+                &mut cache2,
+            )
+            .unwrap();
+            assert_eq!(dst, allocated, "mark_root={mark_root}");
+            assert_eq!(cur.position(), cur2.position(), "mark_root={mark_root}");
+        }
     }
 
     /// PVA-89: a `ScalarValue::String` carrying non-UTF-8 bytes must

--- a/crates/epics-pva-rs/src/server/native_source.rs
+++ b/crates/epics-pva-rs/src/server/native_source.rs
@@ -1215,11 +1215,13 @@ mod tests {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         ChannelContext {
             peer: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-            account: account.to_string(),
-            method: method.to_string(),
-            host: host.to_string(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(crate::server_native::config::ClientCredentials {
+                account: account.to_string(),
+                method: method.to_string(),
+                host: host.to_string(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }
@@ -1254,7 +1256,13 @@ mod tests {
         ) -> Result<(), String> {
             let checked = self
                 .access()
-                .check(pv, &ctx.host, &ctx.account, &ctx.method, "")
+                .check(
+                    pv,
+                    &ctx.creds.host,
+                    &ctx.creds.account,
+                    &ctx.creds.method,
+                    "",
+                )
                 .await;
             self.put_value_checked(checked, value, ctx)
                 .await
@@ -1263,7 +1271,13 @@ mod tests {
         async fn get_value_ctx(&self, pv: &str, ctx: ChannelContext) -> Option<PvField> {
             let checked = self
                 .access()
-                .check(pv, &ctx.host, &ctx.account, &ctx.method, "")
+                .check(
+                    pv,
+                    &ctx.creds.host,
+                    &ctx.creds.account,
+                    &ctx.creds.method,
+                    "",
+                )
                 .await;
             self.get_value_checked(checked, ctx).await
         }
@@ -1274,7 +1288,13 @@ mod tests {
         ) -> Option<MonitorStream<PvField>> {
             let checked = self
                 .access()
-                .check(pv, &ctx.host, &ctx.account, &ctx.method, "")
+                .check(
+                    pv,
+                    &ctx.creds.host,
+                    &ctx.creds.account,
+                    &ctx.creds.method,
+                    "",
+                )
                 .await;
             self.subscribe_checked(checked, ctx).await
         }
@@ -3115,7 +3135,13 @@ ASG(DEFAULT) {
         // PROCESS via the WRITE-gated checked path (no ACF → allowed).
         let checked = source
             .access()
-            .check("CALC:PROC", &ctx.host, &ctx.account, &ctx.method, "")
+            .check(
+                "CALC:PROC",
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.method,
+                "",
+            )
             .await;
         source
             .process_checked(checked, ctx.clone())
@@ -3163,7 +3189,13 @@ ASG(DEFAULT) {
 
         let checked = source
             .access()
-            .check("CALC:PUT.A", &ctx.host, &ctx.account, &ctx.method, "")
+            .check(
+                "CALC:PUT.A",
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.method,
+                "",
+            )
             .await;
         let mut put = PvStructure::new("epics:nt/NTScalar:1.0");
         put.fields
@@ -3206,7 +3238,13 @@ ASG(DEFAULT) {
         let ctx = make_ctx("localhost", "op", "ca");
         let checked = source
             .access()
-            .check("AI:MON", &ctx.host, &ctx.account, &ctx.method, "")
+            .check(
+                "AI:MON",
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.method,
+                "",
+            )
             .await;
 
         let mut rx = source
@@ -3387,7 +3425,13 @@ ASG(DEFAULT) {
         let ctx = make_ctx("localhost", "op", "ca");
         let checked = source
             .access()
-            .check("AI:IDLE", &ctx.host, &ctx.account, &ctx.method, "")
+            .check(
+                "AI:IDLE",
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.method,
+                "",
+            )
             .await;
 
         let mut rx = source
@@ -3421,7 +3465,13 @@ ASG(DEFAULT) {
         let ctx = make_ctx("localhost", "op", "ca");
         let checked = source
             .access()
-            .check("MAILBOX:PV", &ctx.host, &ctx.account, &ctx.method, "")
+            .check(
+                "MAILBOX:PV",
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.method,
+                "",
+            )
             .await;
         assert!(
             source.process_checked(checked, ctx).await.is_err(),

--- a/crates/epics-pva-rs/src/server_native/composite.rs
+++ b/crates/epics-pva-rs/src/server_native/composite.rs
@@ -626,7 +626,7 @@ impl ChannelSource for CompositeSource {
     fn put_delta_checked(
         &self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: crate::server_native::source::ChannelContext,
@@ -653,7 +653,7 @@ impl ChannelSource for CompositeSource {
     fn put_get_checked(
         &self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: crate::server_native::source::ChannelContext,

--- a/crates/epics-pva-rs/src/server_native/composite.rs
+++ b/crates/epics-pva-rs/src/server_native/composite.rs
@@ -628,7 +628,7 @@ impl ChannelSource for CompositeSource {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: crate::server_native::source::ChannelContext,
     ) -> impl std::future::Future<Output = Result<(), OpError>> + Send {
         let name = checked.pv_name().to_string();
@@ -655,7 +655,7 @@ impl ChannelSource for CompositeSource {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: crate::server_native::source::ChannelContext,
     ) -> impl std::future::Future<
         Output = Result<Option<crate::server_native::source::SourceRead>, OpError>,

--- a/crates/epics-pva-rs/src/server_native/composite.rs
+++ b/crates/epics-pva-rs/src/server_native/composite.rs
@@ -213,7 +213,13 @@ impl CompositeSource {
             if src.has_pv_checked(name, ctx.clone()).await {
                 let inner = src
                     .access_gate()
-                    .check(name, &ctx.host, &ctx.account, &ctx.method, &ctx.authority)
+                    .check(
+                        name,
+                        &ctx.creds.host,
+                        &ctx.creds.account,
+                        &ctx.creds.method,
+                        &ctx.creds.authority,
+                    )
                     .await;
                 return Some((src, inner));
             }
@@ -1626,7 +1632,7 @@ mod tests {
             ) -> impl std::future::Future<Output = bool> + Send {
                 let acct = self.checked_account.clone();
                 async move {
-                    *acct.lock() = Some(ctx.account);
+                    *acct.lock() = Some(ctx.creds.account.clone());
                     true
                 }
             }
@@ -1673,11 +1679,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "alice".into(),
-            method: "ca".into(),
-            host: "h".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(crate::server_native::config::ClientCredentials {
+                account: "alice".into(),
+                method: "ca".into(),
+                host: "h".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };
@@ -1693,7 +1701,7 @@ mod tests {
         assert_eq!(
             checked_account.lock().as_deref(),
             Some("alice"),
-            "composite must select via has_pv_checked carrying ctx.account"
+            "composite must select via has_pv_checked carrying ctx.creds.account"
         );
         assert!(
             !plain_seen.load(Ordering::SeqCst),
@@ -1717,11 +1725,13 @@ mod tests {
         use crate::server_native::source::ChannelContext;
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "alice".into(),
-            method: "ca".into(),
-            host: "h".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(crate::server_native::config::ClientCredentials {
+                account: "alice".into(),
+                method: "ca".into(),
+                host: "h".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };

--- a/crates/epics-pva-rs/src/server_native/config.rs
+++ b/crates/epics-pva-rs/src/server_native/config.rs
@@ -89,7 +89,10 @@ pub struct PvaServerConfig {
     pub guid: [u8; 12],
     /// Per-frame read timeout. The server *also* applies the heartbeat-
     /// based idle timeout below — `op_timeout` is just the upper bound on
-    /// any single read.
+    /// how long the peer may go without completing a frame. Enforced
+    /// coarsely by the connection loop's deadline ticker (period
+    /// `op_timeout / 2`, capped at 15 s) rather than a per-read timer,
+    /// so a stall is detected within one tick past the bound.
     pub op_timeout: Duration,
     /// Bind address for the TCP listener (default `0.0.0.0`).
     ///

--- a/crates/epics-pva-rs/src/server_native/op_handle.rs
+++ b/crates/epics-pva-rs/src/server_native/op_handle.rs
@@ -325,11 +325,13 @@ mod tests {
     fn dummy_creds() -> ClientCredentials {
         ClientCredentials {
             peer: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1),
-            account: "anonymous".into(),
-            method: "anonymous".into(),
-            host: "localhost".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(crate::server_native::config::ClientCredentials {
+                account: "anonymous".into(),
+                method: "anonymous".into(),
+                host: "localhost".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }

--- a/crates/epics-pva-rs/src/server_native/shared_pv.rs
+++ b/crates/epics-pva-rs/src/server_native/shared_pv.rs
@@ -1440,7 +1440,7 @@ impl super::source::ChannelSource for SharedSource {
     fn put_delta_checked(
         &self,
         checked: super::source::AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: super::source::ChannelContext,

--- a/crates/epics-pva-rs/src/server_native/shared_pv.rs
+++ b/crates/epics-pva-rs/src/server_native/shared_pv.rs
@@ -1442,7 +1442,7 @@ impl super::source::ChannelSource for SharedSource {
         checked: super::source::AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: super::source::ChannelContext,
     ) -> impl std::future::Future<Output = Result<(), OpError>> + Send {
         let pv = self.pvs.lock().get(checked.pv_name()).cloned();
@@ -1457,7 +1457,9 @@ impl super::source::ChannelSource for SharedSource {
                 )));
             }
             match pv {
-                Some(p) => p.put_delta(&desc, &changed, delta).map_err(OpError::failed),
+                Some(p) => p
+                    .put_delta(&desc, &changed, delta.clone())
+                    .map_err(OpError::failed),
                 None => Err(OpError::failed(format!(
                     "no such PV: {}",
                     checked.pv_name()

--- a/crates/epics-pva-rs/src/server_native/shared_pv.rs
+++ b/crates/epics-pva-rs/src/server_native/shared_pv.rs
@@ -1451,9 +1451,9 @@ impl super::source::ChannelSource for SharedSource {
                 return Err(OpError::denied(format!(
                     "PUT denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             match pv {
@@ -2073,11 +2073,13 @@ mod tests {
 
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: String::new(),
-            method: "anonymous".into(),
-            host: String::new(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: std::sync::Arc::new(crate::server_native::config::ClientCredentials {
+                account: String::new(),
+                method: "anonymous".into(),
+                host: String::new(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };

--- a/crates/epics-pva-rs/src/server_native/source.rs
+++ b/crates/epics-pva-rs/src/server_native/source.rs
@@ -853,13 +853,16 @@ pub trait ChannelSource: Send + Sync + 'static {
     ///
     /// `desc` is the PV introspection (per-field bit numbering);
     /// `changed` is the wire changed-BitSet; `delta` is the decoded
-    /// sparse value (unmarked leaves hold type defaults).
+    /// sparse value, borrowed because the wire layer reuses it as the
+    /// channel's decode scratch across EXECs. Only `changed`-marked
+    /// fields carry client data; unmarked slots hold type defaults or
+    /// stale values from an earlier EXEC and MUST NOT be read.
     fn put_delta_checked(
         &self,
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> impl std::future::Future<Output = Result<(), OpError>> + Send {
         async move {
@@ -881,9 +884,13 @@ pub trait ChannelSource: Send + Sync + 'static {
             // enforces the WRITE gate.
             let merged = match self.get_value_checked(checked.clone(), ctx.clone()).await {
                 Some(prior) => crate::pvdata::encode::fill_unmarked_from_prior(
-                    &desc, &changed, 0, delta, &prior,
+                    &desc,
+                    &changed,
+                    0,
+                    delta.clone(),
+                    &prior,
                 ),
-                None => delta,
+                None => delta.clone(),
             };
             self.put_value_checked(checked, merged, ctx).await
         }
@@ -914,7 +921,7 @@ pub trait ChannelSource: Send + Sync + 'static {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &PvField,
         ctx: ChannelContext,
     ) -> impl std::future::Future<Output = Result<Option<SourceRead>, OpError>> + Send {
         async move {
@@ -2180,7 +2187,7 @@ pub trait ChannelSourceObj: Send + Sync {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &'a PvField,
         ctx: ChannelContext,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), OpError>> + Send + 'a>>;
     /// Dyn forwarder for type-state atomic PUT_GET.
@@ -2189,7 +2196,7 @@ pub trait ChannelSourceObj: Send + Sync {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &'a PvField,
         ctx: ChannelContext,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<Option<SourceRead>, OpError>> + Send + 'a>,
@@ -2479,7 +2486,7 @@ impl<T: ChannelSource + 'static> ChannelSourceObj for T {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &'a PvField,
         ctx: ChannelContext,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), OpError>> + Send + 'a>> {
         Box::pin(<Self as ChannelSource>::put_delta_checked(
@@ -2491,7 +2498,7 @@ impl<T: ChannelSource + 'static> ChannelSourceObj for T {
         checked: AccessChecked,
         desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
-        delta: PvField,
+        delta: &'a PvField,
         ctx: ChannelContext,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<Option<SourceRead>, OpError>> + Send + 'a>,

--- a/crates/epics-pva-rs/src/server_native/source.rs
+++ b/crates/epics-pva-rs/src/server_native/source.rs
@@ -90,33 +90,16 @@ impl RemoteLog {
 pub struct ChannelContext {
     /// Downstream client TCP socket address.
     pub peer: SocketAddr,
-    /// Account name. For `ca`/`anonymous` this comes from
-    /// CONNECTION_VALIDATION; for `x509` it is the verified peer
-    /// leaf-certificate subject CommonName.
-    pub account: String,
-    /// Auth method (`"anonymous"`, `"ca"`, `"x509"`).
-    pub method: String,
-    /// Host identity of the peer as the ACF `HAG(...)` gate matches it —
-    /// [`Self::peer`]'s address in numeric form, port stripped and
-    /// IPv4-mapped IPv6 collapsed to IPv4 (QSRV `ioc/credentials.cpp:27-29`).
-    ///
-    /// NOT reverse-resolved, and never taken from the wire: a client's
-    /// advertised `host` field is ignored by the CONNECTION_VALIDATION
-    /// parser, because this is the string host-scoped ACF rules are matched
-    /// against. See `ClientCredentials::host`.
-    pub host: String,
-    /// Certificate authority for the `x509` method: the root CA's
-    /// subject CommonName. Empty for non-TLS methods. ACF
-    /// `AUTHORITY(...)` rule scopes match against this.
-    pub authority: String,
-    /// Group / role memberships of the peer's `account`, re-derived
-    /// SERVER-SIDE from the local passwd/group DB into
-    /// `ClientCredentials::roles` (NEVER from the wire — pvxs
-    /// `ClientCredentials::roles()` / `osdGetRoles`) and forwarded here so
-    /// role-based ACF rules (`R member group:ops`, `role/...` credential
-    /// strings) can be enforced for native PVA clients. A client cannot
-    /// self-assign these to satisfy a group-gated rule.
-    pub roles: Vec<String>,
+    /// Peer identity in force for this operation — account, method,
+    /// host, authority, and roles, exactly as CONNECTION_VALIDATION /
+    /// the TLS handshake established them (see the
+    /// [`ClientCredentials`](super::config::ClientCredentials) field
+    /// docs for the security derivation rules: `host` and `roles` are
+    /// server-derived and never wire-supplied). One immutable block is
+    /// shared by refcount across every context minted under the same
+    /// connection auth state, so per-operation contexts clone in O(1)
+    /// and all layers read the same strings.
+    pub creds: Arc<super::config::ClientCredentials>,
     /// Decoded INIT pvRequest value for the current operation, when
     /// the wire layer captured one. PVA PUT INIT carries
     /// `record._options.process`/`block`; the data-phase payload is
@@ -754,17 +737,20 @@ pub trait ChannelSource: Send + Sync + 'static {
         ctx: ChannelContext,
     ) -> impl std::future::Future<Output = Option<AccessChecked>> + Send {
         let gate = self.access();
-        let host = ctx.host.clone();
-        let account = ctx.account.clone();
-        let method = ctx.method.clone();
-        let authority = ctx.authority.clone();
-        // forward the peer's role claims so `role/<name>` UAG
-        // members can match.
-        let roles = ctx.roles.clone();
+        // one refcount carries host/account/method/authority and the
+        // peer's role claims (so `role/<name>` UAG members can match).
+        let creds = ctx.creds.clone();
         let name = pv_name.to_string();
         async move {
             let checked = gate
-                .check_with_roles(&name, &host, &account, &roles, &method, &authority)
+                .check_with_roles(
+                    &name,
+                    &creds.host,
+                    &creds.account,
+                    &creds.roles,
+                    &creds.method,
+                    &creds.authority,
+                )
                 .await;
             if checked.allows_read() {
                 Some(checked)
@@ -818,9 +804,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "PUT denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             self.put_value(checked.pv_name(), value).await
@@ -994,9 +980,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "ARRAY get denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             let _ = (offset, count, stride);
@@ -1022,9 +1008,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "ARRAY put denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             let _ = (offset, stride, value);
@@ -1048,9 +1034,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "ARRAY setLength denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             let _ = length;
@@ -1074,9 +1060,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "ARRAY getLength denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             Err(OpError::failed(
@@ -1348,9 +1334,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "RPC denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             self.rpc(checked.pv_name(), request_desc, request_value)
@@ -1390,9 +1376,9 @@ pub trait ChannelSource: Send + Sync + 'static {
                 return Err(OpError::denied(format!(
                     "PROCESS denied by access security: '{}' from {}/{}/{}",
                     checked.pv_name(),
-                    ctx.host,
-                    ctx.account,
-                    ctx.method,
+                    ctx.creds.host,
+                    ctx.creds.account,
+                    ctx.creds.method,
                 )));
             }
             self.process(checked.pv_name()).await

--- a/crates/epics-pva-rs/src/server_native/source.rs
+++ b/crates/epics-pva-rs/src/server_native/source.rs
@@ -857,7 +857,7 @@ pub trait ChannelSource: Send + Sync + 'static {
     fn put_delta_checked(
         &self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -912,7 +912,7 @@ pub trait ChannelSource: Send + Sync + 'static {
     fn put_get_checked(
         &self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -2178,7 +2178,7 @@ pub trait ChannelSourceObj: Send + Sync {
     fn put_delta_checked<'a>(
         &'a self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -2187,7 +2187,7 @@ pub trait ChannelSourceObj: Send + Sync {
     fn put_get_checked<'a>(
         &'a self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -2477,7 +2477,7 @@ impl<T: ChannelSource + 'static> ChannelSourceObj for T {
     fn put_delta_checked<'a>(
         &'a self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,
@@ -2489,7 +2489,7 @@ impl<T: ChannelSource + 'static> ChannelSourceObj for T {
     fn put_get_checked<'a>(
         &'a self,
         checked: AccessChecked,
-        desc: FieldDesc,
+        desc: std::sync::Arc<FieldDesc>,
         changed: crate::proto::BitSet,
         delta: PvField,
         ctx: ChannelContext,

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -810,8 +810,41 @@ impl Drop for AbortOnDrop {
     }
 }
 
-/// Apply the data-phase op continuation after a GET/PUT/RPC EXEC task
-/// has been spawned.
+/// Run a data-phase EXEC body inline on the read-loop thread when it can
+/// complete without waiting; promote it to a spawned task only when it
+/// cannot.
+///
+/// pvxs executes GET/PUT/RPC callbacks synchronously on the connection's
+/// event-loop thread and replies from the same stack. Spawning a task per
+/// EXEC instead costs several cross-thread futex wakes per operation
+/// (worker wake, reply-channel wake, `ExecFinished` wake back to the read
+/// loop) — measured ~8.8 wakes per wire PUT against pvxs's ~0.1. One poll
+/// under a noop waker lets the common already-ready body (local source,
+/// uncontended locks, writer channel below capacity) finish with no task
+/// at all; a body that genuinely waits (remote-fronting source, writer
+/// backpressure) is handed to `spawn`, which schedules an immediate first
+/// poll that re-registers every waker the noop poll discarded.
+///
+/// Returns the abort handle when promoted, `None` when the body already
+/// ran to completion (nothing left to abort). Either way the body's
+/// [`ExecFinishGuard`] has queued (or will queue) its `ExecFinished`, and
+/// the read loop drains that queue only after the caller's
+/// [`finish_exec_data_task`] bookkeeping ran, so the `last_request`
+/// disposition in [`apply_exec_finish`] is unchanged.
+fn poll_inline_or_spawn<F>(fut: F) -> Option<epics_base_rs::runtime::task::TaskAbortHandle>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let mut fut = Box::pin(fut);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    match std::future::Future::poll(fut.as_mut(), &mut cx) {
+        std::task::Poll::Ready(()) => None,
+        std::task::Poll::Pending => Some(epics_base_rs::runtime::task::spawn(fut).abort_handle()),
+    }
+}
+
+/// Apply the data-phase op continuation after a GET/PUT/RPC EXEC body
+/// has been started by [`poll_inline_or_spawn`].
 ///
 /// pvxs records `op->lastRequest = subcmd & 0x10` *while the op stays
 /// `Executing` in `opByIOID`* (`serverget.cpp:470-471`) and only
@@ -822,9 +855,9 @@ impl Drop for AbortOnDrop {
 /// slow source replied, and have the still-in-flight first reply and the new
 /// operation collide on one IOID on the wire.
 ///
-/// The Rust EXEC handlers serialize their response from a spawned task that
+/// The Rust EXEC handlers serialize their response from a body that
 /// cannot reach `ch.ops`, so the read-loop owner defers cleanup to
-/// [`apply_exec_finish`], which fires when the task's [`ExecFinishGuard`]
+/// [`apply_exec_finish`], which fires when the body's [`ExecFinishGuard`]
 /// signals completion (right after the reply is handed to the writer). Both
 /// branches therefore keep the op reserved and install the abort guard; only
 /// the bookkeeping differs:
@@ -834,17 +867,21 @@ impl Drop for AbortOnDrop {
 ///   is out, not before.
 /// - otherwise: leave it `Executing`; the completion owner returns it to
 ///   `Idle` so a later explicit re-EXEC is accepted.
+///
+/// `abort` is `None` when the body completed inline — there is no task to
+/// abort, and the op's guard slot is already `None` (an `Idle` op holds no
+/// guard, and `begin_exec` only admits `Idle` ops).
 fn finish_exec_data_task(
     ch: &mut ChannelState,
     ioid: u32,
     subcmd: u8,
-    abort: epics_base_rs::runtime::task::TaskAbortHandle,
+    abort: Option<epics_base_rs::runtime::task::TaskAbortHandle>,
 ) {
     if let Some(op_mut) = ch.ops.get_mut(&ioid) {
         if subcmd & QosFlags::DESTROY != 0 {
             op_mut.last_request = true;
         }
-        op_mut.data_task_abort = Some(Arc::new(AbortOnDrop(abort)));
+        op_mut.data_task_abort = abort.map(|a| Arc::new(AbortOnDrop(a)));
     }
 }
 
@@ -4417,7 +4454,7 @@ async fn handle_put_get(
         success: false,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
-    let join = epics_base_rs::runtime::task::spawn(async move {
+    let abort = poll_inline_or_spawn(async move {
         // return this op to `Idle` (via the read-loop owner) when the
         // task ends so a later explicit re-EXEC is accepted.
         let _exec_fin_guard = ExecFinishGuard {
@@ -4527,7 +4564,7 @@ async fn handle_put_get(
     // last-request bit (`subcmd & 0x10`), defer the op's removal until its
     // reply has been sent — the same completion-owned cleanup GET/PUT/RPC use
     // (see [`finish_exec_data_task`]).
-    finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+    finish_exec_data_task(ch, ioid, subcmd, abort);
     Ok(())
 }
 
@@ -4763,7 +4800,7 @@ async fn handle_process(
         success: false,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
-    let join = epics_base_rs::runtime::task::spawn(async move {
+    let abort = poll_inline_or_spawn(async move {
         // return this op to `Idle` (via the read-loop owner) when the
         // task ends so a later explicit re-EXEC is accepted.
         let _exec_fin_guard = ExecFinishGuard {
@@ -4807,7 +4844,7 @@ async fn handle_process(
     // last-request bit (`subcmd & 0x10`), defer the op's removal until its
     // reply has been sent — the same completion-owned cleanup GET/PUT/RPC use
     // (see [`finish_exec_data_task`]).
-    finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+    finish_exec_data_task(ch, ioid, subcmd, abort);
     Ok(())
 }
 
@@ -5133,7 +5170,7 @@ async fn handle_channel_array(
         success: false,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
-    let join = epics_base_rs::runtime::task::spawn(async move {
+    let abort = poll_inline_or_spawn(async move {
         let _exec_fin_guard = ExecFinishGuard {
             tx: exec_fin_tx_task,
             fin: exec_fin,
@@ -5212,7 +5249,7 @@ async fn handle_channel_array(
         buf.extend_from_slice(&payload);
         let _ = tx_clone.send(buf).await;
     });
-    finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+    finish_exec_data_task(ch, ioid, subcmd, abort);
     Ok(())
 }
 
@@ -6751,7 +6788,7 @@ async fn handle_op(
                 success: false,
             };
             let exec_fin_tx_task = exec_fin_tx.clone();
-            let join = epics_base_rs::runtime::task::spawn(async move {
+            let abort = poll_inline_or_spawn(async move {
                 // returns this op to `Idle` (via the read-loop owner)
                 // when the task ends, so a later explicit re-EXEC is accepted.
                 let mut exec_fin_guard = ExecFinishGuard {
@@ -6854,7 +6891,7 @@ async fn handle_op(
                 exec_fin_guard.mark_success();
                 let _ = tx_clone.send(buf).await;
             });
-            finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+            finish_exec_data_task(ch, ioid, subcmd, abort);
         }
         OpKind::Put => {
             // pvxs `serverget.cpp:364` derives `isput = cmd!=CMD_GET
@@ -6901,7 +6938,7 @@ async fn handle_op(
                     success: false,
                 };
                 let exec_fin_tx_task = exec_fin_tx.clone();
-                let join = epics_base_rs::runtime::task::spawn(async move {
+                let abort = poll_inline_or_spawn(async move {
                     let mut exec_fin_guard = ExecFinishGuard {
                         tx: exec_fin_tx_task,
                         fin: exec_fin,
@@ -6989,7 +7026,7 @@ async fn handle_op(
                     exec_fin_guard.mark_success();
                     let _ = tx_clone.send(buf).await;
                 });
-                finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+                finish_exec_data_task(ch, ioid, subcmd, abort);
                 return Ok(());
             }
             // PUT EXEC (subcmd & 0x40 == 0): read bitset (which
@@ -7050,7 +7087,7 @@ async fn handle_op(
                 success: false,
             };
             let exec_fin_tx_task = exec_fin_tx.clone();
-            let join = epics_base_rs::runtime::task::spawn(async move {
+            let abort = poll_inline_or_spawn(async move {
                 let mut exec_fin_guard = ExecFinishGuard {
                     tx: exec_fin_tx_task,
                     fin: exec_fin,
@@ -7168,7 +7205,7 @@ async fn handle_op(
                 }
                 let _ = tx_clone.send(buf).await;
             });
-            finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+            finish_exec_data_task(ch, ioid, subcmd, abort);
         }
         OpKind::Monitor => {
             // pvxs `servermon.cpp:643-708` splits the data-phase MONITOR
@@ -7417,7 +7454,7 @@ async fn handle_op(
                 success: false,
             };
             let exec_fin_tx_task = exec_fin_tx.clone();
-            let join = epics_base_rs::runtime::task::spawn(async move {
+            let abort = poll_inline_or_spawn(async move {
                 let mut exec_fin_guard = ExecFinishGuard {
                     tx: exec_fin_tx_task,
                     fin: exec_fin,
@@ -7493,7 +7530,7 @@ async fn handle_op(
                 }
                 let _ = tx_clone.send(buf).await;
             });
-            finish_exec_data_task(ch, ioid, subcmd, join.abort_handle());
+            finish_exec_data_task(ch, ioid, subcmd, abort);
         }
         // PUT_GET / PROCESS / GET_FIELD have dedicated handlers
         // (`handle_put_get`, `handle_process`, `handle_get_field`) and are
@@ -7645,7 +7682,7 @@ async fn handle_get_field(
         success: false,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
-    let join = epics_base_rs::runtime::task::spawn(async move {
+    let abort = poll_inline_or_spawn(async move {
         // terminal finalizer — releases the reserved IOID on EVERY exit
         // (reply sent, panic, or abort), like the GET/PUT/RPC exec tasks.
         let _exec_fin_guard = ExecFinishGuard {
@@ -7685,7 +7722,7 @@ async fn handle_get_field(
     // Install the abort guard on the reserved op so DESTROY_REQUEST /
     // teardown (which drop the op) cancel this task. `subcmd` is irrelevant
     // here — `last_request` is already set on the reserved op above.
-    finish_exec_data_task(chan_mut, ioid, 0, join.abort_handle());
+    finish_exec_data_task(chan_mut, ioid, 0, abort);
     Ok(())
 }
 

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -747,7 +747,10 @@ struct ChannelState {
     name: String,
     cid: u32,
     sid: u32,
-    introspection: Option<FieldDesc>,
+    /// Channel-invariant negotiated descriptor, shared by refcount with
+    /// every op minted on this channel — a per-op deep clone of a full
+    /// NTScalar tree was 11% of server CPU under a PUT load.
+    introspection: Option<Arc<FieldDesc>>,
     /// Source bound at CREATE_CHANNEL that owns this channel. Every
     /// operation (GET/PUT/MONITOR/RPC/PROCESS/GET_FIELD) dispatches
     /// through this owner instead of re-resolving the top-level source
@@ -1146,7 +1149,7 @@ async fn catch_handler_panic<T>(fut: impl std::future::Future<Output = T>) -> Re
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 struct OpState {
-    intro: FieldDesc,
+    intro: Arc<FieldDesc>,
     kind: OpKind,
     /// For MONITOR ops: true once the subscriber task has been spawned.
     /// Subsequent START/pipeline-ack messages are no-ops.
@@ -1870,7 +1873,7 @@ struct MonitorSubscriberArgs {
     sid: u32,
     ioid: u32,
     pv_name: String,
-    intro: FieldDesc,
+    intro: Arc<FieldDesc>,
     mask: BitSet,
     /// Per-channel writer (clone of the connection `ChannelTx`).
     tx: ChannelTx,
@@ -2964,7 +2967,7 @@ struct CreateChannelCompletion {
 /// Successful CREATE_CHANNEL resolution: the descriptor negotiated for
 /// the channel plus the owner source that accepted it.
 struct ResolvedChannel {
-    intro: Option<FieldDesc>,
+    intro: Option<Arc<FieldDesc>>,
     owner: DynSource,
     /// Source-supplied contextual info for the report's per-channel
     /// `info` field, queried from the bound owner at resolution time —
@@ -3339,7 +3342,7 @@ pub(super) async fn handle_connection_io(
                             && let Some(intro) = owner.get_introspection_checked(&name, ctx).await
                             && let Some(ch) = channels.get_mut(&cc.sid)
                         {
-                            ch.introspection = Some(intro);
+                            ch.introspection = Some(Arc::new(intro));
                         }
                     } else {
                         // CREATE_CHANNEL failure sid must be the
@@ -4043,7 +4046,7 @@ fn decode_rpc_exec_arg(
 /// Build a minimal [`OpState`] for non-MONITOR ops (GET / PUT /
 /// PUT_GET / PROCESS). The monitor-specific fields are all defaulted
 /// to inert values — these ops never spawn a subscriber task.
-fn non_monitor_op_state(intro: FieldDesc, kind: OpKind, mask: BitSet) -> OpState {
+fn non_monitor_op_state(intro: Arc<FieldDesc>, kind: OpKind, mask: BitSet) -> OpState {
     OpState {
         intro,
         kind,
@@ -4977,7 +4980,8 @@ async fn handle_channel_array(
         match source.channel_array_init(&pv_name, ctx).await {
             Ok(array_desc) => {
                 let mask = BitSet::all_set(array_desc.total_bits());
-                let mut array_op = non_monitor_op_state(array_desc.clone(), OpKind::Array, mask);
+                let mut array_op =
+                    non_monitor_op_state(Arc::new(array_desc.clone()), OpKind::Array, mask);
                 array_op.pv_request = req_value;
                 ch.ops.insert(ioid, array_op);
 
@@ -5435,7 +5439,10 @@ async fn handle_create_channel(
                     };
                     // Negotiate the descriptor through the bound owner, so
                     // it matches the source that will serve the operations.
-                    let intro = owner.get_introspection_checked(&nm, conn_ctx.clone()).await;
+                    let intro = owner
+                        .get_introspection_checked(&nm, conn_ctx.clone())
+                        .await
+                        .map(Arc::new);
                     // Capture the owner's per-channel report info once at
                     // admission — pvxs lets a Source stash a `ReportInfo`
                     // on the channel control during onCreate
@@ -6137,7 +6144,7 @@ async fn handle_op(
         // can still proceed without a prototype (descriptor-late).
         let intro = match (kind, ch.introspection.clone()) {
             (OpKind::Rpc, Some(d)) => d,
-            (OpKind::Rpc, None) => FieldDesc::Variant,
+            (OpKind::Rpc, None) => Arc::new(FieldDesc::Variant),
             (_, Some(d)) => d,
             (_, None) => {
                 send_chan_op_error(
@@ -7621,7 +7628,7 @@ async fn handle_get_field(
     // DESTROY_REQUEST / channel teardown abort the in-flight task by
     // dropping the op — the same lifecycle GET/PUT/RPC use.
     let mut reserve = non_monitor_op_state(
-        FieldDesc::Variant,
+        Arc::new(FieldDesc::Variant),
         OpKind::GetField,
         BitSet::with_capacity(0),
     );
@@ -9917,7 +9924,7 @@ mod tests {
                     name: "dut".into(),
                     cid: 0,
                     sid,
-                    introspection: Some(intro),
+                    introspection: Some(std::sync::Arc::new(intro)),
                     source,
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -10012,7 +10019,7 @@ mod tests {
                     name: "dut".into(),
                     cid: 0,
                     sid,
-                    introspection: Some(intro),
+                    introspection: Some(std::sync::Arc::new(intro)),
                     source,
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -10106,7 +10113,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro),
+                introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -10201,7 +10208,7 @@ mod tests {
                     name: "dut".into(),
                     cid: 0,
                     sid,
-                    introspection: Some(intro),
+                    introspection: Some(std::sync::Arc::new(intro)),
                     source,
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -10864,7 +10871,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -10974,7 +10981,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -11067,7 +11074,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -11323,7 +11330,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -11491,7 +11498,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -12246,7 +12253,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -12475,7 +12482,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -12642,7 +12649,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -12737,7 +12744,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -12863,7 +12870,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -12964,7 +12971,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -13122,7 +13129,7 @@ mod tests {
         ops.insert(
             ioid,
             OpState {
-                intro: FieldDesc::Variant,
+                intro: std::sync::Arc::new(FieldDesc::Variant),
                 kind: OpKind::Monitor,
                 monitor_started: true,
                 monitor_abort: None,
@@ -13390,7 +13397,7 @@ mod tests {
     ) -> HashMap<u32, ChannelState> {
         let (sid, ioid) = ids;
         let mut op = non_monitor_op_state(
-            intro.clone(),
+            std::sync::Arc::new(intro.clone()),
             OpKind::Monitor,
             BitSet::all_set(intro.total_bits()),
         );
@@ -13429,7 +13436,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: src.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -13864,7 +13871,7 @@ mod tests {
         ops.insert(
             7u32,
             non_monitor_op_state(
-                FieldDesc::Scalar(ScalarType::Int),
+                std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int)),
                 OpKind::Get,
                 BitSet::new(),
             ),
@@ -13876,7 +13883,7 @@ mod tests {
                 name: "dut:pv".into(),
                 cid: 0,
                 sid: 1,
-                introspection: Some(FieldDesc::Scalar(ScalarType::Int)),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int))),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -13912,7 +13919,7 @@ mod tests {
             ops.insert(
                 ioid,
                 non_monitor_op_state(
-                    FieldDesc::Scalar(ScalarType::Int),
+                    std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int)),
                     OpKind::Get,
                     BitSet::new(),
                 ),
@@ -13921,7 +13928,7 @@ mod tests {
                 name: format!("dut:pv{sid}"),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Scalar(ScalarType::Int)),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int))),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -13997,7 +14004,7 @@ mod tests {
         ops.insert(
             7u32,
             non_monitor_op_state(
-                FieldDesc::Scalar(ScalarType::Int),
+                std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int)),
                 OpKind::Get,
                 BitSet::new(),
             ),
@@ -14009,7 +14016,7 @@ mod tests {
                 name: "dut:pv".into(),
                 cid: 0,
                 sid: 1,
-                introspection: Some(FieldDesc::Scalar(ScalarType::Int)),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int))),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -14088,7 +14095,7 @@ mod tests {
         ops.insert(
             ioid,
             OpState {
-                intro: FieldDesc::Variant,
+                intro: std::sync::Arc::new(FieldDesc::Variant),
                 kind: OpKind::Monitor,
                 monitor_started: true,
                 monitor_abort: Some(abort.clone()),
@@ -14206,7 +14213,11 @@ mod tests {
         let abort = Arc::new(AbortOnDrop(task.abort_handle()));
 
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
-        let mut op = non_monitor_op_state(FieldDesc::Variant, OpKind::Get, BitSet::new());
+        let mut op = non_monitor_op_state(
+            std::sync::Arc::new(FieldDesc::Variant),
+            OpKind::Get,
+            BitSet::new(),
+        );
         op.exec_state = ExecState::Executing;
         op.data_task_abort = Some(abort);
         op.last_request = true; // a last-request EXEC that is now cancelled
@@ -14223,7 +14234,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -14296,7 +14307,11 @@ mod tests {
         let ioid: u32 = 123;
 
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
-        let mut op = non_monitor_op_state(FieldDesc::Variant, OpKind::Get, BitSet::new());
+        let mut op = non_monitor_op_state(
+            std::sync::Arc::new(FieldDesc::Variant),
+            OpKind::Get,
+            BitSet::new(),
+        );
         op.exec_state = ExecState::Executing;
         op.last_request = true; // a last-request EXEC, now about to be cancelled
         let stale_op_id = op.monitor_op_id;
@@ -14310,7 +14325,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -15509,7 +15524,7 @@ mod tests {
         ops.insert(
             ioid,
             non_monitor_op_state(
-                intro.clone(),
+                std::sync::Arc::new(intro.clone()),
                 OpKind::Get,
                 BitSet::all_set(intro.total_bits()),
             ),
@@ -15521,7 +15536,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 // Channel was created under alice/ca.
@@ -15747,7 +15762,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -15880,7 +15895,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -16013,7 +16028,7 @@ mod tests {
             ops.insert(
                 ioid,
                 non_monitor_op_state(
-                    intro.clone(),
+                    std::sync::Arc::new(intro.clone()),
                     OpKind::Get,
                     BitSet::all_set(intro.total_bits()),
                 ),
@@ -16025,7 +16040,7 @@ mod tests {
                     name: "dut".into(),
                     cid: 0,
                     sid,
-                    introspection: Some(intro.clone()),
+                    introspection: Some(std::sync::Arc::new(intro.clone())),
                     source: source.clone(),
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -16183,7 +16198,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -16286,7 +16301,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -16621,9 +16636,15 @@ mod tests {
         changed.set(2);
         let delta = three_field_value(0, 99, 0);
 
-        src.put_delta_checked(checked, three_field_intro(), changed, delta, ctx)
-            .await
-            .expect("put_delta_checked must succeed");
+        src.put_delta_checked(
+            checked,
+            std::sync::Arc::new(three_field_intro()),
+            changed,
+            delta,
+            ctx,
+        )
+        .await
+        .expect("put_delta_checked must succeed");
 
         let final_value = stored.lock().clone().expect("a value must be stored");
         let (a, b, c) = three_field_extract(&final_value);
@@ -16679,7 +16700,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -16810,7 +16831,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -17001,7 +17022,13 @@ mod tests {
                     .check("dut", &ctx_a.host, &ctx_a.account, &ctx_a.method, "")
                     .await;
                 src_a
-                    .put_delta_checked(checked, intro_a, changed_a, delta_a, ctx_a)
+                    .put_delta_checked(
+                        checked,
+                        std::sync::Arc::new(intro_a),
+                        changed_a,
+                        delta_a,
+                        ctx_a,
+                    )
                     .await
             });
             let task_c = tokio::spawn(async move {
@@ -17010,7 +17037,13 @@ mod tests {
                     .check("dut", &ctx_c.host, &ctx_c.account, &ctx_c.method, "")
                     .await;
                 src_c
-                    .put_delta_checked(checked, intro_c, changed_c, delta_c, ctx_c)
+                    .put_delta_checked(
+                        checked,
+                        std::sync::Arc::new(intro_c),
+                        changed_c,
+                        delta_c,
+                        ctx_c,
+                    )
                     .await
             });
 
@@ -17128,7 +17161,7 @@ mod tests {
         let mask = BitSet::all_set(intro.total_bits());
         ops.insert(
             ioid,
-            non_monitor_op_state(intro.clone(), OpKind::Process, mask),
+            non_monitor_op_state(std::sync::Arc::new(intro.clone()), OpKind::Process, mask),
         );
         let mut channels = HashMap::new();
         channels.insert(
@@ -17137,7 +17170,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro),
+                introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -17610,7 +17643,10 @@ mod tests {
         let intro = three_field_intro();
         let mask = BitSet::all_set(intro.total_bits());
         let mut ops = HashMap::new();
-        ops.insert(ioid, non_monitor_op_state(intro.clone(), kind, mask));
+        ops.insert(
+            ioid,
+            non_monitor_op_state(std::sync::Arc::new(intro.clone()), kind, mask),
+        );
         let mut channels = HashMap::new();
         channels.insert(
             sid,
@@ -17618,7 +17654,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro),
+                introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -17738,7 +17774,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro),
+                introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -18112,7 +18148,7 @@ mod tests {
         let mut ops = HashMap::new();
         ops.insert(
             ioid,
-            non_monitor_op_state(intro.clone(), OpKind::PutGet, mask),
+            non_monitor_op_state(std::sync::Arc::new(intro.clone()), OpKind::PutGet, mask),
         );
         channels.insert(
             sid,
@@ -18120,7 +18156,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -18298,7 +18334,7 @@ mod tests {
         let mut ops = HashMap::new();
         ops.insert(
             ioid,
-            non_monitor_op_state(intro.clone(), OpKind::PutGet, mask),
+            non_monitor_op_state(std::sync::Arc::new(intro.clone()), OpKind::PutGet, mask),
         );
         let mut channels = HashMap::new();
         channels.insert(
@@ -18307,7 +18343,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -18416,7 +18452,7 @@ mod tests {
         ops.insert(
             ioid,
             OpState {
-                intro: FieldDesc::Variant,
+                intro: std::sync::Arc::new(FieldDesc::Variant),
                 kind: OpKind::Get,
                 monitor_started: false,
                 monitor_abort: None,
@@ -18446,7 +18482,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -18506,7 +18542,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -18573,7 +18609,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source: source.clone(),
                 stat: stat.clone(),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -19344,7 +19380,7 @@ mod tests {
         intro: &FieldDesc,
     ) -> HashMap<u32, ChannelState> {
         let mut op = non_monitor_op_state(
-            intro.clone(),
+            std::sync::Arc::new(intro.clone()),
             OpKind::Monitor,
             BitSet::all_set(intro.total_bits()),
         );
@@ -19368,7 +19404,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: src.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -19545,7 +19581,7 @@ mod tests {
             sid: 1,
             ioid: 2,
             pv_name: "dut".into(),
-            intro: intro.clone(),
+            intro: std::sync::Arc::new(intro.clone()),
             mask: BitSet::with_capacity(intro.total_bits()),
             tx: ChannelTx::new(
                 wire_tx,
@@ -19722,7 +19758,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -19898,7 +19934,7 @@ mod tests {
                 name: "dut".into(),
                 cid: 0,
                 sid: 1,
-                introspection: intro,
+                introspection: intro.map(std::sync::Arc::new),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -20028,7 +20064,7 @@ mod tests {
                     name: format!("dut{sid}"),
                     cid: sid - 1,
                     sid,
-                    introspection: Some(three_field_intro()),
+                    introspection: Some(std::sync::Arc::new(three_field_intro())),
                     source: source.clone(),
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -20055,7 +20091,7 @@ mod tests {
         channels.get_mut(&1).unwrap().ops.insert(
             ioid,
             non_monitor_op_state(
-                three_field_intro(),
+                std::sync::Arc::new(three_field_intro()),
                 OpKind::Get,
                 BitSet::all_set(three_field_intro().total_bits()),
             ),
@@ -20110,7 +20146,7 @@ mod tests {
         channels.get_mut(&1).unwrap().ops.insert(
             ioid,
             non_monitor_op_state(
-                three_field_intro(),
+                std::sync::Arc::new(three_field_intro()),
                 OpKind::Get,
                 BitSet::all_set(three_field_intro().total_bits()),
             ),
@@ -20657,7 +20693,7 @@ mod autoexec_tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(intro.clone()),
+                introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -20864,7 +20900,11 @@ mod r14_tests {
         let mut ops: HashMap<u32, OpState> = HashMap::new();
         ops.insert(
             ioid,
-            non_monitor_op_state(intro.clone(), OpKind::Get, crate::proto::BitSet::new()),
+            non_monitor_op_state(
+                std::sync::Arc::new(intro.clone()),
+                OpKind::Get,
+                crate::proto::BitSet::new(),
+            ),
         );
         channels.insert(
             sid,
@@ -20872,7 +20912,7 @@ mod r14_tests {
                 name: "slow".into(),
                 cid: 1,
                 sid,
-                introspection: Some(intro),
+                introspection: Some(std::sync::Arc::new(intro)),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -21048,7 +21088,7 @@ mod bfr15_tests {
         let mut ops: HashMap<u32, OpState> = HashMap::new();
         ops.insert(
             ioid,
-            non_monitor_op_state(intro.clone(), kind, BitSet::new()),
+            non_monitor_op_state(std::sync::Arc::new(intro.clone()), kind, BitSet::new()),
         );
         let mut channels = HashMap::new();
         channels.insert(
@@ -21057,7 +21097,7 @@ mod bfr15_tests {
                 name: "dut".into(),
                 cid: 1,
                 sid,
-                introspection: Some(intro),
+                introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -21520,7 +21560,11 @@ mod bfr15_tests {
     fn last_request_gpr_error_completion_keeps_op_idle_then_success_removes() {
         let (sid, ioid) = (3u32, 88u32);
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
-        let mut op = non_monitor_op_state(FieldDesc::Variant, OpKind::Get, BitSet::new());
+        let mut op = non_monitor_op_state(
+            std::sync::Arc::new(FieldDesc::Variant),
+            OpKind::Get,
+            BitSet::new(),
+        );
         op.exec_state = ExecState::Executing;
         op.last_request = true;
         let op_id = op.monitor_op_id;
@@ -21534,7 +21578,7 @@ mod bfr15_tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
@@ -21597,7 +21641,7 @@ mod bfr15_tests {
         let (sid, ioid) = (4u32, 90u32);
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
         let mut op = non_monitor_op_state(
-            FieldDesc::Variant,
+            std::sync::Arc::new(FieldDesc::Variant),
             OpKind::GetField,
             BitSet::with_capacity(0),
         );
@@ -21615,7 +21659,7 @@ mod bfr15_tests {
                 name: "dut".into(),
                 cid: 0,
                 sid,
-                introspection: Some(FieldDesc::Variant),
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -776,7 +776,7 @@ struct ChannelState {
     /// control. Per-operation handlers still use the connection's *current*
     /// credential (pvxs builds each `ConnectOp`/`ExecOp` from `conn->cred`),
     /// so only the open/close edges are pinned here.
-    open_cred: ClientCredentials,
+    open_cred: Arc<ClientCredentials>,
     /// ioid → (introspection negotiated for this op, kind)
     ops: HashMap<u32, OpState>,
     /// Reusable PUT-delta decode scratch, keyed by the op intro it was
@@ -2076,11 +2076,11 @@ fn spawn_monitor_subscriber(
             .access_gate()
             .check_with_roles(
                 &pv_name,
-                &mon_ctx.host,
-                &mon_ctx.account,
-                &mon_ctx.roles,
-                &mon_ctx.method,
-                &mon_ctx.authority,
+                &mon_ctx.creds.host,
+                &mon_ctx.creds.account,
+                &mon_ctx.creds.roles,
+                &mon_ctx.creds.method,
+                &mon_ctx.creds.authority,
             )
             .await;
 
@@ -2680,7 +2680,7 @@ async fn process_connection_validation(
     tx: &SrvTx,
     order: ByteOrder,
     x509_locked: bool,
-    cred: &mut ClientCredentials,
+    cred: &mut Arc<ClientCredentials>,
     peer: SocketAddr,
     peer_entry: &crate::server_native::peers::PeerEntry,
     config: &PvaServerConfig,
@@ -2765,7 +2765,7 @@ async fn process_connection_validation(
             // Advertised method: commit the claim. A `None` candidate
             // (anonymous handshake) keeps the current credential unchanged.
             if let Some(claimed) = candidate {
-                *cred = claimed;
+                *cred = Arc::new(claimed);
             }
         }
     }
@@ -3022,7 +3022,7 @@ struct CreateChannelCompletion {
     /// lifecycle callbacks use the credential the channel was opened under —
     /// not whatever the connection re-authenticated to while the resolver
     /// was still running (pvxs `serverchan.cpp:62`).
-    open_cred: ClientCredentials,
+    open_cred: Arc<ClientCredentials>,
     /// `Some` → PV was found; carries the negotiated descriptor and the
     /// owner source bound into the channel. `None` → not found; emit an
     /// error response and insert no channel. Folding "found" and "owner"
@@ -3236,8 +3236,8 @@ pub(super) async fn handle_connection_io(
     // Fed into the server's ACF `AccessGate::check` for every op.
     let x509_locked = x509_identity.is_some();
     let mut cred = match x509_identity {
-        Some(id) => ClientCredentials::x509(id, peer),
-        None => ClientCredentials::anonymous(peer),
+        Some(id) => Arc::new(ClientCredentials::x509(id, peer)),
+        None => Arc::new(ClientCredentials::anonymous(peer)),
     };
     // Per-connection emit-side TypeStore. Only consulted when
     // `config.emit_type_cache` is true (off by default for pvAccessCPP
@@ -4173,7 +4173,7 @@ async fn handle_put_get(
     // Connection-scope inbound decode cache (pvxs `rxRegistry`, conn.h:23).
     decode_cache: &mut TypeCache,
     peer: std::net::SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
     // data-phase-completion sender (see [`handle_op`]). The spawned
     // PUT_GET exec task installs an `ExecFinishGuard` so the owner returns
     // the op to `Idle` when its readback reply is sent.
@@ -4465,11 +4465,7 @@ async fn handle_put_get(
 
     let ctx = crate::server_native::source::ChannelContext {
         peer,
-        account: cred.account.clone(),
-        method: cred.method.clone(),
-        host: cred.host.clone(),
-        authority: cred.authority.clone(),
-        roles: cred.roles.clone(),
+        creds: cred.clone(),
         pv_request: init_pv_request,
         log: Default::default(),
     };
@@ -4528,11 +4524,11 @@ async fn handle_put_get(
                     .access_gate()
                     .check_with_roles(
                         &pv_name,
-                        &ctx.host,
-                        &ctx.account,
-                        &ctx.roles,
-                        &ctx.method,
-                        &ctx.authority,
+                        &ctx.creds.host,
+                        &ctx.creds.account,
+                        &ctx.creds.roles,
+                        &ctx.creds.method,
+                        &ctx.creds.authority,
                     )
                     .await;
                 let outcome = match catch_handler_panic(src.put_get_checked(
@@ -4558,11 +4554,11 @@ async fn handle_put_get(
                     .access_gate()
                     .check_with_roles(
                         &pv_name,
-                        &ctx.host,
-                        &ctx.account,
-                        &ctx.roles,
-                        &ctx.method,
-                        &ctx.authority,
+                        &ctx.creds.host,
+                        &ctx.creds.account,
+                        &ctx.creds.roles,
+                        &ctx.creds.method,
+                        &ctx.creds.authority,
                     )
                     .await;
                 catch_handler_panic(src.read_checked(read_checked, ctx))
@@ -4641,7 +4637,7 @@ async fn handle_process(
     // decoded, so it shares the same cache as every other inbound decode.
     decode_cache: &mut TypeCache,
     peer: std::net::SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
     // data-phase-completion sender (see [`handle_op`]). The spawned
     // PROCESS exec task installs an `ExecFinishGuard` so the owner returns
     // the op to `Idle` when its reply is sent.
@@ -4815,11 +4811,7 @@ async fn handle_process(
     let pv_name = ch.name.clone();
     let ctx = crate::server_native::source::ChannelContext {
         peer,
-        account: cred.account.clone(),
-        method: cred.method.clone(),
-        host: cred.host.clone(),
-        authority: cred.authority.clone(),
-        roles: cred.roles.clone(),
+        creds: cred.clone(),
         // PROCESS INIT pvRequest, preserved from the op state so a source
         // — and a gateway forwarding createChannelProcess(..., pvRequest)
         // — can inspect `record._options`.
@@ -4857,11 +4849,11 @@ async fn handle_process(
             .access_gate()
             .check_with_roles(
                 &pv_name,
-                &ctx.host,
-                &ctx.account,
-                &ctx.roles,
-                &ctx.method,
-                &ctx.authority,
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.roles,
+                &ctx.creds.method,
+                &ctx.creds.authority,
             )
             .await;
         // a panic in the user PROCESS handler becomes an error
@@ -4966,7 +4958,7 @@ async fn handle_channel_array(
     encode_cache: &mut EncodeTypeCache,
     decode_cache: &mut TypeCache,
     peer: std::net::SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
     exec_fin_tx: &mpsc::UnboundedSender<ExecFinished>,
 ) -> PvaResult<()> {
     // Inbound payload decodes with the frame's own header order; `order`
@@ -5050,11 +5042,7 @@ async fn handle_channel_array(
             };
         let ctx = crate::server_native::source::ChannelContext {
             peer,
-            account: cred.account.clone(),
-            method: cred.method.clone(),
-            host: cred.host.clone(),
-            authority: cred.authority.clone(),
-            roles: cred.roles.clone(),
+            creds: cred.clone(),
             pv_request: req_value.clone(),
             log: Default::default(),
         };
@@ -5177,11 +5165,7 @@ async fn handle_channel_array(
 
     let ctx = crate::server_native::source::ChannelContext {
         peer,
-        account: cred.account.clone(),
-        method: cred.method.clone(),
-        host: cred.host.clone(),
-        authority: cred.authority.clone(),
-        roles: cred.roles.clone(),
+        creds: cred.clone(),
         // INIT pvRequest re-supplied so the source knows the bound field.
         pv_request: init_pv_request,
         log: Default::default(),
@@ -5226,11 +5210,11 @@ async fn handle_channel_array(
             .access_gate()
             .check_with_roles(
                 &pv_name,
-                &ctx.host,
-                &ctx.account,
-                &ctx.roles,
-                &ctx.method,
-                &ctx.authority,
+                &ctx.creds.host,
+                &ctx.creds.account,
+                &ctx.creds.roles,
+                &ctx.creds.method,
+                &ctx.creds.authority,
             )
             .await;
         // A panic in the (user / gateway) source handler becomes an error
@@ -5416,7 +5400,7 @@ async fn handle_create_channel(
     order: ByteOrder,
     max_channels_per_connection: usize,
     peer: SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
     cc_tx: &CcTx,
     pending_channel_spawns: &mut usize,
 ) -> PvaResult<()> {
@@ -5562,15 +5546,11 @@ async fn handle_create_channel(
 /// channel is built from `conn->cred`).
 fn channel_lifecycle_ctx(
     peer: SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
 ) -> crate::server_native::source::ChannelContext {
     crate::server_native::source::ChannelContext {
         peer,
-        account: cred.account.clone(),
-        method: cred.method.clone(),
-        host: cred.host.clone(),
-        authority: cred.authority.clone(),
-        roles: cred.roles.clone(),
+        creds: cred.clone(),
         pv_request: None,
         log: Default::default(),
     }
@@ -6109,7 +6089,7 @@ async fn handle_op(
     // op resolves a later 0xFE reference on the same connection.
     decode_cache: &mut TypeCache,
     peer: std::net::SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
     // read-loop owner's MONITOR subscriber-completion sender. The
     // spawned subscriber task installs a `MonitorFinishGuard` cloned from
     // this so its terminal op removal is routed back to the owner. Only the
@@ -6588,11 +6568,7 @@ async fn handle_op(
         if kind == OpKind::Monitor {
             let init_ctx = crate::server_native::source::ChannelContext {
                 peer,
-                account: cred.account.clone(),
-                method: cred.method.clone(),
-                host: cred.host.clone(),
-                authority: cred.authority.clone(),
-                roles: cred.roles.clone(),
+                creds: cred.clone(),
                 pv_request: req_value.clone(),
                 log: Default::default(),
             };
@@ -6600,11 +6576,11 @@ async fn handle_op(
                 .access_gate()
                 .check_with_roles(
                     &ch.name,
-                    &init_ctx.host,
-                    &init_ctx.account,
-                    &init_ctx.roles,
-                    &init_ctx.method,
-                    &init_ctx.authority,
+                    &init_ctx.creds.host,
+                    &init_ctx.creds.account,
+                    &init_ctx.creds.roles,
+                    &init_ctx.creds.method,
+                    &init_ctx.creds.authority,
                 )
                 .await;
             if let Err(e) = source.check_monitor_request(&checked, &init_ctx).await {
@@ -6683,11 +6659,7 @@ async fn handle_op(
                 // pure stream control and carry no per-op options.
                 let mon_ctx = crate::server_native::source::ChannelContext {
                     peer,
-                    account: cred.account.clone(),
-                    method: cred.method.clone(),
-                    host: cred.host.clone(),
-                    authority: cred.authority.clone(),
-                    roles: cred.roles.clone(),
+                    creds: cred.clone(),
                     pv_request: s.pv_request.clone(),
                     log: Default::default(),
                 };
@@ -6808,11 +6780,7 @@ async fn handle_op(
             let tx_clone = chan_tx.clone();
             let intro_t = intro.clone();
             let mask_t = mask.clone();
-            let cred_account = cred.account.clone();
-            let cred_method = cred.method.clone();
-            let cred_host = cred.host.clone();
-            let cred_authority = cred.authority.clone();
-            let cred_roles = cred.roles.clone();
+            let cred_t = cred.clone();
             // forward the decoded INIT pvRequest into the GET
             // context so QSRV group GET honors `record._options`
             // (e.g. `atomic`). Previously dropped here as `None`.
@@ -6845,11 +6813,7 @@ async fn handle_op(
                 };
                 let ctx = crate::server_native::source::ChannelContext {
                     peer,
-                    account: cred_account,
-                    method: cred_method,
-                    host: cred_host,
-                    authority: cred_authority,
-                    roles: cred_roles,
+                    creds: cred_t,
                     pv_request: init_pv_request_t,
                     log: Default::default(),
                 };
@@ -6857,11 +6821,11 @@ async fn handle_op(
                     .access_gate()
                     .check_with_roles(
                         &pv_name,
-                        &ctx.host,
-                        &ctx.account,
-                        &ctx.roles,
-                        &ctx.method,
-                        &ctx.authority,
+                        &ctx.creds.host,
+                        &ctx.creds.account,
+                        &ctx.creds.roles,
+                        &ctx.creds.method,
+                        &ctx.creds.authority,
                     )
                     .await;
                 // a panic in the user GET handler becomes a
@@ -6961,11 +6925,7 @@ async fn handle_op(
                 let tx_clone = chan_tx.clone();
                 let intro_t = intro.clone();
                 let mask_t = mask.clone();
-                let cred_account = cred.account.clone();
-                let cred_method = cred.method.clone();
-                let cred_host = cred.host.clone();
-                let cred_authority = cred.authority.clone();
-                let cred_roles = cred.roles.clone();
+                let cred_t = cred.clone();
                 // forward the INIT pvRequest into the PUT
                 // readback GET context so the readback honors the
                 // same `record._options` the GET path would.
@@ -6994,11 +6954,7 @@ async fn handle_op(
                     };
                     let ctx = crate::server_native::source::ChannelContext {
                         peer,
-                        account: cred_account,
-                        method: cred_method,
-                        host: cred_host,
-                        authority: cred_authority,
-                        roles: cred_roles,
+                        creds: cred_t,
                         pv_request: init_pv_request_t,
                         log: Default::default(),
                     };
@@ -7006,11 +6962,11 @@ async fn handle_op(
                         .access_gate()
                         .check_with_roles(
                             &pv_name,
-                            &ctx.host,
-                            &ctx.account,
-                            &ctx.roles,
-                            &ctx.method,
-                            &ctx.authority,
+                            &ctx.creds.host,
+                            &ctx.creds.account,
+                            &ctx.creds.roles,
+                            &ctx.creds.method,
+                            &ctx.creds.authority,
                         )
                         .await;
                     // a panic in the user GET (PUT readback)
@@ -7123,11 +7079,7 @@ async fn handle_op(
             let src = source.clone();
             let tx_clone = chan_tx.clone();
             let intro_t = intro.clone();
-            let cred_account = cred.account.clone();
-            let cred_method = cred.method.clone();
-            let cred_host = cred.host.clone();
-            let cred_authority = cred.authority.clone();
-            let cred_roles = cred.roles.clone();
+            let cred_t = cred.clone();
             let init_pv_request_t = init_pv_request.clone();
             // ignore a second PUT EXEC while the first write is in
             // flight rather than aborting it (pvxs `serverget.cpp:511-514`).
@@ -7153,11 +7105,7 @@ async fn handle_op(
                 };
                 let ctx = crate::server_native::source::ChannelContext {
                     peer,
-                    account: cred_account,
-                    method: cred_method,
-                    host: cred_host,
-                    authority: cred_authority,
-                    roles: cred_roles,
+                    creds: cred_t,
                     pv_request: init_pv_request_t,
                     log: Default::default(),
                 };
@@ -7171,11 +7119,11 @@ async fn handle_op(
                         .access_gate()
                         .check_with_roles(
                             &pv_name,
-                            &ctx.host,
-                            &ctx.account,
-                            &ctx.roles,
-                            &ctx.method,
-                            &ctx.authority,
+                            &ctx.creds.host,
+                            &ctx.creds.account,
+                            &ctx.creds.roles,
+                            &ctx.creds.method,
+                            &ctx.creds.authority,
                         )
                         .await;
                     // a panic in the user PUT handler becomes an
@@ -7216,11 +7164,11 @@ async fn handle_op(
                                 .access_gate()
                                 .check_with_roles(
                                     &pv_name,
-                                    &ctx.host,
-                                    &ctx.account,
-                                    &ctx.roles,
-                                    &ctx.method,
-                                    &ctx.authority,
+                                    &ctx.creds.host,
+                                    &ctx.creds.account,
+                                    &ctx.creds.roles,
+                                    &ctx.creds.method,
+                                    &ctx.creds.authority,
                                 )
                                 .await;
                             // a panic in the user GET (PUT_GET
@@ -7403,11 +7351,7 @@ async fn handle_op(
                     // selection, so it is omitted.
                     let wm_ctx = crate::server_native::source::ChannelContext {
                         peer,
-                        account: cred.account.clone(),
-                        method: cred.method.clone(),
-                        host: cred.host.clone(),
-                        authority: cred.authority.clone(),
-                        roles: cred.roles.clone(),
+                        creds: cred.clone(),
                         pv_request: None,
                         log: Default::default(),
                     };
@@ -7489,11 +7433,7 @@ async fn handle_op(
             let tx_clone = chan_tx.clone();
             let rpc_ctx_val = crate::server_native::source::ChannelContext {
                 peer,
-                account: cred.account.clone(),
-                method: cred.method.clone(),
-                host: cred.host.clone(),
-                authority: cred.authority.clone(),
-                roles: cred.roles.clone(),
+                creds: cred.clone(),
                 // RPC INIT pvRequest, preserved from the op state — distinct
                 // from the `(req_desc, req_value)` EXEC argument decoded
                 // above. A source (or gateway) can now inspect the
@@ -7527,11 +7467,11 @@ async fn handle_op(
                     .access_gate()
                     .check_with_roles(
                         &pv_name,
-                        &rpc_ctx_val.host,
-                        &rpc_ctx_val.account,
-                        &rpc_ctx_val.roles,
-                        &rpc_ctx_val.method,
-                        &rpc_ctx_val.authority,
+                        &rpc_ctx_val.creds.host,
+                        &rpc_ctx_val.creds.account,
+                        &rpc_ctx_val.creds.roles,
+                        &rpc_ctx_val.creds.method,
+                        &rpc_ctx_val.creds.authority,
                     )
                     .await;
                 // a panic in the user RPC handler becomes an error
@@ -7616,7 +7556,7 @@ async fn handle_get_field(
     channels: &mut HashMap<u32, ChannelState>,
     order: ByteOrder,
     peer: SocketAddr,
-    cred: &ClientCredentials,
+    cred: &Arc<ClientCredentials>,
     // data-phase-completion sender (see [`handle_op`]). The slow-path
     // introspection task installs an `ExecFinishGuard` so the read-loop
     // owner releases the reserved GET_FIELD IOID once the reply is sent
@@ -7709,11 +7649,7 @@ async fn handle_get_field(
     // credentials. `pv_request` is `None` — GET_FIELD carries no pvRequest.
     let conn_ctx = crate::server_native::source::ChannelContext {
         peer,
-        account: cred.account.clone(),
-        method: cred.method.clone(),
-        host: cred.host.clone(),
-        authority: cred.authority.clone(),
-        roles: cred.roles.clone(),
+        creds: cred.clone(),
         pv_request: None,
         log: Default::default(),
     };
@@ -8499,11 +8435,13 @@ mod tests {
         });
         let ctx = crate::server_native::source::ChannelContext {
             peer: "127.0.0.1:9001".parse().unwrap(),
-            account: String::new(),
-            method: "anonymous".into(),
-            host: String::new(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: Arc::new(ClientCredentials {
+                account: String::new(),
+                method: "anonymous".into(),
+                host: String::new(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };
@@ -10029,7 +9967,7 @@ mod tests {
                     introspection: Some(std::sync::Arc::new(intro)),
                     source,
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
                 },
@@ -10038,7 +9976,7 @@ mod tests {
             let config = PvaServerConfig::default();
             let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-            let cred = ClientCredentials::anonymous(TEST_PEER);
+            let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
             // INIT: valid Int descriptor, then a truncated (2-byte) i32
             // value — a present-but-malformed pvRequest body.
@@ -10125,7 +10063,7 @@ mod tests {
                     introspection: Some(std::sync::Arc::new(intro)),
                     source,
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
                 },
@@ -10134,7 +10072,7 @@ mod tests {
             let config = PvaServerConfig::default();
             let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-            let cred = ClientCredentials::anonymous(TEST_PEER);
+            let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
             // INIT: valid Int descriptor, then NOTHING — the value body
             // the descriptor requires is absent (descriptor-only frame).
@@ -10220,7 +10158,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -10229,7 +10167,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // INIT: empty `structure {}` descriptor, no value body.
         let req_desc = FieldDesc::Structure {
@@ -10316,7 +10254,7 @@ mod tests {
                     introspection: Some(std::sync::Arc::new(intro)),
                     source,
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
                 },
@@ -10325,7 +10263,7 @@ mod tests {
             let config = PvaServerConfig::default();
             let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-            let cred = ClientCredentials::anonymous(TEST_PEER);
+            let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
             let mut payload = Vec::new();
             payload.put_u32(sid, order);
@@ -10980,7 +10918,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -10990,7 +10928,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // MONITOR INIT (subcmd 0x08, no pipeline bit) with an unparseable
         // `pipeline` value → pipeline disabled, one Warn logRemote.
@@ -11091,7 +11029,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -11101,7 +11039,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // pipeline=true, a valid queueSize, and an ARRAY ackAny — `Int32A` is
         // Kind::Integer but stores as an array, and `copyOut` has no scalar arm
@@ -11185,7 +11123,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -11195,7 +11133,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // Pipeline MONITOR INIT: subcmd 0x88 (INIT | pipeline), a valid
         // pipeline pvRequest, and the trailing u32 initial-nack rider the
@@ -11272,11 +11210,13 @@ mod tests {
     fn test_channel_ctx() -> crate::server_native::source::ChannelContext {
         crate::server_native::source::ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: String::new(),
-            method: "anonymous".to_string(),
-            host: String::new(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: Arc::new(ClientCredentials {
+                account: String::new(),
+                method: "anonymous".to_string(),
+                host: String::new(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }
@@ -11442,7 +11382,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -11452,7 +11392,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // MONITOR INIT with pipeline=true, queueSize=2 and an explicit
         // initial nack rider of 2 (subcmd 0x88 sets the 0x80 pipeline bit,
@@ -11611,7 +11551,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -11631,7 +11571,7 @@ mod tests {
         config: &PvaServerConfig,
         encode_cache: &mut crate::pvdata::encode::EncodeTypeCache,
         peer: SocketAddr,
-        cred: &ClientCredentials,
+        cred: &Arc<ClientCredentials>,
         mon_fin: &mpsc::UnboundedSender<MonitorFinished>,
     ) -> PvaResult<()> {
         handle_op(
@@ -11724,7 +11664,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // INIT with queueSize 8 — large enough to hold the seed + 3 posts
         // with no squash.
@@ -11797,7 +11737,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 2, order),
@@ -11865,7 +11805,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 8, order),
@@ -11918,7 +11858,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 8, order),
@@ -11976,7 +11916,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 8, order),
@@ -12077,7 +12017,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let (mon_fin_tx, mut mon_fin_rx) = mpsc::unbounded_channel::<MonitorFinished>();
 
         pvx61_drive(
@@ -12141,7 +12081,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let (mon_fin_tx, mut mon_fin_rx) = mpsc::unbounded_channel::<MonitorFinished>();
 
         pvx61_drive(
@@ -12188,7 +12128,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 8, order),
@@ -12367,7 +12307,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -12389,7 +12329,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 8, order),
@@ -12457,7 +12397,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 2, order),
@@ -12597,7 +12537,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -12606,7 +12546,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         pvx61_drive(
             &pvx61_init_frame(sid, ioid, 8, order),
@@ -12765,7 +12705,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -12774,7 +12714,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let (mon_fin_tx, mut mon_fin_rx) = mpsc::unbounded_channel::<MonitorFinished>();
 
         pvx61_drive(
@@ -12861,7 +12801,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -12871,7 +12811,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // MONITOR INIT with pipeline=true, queueSize=2, but subcmd 0x08:
         // the 0x80 bit is CLEAR, so NO initial-nack rider follows the
@@ -12988,7 +12928,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -13002,7 +12942,7 @@ mod tests {
         );
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // MONITOR INIT, pipeline OFF, queueSize=2.
         let req_val = make_pipeline_request(
@@ -13090,7 +13030,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -13100,7 +13040,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // MONITOR INIT (pipeline, queueSize=4 so an ACK is well-formed).
         let req_val = make_pipeline_request(
@@ -13280,7 +13220,7 @@ mod tests {
                 introspection: None,
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -13307,7 +13247,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // ACK frame (subcmd 0x80) with NO u32 ack-count payload.
         let mut payload = Vec::new();
@@ -13360,7 +13300,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
@@ -13413,7 +13353,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
@@ -13557,7 +13497,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: src.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -13602,7 +13542,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // subcmd 0xC4 = ACK(0x80)|START(0x04)|start(0x40), NO ack u32 payload.
         let mut payload = Vec::new();
@@ -13678,7 +13618,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // subcmd 0x84 = ACK(0x80)|STOP(0x04, no start bit), NO ack u32 payload.
         let mut payload = Vec::new();
@@ -13753,7 +13693,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // subcmd 0xC4 with a 3-credit ACK count.
         let mut payload = Vec::new();
@@ -14005,7 +13945,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int))),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -14051,7 +13991,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int))),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             }
@@ -14140,7 +14080,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Scalar(ScalarType::Int))),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -14250,7 +14190,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -14360,7 +14300,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -14452,7 +14392,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -15067,7 +15007,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -15126,7 +15066,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -15182,7 +15122,7 @@ mod tests {
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let mut payload = Vec::new();
         payload.put_u32(sid, inbound_order);
@@ -15279,7 +15219,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -15327,14 +15267,14 @@ mod tests {
 
     /// Build a `ca`-method credential for the given account, used by the
     /// channel-lifecycle credential-pinning regressions below.
-    fn cred_ca(account: &str) -> ClientCredentials {
-        ClientCredentials {
+    fn cred_ca(account: &str) -> Arc<ClientCredentials> {
+        Arc::new(ClientCredentials {
             method: "ca".into(),
             account: account.into(),
             host: "10.0.0.1".into(),
             authority: String::new(),
             roles: Vec::new(),
-        }
+        })
     }
 
     /// Records the `(method, account)` each edge observed: channel open
@@ -15369,7 +15309,7 @@ mod tests {
         ) -> Option<PvField> {
             self.op_reads
                 .lock()
-                .push((ctx.method.clone(), ctx.account.clone()));
+                .push((ctx.creds.method.clone(), ctx.creds.account.clone()));
             if !checked.allows_read() {
                 return None;
             }
@@ -15391,7 +15331,7 @@ mod tests {
         ) {
             self.opened
                 .lock()
-                .push((ctx.method.clone(), ctx.account.clone()));
+                .push((ctx.creds.method.clone(), ctx.creds.account.clone()));
         }
         fn notify_channel_close(
             &self,
@@ -15400,7 +15340,7 @@ mod tests {
         ) {
             self.closed
                 .lock()
-                .push((ctx.method.clone(), ctx.account.clone()));
+                .push((ctx.creds.method.clone(), ctx.creds.account.clone()));
         }
     }
 
@@ -15747,7 +15687,7 @@ mod tests {
                     introspection: None,
                     source: source.clone(),
                     stat: stat.clone(),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
                 },
@@ -15821,7 +15761,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: stat.clone(),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -15901,7 +15841,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -15911,7 +15851,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // PUT INIT: sid + ioid + subcmd=0x08 + pvRequest(type + value).
         // Use an empty Structure pvRequest (full mask).
@@ -16035,7 +15975,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -16045,7 +15985,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let req_desc = FieldDesc::Structure {
             struct_id: String::new(),
@@ -16158,7 +16098,7 @@ mod tests {
         let source: DynSource = Arc::new(shared);
 
         let config = PvaServerConfig::default();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // A channel carrying one already-INIT'd GET op.
         let make_channels = || {
@@ -16181,7 +16121,7 @@ mod tests {
                     introspection: Some(std::sync::Arc::new(intro.clone())),
                     source: source.clone(),
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops,
                     put_scratch: None,
                 },
@@ -16340,7 +16280,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -16350,7 +16290,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // The "empty pvRequest" structure (no `field` child) → wildcard
         // mask. Its only role here is to be a real descriptor the client can
@@ -16444,7 +16384,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -16763,11 +16703,13 @@ mod tests {
             .await;
         let ctx = ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: "u".into(),
-            method: "anonymous".into(),
-            host: "h".into(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: Arc::new(ClientCredentials {
+                account: "u".into(),
+                method: "anonymous".into(),
+                host: "h".into(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         };
@@ -16844,7 +16786,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -16854,7 +16796,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // PUT INIT.
         let req_desc = FieldDesc::Structure {
@@ -16976,7 +16918,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -16986,7 +16928,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // PUT_GET INIT (subcmd 0x08).
         let req_desc = FieldDesc::Structure {
@@ -17143,11 +17085,13 @@ mod tests {
 
             let ctx = ChannelContext {
                 peer: "127.0.0.1:5075".parse().unwrap(),
-                account: "anonymous".into(),
-                method: "anonymous".into(),
-                host: "127.0.0.1".into(),
-                authority: String::new(),
-                roles: Vec::new(),
+                creds: Arc::new(ClientCredentials {
+                    account: "anonymous".into(),
+                    method: "anonymous".into(),
+                    host: "127.0.0.1".into(),
+                    authority: String::new(),
+                    roles: Vec::new(),
+                }),
                 pv_request: None,
                 log: Default::default(),
             };
@@ -17162,7 +17106,13 @@ mod tests {
             let task_a = tokio::spawn(async move {
                 let checked = src_a
                     .access()
-                    .check("dut", &ctx_a.host, &ctx_a.account, &ctx_a.method, "")
+                    .check(
+                        "dut",
+                        &ctx_a.creds.host,
+                        &ctx_a.creds.account,
+                        &ctx_a.creds.method,
+                        "",
+                    )
                     .await;
                 src_a
                     .put_delta_checked(
@@ -17177,7 +17127,13 @@ mod tests {
             let task_c = tokio::spawn(async move {
                 let checked = src_c
                     .access()
-                    .check("dut", &ctx_c.host, &ctx_c.account, &ctx_c.method, "")
+                    .check(
+                        "dut",
+                        &ctx_c.creds.host,
+                        &ctx_c.creds.account,
+                        &ctx_c.creds.method,
+                        "",
+                    )
                     .await;
                 src_c
                     .put_delta_checked(
@@ -17316,7 +17272,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -17327,14 +17283,14 @@ mod tests {
     /// Credentials for the `x509` method carrying a chosen root-CA
     /// authority. `ClientCredentials` fields are all `pub`.
     #[cfg(test)]
-    fn x509_cred(authority: &str) -> ClientCredentials {
-        ClientCredentials {
+    fn x509_cred(authority: &str) -> Arc<ClientCredentials> {
+        Arc::new(ClientCredentials {
             method: "x509".into(),
             account: "operator".into(),
             host: "h.example".into(),
             authority: authority.into(),
             roles: Vec::new(),
-        }
+        })
     }
 
     /// A1: the ACF host identity must come from the socket, never the wire.
@@ -17801,7 +17757,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -17922,7 +17878,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -18279,7 +18235,7 @@ mod tests {
     /// rule is unconditional and only WRITE is AUTHORITY-scoped, so
     /// the peer with the matching CA gets BOTH a successful PUT leg
     /// and a non-empty readback — exercising the fixed GET-leg
-    /// `&ctx.authority` forwarding.
+    /// `&ctx.creds.authority` forwarding.
     #[epics_macros_rs::epics_test]
     async fn put_get_readback_honors_authority() {
         let order = ByteOrder::Little;
@@ -18305,7 +18261,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -18493,7 +18449,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -18633,7 +18589,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -18649,7 +18605,7 @@ mod tests {
         let frame = synth_frame(Command::GetField, order, payload);
 
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         handle_get_field(
             &frame,
             &tx,
@@ -18694,7 +18650,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -18708,7 +18664,7 @@ mod tests {
         let frame = synth_frame(Command::GetField, order, payload);
 
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         handle_get_field(
             &frame,
             &tx,
@@ -18762,7 +18718,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source: source.clone(),
                 stat: stat.clone(),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -18777,7 +18733,7 @@ mod tests {
         let inbound_body = frame.payload.len();
 
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         handle_get_field(
             &frame,
             &tx,
@@ -18868,7 +18824,7 @@ mod tests {
                     introspection: None,
                     source: source.clone(),
                     stat: stat.clone(),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
                 },
@@ -18945,7 +18901,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -18959,7 +18915,7 @@ mod tests {
         let frame = synth_frame(Command::GetField, order, payload);
 
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         // The reserved GET_FIELD op (holding the task's abort guard) lives
         // in `channels`, which stays in scope until after the reply below,
         // so the slow-path task is not aborted before it replies.
@@ -19030,7 +18986,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -19044,7 +19000,7 @@ mod tests {
         let frame = synth_frame(Command::GetField, order, payload);
 
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         // The reserved GET_FIELD op (holding the task's abort guard) lives
         // in `channels`, which stays in scope until after the reply below,
         // so the slow-path task is not aborted before it replies.
@@ -19137,7 +19093,7 @@ mod tests {
                 introspection: None,
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -19152,7 +19108,7 @@ mod tests {
             synth_frame(Command::GetField, order, payload)
         };
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // First GET_FIELD: reserves the IOID and spawns the (blocked) task.
         let frame1 = build();
@@ -19511,11 +19467,13 @@ mod tests {
     fn bfr12_anon_ctx() -> crate::server_native::source::ChannelContext {
         crate::server_native::source::ChannelContext {
             peer: "127.0.0.1:5075".parse().unwrap(),
-            account: String::new(),
-            method: "anonymous".into(),
-            host: String::new(),
-            authority: String::new(),
-            roles: Vec::new(),
+            creds: Arc::new(ClientCredentials {
+                account: String::new(),
+                method: "anonymous".into(),
+                host: String::new(),
+                authority: String::new(),
+                roles: Vec::new(),
+            }),
             pv_request: None,
             log: Default::default(),
         }
@@ -19562,7 +19520,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: src.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -19917,7 +19875,7 @@ mod tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -19928,7 +19886,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // MONITOR INIT (subcmd 0x08): empty pvRequest → full monitor.
         let req_val = PvField::Structure(PvStructure {
@@ -20094,7 +20052,7 @@ mod tests {
                 introspection: intro.map(std::sync::Arc::new),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -20146,7 +20104,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // GET INIT (subcmd 0x08) — succeeds via ch.introspection.
         let mut init_payload = Vec::new();
@@ -20225,7 +20183,7 @@ mod tests {
                     introspection: Some(std::sync::Arc::new(three_field_intro())),
                     source: source.clone(),
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                    open_cred: ClientCredentials::anonymous(TEST_PEER),
+                    open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
                 },
@@ -20260,7 +20218,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // INIT a fresh GET on channel sid=2 reusing ioid=5.
         let mut init_payload = Vec::new();
@@ -20341,7 +20299,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         // PUT INIT (subcmd 0x08).
         let mut init_payload = Vec::new();
@@ -20425,7 +20383,7 @@ mod tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let mut init_payload = Vec::new();
         init_payload.put_u32(sid, order);
@@ -20556,7 +20514,7 @@ mod tests {
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let peer_entry = crate::server_native::peers::PeerEntry::new(false);
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
-        let mut cred = ClientCredentials::anonymous(TEST_PEER);
+        let mut cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         // One connection-scope inbound decode cache shared across both
         // validation frames, mirroring the read loop's single `rx_type_cache`.
         let mut decode_cache = TypeCache::new();
@@ -20694,7 +20652,7 @@ mod tests {
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let peer_entry = crate::server_native::peers::PeerEntry::new(false);
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
-        let mut cred = ClientCredentials::anonymous(TEST_PEER);
+        let mut cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let mut decode_cache = TypeCache::new();
 
         // Initial handshake: identity becomes alice/ca.
@@ -20855,7 +20813,7 @@ mod autoexec_tests {
                 introspection: Some(std::sync::Arc::new(intro.clone())),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
             },
@@ -20865,7 +20823,7 @@ mod autoexec_tests {
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let req_desc = pv_request.descriptor();
         let mut init_payload = Vec::new();
@@ -21053,7 +21011,7 @@ mod r14_tests {
         let source: DynSource = std::sync::Arc::new(SlowGetSource);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
 
         let intro = FieldDesc::Variant;
         let mut channels: HashMap<u32, ChannelState> = HashMap::new();
@@ -21075,7 +21033,7 @@ mod r14_tests {
                 introspection: Some(std::sync::Arc::new(intro)),
                 source: source.clone(),
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -21261,7 +21219,7 @@ mod bfr15_tests {
                 introspection: Some(std::sync::Arc::new(intro)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -21371,7 +21329,7 @@ mod bfr15_tests {
         let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let mon = mpsc::unbounded_channel::<MonitorFinished>().0;
         let (exec_tx, _exec_rx) = mpsc::unbounded_channel::<ExecFinished>();
 
@@ -21464,7 +21422,7 @@ mod bfr15_tests {
         let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let mon = mpsc::unbounded_channel::<MonitorFinished>().0;
         let (exec_tx, _exec_rx) = mpsc::unbounded_channel::<ExecFinished>();
 
@@ -21552,7 +21510,7 @@ mod bfr15_tests {
         let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let mon = mpsc::unbounded_channel::<MonitorFinished>().0;
         let (exec_tx, _exec_rx) = mpsc::unbounded_channel::<ExecFinished>();
 
@@ -21608,7 +21566,7 @@ mod bfr15_tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let cred = ClientCredentials::anonymous(TEST_PEER);
+        let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let mon = mpsc::unbounded_channel::<MonitorFinished>().0;
         let (exec_tx, mut exec_rx) = mpsc::unbounded_channel::<ExecFinished>();
 
@@ -21745,7 +21703,7 @@ mod bfr15_tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },
@@ -21829,7 +21787,7 @@ mod bfr15_tests {
                 introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
                 source,
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
-                open_cred: ClientCredentials::anonymous(TEST_PEER),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
             },

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -790,6 +790,15 @@ struct ChannelState {
     /// earlier EXEC — semantically dead under the `put_delta_checked`
     /// contract (only `changed`-marked fields may be read).
     put_scratch: Option<(Arc<FieldDesc>, PvField)>,
+    /// Memoized inline wire encoding of [`Self::introspection`] for
+    /// GET/PUT/MONITOR INIT replies, keyed by the descriptor Arc and
+    /// the reply byte order. Channel-level for the same reason as
+    /// `put_scratch`: a pvput client re-INITs per put against the one
+    /// negotiated descriptor, so the full `encode_type_desc` tree walk
+    /// would otherwise run on every operation. Only the default
+    /// (`!emit_type_cache`) branch consults it — the 0xFD/0xFE
+    /// TypeStore path already collapses repeats to 3-byte references.
+    intro_wire: Option<(Arc<FieldDesc>, ByteOrder, Vec<u8>)>,
 }
 
 // `source` is a `dyn ChannelSourceObj` trait object with no `Debug`
@@ -3364,6 +3373,7 @@ pub(super) async fn handle_connection_io(
                             open_cred: cc.open_cred,
                             ops: HashMap::new(),
                             put_scratch: None,
+                    intro_wire: None,
                         });
                         // Register the channel (live + lifetime counts and
                         // the per-channel report entry) in one owner call.
@@ -6729,7 +6739,16 @@ async fn handle_op(
             if config.emit_type_cache {
                 encode_type_desc_cached(&intro, order, encode_cache, &mut payload);
             } else {
-                encode_type_desc(&intro, order, &mut payload);
+                match &ch.intro_wire {
+                    Some((d, o, bytes)) if Arc::ptr_eq(d, &intro) && *o == order => {
+                        payload.extend_from_slice(bytes);
+                    }
+                    _ => {
+                        let start = payload.len();
+                        encode_type_desc(&intro, order, &mut payload);
+                        ch.intro_wire = Some((intro.clone(), order, payload[start..].to_vec()));
+                    }
+                }
             }
         }
         let h = PvaHeader::application(true, order, cmd.code(), payload.len() as u32);
@@ -9970,6 +9989,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
             let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10066,6 +10086,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
             let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10161,6 +10182,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10257,6 +10279,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
             let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10921,6 +10944,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -11032,6 +11056,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -11126,6 +11151,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -11385,6 +11411,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -11554,6 +11581,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         (channels, source, pusher)
@@ -12310,6 +12338,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         (channels, source, raw_tx)
@@ -12540,6 +12569,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
@@ -12708,6 +12738,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
@@ -12804,6 +12835,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -12931,6 +12963,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -13033,6 +13066,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -13223,6 +13257,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -13500,6 +13535,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -13948,6 +13984,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -13994,6 +14031,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             }
         };
         // Channel 1 owns IOID 7; channel 2 owns IOID 9.
@@ -14083,6 +14121,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -14193,6 +14232,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -14303,6 +14343,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -14395,6 +14436,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -15010,6 +15052,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
@@ -15069,6 +15112,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
@@ -15222,6 +15266,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let (tx, mut _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
@@ -15433,6 +15478,7 @@ mod tests {
                 open_cred: completion.open_cred,
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let ch = channels.get(&completion.sid).unwrap();
@@ -15479,6 +15525,7 @@ mod tests {
                 open_cred: cred_ca("alice"),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -15542,6 +15589,7 @@ mod tests {
                 open_cred: cred_ca("alice"),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -15616,6 +15664,7 @@ mod tests {
                 open_cred: cred_ca("alice"),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -15690,6 +15739,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
             peer_entry.channel_opened(sid, stat);
@@ -15764,6 +15814,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         peer_entry.channel_opened(1, stat);
@@ -15844,6 +15895,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -15978,6 +16030,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -16124,6 +16177,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops,
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
             channels
@@ -16283,6 +16337,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -16387,6 +16442,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         let mut fresh_cache = TypeCache::new();
@@ -16789,6 +16845,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -16921,6 +16978,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -17275,6 +17333,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -17760,6 +17819,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -17881,6 +17941,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -18264,6 +18325,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -18452,6 +18514,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -18592,6 +18655,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -18653,6 +18717,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -18721,6 +18786,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -18827,6 +18893,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
             let peer_entry = crate::server_native::peers::PeerEntry::new(false);
@@ -18904,6 +18971,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -18989,6 +19057,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -19096,6 +19165,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -19523,6 +19593,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -19878,6 +19949,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -20055,6 +20127,7 @@ mod tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -20186,6 +20259,7 @@ mod tests {
                     open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                     ops: HashMap::new(),
                     put_scratch: None,
+                    intro_wire: None,
                 },
             );
         }
@@ -20816,6 +20890,7 @@ mod autoexec_tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops: HashMap::new(),
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -21036,6 +21111,7 @@ mod r14_tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -21222,6 +21298,7 @@ mod bfr15_tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
         channels
@@ -21706,6 +21783,7 @@ mod bfr15_tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 
@@ -21790,6 +21868,7 @@ mod bfr15_tests {
                 open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
                 ops,
                 put_scratch: None,
+                intro_wire: None,
             },
         );
 

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -3161,6 +3161,21 @@ pub(super) async fn handle_connection_io(
     // `interval` yields its first tick immediately; the task consumed it the
     // same way, so the first beat lands 15 s in.
     hb_tick.tick().await;
+    // Coarse read-stall watchdog: one persistent ticker replaces the
+    // per-read `timeout()` wrapper `read_frame` used to carry (a
+    // timer-wheel insert + cancel per pending read). The arm below
+    // returns `PvaError::Timeout` once the peer has completed no frame
+    // for `op_timeout`, so a stall is detected within
+    // [`op_timeout`, `op_timeout` + tick period] instead of exactly at
+    // `op_timeout` — an acceptable coarsening of a guard whose default
+    // is 64,000 s. Unlike the heartbeat this arm is never latched off:
+    // it must keep watching after `hb_stopped`, or an idle-latched
+    // connection whose peer then wedges mid-frame would never be
+    // reclaimed.
+    let mut op_deadline_tick = epics_base_rs::runtime::task::interval(
+        (op_timeout / 2).clamp(Duration::from_millis(100), Duration::from_secs(15)),
+    );
+    op_deadline_tick.tick().await;
     // Latched when the idle watchdog fires or the writer channel closes —
     // the two conditions that used to `break` the task's loop. Note this
     // stops the *heartbeat*, not the connection: the task ending never tore
@@ -3550,7 +3565,19 @@ pub(super) async fn handle_connection_io(
                 }
                 continue;
             }
-            frame_result = read_frame(&mut reader, &mut rx_buf, op_timeout, max_msg_size) => {
+            _ = op_deadline_tick.tick() => {
+                // Read-stall bound, moved out of `read_frame` (see the
+                // ticker's construction above). `last_rx` stamps every
+                // completed frame, so this fires only when the peer has
+                // sent no complete frame for `op_timeout` — a wedged or
+                // byte-trickling circuit.
+                let elapsed = now_nanos().saturating_sub(last_rx);
+                if Duration::from_nanos(elapsed) >= op_timeout {
+                    return Err(PvaError::Timeout);
+                }
+                continue;
+            }
+            frame_result = read_frame(&mut reader, &mut rx_buf, max_msg_size) => {
                 frame_result?
             }
         };
@@ -5312,7 +5339,6 @@ fn read_array_size(
 async fn read_frame<R: tokio::io::AsyncRead + Unpin>(
     reader: &mut R,
     rx_buf: &mut Vec<u8>,
-    op_timeout: Duration,
     max_msg_size: Option<usize>,
 ) -> PvaResult<Frame> {
     loop {
@@ -5345,13 +5371,15 @@ async fn read_frame<R: tokio::io::AsyncRead + Unpin>(
                 }
             }
         }
+        // No per-read timer: wrapping every read in `timeout()` minted
+        // and cancelled a timer-wheel entry per pending read — pure
+        // churn on a hot circuit. The read-stall bound (`op_timeout`)
+        // is enforced coarsely by the connection loop's deadline tick,
+        // which checks the age of the last completed frame.
         let mut chunk = [0u8; 4096];
-        let n = match epics_base_rs::runtime::task::timeout(op_timeout, reader.read(&mut chunk))
-            .await
-        {
-            Ok(Ok(n)) => n,
-            Ok(Err(e)) => return Err(PvaError::Io(e)),
-            Err(_) => return Err(PvaError::Timeout),
+        let n = match reader.read(&mut chunk).await {
+            Ok(n) => n,
+            Err(e) => return Err(PvaError::Io(e)),
         };
         if n == 0 {
             return Err(PvaError::Protocol("client closed".into()));
@@ -21920,14 +21948,9 @@ mod inbound_message_cap_tests {
         let wire = header_announcing(DEFAULT_MAX_MESSAGE_SIZE as u32 + 1);
         let mut reader = std::io::Cursor::new(wire);
         let mut rx_buf = Vec::new();
-        let err = read_frame(
-            &mut reader,
-            &mut rx_buf,
-            Duration::from_secs(1),
-            Some(DEFAULT_MAX_MESSAGE_SIZE),
-        )
-        .await
-        .expect_err("an over-cap header must be refused");
+        let err = read_frame(&mut reader, &mut rx_buf, Some(DEFAULT_MAX_MESSAGE_SIZE))
+            .await
+            .expect_err("an over-cap header must be refused");
         let msg = err.to_string();
         assert!(
             msg.contains("exceeds max_message_size"),
@@ -21948,7 +21971,7 @@ mod inbound_message_cap_tests {
         wire.extend_from_slice(&[0u8; 16]);
         let mut reader = std::io::Cursor::new(wire);
         let mut rx_buf = Vec::new();
-        let frame = read_frame(&mut reader, &mut rx_buf, Duration::from_secs(1), Some(cap))
+        let frame = read_frame(&mut reader, &mut rx_buf, Some(cap))
             .await
             .expect("a message exactly at the cap must be admitted");
         assert_eq!(frame.payload.len(), cap);
@@ -21960,7 +21983,7 @@ mod inbound_message_cap_tests {
         let wire = header_announcing(cap as u32 + 1);
         let mut reader = std::io::Cursor::new(wire);
         let mut rx_buf = Vec::new();
-        let err = read_frame(&mut reader, &mut rx_buf, Duration::from_secs(1), Some(cap))
+        let err = read_frame(&mut reader, &mut rx_buf, Some(cap))
             .await
             .expect_err("one byte over the cap must be refused");
         assert!(err.to_string().contains("exceeds max_message_size"));
@@ -21974,7 +21997,7 @@ mod inbound_message_cap_tests {
         let wire = header_announcing(DEFAULT_MAX_MESSAGE_SIZE as u32 + 1);
         let mut reader = std::io::Cursor::new(wire);
         let mut rx_buf = Vec::new();
-        let err = read_frame(&mut reader, &mut rx_buf, Duration::from_secs(1), None)
+        let err = read_frame(&mut reader, &mut rx_buf, None)
             .await
             .expect_err("the stream ends after the header, so this cannot succeed");
         // The refusal must be the *stream ending*, not the cap.

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -39,7 +39,7 @@ use crate::proto::{
     QosFlags, Status, WriteExt, encode_size_into, encode_string_into,
 };
 use crate::pvdata::encode::{
-    EncodeTypeCache, TypeCache, decode_pv_field_cached, decode_pv_field_with_bitset_cached,
+    EncodeTypeCache, TypeCache, decode_pv_field_cached, decode_pv_field_with_bitset_into,
     encode_pv_field, encode_type_desc, encode_type_desc_cached,
 };
 use crate::pvdata::{FieldDesc, NoConvert, PvField, RpcReply};
@@ -779,6 +779,17 @@ struct ChannelState {
     open_cred: ClientCredentials,
     /// ioid → (introspection negotiated for this op, kind)
     ops: HashMap<u32, OpState>,
+    /// Reusable PUT-delta decode scratch, keyed by the op intro it was
+    /// built for (`Arc::ptr_eq`). A PUT/PUT_GET EXEC takes it, decodes
+    /// the marked fields in place ([`decode_pv_field_with_bitset_into`])
+    /// and the exec body returns it through [`ExecFinished`] once the
+    /// source call is done. Channel-level (not per-op) because a pvput
+    /// client mints a fresh op per put (INIT/EXEC/DESTROY), which would
+    /// defeat a per-op scratch; ops of one channel negotiating the same
+    /// intro share the tree. Unmarked slots carry stale values from an
+    /// earlier EXEC — semantically dead under the `put_delta_checked`
+    /// contract (only `changed`-marked fields may be read).
+    put_scratch: Option<(Arc<FieldDesc>, PvField)>,
 }
 
 // `source` is a `dyn ChannelSourceObj` trait object with no `Debug`
@@ -993,7 +1004,7 @@ fn begin_exec(ch: &mut ChannelState, ioid: u32) -> Option<u64> {
 /// tags THIS exec instance so a signal that arrives late (an aborted task
 /// whose future drops after its ioid was removed and re-INIT'd) cannot flip a
 /// *fresh* op back to `Idle` ([`apply_exec_finish`] ABA guard).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 struct ExecFinished {
     sid: u32,
     ioid: u32,
@@ -1014,6 +1025,13 @@ struct ExecFinished {
     /// exit that does not explicitly [`ExecFinishGuard::mark_success`] — error
     /// returns, panics, and aborts all skip the marking.
     success: bool,
+    /// PUT/PUT_GET decode scratch travelling back to its channel
+    /// ([`ChannelState::put_scratch`]) once the source call released its
+    /// borrow. `None` for every other op kind, and for exec exits (panic,
+    /// abort) that lost the value. A stale-`op_id` signal may still return
+    /// its scratch: any tree built from the same `Arc`'d intro is a valid
+    /// scratch, so last-writer-wins is safe.
+    scratch: Option<(Arc<FieldDesc>, PvField)>,
 }
 
 /// RAII finalizer held as a single local at the top of a data-phase
@@ -1044,7 +1062,13 @@ impl Drop for ExecFinishGuard {
         // Unbounded so this sync Drop never loses the signal to a full
         // channel; the only `send` failure is a closed receiver (the read
         // loop already ended and dropped every op).
-        let _ = self.tx.send(self.fin);
+        let _ = self.tx.send(ExecFinished {
+            sid: self.fin.sid,
+            ioid: self.fin.ioid,
+            op_id: self.fin.op_id,
+            success: self.fin.success,
+            scratch: self.fin.scratch.take(),
+        });
     }
 }
 
@@ -1076,6 +1100,13 @@ fn apply_exec_finish(channels: &mut HashMap<u32, ChannelState>, fin: ExecFinishe
     let Some(ch) = channels.get_mut(&fin.sid) else {
         return;
     };
+    // Return the PUT decode scratch to its channel before any op
+    // disposition: the channel outlives the op (a pvput client destroys
+    // its op per put), and even a stale-op_id signal carries a tree
+    // valid for reuse (same Arc'd intro; last writer wins).
+    if let Some(s) = fin.scratch {
+        ch.put_scratch = Some(s);
+    }
     let (matches, last_request, kind) = match ch.ops.get(&fin.ioid) {
         Some(op) => (op.monitor_op_id == fin.op_id, op.last_request, op.kind),
         None => return,
@@ -3332,6 +3363,7 @@ pub(super) async fn handle_connection_io(
                             stat: stat.clone(),
                             open_cred: cc.open_cred,
                             ops: HashMap::new(),
+                            put_scratch: None,
                         });
                         // Register the channel (live + lifetime counts and
                         // the per-channel report entry) in one owner call.
@@ -4412,7 +4444,14 @@ async fn handle_put_get(
     } else {
         let changed =
             BitSet::decode(&mut cur, inbound_order).map_err(|e| PvaError::Decode(e.to_string()))?;
-        let put_delta = decode_pv_field_with_bitset_cached(
+        // Same scratch reuse as the PUT EXEC path: decode marked fields
+        // in place, lend to the source, return via `ExecFinished`.
+        let mut put_delta = match ch.put_scratch.take() {
+            Some((d, v)) if Arc::ptr_eq(&d, &intro) => v,
+            _ => crate::pvdata::encode::default_value_for(&intro),
+        };
+        decode_pv_field_with_bitset_into(
+            &mut put_delta,
             &intro,
             &changed,
             0,
@@ -4452,12 +4491,13 @@ async fn handle_put_get(
         ioid,
         op_id,
         success: false,
+        scratch: None,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
     let abort = poll_inline_or_spawn(async move {
         // return this op to `Idle` (via the read-loop owner) when the
         // task ends so a later explicit re-EXEC is accepted.
-        let _exec_fin_guard = ExecFinishGuard {
+        let mut exec_fin_guard = ExecFinishGuard {
             tx: exec_fin_tx_task,
             fin: exec_fin,
         };
@@ -4495,11 +4535,11 @@ async fn handle_put_get(
                         &ctx.authority,
                     )
                     .await;
-                match catch_handler_panic(src.put_get_checked(
+                let outcome = match catch_handler_panic(src.put_get_checked(
                     checked,
                     intro.clone(),
                     changed,
-                    put_delta,
+                    &put_delta,
                     ctx.clone(),
                 ))
                 .await
@@ -4507,7 +4547,12 @@ async fn handle_put_get(
                     Ok(Ok(v)) => Ok(v),
                     Ok(Err(e)) => Err(e.wire_status()),
                     Err(panic) => Err(Status::error(panic)),
-                }
+                };
+                // Source borrow released — send the scratch home with the
+                // completion signal (every later exit goes through the
+                // guard's Drop).
+                exec_fin_guard.fin.scratch = Some((intro.clone(), put_delta));
+                outcome
             } else {
                 let read_checked = src
                     .access_gate()
@@ -4798,6 +4843,7 @@ async fn handle_process(
         ioid,
         op_id,
         success: false,
+        scratch: None,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
     let abort = poll_inline_or_spawn(async move {
@@ -5168,6 +5214,7 @@ async fn handle_channel_array(
         ioid,
         op_id,
         success: false,
+        scratch: None,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
     let abort = poll_inline_or_spawn(async move {
@@ -6786,6 +6833,7 @@ async fn handle_op(
                 ioid,
                 op_id,
                 success: false,
+                scratch: None,
             };
             let exec_fin_tx_task = exec_fin_tx.clone();
             let abort = poll_inline_or_spawn(async move {
@@ -6936,6 +6984,7 @@ async fn handle_op(
                     ioid,
                     op_id,
                     success: false,
+                    scratch: None,
                 };
                 let exec_fin_tx_task = exec_fin_tx.clone();
                 let abort = poll_inline_or_spawn(async move {
@@ -7049,7 +7098,16 @@ async fn handle_op(
             // for whether the PUT EXEC fires automatically after INIT
             // or waits for `reExec()`. Each EXEC frame still carries
             // exactly one value and triggers exactly one write.
-            let delta = decode_pv_field_with_bitset_cached(
+            // Decode the marked fields into the channel's reusable
+            // scratch tree instead of building a default-filled tree per
+            // EXEC (`ChannelState::put_scratch`); the exec body lends it
+            // to the source and returns it via `ExecFinished`.
+            let mut delta = match ch.put_scratch.take() {
+                Some((d, v)) if Arc::ptr_eq(&d, &intro) => v,
+                _ => crate::pvdata::encode::default_value_for(&intro),
+            };
+            decode_pv_field_with_bitset_into(
+                &mut delta,
                 &intro,
                 &changed,
                 0,
@@ -7085,6 +7143,7 @@ async fn handle_op(
                 ioid,
                 op_id,
                 success: false,
+                scratch: None,
             };
             let exec_fin_tx_task = exec_fin_tx.clone();
             let abort = poll_inline_or_spawn(async move {
@@ -7124,14 +7183,18 @@ async fn handle_op(
                     catch_handler_panic(src.put_delta_checked(
                         checked,
                         intro_t.clone(),
-                        changed.clone(),
-                        delta,
+                        changed,
+                        &delta,
                         ctx.clone(),
                     ))
                     .await
                     .map_err(|e| OpError::failed(e))
                     .and_then(|r| r)
                 };
+                // Source borrow released — send the scratch home with the
+                // completion signal (every later exit path goes through
+                // the guard's Drop).
+                exec_fin_guard.fin.scratch = Some((intro_t.clone(), delta));
                 flush_remote_log(&op_log, ioid, order, &tx_clone).await;
                 let mut payload = Vec::new();
                 payload.put_u32(ioid, order);
@@ -7452,6 +7515,7 @@ async fn handle_op(
                 ioid,
                 op_id,
                 success: false,
+                scratch: None,
             };
             let exec_fin_tx_task = exec_fin_tx.clone();
             let abort = poll_inline_or_spawn(async move {
@@ -7680,6 +7744,7 @@ async fn handle_get_field(
         ioid,
         op_id,
         success: false,
+        scratch: None,
     };
     let exec_fin_tx_task = exec_fin_tx.clone();
     let abort = poll_inline_or_spawn(async move {
@@ -9966,6 +10031,7 @@ mod tests {
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops: HashMap::new(),
+                    put_scratch: None,
                 },
             );
             let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10061,6 +10127,7 @@ mod tests {
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops: HashMap::new(),
+                    put_scratch: None,
                 },
             );
             let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10155,6 +10222,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10250,6 +10318,7 @@ mod tests {
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops: HashMap::new(),
+                    put_scratch: None,
                 },
             );
             let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
@@ -10913,6 +10982,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -11023,6 +11093,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -11116,6 +11187,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -11372,6 +11444,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -11540,6 +11613,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         (channels, source, pusher)
@@ -12295,6 +12369,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         (channels, source, raw_tx)
@@ -12524,6 +12599,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
@@ -12691,6 +12767,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
@@ -12786,6 +12863,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -12912,6 +12990,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -13013,6 +13092,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -13202,6 +13282,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
         channels
@@ -13478,6 +13559,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
         channels
@@ -13925,6 +14007,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -13970,6 +14053,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             }
         };
         // Channel 1 owns IOID 7; channel 2 owns IOID 9.
@@ -14058,6 +14142,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -14167,6 +14252,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -14276,6 +14362,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -14367,6 +14454,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -14401,6 +14489,7 @@ mod tests {
                 ioid,
                 op_id: stale_op_id,
                 success: false,
+                scratch: None,
             },
         );
         assert!(
@@ -14423,6 +14512,7 @@ mod tests {
                 ioid,
                 op_id: exec_id,
                 success: true,
+                scratch: None,
             },
         );
         assert!(
@@ -14979,6 +15069,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
@@ -15037,6 +15128,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
@@ -15189,6 +15281,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let (tx, mut _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
@@ -15399,6 +15492,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: completion.open_cred,
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let ch = channels.get(&completion.sid).unwrap();
@@ -15444,6 +15538,7 @@ mod tests {
                 // Channel was created under alice/ca.
                 open_cred: cred_ca("alice"),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -15506,6 +15601,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: cred_ca("alice"),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -15579,6 +15675,7 @@ mod tests {
                 // Channel was created under alice/ca.
                 open_cred: cred_ca("alice"),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -15652,6 +15749,7 @@ mod tests {
                     stat: stat.clone(),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops: HashMap::new(),
+                    put_scratch: None,
                 },
             );
             peer_entry.channel_opened(sid, stat);
@@ -15725,6 +15823,7 @@ mod tests {
                 stat: stat.clone(),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         peer_entry.channel_opened(1, stat);
@@ -15804,6 +15903,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -15937,6 +16037,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -16082,6 +16183,7 @@ mod tests {
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops,
+                    put_scratch: None,
                 },
             );
             channels
@@ -16240,6 +16342,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -16343,6 +16446,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         let mut fresh_cache = TypeCache::new();
@@ -16677,7 +16781,7 @@ mod tests {
             checked,
             std::sync::Arc::new(three_field_intro()),
             changed,
-            delta,
+            &delta,
             ctx,
         )
         .await
@@ -16742,6 +16846,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -16873,6 +16978,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -17063,7 +17169,7 @@ mod tests {
                         checked,
                         std::sync::Arc::new(intro_a),
                         changed_a,
-                        delta_a,
+                        &delta_a,
                         ctx_a,
                     )
                     .await
@@ -17078,7 +17184,7 @@ mod tests {
                         checked,
                         std::sync::Arc::new(intro_c),
                         changed_c,
-                        delta_c,
+                        &delta_c,
                         ctx_c,
                     )
                     .await
@@ -17212,6 +17318,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
         channels
@@ -17696,6 +17803,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
         channels
@@ -17816,6 +17924,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         channels
@@ -18198,6 +18307,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -18385,6 +18495,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -18524,6 +18635,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -18584,6 +18696,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -18651,6 +18764,7 @@ mod tests {
                 stat: stat.clone(),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -18756,6 +18870,7 @@ mod tests {
                     stat: stat.clone(),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops: HashMap::new(),
+                    put_scratch: None,
                 },
             );
             let peer_entry = crate::server_native::peers::PeerEntry::new(false);
@@ -18832,6 +18947,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -18916,6 +19032,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -19022,6 +19139,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -19446,6 +19564,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
         channels
@@ -19800,6 +19919,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -19976,6 +20096,7 @@ mod tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
         channels
@@ -20106,6 +20227,7 @@ mod tests {
                     stat: crate::server_native::peers::ChannelStat::new(String::new()),
                     open_cred: ClientCredentials::anonymous(TEST_PEER),
                     ops: HashMap::new(),
+                    put_scratch: None,
                 },
             );
         }
@@ -20735,6 +20857,7 @@ mod autoexec_tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops: HashMap::new(),
+                put_scratch: None,
             },
         );
 
@@ -20954,6 +21077,7 @@ mod r14_tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -21139,6 +21263,7 @@ mod bfr15_tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
         channels
@@ -21562,6 +21687,7 @@ mod bfr15_tests {
                 ioid,
                 op_id: op_id.wrapping_add(1),
                 success: true,
+                scratch: None,
             },
         );
         assert_eq!(
@@ -21579,6 +21705,7 @@ mod bfr15_tests {
                 ioid,
                 op_id,
                 success: true,
+                scratch: None,
             },
         );
         assert_eq!(op_exec_state(&channels, sid, ioid), ExecState::Idle);
@@ -21620,6 +21747,7 @@ mod bfr15_tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -21632,6 +21760,7 @@ mod bfr15_tests {
                 ioid,
                 op_id,
                 success: false,
+                scratch: None,
             },
         );
         {
@@ -21659,6 +21788,7 @@ mod bfr15_tests {
                 ioid,
                 op_id: op_id2,
                 success: true,
+                scratch: None,
             },
         );
         assert!(
@@ -21701,6 +21831,7 @@ mod bfr15_tests {
                 stat: crate::server_native::peers::ChannelStat::new(String::new()),
                 open_cred: ClientCredentials::anonymous(TEST_PEER),
                 ops,
+                put_scratch: None,
             },
         );
 
@@ -21713,6 +21844,7 @@ mod bfr15_tests {
                 ioid,
                 op_id,
                 success: false,
+                scratch: None,
             },
         );
         assert!(

--- a/doc/qsrv-put-perf.md
+++ b/doc/qsrv-put-perf.md
@@ -1,0 +1,58 @@
+# QSRV PUT path: server CPU per put vs pvxs
+
+Measurement backing the `perf/qsrv-put-op-path` branch. Goal, set by the
+project owner: the Rust qsrv must beat pvxs QSRV2 on PUT — lower server
+CPU per put AND higher puts/s, measured the same day on the same host.
+
+## Method
+
+- Server: `benchsrv` (scratch bin) — the native PVA server +
+  `BridgeProvider`/`QsrvPvStore` over a 2-record `bench.db`, runtime
+  shape selectable (`--workers 0` = current_thread, `N` =
+  `multi_thread(N)`).
+- Client: `putbench` — one `PvaClient`, 100 warmup puts, then 20,000
+  sequential `pvput`s of a scalar to `BENCH:AO` (each put is a fresh
+  INIT/EXEC/DESTROY op, matching `pvput` CLI behaviour).
+- Server CPU: `/proc/<pid>/stat` utime+stime delta across the timed
+  window (100 Hz ticks), µs/put = ticks × 10,000 / 20,000. PID taken
+  with `pgrep -x` (exact name — `-f` matches the measuring shell).
+- Control: pvxs `softIocPVX` on the same host, same db, same client:
+  **108 µs/put, 3,649 puts/s** (measured 2026-08-08).
+
+## Runtime shape sweep (2026-08-09, 96-core host, all branch perf work in)
+
+| workers | server CPU µs/put (runs) | puts/s |
+|---|---|---|
+| 0 (current_thread) | 92.5, 93.0, 97.5 | 3,787–3,935 |
+| 1 | 96.5, 97.0 | 3,858–3,884 |
+| 2 | 115.0, 116.0 | 3,521–3,734 |
+| 4 | 125.5, 126.5 | 3,515–3,706 |
+| 96 (tokio default here) | 132.0, 134.5 | 3,568–3,774 |
+
+The cliff is between 1 and 2 workers: the serving work for one client is
+a single runnable task, and every idle sibling worker adds wake/steal
+churn as the task migrates. A bare `#[tokio::main]` (or
+`new_multi_thread()` without `worker_threads`) sizes the pool to the
+host's CPU count, so the same binary that wins at 1 worker loses to
+pvxs at the host default.
+
+## Default chosen for the server bins
+
+`worker_threads = 1`, multi-thread flavor — the reactor shape pvxs and
+pva2pva serve from (one event loop). Applied to `qsrv_rs`,
+`dual_ioc_rs`, `pva_gateway_rs`, `softioc-rs`, `ca_gateway_rs`,
+`dual_gateway_rs`.
+
+Why not `current_thread` (2–4 µs/put cheaper): the flavor is
+load-bearing. `epics_base_rs::runtime::task::block_on_sync` refuses a
+current-thread runtime (`NotBlockable::CurrentThreadRuntime`) because
+parking its only thread halts the tasks that would wake it, and asyn's
+`block_on_reply` loses its `block_in_place` scheduling courtesy. One
+multi-thread worker keeps every flavor-branched bridge on its normal
+path; `block_in_place` on a 1-worker pool is sound (tokio spawns a
+replacement worker for the blocked one).
+
+Not fixed here, deliberately: client CLIs and short-lived tools (no
+serving hot path), `ca-soak*` load generators (want the parallelism),
+`procserv_rs` (console supervisor), `realtime-*` bins (exec backend, no
+tokio), the `oracle*` parity harness.

--- a/doc/qsrv-put-perf.md
+++ b/doc/qsrv-put-perf.md
@@ -56,3 +56,20 @@ Not fixed here, deliberately: client CLIs and short-lived tools (no
 serving hot path), `ca-soak*` load generators (want the parallelism),
 `procserv_rs` (console supervisor), `realtime-*` bins (exec backend, no
 tokio), the `oracle*` parity harness.
+
+## Final same-day comparison (2026-08-09)
+
+Back-to-back on the same host, same `bench.db`, same `putbench` client,
+20,000 puts per run, 3 runs each. Rust side is the shipped `qsrv-rs`
+release binary (1-worker default above), not the scratch server.
+
+| server | CPU µs/put (runs) | puts/s |
+|---|---|---|
+| pvxs `softIocPVX` | 103.5, 103.5, 104.0 | 3,693–3,724 |
+| `qsrv-rs` | 99.0, 99.5, 102.0 | 3,781–3,842 |
+
+Every `qsrv-rs` run beats every pvxs run on both metrics. The shipped
+bin reads 2–5 µs/put above the scratch `benchsrv` at the same shape
+(96.5–97.0, measured the same day); the difference is not attributed —
+the bin additionally installs a `tracing_subscriber` env-filter, but
+that hypothesis was not isolated.


### PR DESCRIPTION
Removes per-put work that is invariant per connection — credential deep-clones, INIT-reply type re-encoding, channel re-resolution, a timer-wheel entry per pending read — and pins the server bins to a 1-worker tokio runtime, the reactor shape pvxs serves from. Method, worker sweep, and the final same-day comparison (qsrv-rs 99.0–102.0 CPU µs/put / 3,781–3,842 puts/s vs softIocPVX 103.5–104.0 / 3,693–3,724) are in doc/qsrv-put-perf.md.