### PR TITLE
fix: close the findings of the 2026-08-09 upstream-issue audit

### DIFF
--- a/crates/asyn-rs/src/dbd_generated.rs
+++ b/crates/asyn-rs/src/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -395,6 +398,15 @@ pub fn device_link_type(record_type: &str, dtyp: &str) -> Option<DbLinkType> {
 /// The record-own field table for a record type name, or `None` for a type
 /// no vendored `.dbd` declares.
 pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
+    let _ = record_type;
+    None
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
     let _ = record_type;
     None
 }

--- a/crates/epics-base-rs/src/error.rs
+++ b/crates/epics-base-rs/src/error.rs
@@ -50,6 +50,18 @@ pub enum CaError {
     #[error("illegal menu choice: {0}")]
     BadChoice(String),
 
+    /// C `S_db_badDbrtype` ("Illegal Database Request Type") — `dbPut`
+    /// refusing a put to a DBF link field (`field_type > DBF_DEVICE`,
+    /// `dbAccess.c:1340-1347`). Only `dbPutField` changes link fields, by
+    /// routing them through `dbPutFieldLink` (`dbAccess.c:1261-1262`); a
+    /// `dbPut` reached from a record's OUT link (`dbPutLink` →
+    /// `dbDbPutValue`) or from internal code refuses, so a DB link cannot
+    /// silently rewire another record's link field. rsrv answers it with
+    /// ECA_PUTFAIL like every non-zero put status (`to_eca_status`'s
+    /// catch-all).
+    #[error("illegal database request type: {0}")]
+    BadDbrType(String),
+
     #[error("put disabled (DISP=1) for field {0}")]
     PutDisabled(String),
 

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -262,7 +262,7 @@ pub fn new_acf_cell(initial: Option<AccessSecurityConfig>) -> AcfCell {
 const HAG_DNS_REFRESH: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Spawn the periodic HAG re-resolution task for `cell` (UI-107 /
-/// epics-base#863, access-security half). Every [`HAG_DNS_REFRESH`],
+/// epics-base#863, access-security half). Every `HAG_DNS_REFRESH`,
 /// when `asCheckClientIP` is on and a policy is loaded, re-resolves the
 /// raw HAG spellings through [`AccessSecurityConfig::with_refreshed_hags`]
 /// and republishes a changed config via [`AcfCell::store`] — the same
@@ -775,7 +775,7 @@ pub struct AccessSecurityConfig {
     pub uag: HashMap<String, Vec<String>>,
     pub hag: HashMap<String, Vec<String>>,
     /// The HAG members exactly as spelled in the ACF, keyed like `hag`.
-    /// `hag` stores [`hag_members`] resolution *output* (dotted quads
+    /// `hag` stores `hag_members` resolution *output* (dotted quads
     /// under `asCheckClientIP`), which cannot be re-resolved after a
     /// DNS change; [`Self::with_refreshed_hags`] re-runs the resolution
     /// from these raw spellings (epics-base#863 / UI-107).
@@ -785,7 +785,7 @@ pub struct AccessSecurityConfig {
 }
 
 impl AccessSecurityConfig {
-    /// Re-run [`hag_members`] — the single resolution owner — over the
+    /// Re-run `hag_members` — the single resolution owner — over the
     /// raw HAG spellings and return the refreshed config when any
     /// stored member changed, `None` when resolution is unchanged.
     ///

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -257,6 +257,46 @@ pub fn new_acf_cell(initial: Option<AccessSecurityConfig>) -> AcfCell {
     )))
 }
 
+/// HAG DNS re-resolution cadence — the same 60 s the CA client's
+/// `refresh_dns` interval uses for its half of epics-base#863.
+const HAG_DNS_REFRESH: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Spawn the periodic HAG re-resolution task for `cell` (UI-107 /
+/// epics-base#863, access-security half). Every [`HAG_DNS_REFRESH`],
+/// when `asCheckClientIP` is on and a policy is loaded, re-resolves the
+/// raw HAG spellings through [`AccessSecurityConfig::with_refreshed_hags`]
+/// and republishes a changed config via [`AcfCell::store`] — the same
+/// notification path `asInit` uses, so live clients re-evaluate their
+/// rights automatically. C recovers stale HAG IPs only on a manual
+/// `asInit`; this is the sibling of the CA-side `refresh_dns` deviation.
+///
+/// Resolution runs inline in the task (the established `refresh_dns`
+/// pattern): a wedged resolver delays this refresher, nothing else. The
+/// task holds only a `Weak` to the cell and ends when the owning IOC
+/// drops it.
+pub fn spawn_hag_refresh(cell: &AcfCell) {
+    let weak = std::sync::Arc::downgrade(&cell.0);
+    crate::runtime::task::spawn(async move {
+        loop {
+            crate::runtime::task::sleep(HAG_DNS_REFRESH).await;
+            let Some(inner) = weak.upgrade() else { break };
+            if !as_check_client_ip() {
+                continue;
+            }
+            let Some(config) = inner.load_full() else {
+                continue;
+            };
+            if let Some(refreshed) = config.with_refreshed_hags() {
+                tracing::info!(
+                    target: "epics_base_rs::access_security",
+                    "HAG DNS refresh: re-resolved members changed; republishing policy"
+                );
+                AcfCell(inner).store(Some(std::sync::Arc::new(refreshed)));
+            }
+        }
+    });
+}
+
 #[derive(Clone)]
 enum AccessGateInner {
     /// ACF cell + resolver. The cell may hold `None` for "no
@@ -734,11 +774,42 @@ pub struct AsgInp {
 pub struct AccessSecurityConfig {
     pub uag: HashMap<String, Vec<String>>,
     pub hag: HashMap<String, Vec<String>>,
+    /// The HAG members exactly as spelled in the ACF, keyed like `hag`.
+    /// `hag` stores [`hag_members`] resolution *output* (dotted quads
+    /// under `asCheckClientIP`), which cannot be re-resolved after a
+    /// DNS change; [`Self::with_refreshed_hags`] re-runs the resolution
+    /// from these raw spellings (epics-base#863 / UI-107).
+    pub hag_raw: HashMap<String, Vec<String>>,
     pub asg: HashMap<String, AccessSecurityGroup>,
     pub unknown_access: AccessLevel,
 }
 
 impl AccessSecurityConfig {
+    /// Re-run [`hag_members`] — the single resolution owner — over the
+    /// raw HAG spellings and return the refreshed config when any
+    /// stored member changed, `None` when resolution is unchanged.
+    ///
+    /// Only meaningful under `asCheckClientIP` (the default string
+    /// mode stores lowercased literals that no DNS change can move);
+    /// callers gate on [`as_check_client_ip`] before paying for
+    /// resolution. C freezes HAG IPs at ACF load until a manual
+    /// `asInit` (epics-base#863; its PR #862 moves upstream toward
+    /// refresh) — this is the sibling of the CA-side `refresh_dns`
+    /// deviation that closed the client half of that issue.
+    pub fn with_refreshed_hags(&self) -> Option<Self> {
+        let refreshed: HashMap<String, Vec<String>> = self
+            .hag_raw
+            .iter()
+            .map(|(name, raw)| (name.clone(), hag_members(raw)))
+            .collect();
+        if refreshed == self.hag {
+            return None;
+        }
+        let mut new = self.clone();
+        new.hag = refreshed;
+        Some(new)
+    }
+
     /// Render the parsed ACF (UAG/HAG/ASG with their `INP*` links and
     /// RULEs) in C `asDumpFP` shape, as a `String`.
     ///
@@ -1481,6 +1552,7 @@ pub fn parse_acf(content: &str) -> CaResult<AccessSecurityConfig> {
     let mut config = AccessSecurityConfig {
         uag: HashMap::new(),
         hag: HashMap::new(),
+        hag_raw: HashMap::new(),
         asg: HashMap::new(),
         unknown_access: AccessLevel::Read,
     };
@@ -1515,7 +1587,8 @@ pub fn parse_acf(content: &str) -> CaResult<AccessSecurityConfig> {
                 let members = read_brace_list(&mut chars)?;
                 // C `asHagAddHost` reads `asCheckClientIP` at ACF-parse
                 // time and stores names or resolved IPs accordingly.
-                config.hag.insert(name, hag_members(&members));
+                config.hag.insert(name.clone(), hag_members(&members));
+                config.hag_raw.insert(name, members);
             }
             "ASG" => {
                 let name = read_paren_name(&mut chars)?;
@@ -2461,6 +2534,63 @@ ASG(DEFAULT) {
         assert_eq!(entries[1], "alive.invalid");
     }
 
+    /// UI-107 / epics-base#863 (access-security half): under
+    /// `asCheckClientIP` the parsed `hag` holds resolution *output*
+    /// frozen at load time. `with_refreshed_hags` re-runs `hag_members`
+    /// over the raw spellings — the periodic refresher's engine.
+    #[test]
+    fn with_refreshed_hags_recovers_a_stale_resolution() {
+        let _guard = lock_as_check_client_ip();
+        set_as_check_client_ip(true);
+        let mut config = parse_acf("HAG(local) { localhost }\n").unwrap();
+        assert_eq!(config.hag_raw["local"], vec!["localhost"]);
+
+        // Simulate DNS moving after load: the stored quad no longer
+        // matches what `localhost` resolves to.
+        config.hag.insert("local".into(), vec!["192.0.2.1".into()]);
+
+        let refreshed = config
+            .with_refreshed_hags()
+            .expect("a moved resolution must produce a refreshed config");
+        set_as_check_client_ip(false);
+        assert_eq!(refreshed.hag["local"], vec!["127.0.0.1"]);
+        assert_eq!(
+            refreshed.hag_raw["local"],
+            vec!["localhost"],
+            "raw spellings survive the refresh for the next round"
+        );
+    }
+
+    /// An unchanged resolution yields `None` — the refresher
+    /// republishes (re-notifying every connected client) only on real
+    /// movement.
+    #[test]
+    fn with_refreshed_hags_is_none_when_resolution_is_unchanged() {
+        let _guard = lock_as_check_client_ip();
+        set_as_check_client_ip(true);
+        let config = parse_acf("HAG(local) { localhost }\n").unwrap();
+        let idempotent = config.with_refreshed_hags();
+        set_as_check_client_ip(false);
+        assert!(
+            idempotent.is_none(),
+            "a freshly parsed config re-resolves to itself"
+        );
+    }
+
+    /// In default string mode the stored members are lowercased
+    /// literals no DNS change can move — a refresh is always a no-op
+    /// (`spawn_hag_refresh` gates on the flag, but the method must
+    /// hold on its own for direct callers).
+    #[test]
+    fn with_refreshed_hags_is_none_in_name_mode() {
+        let _guard = lock_as_check_client_ip();
+        set_as_check_client_ip(false);
+        let config = parse_acf("HAG(local) { LocalHost }\n").unwrap();
+        assert_eq!(config.hag_raw["local"], vec!["LocalHost"]);
+        assert_eq!(config.hag["local"], vec!["localhost"]);
+        assert!(config.with_refreshed_hags().is_none());
+    }
+
     #[test]
     fn test_check_access_default_rw() {
         let acf = "ASG(DEFAULT) { RULE(1, WRITE) RULE(1, READ) }";
@@ -2747,6 +2877,7 @@ ASG(MIXED_CASE) {
         let config = AccessSecurityConfig {
             uag: HashMap::new(),
             hag: HashMap::new(),
+            hag_raw: HashMap::new(),
             asg: HashMap::new(),
             unknown_access: AccessLevel::Read,
         };

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -218,14 +218,43 @@ pub type InpResolver = std::sync::Arc<
 /// completes against the policy it started with, because it holds that `Arc`
 /// for its whole body. Only the writer changes — it publishes instead of
 /// waiting for in-flight readers.
-pub type AcfCell = std::sync::Arc<arc_swap::ArcSwapOption<AccessSecurityConfig>>;
+///
+/// A newtype (not an alias) so every post-construction swap goes through
+/// [`AcfCell::store`], which fires [`notify_asg_field_changed`] — the one
+/// change signal policy-derived caches ([`AccessGate`]'s check cache, the
+/// QSRV grant cache) and the CA server's `reeval_access_rights` path key
+/// on. A raw `ArcSwapOption` swap would update enforcement (checks load
+/// per-op) but leave those caches and the wire ACCESS_RIGHTS stale.
+#[derive(Clone)]
+pub struct AcfCell(std::sync::Arc<arc_swap::ArcSwapOption<AccessSecurityConfig>>);
+
+impl AcfCell {
+    /// Snapshot the current policy (lock-free guard).
+    pub fn load(&self) -> arc_swap::Guard<Option<std::sync::Arc<AccessSecurityConfig>>> {
+        self.0.load()
+    }
+
+    /// Snapshot the current policy as an owned `Option<Arc<..>>`.
+    pub fn load_full(&self) -> Option<std::sync::Arc<AccessSecurityConfig>> {
+        self.0.load_full()
+    }
+
+    /// Publish a new policy (or `None` to clear it) and fire the
+    /// process-wide access-policy change notification so live
+    /// connections re-evaluate their rights and derived caches drop
+    /// their entries.
+    pub fn store(&self, value: Option<std::sync::Arc<AccessSecurityConfig>>) {
+        self.0.store(value);
+        notify_asg_field_changed();
+    }
+}
 
 /// Build a shared [`AcfCell`] holding `initial`. The single construction
 /// point, so no caller has to name `arc_swap` or get the `Arc` nesting right.
 pub fn new_acf_cell(initial: Option<AccessSecurityConfig>) -> AcfCell {
-    std::sync::Arc::new(arc_swap::ArcSwapOption::new(
+    AcfCell(std::sync::Arc::new(arc_swap::ArcSwapOption::new(
         initial.map(std::sync::Arc::new),
-    ))
+    )))
 }
 
 #[derive(Clone)]

--- a/crates/epics-base-rs/src/server/autosave/save_set.rs
+++ b/crates/epics-base-rs/src/server/autosave/save_set.rs
@@ -365,8 +365,18 @@ pub async fn restore_from_entries_with_mode(
             }
         };
 
+        // A DBF link field takes the no-process write in BOTH modes:
+        // C `reboot_restore` puts via `dbPutField`, and `dbPutField` on a
+        // link field is `dbPutFieldLink` (`dbAccess.c:1261`) — a re-parse
+        // write that never processes. The `dbPut`-analogue `put_pv` would
+        // refuse it (`S_db_badDbrtype`, dbAccess.c:1340).
+        let (base, field) = crate::server::database::parse_pv_name(&entry.pv_name);
+        let is_link_field = db.is_dbf_link_field(base, field);
         let put_result = match mode {
             RestoreMode::NoProcess => db.put_pv_no_process(&entry.pv_name, parsed).await,
+            RestoreMode::Process if is_link_field => {
+                db.put_pv_no_process(&entry.pv_name, parsed).await
+            }
             RestoreMode::Process => db.put_pv(&entry.pv_name, parsed).await,
         };
         match put_result {

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -73,6 +73,31 @@ fn check_no_mod(instance: &crate::server::record::RecordInstance, field: &str) -
     Ok(())
 }
 
+/// C `dbPut`'s link-field refusal (`field_type > DBF_DEVICE` →
+/// `S_db_badDbrtype`, `dbAccess.c:1340-1347`): only `dbPutField` may change a
+/// DBF_INLINK/OUTLINK/FWDLINK field — it routes them through `dbPutFieldLink`
+/// (`dbAccess.c:1261-1262`) — so every `dbPut`-analogue body refuses them
+/// before converting anything. This is what stops a record's DB OUT link
+/// (`dbPutLink` → `dbDbPutValue` → `dbPut`) from silently rewiring another
+/// record's link field on every process. The port's `dbPutField` analogue is
+/// the `put_record_field_from_ca` family, whose ordinary write path re-parses
+/// the link (`RecordInstance::put_common_field`'s INP/OUT/FLNK arms);
+/// `put_pv_no_process` is the autosave-restore entry whose C analogue is
+/// likewise `dbPutField` (`reboot_restore`), so it stays link-writable.
+///
+/// `field` must already be upper-cased.
+fn check_not_link_field(
+    instance: &crate::server::record::RecordInstance,
+    field: &str,
+) -> CaResult<()> {
+    if crate::types::dbf_link_class(instance.record.record_type(), field).is_some() {
+        return Err(CaError::BadDbrType(format!(
+            "dbPut: {field} is a link field; only dbPutField changes link fields"
+        )));
+    }
+    Ok(())
+}
+
 /// Does an *external* put to `field` drive a processing cycle on this record?
 ///
 /// C `dbPutField` (`dbAccess.c:1263-1268`) and pvxs `IOCSource::
@@ -650,6 +675,27 @@ impl PvDatabase {
         put_drives_processing_of(&instance, &field_upper)
     }
 
+    /// Is `record_name.field` a DBF link field (INLINK/OUTLINK/FWDLINK)?
+    ///
+    /// The one owner of the classification lookup
+    /// ([`crate::types::dbf_link_class`] keyed by the record's type). C
+    /// callers split on it before choosing a put entry: `dbPutField` sends
+    /// link fields to `dbPutFieldLink` (`dbAccess.c:1261`), `dbProcessNotify`
+    /// short-circuits them past the notify machinery (`dbNotify.c:337-353`),
+    /// and pvxs QSRV picks `dbChannelPutField` over `dbChannelPut` for them
+    /// (`iocsource.cpp:451-458`). Port callers with a dbPutField-shaped
+    /// entry make the same split against the `dbPut`-analogue bodies' refusal
+    /// (`check_not_link_field`). `false` for an unknown record or a non-link
+    /// field.
+    pub fn is_dbf_link_field(&self, record_name: &str, field: &str) -> bool {
+        let field_upper = field.to_ascii_uppercase();
+        let Some(rec) = self.get_record(record_name) else {
+            return false;
+        };
+        let guard = rec.read();
+        crate::types::dbf_link_class(guard.record.record_type(), &field_upper).is_some()
+    }
+
     fn put_pv_body(&self, name: &str, value: EpicsValue) -> CaResult<()> {
         let (base, field) = super::parse_pv_name(name);
         let field = field.to_ascii_uppercase();
@@ -695,6 +741,10 @@ impl PvDatabase {
                 // The refusal is returned to the caller; `write_out_link_value`
                 // (C `dbPutLink`) turns it into the writer's LINK/INVALID alarm.
                 check_no_mod(&instance, &field)?;
+
+                // C `dbPut` refuses a link-field target the same way, before
+                // conversion (`dbAccess.c:1340`) — see `check_not_link_field`.
+                check_not_link_field(&instance, &field)?;
 
                 let request = dbput_request(&*instance.record, &field, value)?;
 
@@ -1008,6 +1058,7 @@ impl PvDatabase {
                 // Same `dbPut` gate as `put_pv` — this is the third `dbPut` body
                 // (value + monitor post), and C has ONE.
                 check_no_mod(&instance, &field)?;
+                check_not_link_field(&instance, &field)?;
 
                 let request = dbput_request(&*instance.record, &field, value)?;
 
@@ -1599,10 +1650,7 @@ impl PvDatabase {
         // so it processes nothing and returns immediate completion), so the
         // only correction the special case needs is to keep a link field OUT
         // of the notify PACT-defer park.
-        let is_dbf_link_field = {
-            let guard = rec.read();
-            crate::types::dbf_link_class(guard.record.record_type(), &field).is_some()
-        };
+        let is_dbf_link_field = self.is_dbf_link_field(record_name, &field);
         if want_notify && !is_dbf_link_field {
             let mut guard = rec.write();
             if guard.is_processing() {
@@ -2265,6 +2313,14 @@ impl PvDatabase {
     }
 
     /// Put a PV value without triggering process (for restore).
+    ///
+    /// Unlike the `dbPut`-analogue bodies (`put_pv`, `put_pv_and_post`) this
+    /// entry accepts DBF link fields: its production caller is the autosave
+    /// restore, whose C analogue (`reboot_restore`) writes via `dbPutField` —
+    /// and `dbPutField` on a link field is `dbPutFieldLink`, a re-parse
+    /// write that never processes. That is exactly this body's behavior
+    /// (`put_common_field`'s INP/OUT/FLNK arms, no process), so the
+    /// `check_not_link_field` refusal does not apply here.
     pub async fn put_pv_no_process(&self, name: &str, value: EpicsValue) -> CaResult<()> {
         let (base, field) = super::parse_pv_name(name);
         let field = field.to_ascii_uppercase();

--- a/crates/epics-base-rs/src/server/database/link_set.rs
+++ b/crates/epics-base-rs/src/server/database/link_set.rs
@@ -178,6 +178,12 @@ pub struct LinkMetadata {
     /// `display.description` — carried so a link snapshot is complete;
     /// pvxs exposes it through the same `fld_meta` cache.
     pub description: Option<String>,
+    /// ENUM state labels of the remote channel, when it has any. The label
+    /// table a `DBR_STRING`-requesting reader (stringin/lsi INP, printf
+    /// `%s`) renders a remote enum index through — C `dbCa` keeps a second
+    /// `DBR_STRING` monitor (`pgetString`) for that read; here the labels
+    /// ride the same attribute fetch as the limits (CA: `DBR_CTRL_ENUM`).
+    pub enum_choices: Option<Vec<String>>,
 }
 
 /// Ungated remote alarm snapshot for a link — the remote

--- a/crates/epics-base-rs/src/server/database/links.rs
+++ b/crates/epics-base-rs/src/server/database/links.rs
@@ -551,14 +551,30 @@ impl PvDatabase {
         depth: usize,
     ) -> crate::server::recgbl::simm::LinkFetch {
         use crate::server::recgbl::simm::LinkFetch;
-        use crate::server::record::LinkReadAs;
         let Some(value) = self.read_link_value(link, visited, depth) else {
             return empty_read_fetch(link);
         };
-        // A conversion the SOURCE cannot satisfy is C's non-zero `dbGetLink`
-        // status (`dbConvert.c`'s NULL conversion slot), i.e. a FAILED read —
-        // never a silent no-op.
-        let converted = match read_as {
+        match self.apply_link_read_as(link, read_as, value) {
+            Some(v) => LinkFetch::Value(v),
+            None => LinkFetch::Failed,
+        }
+    }
+
+    /// The `dbrType` conversion of one fetched link value — the single owner
+    /// of C `dbGet`'s request-type switch for every framework input read
+    /// (the pre-input [`Self::read_db_link_into_field`] stage, the single-INP
+    /// soft fetch, the DOL fetch, the multi-input loop and the SIOL read).
+    ///
+    /// `None` is C's non-zero `dbGetLink` status (`dbConvert.c`'s NULL
+    /// conversion slot), i.e. a FAILED read — never a silent no-op.
+    pub(crate) fn apply_link_read_as(
+        &self,
+        link: &crate::server::record::ParsedLink,
+        read_as: crate::server::record::LinkReadAs,
+        value: EpicsValue,
+    ) -> Option<EpicsValue> {
+        use crate::server::record::LinkReadAs;
+        match read_as {
             LinkReadAs::Native => Some(value),
             // C `dbGetLink(..., DBR_DOUBLE, ...)`: an array source contributes
             // its element 0 (C asks for one element, so `dbGet` converts offset
@@ -575,10 +591,6 @@ impl PvDatabase {
             LinkReadAs::CharArrayAsString { max_elements } => {
                 char_bytes_as_string(&value, max_elements).map(EpicsValue::String)
             }
-        };
-        match converted {
-            Some(v) => LinkFetch::Value(v),
-            None => LinkFetch::Failed,
         }
     }
 
@@ -598,6 +610,20 @@ impl PvDatabase {
         {
             let guard = rec.read();
             return guard.field_as_dbr_string(&db.field);
+        }
+        // An external ENUM value crosses the wire as a bare index; the label
+        // table lives in the lset's cached metadata (CA: the one-shot
+        // `DBR_CTRL_ENUM` attribute fetch — C `dbCa` instead keeps a second
+        // `DBR_STRING` monitor for exactly this read, `dbCa.c` `pgetString`).
+        // An index past the cached table falls through to the digits, the
+        // same rule as [`value_as_dbr_string`]'s `EnumWithChoices` arm.
+        if let EpicsValue::Enum(idx) = value
+            && let Some(name) = link.external_pv_name()
+            && let Some(m) = self.external_link_metadata(&name)
+            && let Some(choices) = m.enum_choices
+            && let Some(label) = choices.get(*idx as usize)
+        {
+            return Some(PvString::from(label.as_str()));
         }
         crate::server::record::value_as_dbr_string(value)
     }
@@ -1272,6 +1298,12 @@ impl PvDatabase {
             // `display.description` has no C lset slot — it is a pvxs-only
             // pvalink extra (`LinkMetadata::description`).
             description: None,
+            enum_choices: snapshot.enums.as_ref().map(|e| {
+                e.strings
+                    .iter()
+                    .map(|s| s.as_str_lossy().into_owned())
+                    .collect()
+            }),
         })
     }
 

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -1909,13 +1909,13 @@ impl PvDatabase {
                 // `resolve_field` (valued fields, incl. common/virtual ones
                 // like `RTYP`/`TIME` that C answers from dbStaticLib),
                 // `field_desc` (declared-but-valueless record fields), and
-                // the `dbCommon` `DBF_NOACCESS` internals the generated
-                // tables drop (`is_dbcommon_noaccess` — see its doc for the
-                // record-own residual).
+                // the `DBF_NOACCESS` internals the generated tables drop —
+                // record-own (`BPTR`, from `record_noaccess_fields`) and
+                // `dbCommon` (`MLOK`) alike.
                 let upper = field.to_ascii_uppercase();
                 instance.resolve_field(&upper).is_some()
                     || instance.field_desc(&upper).is_some()
-                    || crate::server::record::is_dbcommon_noaccess(&upper)
+                    || instance.resolves_noaccess_name(&upper)
             }
         }
     }
@@ -2445,6 +2445,22 @@ mod tests {
         // create Channel` (see `search_claims_every_dbd_name_but_create_
         // gates_on_a_servable_field` in `epics-pva-rs`).
         assert!(db.has_name("TARGET.MLOK").await);
+        // Record-own `DBF_NOACCESS` twin (`waveform.BPTR`): C's resolver
+        // does not distinguish common from record-own internals
+        // (`dbFindField` walks the type's full `dbFldDes` set), so the
+        // same answer-then-refuse applies. The generated tables drop the
+        // descs but keep the names (`record_noaccess_fields`).
+        db.add_record(
+            "WF",
+            Box::new(crate::server::records::waveform::WaveformRecord::new(
+                8,
+                crate::types::DbFieldType::Double,
+            )),
+        )
+        .await
+        .unwrap();
+        assert!(db.has_name("WF.BPTR").await);
+        assert!(!db.has_name("WF.NOSUCH").await);
         assert!(db.has_name("ALIAS_NAME.EGU").await);
         assert!(!db.has_name("ALIAS_NAME.NOSUCH").await);
         // `$` re-views a DBF_STRING/link field as a char array; anything

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -1858,7 +1858,6 @@ impl PvDatabase {
         // filtered SimplePv never answers a SEARCH and the client never
         // reaches CREATE_CHAN. See that function for the full rationale.
         let record_path = filters::split_channel_name(name).record_path;
-        let (base, _) = parse_pv_name(&record_path);
         if self
             .inner
             .simple_pvs
@@ -1867,15 +1866,58 @@ impl PvDatabase {
         {
             return true;
         }
-        if self.inner.records.read().contains_key(base) {
+        // C's search-side test is `dbChannelTest` (`dbChannel.c:441-464`),
+        // which resolves the FIELD too — `REC.NOSUCH` answers "does not
+        // exist" rather than drawing the client into a CREATE_CHAN it must
+        // then refuse (pvxs#193). Validate an explicit suffix; a bare name
+        // binds `VAL`, which every record type declares, so the record's
+        // existence alone answers it — that also keeps this function
+        // lock-free per record for the DB-link locality callers, which
+        // pass suffix-less record names.
+        let (base, explicit_field) = match record_path.rsplit_once('.') {
+            Some((base, field)) => (base, Some(field)),
+            None => (record_path.as_str(), None),
+        };
+        let rec = self.inner.records.read().get(base).cloned().or_else(|| {
+            // Alias entry exists and points to a live record
+            // (epics-base PR #336).
+            let target = self.inner.aliases.read().get(base).cloned();
+            target.and_then(|t| self.inner.records.read().get(&t).cloned())
+        });
+        let Some(rec) = rec else {
+            return false;
+        };
+        let Some(field) = explicit_field else {
             return true;
+        };
+        let instance = rec.read();
+        // Trailing `$` is the long-string modifier, part of the channel
+        // syntax (`dbChannel.c:486-505`): eligible only on a `DBF_STRING`
+        // or link field, and `dbChannelTest` refuses it anywhere else.
+        match field.strip_suffix('$') {
+            Some(core) => instance
+                .resolve_string_view_field(&core.to_ascii_uppercase())
+                .is_some(),
+            None => {
+                // Existence is the DECLARED-name question, not the
+                // has-a-value question: `dbNameToAddr` resolves any field
+                // the `.dbd` declares — including `DBF_NOACCESS` ones like
+                // `MLOK` — so pvxs answers the SEARCH for them and refuses
+                // at CREATE instead (measured against `softIocPVX`:
+                // `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`).
+                // Three name sources, matching the port's field model:
+                // `resolve_field` (valued fields, incl. common/virtual ones
+                // like `RTYP`/`TIME` that C answers from dbStaticLib),
+                // `field_desc` (declared-but-valueless record fields), and
+                // the `dbCommon` `DBF_NOACCESS` internals the generated
+                // tables drop (`is_dbcommon_noaccess` — see its doc for the
+                // record-own residual).
+                let upper = field.to_ascii_uppercase();
+                instance.resolve_field(&upper).is_some()
+                    || instance.field_desc(&upper).is_some()
+                    || crate::server::record::is_dbcommon_noaccess(&upper)
+            }
         }
-        // Alias entry exists and points to a live record
-        // (epics-base PR #336).
-        if let Some(target) = self.inner.aliases.read().get(base) {
-            return self.inner.records.read().contains_key(target);
-        }
-        false
     }
 
     /// Look up an entry by name. Supports "record.FIELD" syntax.
@@ -2376,6 +2418,39 @@ mod tests {
         assert!(db.has_name("ALIAS_NAME").await);
         assert!(db.has_name("TARGET").await);
         assert!(!db.has_name("NOT:THERE").await);
+    }
+
+    /// C answers a SEARCH through `dbChannelTest` (`dbChannel.c:441-464`),
+    /// which validates the field: `REC.NOSUCH` is "does not exist", not an
+    /// invitation to a CREATE_CHAN the server must then refuse (pvxs#193).
+    /// One case per boundary: bare name, real field, missing field, the
+    /// alias twin of each, and the `$` modifier's eligibility split.
+    #[epics_macros_rs::epics_test]
+    async fn search_gate_refuses_a_field_the_record_does_not_have() {
+        let db = PvDatabase::new();
+        db.add_record(
+            "TARGET",
+            Box::new(crate::server::records::ai::AiRecord::new(42.0)),
+        )
+        .await
+        .unwrap();
+        db.add_alias("ALIAS_NAME", "TARGET").await.unwrap();
+
+        assert!(db.has_name("TARGET.VAL").await);
+        assert!(db.has_name("TARGET.SEVR").await);
+        assert!(!db.has_name("TARGET.NOSUCH").await);
+        // Declared but valueless (`MLOK` is `DBF_NOACCESS`): `dbNameToAddr`
+        // resolves it, so the search answers and CREATE is where the
+        // refusal lands — measured `pvxget ORACLE:AI.MLOK` → `Refused to
+        // create Channel` (see `search_claims_every_dbd_name_but_create_
+        // gates_on_a_servable_field` in `epics-pva-rs`).
+        assert!(db.has_name("TARGET.MLOK").await);
+        assert!(db.has_name("ALIAS_NAME.EGU").await);
+        assert!(!db.has_name("ALIAS_NAME.NOSUCH").await);
+        // `$` re-views a DBF_STRING/link field as a char array; anything
+        // else is `S_dbLib_fieldNotFound` (`dbChannel.c:486-505`).
+        assert!(db.has_name("TARGET.EGU$").await);
+        assert!(!db.has_name("TARGET.VAL$").await);
     }
 
     #[epics_macros_rs::epics_test]

--- a/crates/epics-base-rs/src/server/database/processing.rs
+++ b/crates/epics-base-rs/src/server/database/processing.rs
@@ -2092,8 +2092,13 @@ impl PvDatabase {
             }
         }
 
-        // Read INP value
-        let inp_value = self.read_link_value_soft(&inp_parsed, is_soft, visited, depth);
+        // Read INP value, converted to the record's declared `dbrType`
+        // request (stringin/lsi ask for `DBR_STRING`/`dbGetLinkLS` —
+        // `devSiSoft.c:53`, `devLsiSoft.c:32` — so an ENUM/MENU source
+        // delivers its state label, not the index).
+        let inp_value = self
+            .read_link_value_soft(&inp_parsed, is_soft, visited, depth)
+            .and_then(|v| self.typed_input_value(&rec, "INP", &inp_parsed, v));
 
         // epics-base PR #d0cf47c: single-INP MS-class link must also
         // propagate the source record's STAT/SEVR/AMSG just like the
@@ -2144,7 +2149,12 @@ impl PvDatabase {
         // never reaches here (`dol_info` excludes it — the constant is seeded
         // once at init), so the PP-aware fetch is the right one.
         let dol_value = if let Some((ref dol_parsed, _oif)) = dol_info {
-            self.fetch_input_link(&rec, dol_parsed, visited, depth)
+            // Converted to the record's declared request: stringout reads
+            // DOL with `DBR_STRING` (`stringoutRecord.c:141`), lso via
+            // `dbGetLinkLS` (`lsoRecord.c:114`) — an ENUM/MENU DOL source
+            // delivers its label, not the index.
+            let fetch = self.fetch_input_link(&rec, dol_parsed, visited, depth);
+            self.convert_link_fetch(&rec, "DOL", dol_parsed, fetch)
                 .value()
         } else {
             None
@@ -2209,7 +2219,10 @@ impl PvDatabase {
 
         // 1.5. Multi-input link fetch (calc/calcout/sel/sub)
         // Also collect alarm info from source records for MS/NMS propagation.
-        let multi_input_values: Vec<(String, EpicsValue)>;
+        // (value field, value, store-raw) — `store_raw` marks a value a
+        // string-class declared request produced, which must reach the field
+        // as-is instead of through the numeric store funnel below.
+        let multi_input_values: Vec<(String, EpicsValue, bool)>;
         let mut link_alarms: Vec<(
             crate::server::record::MonitorSwitch,
             super::links::LinkAlarm,
@@ -2290,6 +2303,38 @@ impl PvDatabase {
                         self.process_passive_db_source(db, visited, depth);
                     }
                     let (fetch, alarm) = self.read_link_with_alarm(&parsed);
+                    // The record's declared per-link request (printf reads a
+                    // `%s` slot with `DBR_STRING`, `printfRecord.c:291`) —
+                    // a conversion miss counts as a failed read below. A
+                    // string-class request also bypasses the store's
+                    // `to_f64` funnel: that funnel IS the `DBR_DOUBLE`
+                    // request of the calc-class records (calcRecord.c:434),
+                    // not a rule of the store.
+                    let (fetch, store_raw) = match fetch {
+                        crate::server::recgbl::simm::LinkFetch::Value(v) => {
+                            use crate::server::recgbl::simm::LinkFetch;
+                            use crate::server::record::LinkReadAs;
+                            let source = self.resolve_out_target(&parsed);
+                            let read_as = {
+                                let instance = rec.read();
+                                instance.record.input_link_read_as(link_field, &source)
+                            };
+                            match read_as {
+                                None => (LinkFetch::NoData, false),
+                                Some(read_as) => {
+                                    let raw = matches!(
+                                        read_as,
+                                        LinkReadAs::String | LinkReadAs::CharArrayAsString { .. }
+                                    );
+                                    match self.apply_link_read_as(&parsed, read_as, v) {
+                                        Some(v) => (LinkFetch::Value(v), raw),
+                                        None => (LinkFetch::Failed, false),
+                                    }
+                                }
+                            }
+                        }
+                        f => (f, false),
+                    };
                     let read_failed = !fetch.is_ok();
                     any_input_read_failed |= read_failed;
                     // `NoData` (a CONSTANT link) delivers nothing — the value
@@ -2307,7 +2352,7 @@ impl PvDatabase {
                         _ => None,
                     };
                     if let Some(value) = value {
-                        results.push((val_field.clone(), value));
+                        results.push((val_field.clone(), value, store_raw));
                     }
                     // "Resolved" is C's `RTN_SUCCESS(dbGetLink(...))` — status
                     // 0 — which a CONSTANT link satisfies (it delivers nothing
@@ -2596,8 +2641,14 @@ impl PvDatabase {
                 // `to_f64()` answers None for every array variant, so routing every
                 // value through it dropped array-valued links outright — AA..LL never
                 // populated and the record calculated on an empty array.
-                for (val_field, value) in &multi_input_values {
-                    if value.is_array() {
+                for (val_field, value, store_raw) in &multi_input_values {
+                    if *store_raw {
+                        // A string-class declared request (printf `%s`)
+                        // already produced the value the record asked for —
+                        // the numeric funnel below is the OTHER records'
+                        // `DBR_DOUBLE` request, not a store rule.
+                        let _ = instance.record.put_field_internal(val_field, value.clone());
+                    } else if value.is_array() {
                         if instance
                             .record
                             .put_field_internal(val_field, value.clone())
@@ -5332,6 +5383,65 @@ impl PvDatabase {
         self.fetch_link(reader, link)
     }
 
+    /// Apply the reader's declared `dbrType` request
+    /// ([`Record::input_link_read_as`](crate::server::record::Record::input_link_read_as))
+    /// to one delivered link value — C's `dbGetLink(plink, dbrType, ...)`
+    /// second argument, which the generic fetch paths never passed: they
+    /// delivered the source's native value and let the target field coerce
+    /// blind, turning a `DBR_STRING` request at an ENUM/MENU source into
+    /// index digits (epics-base#183).
+    ///
+    /// The source is resolved with NO record lock held (the
+    /// [`Self::read_db_link_into_field`] rule: a self-referencing link
+    /// would otherwise re-enter this record's own gate), and only when the
+    /// fetch actually delivered a value. `None` from the record is C's
+    /// `default: break` — no read — mapped to `NoData`; a conversion the
+    /// source cannot satisfy is a FAILED read (C's non-zero status).
+    fn convert_link_fetch(
+        &self,
+        rec: &Arc<parking_lot::RwLock<RecordInstance>>,
+        link_field: &str,
+        link: &crate::server::record::ParsedLink,
+        fetch: crate::server::recgbl::simm::LinkFetch,
+    ) -> crate::server::recgbl::simm::LinkFetch {
+        use crate::server::recgbl::simm::LinkFetch;
+        let LinkFetch::Value(value) = fetch else {
+            return fetch;
+        };
+        let source = self.resolve_out_target(link);
+        let read_as = {
+            let instance = rec.read();
+            instance.record.input_link_read_as(link_field, &source)
+        };
+        match read_as {
+            None => LinkFetch::NoData,
+            Some(read_as) => match self.apply_link_read_as(link, read_as, value) {
+                Some(v) => LinkFetch::Value(v),
+                None => LinkFetch::Failed,
+            },
+        }
+    }
+
+    /// The `Option`-shaped twin of [`Self::convert_link_fetch`] for the
+    /// single-INP soft path, whose reader deals in `Option<EpicsValue>`:
+    /// a conversion (or declaration) miss is `None`, which that path
+    /// already classifies as a failed read of a real link (LINK alarm,
+    /// VAL untouched — C `read_si` returning `dbGetLink`'s status).
+    fn typed_input_value(
+        &self,
+        rec: &Arc<parking_lot::RwLock<RecordInstance>>,
+        link_field: &str,
+        link: &crate::server::record::ParsedLink,
+        value: EpicsValue,
+    ) -> Option<EpicsValue> {
+        let source = self.resolve_out_target(link);
+        let read_as = {
+            let instance = rec.read();
+            instance.record.input_link_read_as(link_field, &source)
+        }?;
+        self.apply_link_read_as(link, read_as, value)
+    }
+
     /// C `dbDbGetValue`'s tail, applied to the reader: the ONE place a
     /// process-time link read folds its source's alarm in. Computes the
     /// `(MS class, source alarm)` pair through the inheritance owner with no
@@ -6113,8 +6223,11 @@ impl PvDatabase {
             // locality fallback) / Ca / Pva / constant via `fetch_link`
             // (C `dbGetLink`), which keeps C's three outcomes apart: a value,
             // a CONSTANT link's "status 0 with the buffer untouched", and a
-            // failure.
+            // failure. Converted to the record's declared request: stringin
+            // reads SIOL with `DBR_STRING` (`stringinRecord.c:208`), lsi via
+            // `dbGetLinkLS` (`lsiRecord.c:244`).
             let fetch = self.fetch_link(rec, &siol_link);
+            let fetch = self.convert_link_fetch(rec, "SIOL", &siol_link, fetch);
             let mut instance = rec.write();
 
             // C reads SIOL with a plain `dbGetLink`, whose failure path is

--- a/crates/epics-base-rs/src/server/db_loader/mod.rs
+++ b/crates/epics-base-rs/src/server/db_loader/mod.rs
@@ -1520,6 +1520,23 @@ pub fn apply_fields(
         );
 
         if owned {
+            // C refuses `field(VAL, ...)` on a long-string field at load
+            // time: lso/lsi/printf VAL (and lsi OVAL) is `DBF_NOACCESS` +
+            // `SPC_DBADDR`, and `dbPutString` reports "Can't set array
+            // field before iocInit()" (epics-base#548 keeps it that way).
+            // The port refuses identically; asking `long_string_fields`
+            // names that constraint instead of the accidental Char-parse
+            // failure the value text would otherwise produce.
+            if record
+                .long_string_fields()
+                .iter()
+                .any(|f| f.eq_ignore_ascii_case(&upper_name))
+            {
+                return Err(CaError::InvalidValue(format!(
+                    "field {upper_name}: can't set array field before iocInit() \
+                     (a long-string field is not settable from a .db file, as in C)"
+                )));
+            }
             // Parse to the type the record STORES, exactly as
             // `put_field_internal_default` coerces to it: `put_field`'s arms
             // match on what is stored, and a `menu()` field is declared

--- a/crates/epics-base-rs/src/server/db_loader/substitution.rs
+++ b/crates/epics-base-rs/src/server/db_loader/substitution.rs
@@ -279,21 +279,34 @@ impl Parser {
 
     /// `file WORD|QUOTE { ... }`
     fn parse_file(&mut self) -> CaResult<()> {
+        let entry_line = self.line();
         self.expect(&Tok::File)?;
         let filename = self.expect_str()?;
+        let loads_before = self.loads.len();
         self.expect(&Tok::OBrace)?;
         // `file "x" {}` — empty body, no loads.
         if self.peek() == Some(&Tok::CBrace) {
             self.next();
-            return Ok(());
+        } else {
+            match self.peek() {
+                Some(Tok::Pattern) => self.parse_pattern_block(&filename)?,
+                // variable_substitutions: a sequence of `{ var=val,... }`
+                // rows, or nested `global {}` blocks.
+                _ => self.parse_variable_substitutions(&filename)?,
+            }
+            self.expect(&Tok::CBrace)?;
         }
-        match self.peek() {
-            Some(Tok::Pattern) => self.parse_pattern_block(&filename)?,
-            // variable_substitutions: a sequence of `{ var=val,... }`
-            // rows, or nested `global {}` blocks.
-            _ => self.parse_variable_substitutions(&filename)?,
+        // C dbLoadTemplate silently drops a `file` entry whose body
+        // yields no rows (empty `{}`, row-less pattern, globals-only) —
+        // epics-base#666. Upstream is undecided between expand-once and
+        // a doc fix, so the semantics stay; only the silence goes.
+        if self.loads.len() == loads_before {
+            tracing::warn!(
+                file = %filename,
+                line = entry_line,
+                "substitutions entry produced no template loads"
+            );
         }
-        self.expect(&Tok::CBrace)?;
         Ok(())
     }
 
@@ -614,6 +627,61 @@ file "rec.db" {
         let src = r#"file "rec.db" { }"#;
         let loads = parse_substitutions(src).unwrap();
         assert!(loads.is_empty());
+    }
+
+    /// epics-base#666: the zero-load entry stays legal (pinned above),
+    /// but must no longer be silent. All three row-less shapes warn;
+    /// an entry with rows does not.
+    #[test]
+    fn zero_load_file_entry_warns() {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+
+        #[derive(Clone, Default)]
+        struct Buf(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for Buf {
+            fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(b);
+                Ok(b.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for Buf {
+            type Writer = Buf;
+            fn make_writer(&'a self) -> Buf {
+                self.clone()
+            }
+        }
+
+        let captured = |src: &str| {
+            let buf = Buf::default();
+            let subscriber = tracing_subscriber::fmt()
+                .with_writer(buf.clone())
+                .with_max_level(tracing::Level::WARN)
+                .finish();
+            let _guard = tracing::subscriber::set_default(subscriber);
+            parse_substitutions(src).unwrap();
+            String::from_utf8_lossy(&buf.0.lock().unwrap()).into_owned()
+        };
+
+        for src in [
+            r#"file "rec.db" { }"#,
+            r#"file "rec.db" { pattern {N} }"#,
+            r#"file "rec.db" { global {A=1} }"#,
+        ] {
+            let out = captured(src);
+            assert!(
+                out.contains("no template loads") && out.contains("rec.db"),
+                "row-less entry {src:?} must warn, got: {out:?}"
+            );
+        }
+        assert_eq!(
+            captured(r#"file "rec.db" { { A=1 } }"#),
+            "",
+            "an entry with rows must not warn"
+        );
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -671,6 +671,11 @@ impl IocApplication {
         // adjacent: a config that only lands in a shell-local copy is
         // access security silently OFF).
         let acf = access_security::new_acf_cell(acf);
+        // Periodic HAG DNS re-resolution under asCheckClientIP — C
+        // freezes HAG IPs at ACF load until a manual asInit
+        // (epics-base#863 / UI-107). Weak-referenced: ends when this
+        // IOC's cell drops.
+        access_security::spawn_hag_refresh(&acf);
 
         // Register record type factories with global registry so dbLoadRecords
         // (called from st.cmd) can find them. This bridges the injected factories

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -341,7 +341,13 @@ pub struct IocRunConfig {
     /// (epics-base PR #69, `EPICS_CAS_SERVER_PORT`) while keeping the
     /// canonical UDP discovery port.
     pub tcp_port: Option<u16>,
-    pub acf: Option<access_security::AccessSecurityConfig>,
+    /// The IOC's single live Access Security policy cell, seeded from
+    /// [`IocApplication::acf`] and shared with the startup/interactive
+    /// iocsh shells (whose `asInit` stores into it). A protocol runner
+    /// must hand this cell to every server it builds — never re-wrap
+    /// the config in a fresh cell — so a later `asInit`/ACF reload
+    /// reaches all of them at once.
+    pub acf: access_security::AcfCell,
     pub autosave_config: Option<autosave::SaveSetConfig>,
     pub autosave_manager: Option<Arc<autosave::AutosaveManager>>,
     pub shell_commands: Vec<CommandDef>,
@@ -659,6 +665,13 @@ impl IocApplication {
             link_set_installers,
         } = self;
 
+        // The IOC's single live policy cell, created BEFORE the startup
+        // script runs so the script's `asInit` and the servers built
+        // afterwards observe the same store (upstream issue #667
+        // adjacent: a config that only lands in a shell-local copy is
+        // access security silently OFF).
+        let acf = access_security::new_acf_cell(acf);
+
         // Register record type factories with global registry so dbLoadRecords
         // (called from st.cmd) can find them. This bridges the injected factories
         // to the global registry that the iocsh dbLoadRecords command uses.
@@ -691,6 +704,7 @@ impl IocApplication {
         if let Some(script) = startup_script {
             let db1 = db.clone();
             let b1 = bridge.clone();
+            let acf1 = acf.clone();
 
             let (tx, rx) = crate::runtime::sync::oneshot::channel();
             // Mandatory: the startup script is what loads this IOC's database.
@@ -709,7 +723,7 @@ impl IocApplication {
                 crate::runtime::task::StackSizeClass::Big,
             )
             .try_spawn(move || {
-                let shell = iocsh::IocShell::new(db1, b1);
+                let shell = iocsh::IocShell::new_with_acf(db1, b1, acf1);
                 for cmd in startup_commands {
                     shell.register(cmd);
                 }
@@ -1072,6 +1086,7 @@ impl IocApplication {
         if !pending.is_empty() {
             let db1 = db.clone();
             let b1 = bridge.clone();
+            let acf1 = acf.clone();
             let shell_cmds_clone = shell_commands.clone();
             let (tx, rx) = crate::runtime::sync::oneshot::channel();
             // Mandatory for the same reason as "iocsh-startup": the queue holds
@@ -1086,7 +1101,7 @@ impl IocApplication {
                 crate::runtime::task::StackSizeClass::Big,
             )
             .try_spawn(move || {
-                let shell = iocsh::IocShell::new(db1, b1);
+                let shell = iocsh::IocShell::new_with_acf(db1, b1, acf1);
                 for cmd in shell_cmds_clone {
                     shell.register(cmd);
                 }

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -732,7 +732,10 @@ impl IocApplication {
                 for cmd in startup_commands {
                     shell.register(cmd);
                 }
-                let result = shell.execute_script(&script);
+                // The iocshLoad mirror: C `iocsh(pathname)` is
+                // `iocshLoad(pathname, NULL)`, which also records
+                // IOCSH_STARTUP_SCRIPT (epics-base#469).
+                let result = shell.execute_script_with_macros(&script, &Default::default());
                 let _ = tx.send(result);
             })
             .map_err(|e| {

--- a/crates/epics-base-rs/src/server/iocsh/access_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/access_commands.rs
@@ -5,12 +5,16 @@
 //! `asIocRegister.c`. The Rust port previously registered none of
 //! them, so an ACF could not be loaded or inspected from the shell.
 //!
-//! These commands operate on a process-global ACF state holder
-//! ([`as_state`]) that mirrors the C `asDbLib.c` globals — a deferred
-//! filename + substitutions string set by `asSetFilename` /
-//! `asSetSubstitutions`, and the parsed [`AccessSecurityConfig`]
-//! activated by `asInit`. The C flow is identical: `asSetFilename`
-//! has "no immediate effect", `asInit` does the (re)load.
+//! The deferred filename + substitutions strings set by
+//! `asSetFilename` / `asSetSubstitutions` live in a process-global
+//! holder ([`as_state`]) mirroring the C `asDbLib.c` globals. The
+//! parsed [`AccessSecurityConfig`] that `asInit` activates does NOT —
+//! it is stored into the shell context's live
+//! [`AcfCell`](crate::server::access_security::AcfCell), the same
+//! cell the IOC's protocol servers gate on, so a script-driven
+//! `asInit` enforces exactly as C's does. The C flow is otherwise
+//! identical: `asSetFilename` has "no immediate effect", `asInit`
+//! does the (re)load.
 
 use std::sync::Mutex;
 
@@ -20,7 +24,13 @@ use crate::server::access_security::{
 };
 
 /// Process-global access-security shell state. Mirrors the
-/// `asDbLib.c` file-scope globals (`acf`, `substitutions`).
+/// `asDbLib.c` file-scope globals (`acf`, `substitutions`) — the
+/// *deferred load parameters* only. The active parsed configuration
+/// lives in the shell context's
+/// [`AcfCell`](crate::server::access_security::AcfCell)
+/// ([`CommandContext::acf`]), the same cell the IOC's servers gate
+/// on, so `asInit` here is a live (re)load exactly as C's
+/// `asInitCommon` swaps the process `asBase`.
 #[derive(Default)]
 struct AsState {
     /// Path to the ACF file, set by `asSetFilename`. `None` until set.
@@ -28,8 +38,6 @@ struct AsState {
     /// Macro substitutions applied when reading the ACF, set by
     /// `asSetSubstitutions`.
     substitutions: Option<String>,
-    /// The active parsed configuration, populated by `asInit`.
-    config: Option<AccessSecurityConfig>,
 }
 
 fn as_state() -> &'static Mutex<AsState> {
@@ -217,7 +225,12 @@ fn cmd_as_init() -> CommandDef {
                 config.hag.len(),
                 config.asg.len()
             );
-            as_state().lock().unwrap().config = Some(config);
+            // Publish into the IOC's live policy cell — the store fires
+            // the process-wide change notification, so live CA clients
+            // re-evaluate their ACCESS_RIGHTS and policy caches drop
+            // (C: `asInitialize` swaps `pasbase` and re-computes every
+            // ASGCLIENT, asLibRoutines.c `asInitCommon`).
+            ctx.acf().store(Some(std::sync::Arc::new(config)));
             ctx.println(&summary);
             Ok(CommandOutcome::Continue)
         },
@@ -225,9 +238,12 @@ fn cmd_as_init() -> CommandDef {
 }
 
 /// Helper: run `f` with the active config, or report "not loaded".
+/// Reads the shell's live
+/// [`AcfCell`](crate::server::access_security::AcfCell) — the same
+/// policy the servers enforce — so the `as*` inspection commands can
+/// never show a config the gates are not actually using.
 fn with_config<F: FnOnce(&AccessSecurityConfig)>(ctx: &CommandContext, f: F) -> CommandResult {
-    let st = as_state().lock().unwrap();
-    match &st.config {
+    match &*ctx.acf().load() {
         Some(cfg) => {
             f(cfg);
             Ok(CommandOutcome::Continue)
@@ -567,7 +583,7 @@ mod tests {
             "asInit with no filename must be a Continue no-op, not an error"
         );
         assert!(
-            as_state().lock().unwrap().config.is_none(),
+            ctx.acf().load().is_none(),
             "no filename must leave access security disabled (no config)"
         );
     }
@@ -596,8 +612,9 @@ mod tests {
         let a = parse_args(&[], &init.args).unwrap();
         assert!(init.handler.call(&a, &ctx).is_ok());
 
-        // Config is now active.
-        assert!(as_state().lock().unwrap().config.is_some());
+        // Config is now active in the context's live cell — the one
+        // the IOC's servers gate on.
+        assert!(ctx.acf().load().is_some());
     }
 
     /// asInit on a malformed ACF surfaces the parse error.

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -89,7 +89,7 @@ fn cmd_db_delete_record() -> CommandDef {
             if ctx.block_on(ctx.db().remove_record(&name)) {
                 ctx.println(&format!("dbDeleteRecord: removed '{name}'"));
             } else {
-                ctx.println(&format!("dbDeleteRecord: no record named '{name}'"));
+                return Err(format!("dbDeleteRecord: no record named '{name}'"));
             }
             Ok(CommandOutcome::Continue)
         },
@@ -664,15 +664,13 @@ fn cmd_pushd() -> CommandDef {
             let cwd = match std::env::current_dir() {
                 Ok(p) => p,
                 Err(e) => {
-                    ctx.println(&format!("pushd: cannot read cwd: {e}"));
-                    return Ok(CommandOutcome::Continue);
+                    return Err(format!("pushd: cannot read cwd: {e}"));
                 }
             };
             match &args[0] {
                 ArgValue::String(dir) => {
                     if let Err(e) = std::env::set_current_dir(dir) {
-                        ctx.println(&format!("pushd: {dir}: {e}"));
-                        return Ok(CommandOutcome::Continue);
+                        return Err(format!("pushd: {dir}: {e}"));
                     }
                     dir_stack().lock().unwrap().push(cwd);
                 }
@@ -680,14 +678,12 @@ fn cmd_pushd() -> CommandDef {
                     // No arg: swap cwd with top of stack.
                     let mut stack = dir_stack().lock().unwrap();
                     let Some(top) = stack.pop() else {
-                        ctx.println("pushd: directory stack empty");
-                        return Ok(CommandOutcome::Continue);
+                        return Err("pushd: directory stack empty".into());
                     };
                     if let Err(e) = std::env::set_current_dir(&top) {
                         // Restore on failure.
                         stack.push(top);
-                        ctx.println(&format!("pushd: {e}"));
-                        return Ok(CommandOutcome::Continue);
+                        return Err(format!("pushd: {e}"));
                     }
                     stack.push(cwd);
                 }
@@ -707,14 +703,12 @@ fn cmd_popd() -> CommandDef {
         |_args: &[ArgValue], ctx: &CommandContext| {
             let mut stack = dir_stack().lock().unwrap();
             let Some(top) = stack.pop() else {
-                ctx.println("popd: directory stack empty");
-                return Ok(CommandOutcome::Continue);
+                return Err("popd: directory stack empty".into());
             };
             if let Err(e) = std::env::set_current_dir(&top) {
                 // Restore the entry — failed cd must not lose stack state.
                 stack.push(top);
-                ctx.println(&format!("popd: {e}"));
-                return Ok(CommandOutcome::Continue);
+                return Err(format!("popd: {e}"));
             }
             drop(stack);
             print_stack(ctx);
@@ -791,24 +785,19 @@ fn cmd_db_create_record() -> CommandDef {
                     return Ok(CommandOutcome::Continue);
                 }
             };
+            // Failures return Err so `on error` sees them — current C
+            // base wraps exactly these in `iocshSetError`
+            // (dbStaticIocRegister.c:282-310); epics-base#498 / UI-105.
             if let Err(e) = db_loader::validate_record_name(&name, 0, 0) {
-                ctx.println(&format!("dbCreateRecord: {e}"));
-                return Ok(CommandOutcome::Continue);
+                return Err(format!("dbCreateRecord: {e}"));
             }
             if ctx.db().get_record(&name).is_some() {
-                ctx.println(&format!("dbCreateRecord: record '{name}' already exists"));
-                return Ok(CommandOutcome::Continue);
+                return Err(format!("dbCreateRecord: record '{name}' already exists"));
             }
-            let record = match db_loader::create_record(&rec_type) {
-                Ok(r) => r,
-                Err(e) => {
-                    ctx.println(&format!("dbCreateRecord: {e}"));
-                    return Ok(CommandOutcome::Continue);
-                }
-            };
+            let record =
+                db_loader::create_record(&rec_type).map_err(|e| format!("dbCreateRecord: {e}"))?;
             if let Err(e) = ctx.block_on(ctx.db().add_record(&name, record)) {
-                ctx.println(&format!("dbCreateRecord: {e}"));
-                return Ok(CommandOutcome::Continue);
+                return Err(format!("dbCreateRecord: {e}"));
             }
             ctx.println(&format!("dbCreateRecord: created '{name}' ({rec_type})"));
             Ok(CommandOutcome::Continue)
@@ -1136,6 +1125,11 @@ async fn install_record_defs(
     defs: Vec<db_loader::DbRecordDef>,
     breaktable_registry: &crate::server::cvt_bpt::BreakTableRegistry,
 ) -> Result<(), String> {
+    // Non-fatal per-record failures (alias reject, merge-field put): the
+    // load continues past them, but the command must still end in Err so
+    // `on error` fires — C's dbLoadRecords returns non-zero after its
+    // parser recovered and kept going (epics-base#498 / UI-105).
+    let mut deferred: Vec<String> = Vec::new();
     for mut def in defs {
         // Resolve a `LINR` field naming a loaded breakpoint table to its
         // menuConvert index (shared with the IocBuilder load path).
@@ -1220,10 +1214,12 @@ async fn install_record_defs(
             // are also registered (C parser appends).
             for alias in &def.aliases {
                 if let Err(e) = ctx.db().add_alias(alias, &def.name).await {
-                    eprintln!(
+                    let msg = format!(
                         "dbLoadRecords: alias '{alias}' for '{}' rejected: {e}",
                         def.name
                     );
+                    eprintln!("{msg}");
+                    deferred.push(msg);
                 }
             }
 
@@ -1275,7 +1271,10 @@ async fn install_record_defs(
                         }
                         Ok(CommonFieldPutResult::NoChange) => {}
                         Err(e) => {
-                            eprintln!("put_common_field({name}) failed for {}: {e}", def.name);
+                            let msg =
+                                format!("put_common_field({name}) failed for {}: {e}", def.name);
+                            eprintln!("{msg}");
+                            deferred.push(msg);
                         }
                     }
                 }
@@ -1333,6 +1332,13 @@ async fn install_record_defs(
             ctx.println(&e);
             return Err(e);
         }
+    }
+    if let Some(first) = deferred.first() {
+        return Err(if deferred.len() == 1 {
+            first.clone()
+        } else {
+            format!("{first} (+{} more)", deferred.len() - 1)
+        });
     }
     Ok(())
 }

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -805,6 +805,15 @@ mod tests {
         assert!(echoes_script_line(""));
     }
 
+    /// A path as an unquoted iocsh token. The arg scanner honors C's
+    /// out-of-quote backslash escape, which would eat the separators of
+    /// a native Windows path — forward slashes survive the scanner and
+    /// every Windows API accepts them (what a real Windows st.cmd
+    /// writes too).
+    fn script_token(p: &std::path::Path) -> String {
+        p.display().to_string().replace('\\', "/")
+    }
+
     fn make_shell() -> IocShell {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let db = Arc::new(PvDatabase::new());
@@ -956,7 +965,7 @@ mod tests {
         assert_eq!(shell.script_depth.get(), 0, "depth ticket fully released");
 
         let path2 = dir.path().join("self2.cmd");
-        std::fs::write(&path2, format!("iocshLoad {}\n", path2.display())).unwrap();
+        std::fs::write(&path2, format!("iocshLoad {}\n", script_token(&path2))).unwrap();
         let err = shell
             .execute_script(&path2.display().to_string())
             .expect_err("self-include via iocshLoad must fail at the cap");
@@ -999,7 +1008,7 @@ mod tests {
         let inner = dir.path().join("inner.cmd");
         std::fs::write(&inner, "#- inner\n").unwrap();
         let outer = dir.path().join("outer.cmd");
-        std::fs::write(&outer, format!("iocshLoad {}\n", inner.display())).unwrap();
+        std::fs::write(&outer, format!("iocshLoad {}\n", script_token(&inner))).unwrap();
         let outer_path = outer.display().to_string();
 
         // SAFETY: single-threaded test process (nextest), sole owner of
@@ -1350,7 +1359,7 @@ mod tests {
         let shell = make_shell();
         let tmp = std::env::temp_dir().join("iocsh_load_macro_cmd.cmd");
         std::fs::write(&tmp, "$(CMD)\n").unwrap();
-        let line = format!("iocshLoad {} CMD=dbl", tmp.display());
+        let line = format!("iocshLoad {} CMD=dbl", script_token(&tmp));
         let result = shell.execute_line(&line);
         std::fs::remove_file(&tmp).ok();
         assert!(matches!(result, Ok(CommandOutcome::Continue)));
@@ -1362,7 +1371,7 @@ mod tests {
         let shell = make_shell();
         let tmp = std::env::temp_dir().join("iocsh_load_no_macros.cmd");
         std::fs::write(&tmp, "dbl\n").unwrap();
-        let line = format!("iocshLoad {}", tmp.display());
+        let line = format!("iocshLoad {}", script_token(&tmp));
         let result = shell.execute_line(&line);
         std::fs::remove_file(&tmp).ok();
         assert!(matches!(result, Ok(CommandOutcome::Continue)));
@@ -1396,7 +1405,7 @@ mod tests {
         let script_path = std::env::temp_dir().join("iocsh_dup_load.cmd");
         std::fs::write(
             &script_path,
-            format!("dbLoadRecords {}\n", db_path.display()),
+            format!("dbLoadRecords {}\n", script_token(&db_path)),
         )
         .unwrap();
         let result = shell.execute_script(script_path.to_str().unwrap());
@@ -1430,7 +1439,7 @@ mod tests {
         let shell = make_shell();
         let tmp = std::env::temp_dir().join("iocsh_load_err.cmd");
         std::fs::write(&tmp, "nonexistent_cmd\ndbl\n").unwrap();
-        let line = format!("iocshLoad {}", tmp.display());
+        let line = format!("iocshLoad {}", script_token(&tmp));
         let result = shell.execute_line(&line);
         std::fs::remove_file(&tmp).ok();
         assert!(

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -299,11 +299,17 @@ impl IocShell {
     /// Macros use `$(KEY)` / `${KEY}` syntax via `db_loader::substitute_macros`.
     /// Per-line errors are reported (matching `execute_script`) but
     /// the script continues to the next line.
+    ///
+    /// As the `iocshLoad` mirror this is also the level that records
+    /// `IOCSH_STARTUP_SCRIPT` — top-level loads enter here (C
+    /// `iocsh(pathname)` is `iocshLoad(pathname, NULL)`), `<` includes
+    /// enter [`Self::execute_script`] (C `iocshBody`) and never set it.
     pub fn execute_script_with_macros(
         &self,
         path: &str,
         macros: &HashMap<String, String>,
     ) -> Result<(), String> {
+        set_startup_script_once(path);
         let _depth = self.enter_script(path)?;
         let content =
             std::fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
@@ -344,6 +350,10 @@ impl IocShell {
     /// do not abort execution. The final return value is `Err` if any command
     /// failed — the equivalent of `iocshSetError` propagating a non-zero exit
     /// status to startup-script callers (e.g., automated IOC verification).
+    ///
+    /// This is the `iocshBody`-with-a-file level (`<` includes land
+    /// here) — it does not record `IOCSH_STARTUP_SCRIPT`; see
+    /// [`Self::execute_script_with_macros`].
     pub fn execute_script(&self, path: &str) -> Result<(), String> {
         let _depth = self.enter_script(path)?;
         let content =
@@ -658,6 +668,19 @@ fn echoes_script_line(line: &str) -> bool {
     !line.trim_start().starts_with("#-")
 }
 
+/// C `iocshLoad` (`iocsh.cpp:1347-1351`) records the loaded script in
+/// `IOCSH_STARTUP_SCRIPT` — since epics-base#469's fix only when the
+/// variable is not already set, so it permanently names the *first*
+/// script (or an inherited value from the parent environment) and a
+/// nested `iocshLoad` no longer overwrites it. Set before the file is
+/// even opened, like C — an unreadable path still lands here.
+fn set_startup_script_once(path: &str) {
+    if std::env::var_os("IOCSH_STARTUP_SCRIPT").is_none() {
+        // SAFETY: same single-threaded-shell rationale as `epicsEnvSet`.
+        unsafe { std::env::set_var("IOCSH_STARTUP_SCRIPT", path) };
+    }
+}
+
 ///
 /// Returns `(physical_line_number, logical_line)` pairs. The line
 /// number is the 1-based index of the *first* physical line in the
@@ -961,6 +984,53 @@ mod tests {
             .execute_script(&outer_path)
             .expect("re-running the same include must succeed");
         assert_eq!(shell.script_depth.get(), 0);
+    }
+
+    /// epics-base#469 (as fixed upstream in 48eed22f3): the first
+    /// loaded script — and only the first — lands in
+    /// `IOCSH_STARTUP_SCRIPT`; a nested `iocshLoad` does not overwrite
+    /// it, a `<` include (the `iocshBody` path) never sets it, and an
+    /// inherited value from the parent environment is kept. One test fn
+    /// so the process-global variable has a single owner.
+    #[test]
+    fn startup_script_env_is_first_load_only() {
+        let shell = make_shell();
+        let dir = tempfile::tempdir().unwrap();
+        let inner = dir.path().join("inner.cmd");
+        std::fs::write(&inner, "#- inner\n").unwrap();
+        let outer = dir.path().join("outer.cmd");
+        std::fs::write(&outer, format!("iocshLoad {}\n", inner.display())).unwrap();
+        let outer_path = outer.display().to_string();
+
+        // SAFETY: single-threaded test process (nextest), sole owner of
+        // this variable.
+        unsafe { std::env::remove_var("IOCSH_STARTUP_SCRIPT") };
+        shell
+            .execute_script_with_macros(&outer_path, &HashMap::new())
+            .unwrap();
+        assert_eq!(
+            std::env::var("IOCSH_STARTUP_SCRIPT").as_deref(),
+            Ok(outer_path.as_str()),
+            "the outer script wins; the nested iocshLoad must not overwrite"
+        );
+
+        unsafe { std::env::remove_var("IOCSH_STARTUP_SCRIPT") };
+        shell.execute_script(&inner.display().to_string()).unwrap();
+        assert!(
+            std::env::var_os("IOCSH_STARTUP_SCRIPT").is_none(),
+            "the iocshBody path ('<' includes) must not set the variable"
+        );
+
+        unsafe { std::env::set_var("IOCSH_STARTUP_SCRIPT", "inherited.cmd") };
+        shell
+            .execute_script_with_macros(&outer_path, &HashMap::new())
+            .unwrap();
+        assert_eq!(
+            std::env::var("IOCSH_STARTUP_SCRIPT").as_deref(),
+            Ok("inherited.cmd"),
+            "a value inherited from the environment is kept (C getenv guard)"
+        );
+        unsafe { std::env::remove_var("IOCSH_STARTUP_SCRIPT") };
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -42,6 +42,31 @@ pub struct IocShell {
     /// because the shell drives one script at a time on a single
     /// thread; the `on error` command mutates it mid-script.
     on_error: std::cell::Cell<OnError>,
+    /// Nesting depth of the running `<` / `iocshLoad` script includes —
+    /// `Cell` for the same single-thread reason as `on_error`. C has no
+    /// explicit bound: a self-including script survives only because each
+    /// nested include holds its `FILE*` open and `fopen` eventually fails
+    /// at the process fd limit (epics-base#499). This port reads the whole
+    /// script and closes the fd before recursing, so without an explicit
+    /// cap the recursion is bounded only by the thread stack — a Rust
+    /// stack-overflow abort at boot. See [`MAX_SCRIPT_DEPTH`].
+    script_depth: std::cell::Cell<usize>,
+}
+
+/// Deepest `<` / `iocshLoad` script nesting the shell will enter before
+/// refusing the include — the explicit form of C's incidental fd-limit
+/// backstop (epics-base#499). 32 matches the `db_loader`'s
+/// `max_include_depth` for DB-file includes.
+const MAX_SCRIPT_DEPTH: usize = 32;
+
+/// Depth ticket for one running script — every exit path of the script
+/// executors releases it via `Drop`.
+struct ScriptDepthGuard<'a>(&'a IocShell);
+
+impl Drop for ScriptDepthGuard<'_> {
+    fn drop(&mut self) {
+        self.0.script_depth.set(self.0.script_depth.get() - 1);
+    }
 }
 
 impl IocShell {
@@ -77,7 +102,23 @@ impl IocShell {
             registry: Arc::new(RwLock::new(registry)),
             ctx: CommandContext::new_with_acf(db, bridge, acf),
             on_error: std::cell::Cell::new(OnError::Continue),
+            script_depth: std::cell::Cell::new(0),
         }
+    }
+
+    /// Take a depth ticket for one nested script, refusing past
+    /// [`MAX_SCRIPT_DEPTH`] so a self-including script errors out at the
+    /// include line instead of overflowing the thread stack.
+    fn enter_script(&self, path: &str) -> Result<ScriptDepthGuard<'_>, String> {
+        let depth = self.script_depth.get();
+        if depth >= MAX_SCRIPT_DEPTH {
+            return Err(format!(
+                "'{path}': script include depth exceeds {MAX_SCRIPT_DEPTH} — \
+                 recursive '<' / iocshLoad?"
+            ));
+        }
+        self.script_depth.set(depth + 1);
+        Ok(ScriptDepthGuard(self))
     }
 
     /// Register an additional command (thread-safe, takes &self).
@@ -263,6 +304,7 @@ impl IocShell {
         path: &str,
         macros: &HashMap<String, String>,
     ) -> Result<(), String> {
+        let _depth = self.enter_script(path)?;
         let content =
             std::fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
         let mut last_err: Option<String> = None;
@@ -303,6 +345,7 @@ impl IocShell {
     /// failed — the equivalent of `iocshSetError` propagating a non-zero exit
     /// status to startup-script callers (e.g., automated IOC verification).
     pub fn execute_script(&self, path: &str) -> Result<(), String> {
+        let _depth = self.enter_script(path)?;
         let content =
             std::fs::read_to_string(path).map_err(|e| format!("cannot read '{}': {}", path, e))?;
 
@@ -868,6 +911,56 @@ mod tests {
         // A non-existent file should return an error
         let result = shell.execute_line("< nonexistent_file.cmd");
         assert!(result.is_err());
+    }
+
+    /// epics-base#499: a self-including script must error out at the
+    /// depth cap, not abort the IOC with a stack overflow. C survives
+    /// only because each nested include holds its `FILE*` open until
+    /// `fopen` fails at the fd limit; this port closes the file before
+    /// recursing, so the cap is explicit. Covers both recursion entries
+    /// (`<` and `iocshLoad`) and checks the depth ticket unwinds to 0.
+    #[test]
+    fn self_including_script_errors_at_the_depth_cap() {
+        let shell = make_shell();
+        let dir = tempfile::tempdir().unwrap();
+
+        let path = dir.path().join("self.cmd");
+        std::fs::write(&path, format!("< {}\n", path.display())).unwrap();
+        let err = shell
+            .execute_script(&path.display().to_string())
+            .expect_err("self-include via '<' must fail at the cap");
+        assert!(err.contains("depth exceeds"), "got: {err}");
+        assert_eq!(shell.script_depth.get(), 0, "depth ticket fully released");
+
+        let path2 = dir.path().join("self2.cmd");
+        std::fs::write(&path2, format!("iocshLoad {}\n", path2.display())).unwrap();
+        let err = shell
+            .execute_script(&path2.display().to_string())
+            .expect_err("self-include via iocshLoad must fail at the cap");
+        assert!(err.contains("depth exceeds"), "got: {err}");
+        assert_eq!(shell.script_depth.get(), 0, "depth ticket fully released");
+    }
+
+    /// Legitimate nesting under the cap keeps working, and the depth
+    /// resets between runs (the guard is a ticket, not a ratchet).
+    #[test]
+    fn nested_include_under_the_cap_still_runs() {
+        let shell = make_shell();
+        let dir = tempfile::tempdir().unwrap();
+        let inner = dir.path().join("inner.cmd");
+        std::fs::write(&inner, "#- inner\n").unwrap();
+        let outer = dir.path().join("outer.cmd");
+        std::fs::write(&outer, format!("< {}\n", inner.display())).unwrap();
+        let outer_path = outer.display().to_string();
+        shell
+            .execute_script(&outer_path)
+            .expect("two-level include must succeed");
+        assert_eq!(shell.script_depth.get(), 0);
+        // A second run starts from depth 0 again.
+        shell
+            .execute_script(&outer_path)
+            .expect("re-running the same include must succeed");
+        assert_eq!(shell.script_depth.get(), 0);
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -1105,7 +1105,9 @@ mod tests {
     /// epics-base PR #812 — `dbCreateRecord <type> <name>` creates a
     /// new record at runtime through the same factory registry as
     /// `dbLoadRecords`. Verifies the happy path plus three rejection
-    /// branches (duplicate name, bad name, unknown record type).
+    /// branches (duplicate name, bad name, unknown record type), which
+    /// return Err so `on error` sees them — current C base wraps these
+    /// in `iocshSetError` (epics-base#498 / UI-105).
     #[test]
     fn test_execute_line_db_create_record_happy_path() {
         let shell = make_shell();
@@ -1119,9 +1121,9 @@ mod tests {
     #[test]
     fn test_execute_line_db_create_record_rejects_duplicate() {
         let shell = make_shell();
-        // TEST_REC was added by make_shell() — re-creating must fail
-        // gracefully (logged via println, returns Continue, not Err).
-        shell.execute_line("dbCreateRecord ai TEST_REC").unwrap();
+        // TEST_REC was added by make_shell() — re-creating must fail.
+        let r = shell.execute_line("dbCreateRecord ai TEST_REC");
+        assert!(r.is_err(), "duplicate name must return Err");
         // After the rejected call, the original record (val=42.0) is
         // still there, not overwritten. Verify with dbgf which reads
         // the live VAL.
@@ -1135,16 +1137,38 @@ mod tests {
         // Space inside the name → validate_record_name returns Err.
         // Quote so the parser keeps the space as one argument.
         let r = shell.execute_line("dbCreateRecord ai \"BAD NAME\"");
-        // The command itself returns Continue (errors are printed),
-        // and the record must NOT be in the registry afterward.
-        assert!(matches!(r, Ok(CommandOutcome::Continue)));
+        assert!(r.is_err(), "bad name must return Err");
     }
 
     #[test]
     fn test_execute_line_db_create_record_rejects_unknown_type() {
         let shell = make_shell();
         let r = shell.execute_line("dbCreateRecord nonexistent NEW_REC");
-        assert!(matches!(r, Ok(CommandOutcome::Continue)));
+        assert!(r.is_err(), "unknown record type must return Err");
+    }
+
+    /// UI-105 / epics-base#498 — a failing db* command must trip
+    /// `on error break`, not just print. The failure here is a real
+    /// command failure (unknown record type), not an unknown command.
+    #[test]
+    fn on_error_break_stops_at_a_failed_db_command() {
+        let shell = make_shell();
+        let dir = std::env::temp_dir().join(format!("iocsh_ui105_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("st.cmd");
+        std::fs::write(
+            &path,
+            "on error break\ndbCreateRecord nonexistent X\ndbCreateRecord ai SHOULD_NOT_EXIST\n",
+        )
+        .unwrap();
+        let result = shell.execute_script(path.to_str().unwrap());
+        assert!(result.is_err(), "script must surface the db failure");
+        let r = shell.execute_line("dbgf SHOULD_NOT_EXIST");
+        assert!(
+            r.is_err(),
+            "on error break must stop before the next line creates the record"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// PR #603 — line ending in `\` joins to the next physical line.

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -51,6 +51,22 @@ impl IocShell {
     /// capture it where the runtime is known (`BlockingBridge::capture()` on
     /// the async setup path).
     pub fn new(db: Arc<PvDatabase>, bridge: crate::runtime::task::BlockingBridge) -> Self {
+        Self::new_with_acf(
+            db,
+            bridge,
+            crate::server::access_security::new_acf_cell(None),
+        )
+    }
+
+    /// Create a shell whose `as*` commands administer `acf` — the live
+    /// policy cell of the IOC's servers. Server-owning roots
+    /// (`IocApplication::run`, a server's `run_with_shell`) must use
+    /// this so a script or interactive `asInit` reaches the gates.
+    pub fn new_with_acf(
+        db: Arc<PvDatabase>,
+        bridge: crate::runtime::task::BlockingBridge,
+        acf: crate::server::access_security::AcfCell,
+    ) -> Self {
         let mut registry = CommandRegistry::new();
         commands::register_builtins(&mut registry);
         // C `iocshRegisterCommon` publishes the base version and target arch as
@@ -59,7 +75,7 @@ impl IocShell {
         crate::runtime::env::register_iocsh_env_vars();
         Self {
             registry: Arc::new(RwLock::new(registry)),
-            ctx: CommandContext::new(db, bridge),
+            ctx: CommandContext::new_with_acf(db, bridge, acf),
             on_error: std::cell::Cell::new(OnError::Continue),
         }
     }

--- a/crates/epics-base-rs/src/server/iocsh/registry.rs
+++ b/crates/epics-base-rs/src/server/iocsh/registry.rs
@@ -88,15 +88,38 @@ impl CommandDef {
 pub struct CommandContext {
     db: Arc<PvDatabase>,
     bridge: crate::runtime::task::BlockingBridge,
+    /// The IOC's live Access Security policy cell. `asInit` stores the
+    /// parsed ACF here and the `as*` inspection commands read it — the
+    /// same cell the IOC's protocol servers gate on when the shell was
+    /// built by a server-owning root ([`CommandContext::new_with_acf`]).
+    /// [`CommandContext::new`] creates a fresh unobserved cell for
+    /// standalone shells that administer no server.
+    acf: crate::server::access_security::AcfCell,
     /// Output writer — defaults to stdout, redirected to a file by `>` / `>>`.
     output: std::cell::RefCell<Box<dyn std::io::Write>>,
 }
 
 impl CommandContext {
     pub fn new(db: Arc<PvDatabase>, bridge: crate::runtime::task::BlockingBridge) -> Self {
+        Self::new_with_acf(
+            db,
+            bridge,
+            crate::server::access_security::new_acf_cell(None),
+        )
+    }
+
+    /// Build a context that administers `acf` — the policy cell the
+    /// owning IOC's servers enforce, so `asInit` from this shell is a
+    /// live (re)load rather than a dead-end copy.
+    pub fn new_with_acf(
+        db: Arc<PvDatabase>,
+        bridge: crate::runtime::task::BlockingBridge,
+        acf: crate::server::access_security::AcfCell,
+    ) -> Self {
         Self {
             db,
             bridge,
+            acf,
             output: std::cell::RefCell::new(Box::new(std::io::stdout())),
         }
     }
@@ -104,6 +127,11 @@ impl CommandContext {
     /// Access the PV database.
     pub fn db(&self) -> &Arc<PvDatabase> {
         &self.db
+    }
+
+    /// The IOC's live Access Security policy cell.
+    pub fn acf(&self) -> &crate::server::access_security::AcfCell {
+        &self.acf
     }
 
     /// The captured runtime access — for spawning tasks or blocking on async

--- a/crates/epics-base-rs/src/server/iocsh/registry.rs
+++ b/crates/epics-base-rs/src/server/iocsh/registry.rs
@@ -288,20 +288,29 @@ pub(crate) fn tokenize(line: &str) -> Vec<String> {
 /// equivalently — see macCore.c:777). A `)` inside a `${...}` body (e.g.
 /// `${foo(bar)}`) must NOT be mistaken for the outer call's closing paren.
 /// Returns the byte offset of ')' or the string length if not found.
+///
+/// Quoting and escaping follow the same rules as `lint_line` and the
+/// splitters, so the three scanners agree on where the call ends: both
+/// `"` and `'` quote, and a backslash escapes the next character in and
+/// out of quotes (C split(), measured: `echo(a\))` prints `a)`,
+/// `echo('a)b')` prints `a)b`).
 fn find_closing_paren(s: &str) -> usize {
-    let mut in_quotes = false;
+    // `0` = not in a quote; otherwise the opening quote byte.
+    let mut quote = 0u8;
     let bytes = s.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
         let ch = bytes[i];
-        if in_quotes {
-            if ch == b'\\' {
-                i += 1; // skip escaped char
-            } else if ch == b'"' {
-                in_quotes = false;
+        if ch == b'\\' {
+            i += 2; // skip the escaped char too
+            continue;
+        }
+        if quote != 0 {
+            if ch == quote {
+                quote = 0;
             }
-        } else if ch == b'"' {
-            in_quotes = true;
+        } else if ch == b'"' || ch == b'\'' {
+            quote = ch;
         } else if ch == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
             // Skip $(...) — find the matching ')' for the macro ref
             if let Some(end) = bytes[i + 2..].iter().position(|&c| c == b')') {
@@ -329,10 +338,21 @@ fn find_closing_paren(s: &str) -> usize {
 /// both `"` and `'` open a quoted string; the quote is closed
 /// only by the *same* character it was opened with — matching C
 /// `iocsh.cpp` `split()` (`if ((c == '"') || (c == '\'')) quote = c;`).
+/// Outside a quote a backslash consumes itself and takes the next
+/// character literally (`iocsh.cpp:275-278,326`): `\,` does not split,
+/// `\"` does not open a quote. Escapes are interpreted in the first
+/// pass, exactly once; the second pass only trims and strips the outer
+/// quotes of a part whose first non-blank character was a *functional*
+/// quote — an escape-produced quote is data and stays. (The previous
+/// shape re-ran escape processing in the second pass, collapsing
+/// `"a\\\\b"` twice.)
 fn split_comma_args(s: &str) -> Vec<String> {
-    // First, split on commas respecting quoted strings
-    let mut raw_parts: Vec<String> = Vec::new();
+    // First, split on commas respecting quoted strings. `opens_quoted`
+    // remembers whether the part's first non-blank char was a functional
+    // opening quote — the only parts the second pass may strip.
+    let mut raw_parts: Vec<(String, bool)> = Vec::new();
     let mut current = String::new();
+    let mut opens_quoted = false;
     // `0` = not in a quote; otherwise the opening quote char.
     let mut quote: char = '\0';
     let mut chars = s.chars().peekable();
@@ -358,50 +378,43 @@ fn split_comma_args(s: &str) -> Vec<String> {
             } else {
                 current.push(ch);
             }
+        } else if ch == '\\' {
+            // C split() outside a quote: the backslash is consumed and
+            // the next character is literal — it neither splits nor
+            // opens a quote. A trailing backslash is lint_line's
+            // "Trailing backslash." and never gets here.
+            if let Some(next) = chars.next() {
+                current.push(next);
+            }
         } else if ch == '"' || ch == '\'' {
+            if current.chars().all(char::is_whitespace) {
+                opens_quoted = true;
+            }
             quote = ch;
             current.push(ch);
         } else if ch == ',' {
-            raw_parts.push(std::mem::take(&mut current));
+            raw_parts.push((std::mem::take(&mut current), opens_quoted));
+            opens_quoted = false;
         } else {
             current.push(ch);
         }
     }
-    raw_parts.push(current);
+    raw_parts.push((current, opens_quoted));
 
-    // Now process each part: trim whitespace, then strip outer quotes
+    // Now process each part: trim whitespace, then strip outer quotes.
     let mut args = Vec::new();
-    for part in raw_parts {
+    for (part, opens_quoted) in raw_parts {
         let trimmed = part.trim();
         if trimmed.is_empty() && args.is_empty() {
             continue; // skip leading empty
         }
-        let outer_quote = trimmed.chars().next().filter(|c| *c == '"' || *c == '\'');
+        let outer_quote = trimmed
+            .chars()
+            .next()
+            .filter(|c| (*c == '"' || *c == '\'') && opens_quoted);
         if let Some(q) = outer_quote {
             if trimmed.len() >= 2 && trimmed.ends_with(q) {
-                // Strip outer quotes and process escapes
-                let inner = &trimmed[1..trimmed.len() - 1];
-                let mut val = String::new();
-                let mut chs = inner.chars().peekable();
-                while let Some(c) = chs.next() {
-                    if c == '\\' {
-                        if let Some(&next) = chs.peek() {
-                            match next {
-                                '"' | '\'' | '\\' => {
-                                    val.push(chs.next().unwrap());
-                                }
-                                _ => {
-                                    val.push(c);
-                                }
-                            }
-                        } else {
-                            val.push(c);
-                        }
-                    } else {
-                        val.push(c);
-                    }
-                }
-                args.push(val);
+                args.push(trimmed[1..trimmed.len() - 1].to_string());
                 continue;
             }
         }
@@ -415,6 +428,9 @@ fn split_comma_args(s: &str) -> Vec<String> {
 ///
 /// both `"` and `'` delimit a quoted string; the quote is closed
 /// only by the matching character — mirrors C `iocsh.cpp` `split()`.
+/// Outside a quote a backslash consumes itself and takes the next
+/// character literally (`iocsh.cpp:275-278,326`): `echo \"hello\"`
+/// yields the token `"hello"`, `a\ b` is one token `a b`.
 fn split_space_args(s: &str) -> Vec<String> {
     let mut args = Vec::new();
     let mut current = String::new();
@@ -442,6 +458,15 @@ fn split_space_args(s: &str) -> Vec<String> {
                 quote = '\0';
             } else {
                 current.push(ch);
+            }
+        } else if ch == '\\' {
+            // C split() outside a quote: consume the backslash, take the
+            // next character literally — a `\"` is data, a `\ ` is not a
+            // separator. A trailing backslash is lint_line's
+            // "Trailing backslash." and never gets here.
+            if let Some(next) = chars.next() {
+                current.push(next);
+                has_token = true;
             }
         } else if ch == '"' || ch == '\'' {
             quote = ch;
@@ -664,6 +689,40 @@ mod tests {
     #[test]
     fn test_tokenize_escaped_backslash() {
         assert_eq!(tokenize(r#"cmd "a\\b""#), vec!["cmd", r#"a\b"#]);
+    }
+
+    /// C split() outside a quote (iocsh.cpp:275-278,326): the backslash
+    /// consumes itself and the next character is literal — it neither
+    /// separates nor opens a quote nor closes the call. Every expected
+    /// token below was measured on the reference softIoc's `echo`.
+    #[test]
+    fn out_of_quote_backslash_escapes_like_c_split() {
+        // Space syntax: `echo \"hello\"` prints `"hello"`, `echo a\ b`
+        // prints `a b`.
+        assert_eq!(tokenize(r#"echo \"hello\""#), vec!["echo", r#""hello""#]);
+        assert_eq!(tokenize(r#"echo a\ b"#), vec!["echo", "a b"]);
+        // Call syntax: `echo(a\,b)` prints `a,b` — the escaped comma
+        // does not split the argument.
+        assert_eq!(tokenize(r#"echo(a\,b)"#), vec!["echo", "a,b"]);
+        // Escape-produced quotes are data, not outer quotes — nothing
+        // strips them: `echo(\"hi\")` prints `"hi"`.
+        assert_eq!(tokenize(r#"echo(\"hi\")"#), vec!["echo", r#""hi""#]);
+        // The closing-paren scanner honors the same rules:
+        // `echo(a\))` prints `a)`, `echo('a)b')` prints `a)b`.
+        assert_eq!(tokenize(r#"echo(a\))"#), vec!["echo", "a)"]);
+        assert_eq!(tokenize(r#"echo('a)b')"#), vec!["echo", "a)b"]);
+        // lint_line agrees these lines are well-formed — pre-fix it
+        // passed them and the splitters then mis-parsed.
+        assert_eq!(lint_line(r#"echo \"hello\""#), None);
+        assert_eq!(lint_line(r#"echo(a\,b)"#), None);
+    }
+
+    /// Escapes are interpreted exactly once: the call splitter's second
+    /// pass no longer re-processes them, so an in-quote `\\\\` (four
+    /// backslashes in the script) yields two, not one.
+    #[test]
+    fn call_syntax_escapes_are_not_double_processed() {
+        assert_eq!(tokenize(r#"cmd("a\\\\b")"#), vec!["cmd", r#"a\\b"#]);
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/record/dbd_generated.rs
+++ b/crates/epics-base-rs/src/server/record/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -3882,6 +3885,13 @@ pub static A_SUB_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(aSub)` — the `DBF_NOACCESS` internal names dropped from
+/// [`A_SUB_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static A_SUB_NOACCESS: &[&str] = &[
+    "SADR", "CADR", "OVLA", "OVLB", "OVLC", "OVLD", "OVLE", "OVLF", "OVLG", "OVLH", "OVLI", "OVLJ",
+    "OVLK", "OVLL", "OVLM", "OVLN", "OVLO", "OVLP", "OVLQ", "OVLR", "OVLS", "OVLT", "OVLU",
+];
+
 /// `recordtype(aai)` — 19 CA-visible own fields from `dbd/aaiRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static AAI_FIELDS: &[FieldDesc] = &[
     // DBF_DOUBLE from cvt_dbaddr.types; re-typed at runtime by `FTVL`.
@@ -4152,6 +4162,10 @@ pub static AAI_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(aai)` — the `DBF_NOACCESS` internal names dropped from
+/// [`AAI_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static AAI_NOACCESS: &[&str] = &["BPTR", "SIMPVT"];
 
 /// `recordtype(aao)` — 21 CA-visible own fields from `dbd/aaoRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static AAO_FIELDS: &[FieldDesc] = &[
@@ -4451,6 +4465,10 @@ pub static AAO_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(aao)` — the `DBF_NOACCESS` internal names dropped from
+/// [`AAO_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static AAO_NOACCESS: &[&str] = &["BPTR", "SIMPVT"];
 
 /// `recordtype(acalcout)` — 132 CA-visible own fields from `dbd/aCalcoutRecord.dbd` (6 `DBF_NOACCESS` internals dropped).
 pub static ACALCOUT_FIELDS: &[FieldDesc] = &[
@@ -6318,6 +6336,10 @@ pub static ACALCOUT_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(acalcout)` — the `DBF_NOACCESS` internal names dropped from
+/// [`ACALCOUT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static ACALCOUT_NOACCESS: &[&str] = &["RPVT", "PAVL", "PAA", "POAV", "RPCL", "ORPC"];
+
 /// `recordtype(ai)` — 43 CA-visible own fields from `dbd/aiRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static AI_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -6923,6 +6945,10 @@ pub static AI_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(ai)` — the `DBF_NOACCESS` internal names dropped from
+/// [`AI_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static AI_NOACCESS: &[&str] = &["PBRK", "SIMPVT"];
 
 /// `recordtype(ao)` — 52 CA-visible own fields from `dbd/aoRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static AO_FIELDS: &[FieldDesc] = &[
@@ -7655,6 +7681,10 @@ pub static AO_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(ao)` — the `DBF_NOACCESS` internal names dropped from
+/// [`AO_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static AO_NOACCESS: &[&str] = &["PBRK", "SIMPVT"];
 
 /// `recordtype(asyn)` — 76 CA-visible own fields from `dbd/asynRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static ASYN_FIELDS: &[FieldDesc] = &[
@@ -8727,6 +8757,10 @@ pub static ASYN_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(asyn)` — the `DBF_NOACCESS` internal names dropped from
+/// [`ASYN_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static ASYN_NOACCESS: &[&str] = &["OPTR", "IPTR"];
+
 /// `recordtype(bi)` — 22 CA-visible own fields from `dbd/biRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static BI_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -9038,6 +9072,10 @@ pub static BI_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(bi)` — the `DBF_NOACCESS` internal names dropped from
+/// [`BI_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static BI_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(bo)` — 26 CA-visible own fields from `dbd/boRecord.dbd` (3 `DBF_NOACCESS` internals dropped).
 pub static BO_FIELDS: &[FieldDesc] = &[
@@ -9407,6 +9445,10 @@ pub static BO_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(bo)` — the `DBF_NOACCESS` internal names dropped from
+/// [`BO_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static BO_NOACCESS: &[&str] = &["RPVT", "WDPT", "SIMPVT"];
+
 /// `recordtype(busy)` — 24 CA-visible own fields from `dbd/busyRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static BUSY_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -9746,6 +9788,10 @@ pub static BUSY_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(busy)` — the `DBF_NOACCESS` internal names dropped from
+/// [`BUSY_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static BUSY_NOACCESS: &[&str] = &["RPVT", "WDPT"];
 
 /// `recordtype(calc)` — 85 CA-visible own fields from `dbd/calcRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static CALC_FIELDS: &[FieldDesc] = &[
@@ -10940,6 +10986,10 @@ pub static CALC_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(calc)` — the `DBF_NOACCESS` internal names dropped from
+/// [`CALC_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static CALC_NOACCESS: &[&str] = &["RPCL"];
 
 /// `recordtype(calcout)` — 119 CA-visible own fields from `dbd/calcoutRecord.dbd` (4 `DBF_NOACCESS` internals dropped).
 pub static CALCOUT_FIELDS: &[FieldDesc] = &[
@@ -12611,6 +12661,10 @@ pub static CALCOUT_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(calcout)` — the `DBF_NOACCESS` internal names dropped from
+/// [`CALCOUT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static CALCOUT_NOACCESS: &[&str] = &["RPVT", "EPVT", "RPCL", "ORPC"];
+
 /// `recordtype(compress)` — 20 CA-visible own fields from `dbd/compressRecord.dbd` (3 `DBF_NOACCESS` internals dropped).
 pub static COMPRESS_FIELDS: &[FieldDesc] = &[
     // DBF_DOUBLE from cvt_dbaddr.types.
@@ -12895,6 +12949,10 @@ pub static COMPRESS_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(compress)` — the `DBF_NOACCESS` internal names dropped from
+/// [`COMPRESS_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static COMPRESS_NOACCESS: &[&str] = &["BPTR", "SPTR", "WPTR"];
 
 /// `recordtype(dfanout)` — 42 CA-visible own fields from `dbd/dfanoutRecord.dbd` (0 `DBF_NOACCESS` internals dropped).
 pub static DFANOUT_FIELDS: &[FieldDesc] = &[
@@ -13632,6 +13690,10 @@ pub static EVENT_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(event)` — the `DBF_NOACCESS` internal names dropped from
+/// [`EVENT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static EVENT_NOACCESS: &[&str] = &["EPVT", "SIMPVT"];
+
 /// `recordtype(fanout)` — 22 CA-visible own fields from `dbd/fanoutRecord.dbd` (0 `DBF_NOACCESS` internals dropped).
 pub static FANOUT_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -14271,6 +14333,10 @@ pub static HISTOGRAM_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(histogram)` — the `DBF_NOACCESS` internal names dropped from
+/// [`HISTOGRAM_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static HISTOGRAM_NOACCESS: &[&str] = &["BPTR", "WDOG", "SIMPVT"];
+
 /// `recordtype(int64in)` — 29 CA-visible own fields from `dbd/int64inRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static INT64IN_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -14680,6 +14746,10 @@ pub static INT64IN_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(int64in)` — the `DBF_NOACCESS` internal names dropped from
+/// [`INT64IN_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static INT64IN_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(int64out)` — 32 CA-visible own fields from `dbd/int64outRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static INT64OUT_FIELDS: &[FieldDesc] = &[
@@ -15133,6 +15203,10 @@ pub static INT64OUT_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(int64out)` — the `DBF_NOACCESS` internal names dropped from
+/// [`INT64OUT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static INT64OUT_NOACCESS: &[&str] = &["SIMPVT"];
+
 /// `recordtype(longin)` — 29 CA-visible own fields from `dbd/longinRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static LONGIN_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -15542,6 +15616,10 @@ pub static LONGIN_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(longin)` — the `DBF_NOACCESS` internal names dropped from
+/// [`LONGIN_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static LONGIN_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(longout)` — 35 CA-visible own fields from `dbd/longoutRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static LONGOUT_FIELDS: &[FieldDesc] = &[
@@ -16037,6 +16115,10 @@ pub static LONGOUT_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(longout)` — the `DBF_NOACCESS` internal names dropped from
+/// [`LONGOUT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static LONGOUT_NOACCESS: &[&str] = &["SIMPVT", "OUTPVT"];
+
 /// `recordtype(lsi)` — 15 CA-visible own fields from `dbd/lsiRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static LSI_FIELDS: &[FieldDesc] = &[
     // DBF_STRING from cvt_dbaddr.types.
@@ -16252,6 +16334,10 @@ pub static LSI_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(lsi)` — the `DBF_NOACCESS` internal names dropped from
+/// [`LSI_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static LSI_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(lso)` — 19 CA-visible own fields from `dbd/lsoRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static LSO_FIELDS: &[FieldDesc] = &[
@@ -16524,6 +16610,10 @@ pub static LSO_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(lso)` — the `DBF_NOACCESS` internal names dropped from
+/// [`LSO_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static LSO_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(mbbi)` — 70 CA-visible own fields from `dbd/mbbiRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static MBBI_FIELDS: &[FieldDesc] = &[
@@ -17509,6 +17599,10 @@ pub static MBBI_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(mbbi)` — the `DBF_NOACCESS` internal names dropped from
+/// [`MBBI_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static MBBI_NOACCESS: &[&str] = &["SIMPVT"];
+
 /// `recordtype(mbbiDirect)` — 48 CA-visible own fields from `dbd/mbbiDirectRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static MBBI_DIRECT_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -18184,6 +18278,10 @@ pub static MBBI_DIRECT_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(mbbiDirect)` — the `DBF_NOACCESS` internal names dropped from
+/// [`MBBI_DIRECT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static MBBI_DIRECT_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(mbbo)` — 73 CA-visible own fields from `dbd/mbboRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static MBBO_FIELDS: &[FieldDesc] = &[
@@ -19212,6 +19310,10 @@ pub static MBBO_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(mbbo)` — the `DBF_NOACCESS` internal names dropped from
+/// [`MBBO_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static MBBO_NOACCESS: &[&str] = &["SIMPVT"];
+
 /// `recordtype(mbboDirect)` — 54 CA-visible own fields from `dbd/mbboDirectRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static MBBO_DIRECT_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -19971,6 +20073,10 @@ pub static MBBO_DIRECT_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(mbboDirect)` — the `DBF_NOACCESS` internal names dropped from
+/// [`MBBO_DIRECT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static MBBO_DIRECT_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(permissive)` — 5 CA-visible own fields from `dbd/permissiveRecord.dbd` (0 `DBF_NOACCESS` internals dropped).
 pub static PERMISSIVE_FIELDS: &[FieldDesc] = &[
@@ -22208,6 +22314,10 @@ pub static SCALCOUT_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(scalcout)` — the `DBF_NOACCESS` internal names dropped from
+/// [`SCALCOUT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static SCALCOUT_NOACCESS: &[&str] = &["RPVT", "STRS", "RPCL", "ORPC"];
 
 /// `recordtype(sel)` — 59 CA-visible own fields from `dbd/selRecord.dbd` (0 `DBF_NOACCESS` internals dropped).
 pub static SEL_FIELDS: &[FieldDesc] = &[
@@ -26205,6 +26315,10 @@ pub static STRINGIN_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(stringin)` — the `DBF_NOACCESS` internal names dropped from
+/// [`STRINGIN_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static STRINGIN_NOACCESS: &[&str] = &["SIMPVT"];
+
 /// `recordtype(stringout)` — 16 CA-visible own fields from `dbd/stringoutRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static STRINGOUT_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -26432,6 +26546,10 @@ pub static STRINGOUT_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(stringout)` — the `DBF_NOACCESS` internal names dropped from
+/// [`STRINGOUT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static STRINGOUT_NOACCESS: &[&str] = &["SIMPVT"];
 
 /// `recordtype(sub)` — 85 CA-visible own fields from `dbd/subRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static SUB_FIELDS: &[FieldDesc] = &[
@@ -27627,6 +27745,10 @@ pub static SUB_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(sub)` — the `DBF_NOACCESS` internal names dropped from
+/// [`SUB_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static SUB_NOACCESS: &[&str] = &["SADR"];
+
 /// `recordtype(subArray)` — 12 CA-visible own fields from `dbd/subArrayRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static SUB_ARRAY_FIELDS: &[FieldDesc] = &[
     // DBF_DOUBLE from cvt_dbaddr.types; re-typed at runtime by `FTVL`.
@@ -27799,6 +27921,10 @@ pub static SUB_ARRAY_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(subArray)` — the `DBF_NOACCESS` internal names dropped from
+/// [`SUB_ARRAY_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static SUB_ARRAY_NOACCESS: &[&str] = &["BPTR"];
 
 /// `recordtype(swait)` — 87 CA-visible own fields from `dbd/swaitRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static SWAIT_FIELDS: &[FieldDesc] = &[
@@ -29021,6 +29147,10 @@ pub static SWAIT_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(swait)` — the `DBF_NOACCESS` internal names dropped from
+/// [`SWAIT_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static SWAIT_NOACCESS: &[&str] = &["CBST", "RPCL"];
 
 /// `recordtype(transform)` — 151 CA-visible own fields from `dbd/transformRecord.dbd` (17 `DBF_NOACCESS` internals dropped).
 pub static TRANSFORM_FIELDS: &[FieldDesc] = &[
@@ -31140,6 +31270,13 @@ pub static TRANSFORM_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(transform)` — the `DBF_NOACCESS` internal names dropped from
+/// [`TRANSFORM_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static TRANSFORM_NOACCESS: &[&str] = &[
+    "RPVT", "RPCA", "RPCB", "RPCC", "RPCD", "RPCE", "RPCF", "RPCG", "RPCH", "RPCI", "RPCJ", "RPCK",
+    "RPCL", "RPCM", "RPCN", "RPCO", "RPCP",
+];
+
 /// `recordtype(waveform)` — 21 CA-visible own fields from `dbd/waveformRecord.dbd` (2 `DBF_NOACCESS` internals dropped).
 pub static WAVEFORM_FIELDS: &[FieldDesc] = &[
     // DBF_DOUBLE from cvt_dbaddr.types; re-typed at runtime by `FTVL`.
@@ -31438,6 +31575,10 @@ pub static WAVEFORM_FIELDS: &[FieldDesc] = &[
         prop: false,
     },
 ];
+
+/// `recordtype(waveform)` — the `DBF_NOACCESS` internal names dropped from
+/// [`WAVEFORM_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static WAVEFORM_NOACCESS: &[&str] = &["BPTR", "SIMPVT"];
 
 /// `dbCommon.dbd` — the 34 CA-visible fields every record type carries.
 ///
@@ -31924,6 +32065,14 @@ pub static DB_COMMON_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// The `DBF_NOACCESS` internals of `dbCommon.dbd`, dropped from
+/// [`DB_COMMON_FIELDS`]: resolvable (a SEARCH is answered), never
+/// servable — see `record_noaccess_fields` for the record-own twins.
+pub static DB_COMMON_NOACCESS: &[&str] = &[
+    "MLOK", "MLIS", "BKLNK", "ASP", "PPN", "PPNR", "SPVT", "RSET", "DSET", "DPVT", "RDES", "LSET",
+    "BKPT", "TIME",
+];
+
 // ---------------------------------------------------------------------
 // Per-record-type device menus (C `dbDeviceMenu`), in `.dbd` declaration
 // order. The index is wire-visible: it IS the value of the DTYP field.
@@ -32379,6 +32528,57 @@ pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
         "swait" => SWAIT_FIELDS,
         "transform" => TRANSFORM_FIELDS,
         "waveform" => WAVEFORM_FIELDS,
+        _ => return None,
+    })
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
+    Some(match record_type {
+        "aSub" => A_SUB_NOACCESS,
+        "aai" => AAI_NOACCESS,
+        "aao" => AAO_NOACCESS,
+        "acalcout" => ACALCOUT_NOACCESS,
+        "ai" => AI_NOACCESS,
+        "ao" => AO_NOACCESS,
+        "asyn" => ASYN_NOACCESS,
+        "bi" => BI_NOACCESS,
+        "bo" => BO_NOACCESS,
+        "busy" => BUSY_NOACCESS,
+        "calc" => CALC_NOACCESS,
+        "calcout" => CALCOUT_NOACCESS,
+        "compress" => COMPRESS_NOACCESS,
+        "dfanout" => &[],
+        "event" => EVENT_NOACCESS,
+        "fanout" => &[],
+        "histogram" => HISTOGRAM_NOACCESS,
+        "int64in" => INT64IN_NOACCESS,
+        "int64out" => INT64OUT_NOACCESS,
+        "longin" => LONGIN_NOACCESS,
+        "longout" => LONGOUT_NOACCESS,
+        "lsi" => LSI_NOACCESS,
+        "lso" => LSO_NOACCESS,
+        "mbbi" => MBBI_NOACCESS,
+        "mbbiDirect" => MBBI_DIRECT_NOACCESS,
+        "mbbo" => MBBO_NOACCESS,
+        "mbboDirect" => MBBO_DIRECT_NOACCESS,
+        "permissive" => &[],
+        "printf" => &[],
+        "scalcout" => SCALCOUT_NOACCESS,
+        "sel" => &[],
+        "seq" => &[],
+        "sseq" => &[],
+        "state" => &[],
+        "stringin" => STRINGIN_NOACCESS,
+        "stringout" => STRINGOUT_NOACCESS,
+        "sub" => SUB_NOACCESS,
+        "subArray" => SUB_ARRAY_NOACCESS,
+        "swait" => SWAIT_NOACCESS,
+        "transform" => TRANSFORM_NOACCESS,
+        "waveform" => WAVEFORM_NOACCESS,
         _ => return None,
     })
 }

--- a/crates/epics-base-rs/src/server/record/mod.rs
+++ b/crates/epics-base-rs/src/server/record/mod.rs
@@ -38,7 +38,7 @@ pub use record_instance::{
     AlarmAck, AmbientWriteOriginScope, DeferredNotifyPut, NotifyWaitSet, PactExit,
     ProcessCompletion, RecordInstance, ambient_write_origin_scope,
 };
-pub(crate) use record_instance::{ambient_write_origin, value_as_dbr_string};
+pub(crate) use record_instance::{ambient_write_origin, is_dbcommon_noaccess, value_as_dbr_string};
 pub use record_trait::{
     ArrayMonitorPost, Asl, CommonFieldPutResult, ConstantInitLink, CyclePostMask,
     EPICS_TIME_EVENT_DEVICE_TIME, FieldDeclaration, FieldDesc, FieldMetadataOverride,

--- a/crates/epics-base-rs/src/server/record/mod.rs
+++ b/crates/epics-base-rs/src/server/record/mod.rs
@@ -38,7 +38,7 @@ pub use record_instance::{
     AlarmAck, AmbientWriteOriginScope, DeferredNotifyPut, NotifyWaitSet, PactExit,
     ProcessCompletion, RecordInstance, ambient_write_origin_scope,
 };
-pub(crate) use record_instance::{ambient_write_origin, is_dbcommon_noaccess, value_as_dbr_string};
+pub(crate) use record_instance::{ambient_write_origin, value_as_dbr_string};
 pub use record_trait::{
     ArrayMonitorPost, Asl, CommonFieldPutResult, ConstantInitLink, CyclePostMask,
     EPICS_TIME_EVENT_DEVICE_TIME, FieldDeclaration, FieldDesc, FieldMetadataOverride,

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -28,9 +28,8 @@ use super::scan::{ScanType, SimModeScan};
 ///
 /// These are common fields — no record's `field_list` declares them — so the
 /// declaration names them here. The remaining `SPC_NOMOD` entries in
-/// `dbCommon.dbd` (MLOK, MLIS, BKLNK, ASP, PPN, PPNR, SPVT, RSET, DSET, DPVT,
-/// RDES, LSET, BKPT) are `DBF_NOACCESS`: they have no field API in this port at
-/// all, and C refuses them one level earlier, at `dbNameToAddr`.
+/// `dbCommon.dbd` are `DBF_NOACCESS` ([`DBCOMMON_NOACCESS`]): they have no
+/// field API in this port at all.
 ///
 /// TIME is `DBF_NOACCESS` in C too (`dbpf REC.TIME` → "failed"), but this port
 /// resolves `.TIME`, so the declaration must cover it.
@@ -40,6 +39,31 @@ const DBCOMMON_NOMOD: &[&str] = &[
     "NAME", "STAT", "SEVR", "AMSG", "NSTA", "NSEV", "NAMSG", "ACKS", "ACKT", "LCNT", "PACT",
     "PUTF", "RPRO", "TIME", "UTAG",
 ];
+
+/// The `DBF_NOACCESS` fields of `dbCommon.dbd` — C-internal pointers with no
+/// value API in this port (the generated tables drop them, `dbd_generated`
+/// module docs). Their NAMES still exist to C's resolver: `dbNameToAddr`
+/// resolves a `DBF_NOACCESS` field and the refusal lands at channel
+/// *creation*, where `mapDBFToDBR` yields `DBR_NOACCESS` — measured against
+/// `softIocPVX`: `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`, i.e.
+/// the SEARCH was answered. The search gate
+/// (`PvDatabase::has_name_no_resolve`) consults this list so those names
+/// keep answering; every *value* path stays closed to them.
+///
+/// Record-own `DBF_NOACCESS` internals (`BPTR` and friends) are NOT listed —
+/// the generator drops their names with their descs, so a search for them is
+/// refused where C would answer and then refuse the create. Restoring them
+/// needs the generator to emit the dropped names.
+const DBCOMMON_NOACCESS: &[&str] = &[
+    "MLOK", "MLIS", "BKLNK", "ASP", "PPN", "PPNR", "SPVT", "RSET", "DSET", "DPVT", "RDES", "LSET",
+    "BKPT",
+];
+
+/// Is `field` (already uppercased) a `dbCommon` `DBF_NOACCESS` internal —
+/// a name C resolves but never serves? See [`DBCOMMON_NOACCESS`].
+pub(crate) fn is_dbcommon_noaccess(field: &str) -> bool {
+    DBCOMMON_NOACCESS.contains(&field)
+}
 
 thread_local! {
     /// The origin tag applied to every event posted from the current

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -52,8 +52,9 @@ const DBCOMMON_NOMOD: &[&str] = &[
 /// consults this — via [`RecordInstance::resolves_noaccess_name`] — so those
 /// names keep answering; every *value* path stays closed to them.
 ///
-/// The name list is the generated spec ([`DB_COMMON_NOACCESS`]
-/// (super::dbd_generated::DB_COMMON_NOACCESS)) minus the names the port
+/// The name list is the generated spec
+/// ([`DB_COMMON_NOACCESS`](super::dbd_generated::DB_COMMON_NOACCESS))
+/// minus the names the port
 /// *serves* despite their C `DBF_NOACCESS` typing: `TIME` resolves to a real
 /// value here (see [`DBCOMMON_NOMOD`]), so it is answered by the gate's
 /// resolve arm, not this one.

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -366,12 +366,15 @@ pub(crate) struct MetadataSnapshot {
 /// below feed the live-computed `field_metadata_override`, never the
 /// cache — its invalidation on their write is harmless).
 ///
-/// Currently uncovered (because it is not yet populated by any
-/// `populate_*` function): `DESC` (would map to `display.description`
-/// — populate hook missing). The `Q:form` info tag is now wired
-/// (`populate_display_info` -> `display.form`), but as an immutable
-/// load-time info tag — not a runtime field — it needs no cache
-/// invalidation and so is intentionally absent from this field set.
+/// Deliberate exception: `DESC` feeds `display.description`
+/// (`populate_display_info`) but stays OUT of this set — C never marks
+/// it prop(YES) (epics-base#785), so a DESC write must not post
+/// DBE_PROPERTY. Its cache invalidation is owned by the DESC arm of
+/// `put_common_field`, the single writer of `common.desc`. The
+/// `Q:form` info tag is now wired (`populate_display_info` ->
+/// `display.form`), but as an immutable load-time info tag — not a
+/// runtime field — it needs no cache invalidation and so is
+/// intentionally absent from this field set.
 fn is_metadata_field(name: &str) -> bool {
     matches!(
         name,
@@ -785,11 +788,14 @@ pub struct RecordInstance {
     /// # Symmetric note for `populate_*` extensions
     ///
     /// If a future change adds a new field to `populate_display_info`,
-    /// `populate_control_info`, or `populate_enum_info` (e.g. populating
-    /// `display.description` from DESC), the new source field name MUST
-    /// also be added to `is_metadata_field` so writes to it invalidate
-    /// the cache. (The `Q:form` -> `display.form` mapping is exempt: it
-    /// reads an immutable load-time info tag, not a runtime field.)
+    /// `populate_control_info`, or `populate_enum_info`, the new source
+    /// field name MUST also be added to `is_metadata_field` so writes
+    /// to it invalidate the cache — unless, like DESC
+    /// (`display.description`), the field must not post DBE_PROPERTY;
+    /// then its write owner invalidates directly (see the DESC arm of
+    /// `put_common_field`). (The `Q:form` -> `display.form` mapping is
+    /// exempt: it reads an immutable load-time info tag, not a runtime
+    /// field.)
     pub(crate) metadata_cache: StdMutex<Option<MetadataSnapshot>>,
 }
 
@@ -2211,6 +2217,17 @@ impl RecordInstance {
                 display.form = form;
             }
         }
+        // `display.description` from dbCommon DESC — pvxs QSRV fills it
+        // on every metadata populate (iocsource.cpp:306-310), for every
+        // record type including those with no other display source. The
+        // qsrv builders always emit the leaf (defaulting a `None`
+        // display), so creating the DisplayInfo here changes leaf
+        // values, never the wire shape. Cache freshness is owned by the
+        // DESC arm of `put_common_field`, which invalidates without
+        // posting DBE_PROPERTY (epics-base#785 / UI-106).
+        snap.display
+            .get_or_insert_with(Default::default)
+            .description = self.common.desc.clone();
     }
 
     /// Populate ControlInfo from record fields if applicable.
@@ -2988,7 +3005,16 @@ impl RecordInstance {
                 if let EpicsValue::String(s) = value {
                     // DBF_STRING data field — store the bytes verbatim so a
                     // non-UTF-8 DESC round-trips unchanged.
-                    self.common.desc = s;
+                    if self.common.desc != s {
+                        self.common.desc = s;
+                        // DESC feeds `display.description` (a metadata-cache
+                        // source) but is not property-class — C never marks
+                        // it prop(YES) (epics-base#785) — so refresh the
+                        // cache here at the write owner without posting
+                        // DBE_PROPERTY: the pvxs behavior (fresh on the next
+                        // metadata build, no event).
+                        self.invalidate_metadata_cache();
+                    }
                 }
             }
             "PHAS" => {
@@ -5774,7 +5800,9 @@ mod metadata_cache_tests {
         inst.notify_field_written("VAL");
         assert!(inst.metadata_cache.lock().unwrap().is_some());
 
-        // Same for DESC
+        // DESC is not property-class either — its cache invalidation
+        // is owned by the DESC arm of `put_common_field`, not by this
+        // notify path (UI-106).
         inst.notify_field_written("DESC");
         assert!(inst.metadata_cache.lock().unwrap().is_some());
     }
@@ -5826,6 +5854,50 @@ mod metadata_cache_tests {
         assert!(
             inst.metadata_cache.lock().unwrap().is_none(),
             "real metadata change must invalidate cache"
+        );
+    }
+
+    /// UI-106 / epics-base#785 — DESC feeds `display.description`
+    /// (pvxs fills it on every metadata populate, iocsource.cpp:306-310),
+    /// and a changed DESC refreshes the cache at its write owner so the
+    /// next snapshot serves the new text.
+    #[test]
+    fn desc_reaches_display_description_and_a_write_refreshes_it() {
+        let mut inst = ai_instance();
+        inst.put_common_field("DESC", EpicsValue::String("before".into()))
+            .unwrap();
+        let snap = inst.snapshot_for_field("VAL").unwrap();
+        assert_eq!(
+            snap.display.as_ref().unwrap().description.as_str_lossy(),
+            "before"
+        );
+        inst.put_common_field("DESC", EpicsValue::String("after".into()))
+            .unwrap();
+        assert!(
+            inst.metadata_cache.lock().unwrap().is_none(),
+            "a changed DESC must invalidate the metadata cache"
+        );
+        let snap = inst.snapshot_for_field("VAL").unwrap();
+        assert_eq!(
+            snap.display.as_ref().unwrap().description.as_str_lossy(),
+            "after"
+        );
+    }
+
+    /// …and an idempotent DESC put must NOT invalidate — same
+    /// discipline as faac1df1 for the property-class fields.
+    #[test]
+    fn an_idempotent_desc_put_keeps_the_cache() {
+        let mut inst = ai_instance();
+        inst.put_common_field("DESC", EpicsValue::String("same".into()))
+            .unwrap();
+        let _ = inst.snapshot_for_field("VAL");
+        assert!(inst.metadata_cache.lock().unwrap().is_some());
+        inst.put_common_field("DESC", EpicsValue::String("same".into()))
+            .unwrap();
+        assert!(
+            inst.metadata_cache.lock().unwrap().is_some(),
+            "an unchanged DESC must not invalidate the metadata cache"
         );
     }
 

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -28,8 +28,8 @@ use super::scan::{ScanType, SimModeScan};
 ///
 /// These are common fields — no record's `field_list` declares them — so the
 /// declaration names them here. The remaining `SPC_NOMOD` entries in
-/// `dbCommon.dbd` are `DBF_NOACCESS` ([`DBCOMMON_NOACCESS`]): they have no
-/// field API in this port at all.
+/// `dbCommon.dbd` are `DBF_NOACCESS` ([`is_dbcommon_noaccess`]): they have
+/// no field API in this port at all.
 ///
 /// TIME is `DBF_NOACCESS` in C too (`dbpf REC.TIME` → "failed"), but this port
 /// resolves `.TIME`, so the declaration must cover it.
@@ -40,29 +40,25 @@ const DBCOMMON_NOMOD: &[&str] = &[
     "PUTF", "RPRO", "TIME", "UTAG",
 ];
 
-/// The `DBF_NOACCESS` fields of `dbCommon.dbd` — C-internal pointers with no
-/// value API in this port (the generated tables drop them, `dbd_generated`
-/// module docs). Their NAMES still exist to C's resolver: `dbNameToAddr`
-/// resolves a `DBF_NOACCESS` field and the refusal lands at channel
-/// *creation*, where `mapDBFToDBR` yields `DBR_NOACCESS` — measured against
-/// `softIocPVX`: `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`, i.e.
-/// the SEARCH was answered. The search gate
-/// (`PvDatabase::has_name_no_resolve`) consults this list so those names
-/// keep answering; every *value* path stays closed to them.
-///
-/// Record-own `DBF_NOACCESS` internals (`BPTR` and friends) are NOT listed —
-/// the generator drops their names with their descs, so a search for them is
-/// refused where C would answer and then refuse the create. Restoring them
-/// needs the generator to emit the dropped names.
-const DBCOMMON_NOACCESS: &[&str] = &[
-    "MLOK", "MLIS", "BKLNK", "ASP", "PPN", "PPNR", "SPVT", "RSET", "DSET", "DPVT", "RDES", "LSET",
-    "BKPT",
-];
-
 /// Is `field` (already uppercased) a `dbCommon` `DBF_NOACCESS` internal —
-/// a name C resolves but never serves? See [`DBCOMMON_NOACCESS`].
+/// a name C resolves but never serves?
+///
+/// These are C-internal pointers with no value API in this port. Their NAMES
+/// still exist to C's resolver: `dbNameToAddr` resolves a `DBF_NOACCESS`
+/// field and the refusal lands at channel *creation*, where `mapDBFToDBR`
+/// yields `DBR_NOACCESS` — measured against `softIocPVX`:
+/// `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`, i.e. the SEARCH
+/// was answered. The search gate (`PvDatabase::has_name_no_resolve`)
+/// consults this — via [`RecordInstance::resolves_noaccess_name`] — so those
+/// names keep answering; every *value* path stays closed to them.
+///
+/// The name list is the generated spec ([`DB_COMMON_NOACCESS`]
+/// (super::dbd_generated::DB_COMMON_NOACCESS)) minus the names the port
+/// *serves* despite their C `DBF_NOACCESS` typing: `TIME` resolves to a real
+/// value here (see [`DBCOMMON_NOMOD`]), so it is answered by the gate's
+/// resolve arm, not this one.
 pub(crate) fn is_dbcommon_noaccess(field: &str) -> bool {
-    DBCOMMON_NOACCESS.contains(&field)
+    super::dbd_generated::DB_COMMON_NOACCESS.contains(&field) && !DBCOMMON_NOMOD.contains(&field)
 }
 
 thread_local! {
@@ -1747,6 +1743,18 @@ impl RecordInstance {
     /// from a `dbFldDes`.
     pub(crate) fn field_desc(&self, field: &str) -> Option<&'static FieldDesc> {
         field_desc_of(self.record.as_ref(), field)
+    }
+
+    /// Is `field` (already uppercased) a `DBF_NOACCESS` internal name —
+    /// record-own (`BPTR`, `RPVT`, ...) or `dbCommon` (`MLOK`, `RSET`, ...)?
+    ///
+    /// C's `dbNameToAddr` resolves such a name, so a SEARCH for it is
+    /// answered and the refusal lands at channel creation (`mapDBFToDBR` →
+    /// `DBR_NOACCESS`). The search gate (`PvDatabase::has_name_no_resolve`)
+    /// asks this so the port answers the same way; every value path stays
+    /// closed to these names.
+    pub(crate) fn resolves_noaccess_name(&self, field: &str) -> bool {
+        is_dbcommon_noaccess(field) || self.record.noaccess_names().contains(&field)
     }
 
     /// The `DBF_*` type `field` is SERVED as — the single source of truth for

--- a/crates/epics-base-rs/src/server/record/record_trait.rs
+++ b/crates/epics-base-rs/src/server/record/record_trait.rs
@@ -1229,12 +1229,24 @@ pub enum InputFetchPolicy {
 pub trait FieldDeclaration {
     /// The record type's field descriptors, in `.dbd` declaration order.
     fn field_list(&self) -> &'static [FieldDesc];
+
+    /// The record-own `DBF_NOACCESS` internal names the generator dropped
+    /// from [`FieldDeclaration::field_list`] (`BPTR`, `RPVT`, ...): names
+    /// C's `dbNameToAddr` resolves — so a SEARCH is answered — but whose
+    /// channel is refused at creation. Same base-table-then-own resolution
+    /// as `field_list`.
+    fn noaccess_names(&self) -> &'static [&'static str];
 }
 
 impl<R: Record + ?Sized> FieldDeclaration for R {
     fn field_list(&self) -> &'static [FieldDesc] {
         super::dbd_generated::record_fields(self.record_type())
             .unwrap_or_else(|| self.declared_fields())
+    }
+
+    fn noaccess_names(&self) -> &'static [&'static str] {
+        super::dbd_generated::record_noaccess_fields(self.record_type())
+            .unwrap_or_else(|| self.declared_noaccess_fields())
     }
 }
 
@@ -1308,6 +1320,15 @@ pub trait Record: Send + Sync + 'static {
     /// [`Record::implements_field`] for that — see its docs for why the two
     /// must not be the same question.
     fn declared_fields(&self) -> &'static [FieldDesc] {
+        &[]
+    }
+
+    /// The analogue of [`Record::declared_fields`] for
+    /// [`FieldDeclaration::noaccess_names`]: the record-own `DBF_NOACCESS`
+    /// internal names of a record type no base `.dbd` declares. A downstream
+    /// crate whose generated table reports dropped internals returns its
+    /// `record_noaccess_fields` entry here, next to its `declared_fields`.
+    fn declared_noaccess_fields(&self) -> &'static [&'static str] {
         &[]
     }
 

--- a/crates/epics-base-rs/src/server/record/record_trait.rs
+++ b/crates/epics-base-rs/src/server/record/record_trait.rs
@@ -3202,9 +3202,12 @@ pub trait Record: Send + Sync + 'static {
         let _ = (link_field, target);
     }
 
-    /// The `dbrType` this record's [`ProcessAction::ReadDbLink`] on
-    /// `link_field` asks the SOURCE for — the READ twin of
-    /// [`Self::typed_output_buffer`], and C's `dbGetLink` second argument.
+    /// The `dbrType` this record's framework-run input read on `link_field`
+    /// asks the SOURCE for — the READ twin of [`Self::typed_output_buffer`],
+    /// and C's `dbGetLink` second argument. Consulted by every framework
+    /// fetch path: the pre-input [`ProcessAction::ReadDbLink`] stage, the
+    /// single-INP soft fetch, the closed-loop DOL fetch, the multi-input
+    /// loop and the SIOL simulation read.
     ///
     /// `source` is the far end of the input link as C's
     /// `dbGetLinkDBFtype`/`dbGetNelements` report it (the same lset accessors

--- a/crates/epics-base-rs/src/server/records/lsi.rs
+++ b/crates/epics-base-rs/src/server/records/lsi.rs
@@ -108,6 +108,29 @@ impl Record for LsiRecord {
         "lsi"
     }
 
+    /// C reads INP (`devLsiSoft.c:32`) and SIOL (`lsiRecord.c:244`) through
+    /// `dbGetLinkLS` (`dbLink.c:497-505`), whose switch is on the SOURCE
+    /// class: a `DBF_CHAR`/`DBF_UCHAR` source is read as the bytes it
+    /// spells (capped at SIZV), anything else as `DBR_STRING` — so an
+    /// ENUM/MENU source delivers its state label (epics-base#183).
+    fn input_link_read_as(
+        &self,
+        link_field: &str,
+        source: &crate::server::record::OutTarget,
+    ) -> Option<crate::server::record::LinkReadAs> {
+        use crate::server::record::LinkReadAs;
+        use crate::types::DbFieldType;
+        Some(match link_field {
+            "INP" | "SIOL" => match source.field_type {
+                Some(DbFieldType::Char | DbFieldType::UChar) => LinkReadAs::CharArrayAsString {
+                    max_elements: self.sizv as usize,
+                },
+                _ => LinkReadAs::String,
+            },
+            _ => LinkReadAs::Native,
+        })
+    }
+
     /// `DBF_MENU` fields, served as `DBR_ENUM` (`lsiRecord.dbd.pod`): `SIMM`
     /// is `menu(menuYesNo)` (two-choice NO/YES). `MPST`/`APST` are
     /// `menu(menuPost)` (On Change, Always) — unlike the array records

--- a/crates/epics-base-rs/src/server/records/lsi.rs
+++ b/crates/epics-base-rs/src/server/records/lsi.rs
@@ -113,6 +113,13 @@ impl Record for LsiRecord {
     /// class: a `DBF_CHAR`/`DBF_UCHAR` source is read as the bytes it
     /// spells (capped at SIZV), anything else as `DBR_STRING` — so an
     /// ENUM/MENU source delivers its state label (epics-base#183).
+    ///
+    /// Deliberate deviation: `dbGetLinkLS` returns 0 — success, nothing
+    /// written — when the source type is unknown (`dtyp < 0`, a
+    /// disconnected CA source; `dbLink.c:504-505`), so C keeps stale VAL
+    /// with no alarm. That silent success is the same wart family as
+    /// `putStringUlong`'s accepted-but-writes-nothing (`c_parse.rs`); the
+    /// port keeps its failed-read LINK alarm instead.
     fn input_link_read_as(
         &self,
         link_field: &str,

--- a/crates/epics-base-rs/src/server/records/lso.rs
+++ b/crates/epics-base-rs/src/server/records/lso.rs
@@ -111,6 +111,29 @@ impl Record for LsoRecord {
         "lso"
     }
 
+    /// C reads the closed-loop DOL through `dbGetLinkLS` (`lsoRecord.c:114`,
+    /// `dbLink.c:497-505`), whose switch is on the SOURCE class: a
+    /// `DBF_CHAR`/`DBF_UCHAR` source is read as the bytes it spells (capped
+    /// at SIZV), anything else as `DBR_STRING` — so an ENUM/MENU source
+    /// delivers its state label (epics-base#183).
+    fn input_link_read_as(
+        &self,
+        link_field: &str,
+        source: &crate::server::record::OutTarget,
+    ) -> Option<crate::server::record::LinkReadAs> {
+        use crate::server::record::LinkReadAs;
+        use crate::types::DbFieldType;
+        Some(match link_field {
+            "DOL" => match source.field_type {
+                Some(DbFieldType::Char | DbFieldType::UChar) => LinkReadAs::CharArrayAsString {
+                    max_elements: self.sizv as usize,
+                },
+                _ => LinkReadAs::String,
+            },
+            _ => LinkReadAs::Native,
+        })
+    }
+
     /// `DBF_MENU` fields, served as `DBR_ENUM` (`lsoRecord.dbd.pod`): `SIMM`
     /// is `menu(menuYesNo)` (two-choice NO/YES). `MPST`/`APST` are
     /// `menu(menuPost)` (On Change, Always) — unlike the array records whose

--- a/crates/epics-base-rs/src/server/records/printf.rs
+++ b/crates/epics-base-rs/src/server/records/printf.rs
@@ -107,6 +107,50 @@ impl PrintfRecord {
         v.to_f64().unwrap_or(0.0)
     }
 
+    /// Which INP0..INP9 slots FMT consumes with a plain `%s` (no `l`
+    /// modifier) — the directives C reads with `DBR_STRING`
+    /// (`printfRecord.c:291`), so an ENUM/MENU source delivers its label.
+    /// Classified under the resolved-links slot mapping (a failed `*`
+    /// width shifts consumption at format time, `printfRecord.c:167-168`,
+    /// which a fetch-time request cannot see; those directives emit IVLS).
+    fn plain_string_slots(&self) -> [bool; 10] {
+        let mut out = [false; 10];
+        let bytes = self.fmt.as_bytes();
+        let mut i = 0;
+        let mut slot = 0usize;
+        while i < bytes.len() && slot < out.len() {
+            if bytes[i] != b'%' {
+                i += 1;
+                continue;
+            }
+            if bytes.get(i + 1) == Some(&b'%') {
+                i += 2;
+                continue;
+            }
+            let (d, next) = Self::parse_directive(bytes, i);
+            i = next;
+            if d.bad {
+                continue;
+            }
+            // Consumption order mirrors `apply_fmt`: `*` width, then `*`
+            // precision (both numeric), then the conversion's own slot.
+            if d.star_width {
+                slot += 1;
+            }
+            if d.star_prec {
+                slot += 1;
+            }
+            if slot >= out.len() {
+                break;
+            }
+            if d.conv == b's' && !d.long {
+                out[slot] = true;
+            }
+            slot += 1;
+        }
+        out
+    }
+
     /// Parse one `%...` directive starting at `bytes[i]` (which is `%`).
     /// Returns the directive and the index just past the conversion
     /// char. Consumes `*` width/precision values from `star_idx`.
@@ -622,6 +666,38 @@ impl Record for PrintfRecord {
             }
         }
         Ok(())
+    }
+
+    /// A..J are C locals (`GET_PRINT`'s per-directive `val` buffer,
+    /// `printfRecord.c:47`), not DBF-typed fields: each cycle stores
+    /// whatever type the directive's request delivered — `%s` a string,
+    /// numerics a number. The default's coercion types the slot by its
+    /// PREVIOUS value (initially `Double`), which turned every string
+    /// delivery into `atof()` = 0.0 before `%s` could read it.
+    fn put_field_internal(&mut self, name: &str, value: EpicsValue) -> CaResult<()> {
+        if let Some(idx) = Self::val_index(name) {
+            self.vals[idx] = value;
+            return Ok(());
+        }
+        crate::server::record::put_field_internal_default(self, name, value)
+    }
+
+    /// C `GET_PRINT` reads each link with the conversion's own `dbrType`:
+    /// `%s` is `dbGetLink(..., DBR_STRING, ...)` (`printfRecord.c:291`), so
+    /// an ENUM/MENU source delivers its state label, not the index
+    /// (epics-base#183). Every other conversion's numeric request is
+    /// value-equivalent to the native fetch (`%ls` reads the char array the
+    /// native fetch already delivers).
+    fn input_link_read_as(
+        &self,
+        link_field: &str,
+        _source: &crate::server::record::OutTarget,
+    ) -> Option<crate::server::record::LinkReadAs> {
+        use crate::server::record::LinkReadAs;
+        Some(match Self::inp_index(link_field) {
+            Some(idx) if self.plain_string_slots()[idx] => LinkReadAs::String,
+            _ => LinkReadAs::Native,
+        })
     }
 
     fn multi_input_links(&self) -> &[(&'static str, &'static str)] {

--- a/crates/epics-base-rs/src/server/records/printf.rs
+++ b/crates/epics-base-rs/src/server/records/printf.rs
@@ -110,9 +110,21 @@ impl PrintfRecord {
     /// Which INP0..INP9 slots FMT consumes with a plain `%s` (no `l`
     /// modifier) — the directives C reads with `DBR_STRING`
     /// (`printfRecord.c:291`), so an ENUM/MENU source delivers its label.
-    /// Classified under the resolved-links slot mapping (a failed `*`
-    /// width shifts consumption at format time, `printfRecord.c:167-168`,
-    /// which a fetch-time request cannot see; those directives emit IVLS).
+    ///
+    /// Deliberate deviation, stated precisely: this map is computed at
+    /// FETCH time under the no-failure slot pairing. When a `*` width
+    /// link fails at read time, C's `goto bad_format`
+    /// (`printfRecord.c:167-168`) skips the conversion's own `plink++`,
+    /// so C's LATER directives consume shifted slots with fresh
+    /// format-time reads under their own DBR types — a pairing this
+    /// fetch-time request cannot see. `apply_fmt` reproduces the slot
+    /// SHIFT itself; only the shifted slot's fetch conversion stays as
+    /// requested here. Closing that would need either a corrective
+    /// second fetch (a PP link source would process twice — a real
+    /// semantic break C does not have) or C's lazy read-during-format
+    /// model, which the async-read/sync-format phase split rules out.
+    /// The failed-`*` directive itself emits IVLS in both
+    /// implementations.
     fn plain_string_slots(&self) -> [bool; 10] {
         let mut out = [false; 10];
         let bytes = self.fmt.as_bytes();

--- a/crates/epics-base-rs/src/server/records/stringin.rs
+++ b/crates/epics-base-rs/src/server/records/stringin.rs
@@ -76,6 +76,20 @@ impl Record for StringinRecord {
         "stringin"
     }
 
+    /// C reads INP (`devSiSoft.c:53`) and SIOL (`stringinRecord.c:208`) with
+    /// a plain `dbGetLink(..., DBR_STRING, ...)`: an ENUM/MENU source
+    /// delivers its state label, never the index digits (epics-base#183).
+    fn input_link_read_as(
+        &self,
+        link_field: &str,
+        _source: &crate::server::record::OutTarget,
+    ) -> Option<crate::server::record::LinkReadAs> {
+        Some(match link_field {
+            "INP" | "SIOL" => crate::server::record::LinkReadAs::String,
+            _ => crate::server::record::LinkReadAs::Native,
+        })
+    }
+
     /// `SIMM` is `DBF_MENU menu(menuYesNo)` (`stringinRecord.dbd.pod`): the
     /// two-choice NO/YES simulation menu. `MPST`/`APST` are
     /// `menu(stringinPOST)` (`stringinRecord.dbd.pod:21-24,95-107`), whose

--- a/crates/epics-base-rs/src/server/records/stringout.rs
+++ b/crates/epics-base-rs/src/server/records/stringout.rs
@@ -87,6 +87,20 @@ impl Record for StringoutRecord {
         "stringout"
     }
 
+    /// C reads the closed-loop DOL with a plain `dbGetLink(..., DBR_STRING,
+    /// ...)` (`stringoutRecord.c:141`): an ENUM/MENU source delivers its
+    /// state label, never the index digits (epics-base#183).
+    fn input_link_read_as(
+        &self,
+        link_field: &str,
+        _source: &crate::server::record::OutTarget,
+    ) -> Option<crate::server::record::LinkReadAs> {
+        Some(match link_field {
+            "DOL" => crate::server::record::LinkReadAs::String,
+            _ => crate::server::record::LinkReadAs::Native,
+        })
+    }
+
     /// `SIMM` is `DBF_MENU menu(menuYesNo)` (`stringoutRecord.dbd.pod`): the
     /// two-choice NO/YES simulation menu. `MPST`/`APST` are
     /// `menu(stringoutPOST)` (`stringoutRecord.dbd.pod:19-22,128-139`), whose

--- a/crates/epics-base-rs/src/server/snapshot.rs
+++ b/crates/epics-base-rs/src/server/snapshot.rs
@@ -40,8 +40,10 @@ pub struct DisplayInfo {
     /// Display format hint (0=Default, 1=String, 2=Binary, 3=Decimal,
     /// 4=Hex, 5=Exponential, 6=Engineering). From record's Q:form info tag.
     pub form: i16,
-    /// Record description (DESC field).
-    pub description: String,
+    /// Record description (DESC field). `PvString` for the same
+    /// byte-preserving reason as `units`: a non-UTF-8 DESC must reach
+    /// the wire unmangled.
+    pub description: PvString,
 }
 
 /// Control limits (DRVH/DRVL for output records, or HOPR/LOPR).

--- a/crates/epics-base-rs/src/types/c_parse.rs
+++ b/crates/epics-base-rs/src/types/c_parse.rs
@@ -128,9 +128,7 @@ fn parse(target: NumericField, s: &str) -> Option<EpicsValue> {
         // out-of-range *positive* band is rejected.
         NumericField::UChar => EpicsValue::UChar(outside_band(parse_ulong(s)?, 0xff)? as u8),
         NumericField::UShort => EpicsValue::UShort(outside_band(parse_ulong(s)?, 0xffff)? as u16),
-        NumericField::ULong => {
-            EpicsValue::ULong(outside_band(parse_ulong(s)?, 0xffff_ffff)? as u32)
-        }
+        NumericField::ULong => EpicsValue::ULong(parse_ulong_via_double(s)?),
         // No band: the destination is as wide as `unsigned long`.
         NumericField::UInt64 => EpicsValue::UInt64(parse_ulong(s)?),
 
@@ -163,6 +161,56 @@ fn outside_band(v: u64, max: u64) -> Option<u64> {
     (!(v > max && v <= !max)).then_some(v)
 }
 
+/// C `putStringUlong` (`dbConvert.c:1036-1067`) — the one string→integer row
+/// with a fallback: on `S_stdlib_noConversion`, or on a successful parse that
+/// stopped at `.`/`e`/`E`, re-parse via double, because "db_access pretends
+/// unsigned long is double". So `1.0e3` stores 1000 and `".5"` stores 0. The
+/// double is stored only inside `0..=UINT_MAX`; above/below it C keeps the
+/// already-parsed integer prefix (`1.5e20` stores 1). An integer parse that
+/// overflowed (ERANGE or the band test) gets NO fallback and stays refused.
+///
+/// Deviation: with no leading digits AND a double outside `0..=UINT_MAX`
+/// (e.g. `-.5`), C reports success while writing nothing — the field keeps
+/// its old value (`dbConvert.c:1055-1058` skips the store, status stays 0;
+/// measured: `dbpf B.SVAL -.5` leaves the previous value in place).
+/// "Accepted but writes nothing" is not expressible through this owner's
+/// return value, so that input is refused instead. Relatedly, on a
+/// double-parse ERANGE (`1e999`) C returns the error AFTER the first parse
+/// already wrote the integer prefix through `pdst` (measured: the field
+/// becomes 1); this owner refuses without writing — puts here are atomic.
+fn parse_ulong_via_double(s: &str) -> Option<u32> {
+    let d = scan_int(s);
+    let int_value = if d.any {
+        let v = u64::try_from(d.magnitude?).ok()?;
+        let v = if d.negative { v.wrapping_neg() } else { v };
+        Some(outside_band(v, 0xffff_ffff)? as u32)
+    } else {
+        None
+    };
+    let stopped_at_float = s
+        .as_bytes()
+        .get(d.end)
+        .is_some_and(|c| matches!(c, b'.' | b'e' | b'E'));
+    match int_value {
+        Some(prefix) if stopped_at_float => match parse_double(s) {
+            Some(dval) if (0.0..=u32::MAX as f64).contains(&dval) => Some(dval as u32),
+            // Out-of-band double: C skips the store, keeping the integer
+            // prefix the first parse already wrote into the field.
+            Some(_) => Some(prefix),
+            // Double-parse ERANGE (`1e999`): C returns that status.
+            None => None,
+        },
+        Some(prefix) => Some(prefix),
+        // No digits at all (S_stdlib_noConversion) → via-double or refuse.
+        None => {
+            let dval = parse_double(s)?;
+            (0.0..=u32::MAX as f64)
+                .contains(&dval)
+                .then_some(dval as u32)
+        }
+    }
+}
+
 /// What the integer scanner found, before it is given a signedness.
 struct Digits {
     negative: bool,
@@ -172,6 +220,10 @@ struct Digits {
     /// Whether any digit was consumed at all. `false` is `strtol`'s
     /// `endp == str`, i.e. `S_stdlib_noConversion`.
     any: bool,
+    /// Byte index where scanning stopped — `strtol`'s `*endp`. C's
+    /// `putStringUlong` reads the character here to decide on the
+    /// via-double fallback.
+    end: usize,
 }
 
 /// The scanning half of `strtol`/`strtoul` with `base == 0`: leading space, an
@@ -225,6 +277,7 @@ fn scan_int(s: &str) -> Digits {
         negative,
         magnitude,
         any,
+        end: i,
     }
 }
 
@@ -473,6 +526,47 @@ mod tests {
         assert_eq!(
             put(NumericField::UInt64, "-1"),
             Some(EpicsValue::UInt64(u64::MAX))
+        );
+    }
+
+    /// C `putStringUlong`'s via-double fallback (`dbConvert.c:1042-1057`) —
+    /// DBF_ULONG only, "db_access pretends unsigned long is double". Every
+    /// expected value measured via `dbpf B.SVAL <s>` on the reference softIoc
+    /// (bi.SVAL is a plain DBF_ULONG field).
+    #[test]
+    fn ulong_string_put_falls_back_via_double() {
+        // Integer parse stops at '.'/'e' → re-parse as double.
+        assert_eq!(
+            put(NumericField::ULong, "1.0e3"),
+            Some(EpicsValue::ULong(1000))
+        );
+        // No digits at all (S_stdlib_noConversion) → via-double, truncated.
+        assert_eq!(put(NumericField::ULong, ".5"), Some(EpicsValue::ULong(0)));
+        // Fallback double above UINT_MAX → the integer prefix is kept.
+        assert_eq!(
+            put(NumericField::ULong, "1.5e20"),
+            Some(EpicsValue::ULong(1))
+        );
+        // Sign-extended prefix kept when the double is negative.
+        assert_eq!(
+            put(NumericField::ULong, "-1.5"),
+            Some(EpicsValue::ULong(4294967295))
+        );
+        // Double-parse ERANGE is refused (C returns S_stdlib_overflow; it
+        // has also already partially written the prefix — see the owner's
+        // deviation note).
+        assert_eq!(put(NumericField::ULong, "1e999"), None);
+        // Band overflow on the integer parse gets NO fallback.
+        assert_eq!(put(NumericField::ULong, "4294967296.5"), None);
+        // No digits + double outside the band: C silently writes nothing;
+        // this owner refuses (documented deviation).
+        assert_eq!(put(NumericField::ULong, "-.5"), None);
+        // The fallback is putStringUlong-only: UInt64 keeps the longest
+        // integer prefix (C `putStringUInt64`, dbConvert.c:1089-1109, has
+        // no via-double path).
+        assert_eq!(
+            put(NumericField::UInt64, "1.0e3"),
+            Some(EpicsValue::UInt64(1))
         );
     }
 

--- a/crates/epics-base-rs/tests/asinit_reaches_live_gate.rs
+++ b/crates/epics-base-rs/tests/asinit_reaches_live_gate.rs
@@ -1,0 +1,81 @@
+//! A script-driven `asInit` must reach the IOC's LIVE access-security
+//! gate, not a shell-local copy.
+//!
+//! Upstream context: epics-base issue #667 territory (`asDbLib` global
+//! state vs the running servers). The Rust port's `asInit` previously
+//! stored the parsed ACF only into the `as_state()` shell global —
+//! `astac`/`asdbdump` showed a loaded config while every server kept
+//! gating on its own untouched `AcfCell` (= permissive). Access
+//! security was silently OFF for any IOC configured from its st.cmd
+//! rather than through `IocApplication::acf()`.
+//!
+//! The fix threads ONE `AcfCell` per IOC: created by
+//! `IocApplication::run` before the startup script, administered by the
+//! script/interactive shells, and handed to every protocol server via
+//! `IocRunConfig.acf`. These tests pin both halves of that invariant.
+
+use std::io::Write;
+
+use epics_base_rs::server::access_security::{
+    AccessLevel, asg_change_generation, new_acf_cell, parse_acf,
+};
+use epics_base_rs::server::ioc_app::IocApplication;
+
+/// UAG `ops` may write; everyone else reads only.
+const ACF: &str =
+    "UAG(ops) { alice }\nASG(DEFAULT) { RULE(1, READ) RULE(1, WRITE) { UAG(ops) } }\n";
+
+/// Owner path: st.cmd `asSetFilename` + `asInit` → the parsed policy is
+/// live in `IocRunConfig.acf` — the very cell the protocol runner hands
+/// its servers — by the time the runner is entered.
+#[epics_macros_rs::epics_test]
+async fn script_asinit_lands_in_the_run_config_cell() {
+    let acf_file = tempfile::Builder::new().suffix(".acf").tempfile().unwrap();
+    write!(acf_file.as_file(), "{ACF}").unwrap();
+
+    let mut script = tempfile::Builder::new().suffix(".cmd").tempfile().unwrap();
+    writeln!(script, "asSetFilename(\"{}\")", acf_file.path().display()).unwrap();
+    writeln!(script, "asInit").unwrap();
+
+    IocApplication::new()
+        .startup_script(script.path().to_str().unwrap())
+        .run(|config| async move {
+            let policy = config.acf.load_full().expect(
+                "asInit from the startup script must populate the IOC's \
+                 live policy cell, not a shell-local copy",
+            );
+            assert!(
+                policy.uag.contains_key("ops"),
+                "the cell must hold the script's parsed ACF"
+            );
+            // The policy is enforceable exactly as the servers will
+            // enforce it: bob reads, alice writes.
+            assert_eq!(
+                policy.check_access("DEFAULT", "somehost", "bob"),
+                AccessLevel::Read
+            );
+            assert_eq!(
+                policy.check_access("DEFAULT", "somehost", "alice"),
+                AccessLevel::ReadWrite
+            );
+            Ok(())
+        })
+        .await
+        .unwrap();
+}
+
+/// Change-signal half: a post-boot `AcfCell::store` (what `asInit` and
+/// the `reload_acf*` paths do) must move the process ASG-change
+/// generation, so the CA `reeval_access_rights` task, the
+/// `AccessGate` check cache and the QSRV grant cache all observe the
+/// swap instead of serving grants computed under the old policy.
+#[epics_macros_rs::epics_test]
+async fn acf_cell_store_moves_the_change_generation() {
+    let cell = new_acf_cell(None);
+    let before = asg_change_generation();
+    cell.store(Some(std::sync::Arc::new(parse_acf(ACF).unwrap())));
+    assert!(
+        asg_change_generation() > before,
+        "AcfCell::store must fire the ASG-change notification"
+    );
+}

--- a/crates/epics-base-rs/tests/calcout_link_status.rs
+++ b/crates/epics-base-rs/tests/calcout_link_status.rs
@@ -101,9 +101,13 @@ async fn calcout_input_status_reclassifies_on_special() {
     poll_status(&db, "CALC_SP.INCV", CON, "empty INPC → CON").await;
 
     // A client put to the INP link re-runs checkLinks via special().
-    db.put_pv("CALC_SP.INPC", EpicsValue::String("CALC_SP_TGT.VAL".into()))
-        .await
-        .unwrap();
+    db.put_record_field_from_ca_no_notify(
+        "CALC_SP",
+        "INPC",
+        EpicsValue::String("CALC_SP_TGT.VAL".into()),
+    )
+    .await
+    .unwrap();
     poll_status(&db, "CALC_SP.INCV", LOC, "INPC repointed to local → LOC").await;
 }
 
@@ -123,9 +127,13 @@ async fn calcout_outv_classifies_via_process() {
 
     // Configure a local OUT link, then process: check_alarms mirrors
     // common.out into the record and re-classifies OUTV → LOC.
-    db.put_pv("CALC_OUT.OUT", EpicsValue::String("CALC_OUT_TGT".into()))
-        .await
-        .unwrap();
+    db.put_record_field_from_ca_no_notify(
+        "CALC_OUT",
+        "OUT",
+        EpicsValue::String("CALC_OUT_TGT".into()),
+    )
+    .await
+    .unwrap();
     let mut visited = HashSet::new();
     db.process_record_with_links("CALC_OUT", &mut visited, 0)
         .await

--- a/crates/epics-base-rs/tests/db_load_refuses_long_string_val.rs
+++ b/crates/epics-base-rs/tests/db_load_refuses_long_string_val.rs
@@ -1,0 +1,51 @@
+//! UI-80 (epics-base#548): `field(VAL, "...")` on a long-string record
+//! (`lso`/`lsi`/`printf`) is refused at `.db` load, as in C — the field is
+//! `DBF_NOACCESS` + `SPC_DBADDR`, and the reference softIoc reports
+//! `Can't set 'L.VAL' to 'hello' Can't set array field before iocInit() :
+//! Bad Field value` (measured). The port refused too, but with an
+//! accidental Char-parse diagnostic that blamed the value's syntax; the
+//! loader now consults `Record::long_string_fields` and names the real
+//! constraint.
+
+use std::collections::HashMap;
+
+use epics_base_rs::server::ioc_builder::IocBuilder;
+
+async fn load(db: &str) -> Result<(), String> {
+    let builder = IocBuilder::new()
+        .db_string(db, &HashMap::new())
+        .expect("parse is fine — the refusal happens at field application");
+    match builder.build().await {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[epics_macros_rs::epics_test]
+async fn lso_val_in_db_is_refused_with_the_real_reason() {
+    let msg = load(r#"record(lso, "L") { field(VAL, "hello") }"#)
+        .await
+        .expect_err("C refuses lso VAL from a .db (measured on softIoc)");
+    assert!(
+        msg.contains("before iocInit"),
+        "diagnostic must name the real constraint, got: {msg}"
+    );
+    assert!(
+        !msg.contains("cannot parse"),
+        "must not blame the value's syntax, got: {msg}"
+    );
+}
+
+#[epics_macros_rs::epics_test]
+async fn printf_val_in_db_is_refused_and_other_lso_fields_still_load() {
+    // Family member: printf VAL is in `long_string_fields` too.
+    let msg = load(r#"record(printf, "P") { field(VAL, "x") }"#)
+        .await
+        .expect_err("printf VAL is the same DBF_NOACCESS refusal family");
+    assert!(msg.contains("before iocInit"), "got: {msg}");
+
+    // Control: the gate is field-specific — an ordinary lso field loads.
+    load(r#"record(lso, "L2") { field(SIZV, "80") }"#)
+        .await
+        .expect("non-long-string lso fields must still load");
+}

--- a/crates/epics-base-rs/tests/dbput_nomod_gate.rs
+++ b/crates/epics-base-rs/tests/dbput_nomod_gate.rs
@@ -40,7 +40,7 @@ async fn build() -> PvDatabase {
     db.add_record("AO", Box::new(AoRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("AO.OUT", EpicsValue::String("WF.NELM PP".into()))
+    db.put_record_field_from_ca_no_notify("AO", "OUT", EpicsValue::String("WF.NELM PP".into()))
         .await
         .unwrap();
 

--- a/crates/epics-base-rs/tests/dbput_refuses_link_fields.rs
+++ b/crates/epics-base-rs/tests/dbput_refuses_link_fields.rs
@@ -1,0 +1,188 @@
+//! UI-64 (epics-base#876): only `dbPutField` changes DBF link fields.
+//!
+//! C `dbPut` refuses a put to an INLINK/OUTLINK/FWDLINK target with
+//! `S_db_badDbrtype` (`field_type > DBF_DEVICE`, `dbAccess.c:1340-1347`);
+//! `dbPutField` routes link fields through `dbPutFieldLink` instead
+//! (`dbAccess.c:1261-1262`). The pre-fix port let every write funnel fall
+//! through to `put_common_field`'s INP/OUT/FLNK re-parse arms, so a record's
+//! DB OUT link could silently rewire another record's link field on every
+//! process cycle.
+//!
+//! One boundary per put entry: the `dbPut` analogues (`put_pv`,
+//! `put_pv_and_post`, the OUT-link route) refuse; the `dbPutField` analogues
+//! (`put_record_field_from_ca_no_notify`, the autosave restore's
+//! `put_pv_no_process`) still rewire.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use epics_base_rs::error::CaError;
+use epics_base_rs::server::autosave::save_file::{SaveEntry, write_save_file};
+use epics_base_rs::server::autosave::save_set::{RestoreMode, restore_from_entries_with_mode};
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::recgbl::alarm_status;
+use epics_base_rs::server::record::AlarmSeverity;
+use epics_base_rs::types::EpicsValue;
+
+async fn build(db_text: &str) -> Arc<PvDatabase> {
+    let (db, _) = IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    db
+}
+
+fn link_text(db: &PvDatabase, name: &str) -> String {
+    match db.get_pv(name).unwrap() {
+        EpicsValue::String(s) => s.as_str_lossy().into_owned(),
+        EpicsValue::CharArray(b) => String::from_utf8_lossy(&b)
+            .trim_end_matches('\0')
+            .to_string(),
+        other => panic!("{name} is not string-shaped: {other:?}"),
+    }
+}
+
+/// The cited defect: a stringout whose OUT names another record's INP. C's
+/// `dbPutLink` → `dbDbPutValue` → `dbPut` refuses (`S_db_badDbrtype`) and
+/// `setLinkAlarm` puts the WRITER in LINK/INVALID; the target's INP text
+/// never changes. Pre-fix the port rewired `TGT.INP` to the stringout's VAL.
+#[epics_macros_rs::epics_test]
+async fn db_out_link_write_to_a_link_field_is_refused() {
+    let db = build(
+        r#"
+        record(ai, "TGT") { }
+        record(stringout, "SRC") { field(VAL, "REWIRED.VAL") field(OUT, "TGT.INP") }
+        "#,
+    )
+    .await;
+    let mut v = HashSet::new();
+    db.process_record_with_links("SRC", &mut v, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        link_text(&db, "TGT.INP"),
+        "",
+        "the DB OUT link must not rewire TGT.INP (C dbPut refuses, dbAccess.c:1340)"
+    );
+    let rec = db.get_record("SRC").unwrap();
+    let (stat, sevr) = {
+        let inst = rec.read();
+        (inst.common.stat, inst.common.sevr)
+    };
+    assert_eq!(
+        (stat, sevr),
+        (alarm_status::LINK_ALARM, AlarmSeverity::Invalid),
+        "the refused put lands on the writer as LINK/INVALID (C setLinkAlarm)"
+    );
+}
+
+/// `put_pv` is the public `dbPut` analogue: an INLINK and a FWDLINK target
+/// both refuse with the `S_db_badDbrtype` analogue, text unchanged.
+#[epics_macros_rs::epics_test]
+async fn put_pv_refuses_link_fields_with_bad_dbrtype() {
+    let db = build(r#"record(ai, "R1") { }"#).await;
+    for field in ["INP", "FLNK"] {
+        let err = db
+            .put_pv(
+                &format!("R1.{field}"),
+                EpicsValue::String("OTHER.VAL".into()),
+            )
+            .await
+            .expect_err("put_pv is the dbPut analogue and must refuse a link field");
+        assert!(
+            matches!(err, CaError::BadDbrType(_)),
+            "expected BadDbrType for {field}, got {err:?}"
+        );
+        assert_eq!(link_text(&db, &format!("R1.{field}")), "");
+    }
+}
+
+/// `put_pv_and_post` is another `dbPut` body (value + monitor post) and
+/// takes the same refusal.
+#[epics_macros_rs::epics_test]
+async fn put_pv_and_post_refuses_a_link_field() {
+    let db = build(r#"record(ai, "R2") { }"#).await;
+    let err = db
+        .put_pv_and_post("R2.INP", EpicsValue::String("OTHER.VAL".into()))
+        .await
+        .expect_err("put_pv_and_post shares dbPut's link-field refusal");
+    assert!(matches!(err, CaError::BadDbrType(_)), "got {err:?}");
+    assert_eq!(link_text(&db, "R2.INP"), "");
+}
+
+/// The `dbPutField` analogue still rewires: this is `dbPutFieldLink`
+/// (`dbAccess.c:1261`), the one sanctioned link-write path.
+#[epics_macros_rs::epics_test]
+async fn ca_route_still_rewires_a_link_field() {
+    let db = build(
+        r#"
+        record(ai, "SRC3") { }
+        record(ai, "R3") { }
+        "#,
+    )
+    .await;
+    db.put_record_field_from_ca_no_notify("R3", "INP", EpicsValue::String("SRC3.VAL".into()))
+        .await
+        .unwrap();
+    assert_eq!(link_text(&db, "R3.INP"), "SRC3.VAL");
+}
+
+/// `put_pv_no_process` is the autosave-restore entry; its C analogue
+/// (`reboot_restore` → `dbPutField`) permits link-field writes, so it must
+/// keep permitting them.
+#[epics_macros_rs::epics_test]
+async fn put_pv_no_process_still_rewires_for_restore() {
+    let db = build(
+        r#"
+        record(ai, "SRC4") { }
+        record(ai, "R4") { }
+        "#,
+    )
+    .await;
+    db.put_pv_no_process("R4.INP", EpicsValue::String("SRC4.VAL".into()))
+        .await
+        .unwrap();
+    assert_eq!(link_text(&db, "R4.INP"), "SRC4.VAL");
+}
+
+/// An autosave restore in `RestoreMode::Process` must still restore a saved
+/// link field: C's restore writes via `dbPutField`, and `dbPutField` on a
+/// link field is the no-process `dbPutFieldLink` write — not the `dbPut`
+/// that now refuses.
+#[epics_macros_rs::epics_test]
+async fn autosave_process_mode_restores_a_link_field() {
+    let db = build(
+        r#"
+        record(ai, "SRC5") { }
+        record(ai, "R5") { }
+        "#,
+    )
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("links.sav");
+    write_save_file(
+        &path,
+        &[SaveEntry {
+            pv_name: "R5.INP".into(),
+            value: "SRC5.VAL".into(),
+            connected: true,
+        }],
+    )
+    .await
+    .unwrap();
+
+    let result = restore_from_entries_with_mode(&db, &path, RestoreMode::Process)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.failed_puts.len(),
+        0,
+        "link-field restore must not fail: {:?}",
+        result.failed_puts
+    );
+    assert_eq!(link_text(&db, "R5.INP"), "SRC5.VAL");
+}

--- a/crates/epics-base-rs/tests/enum_link_reads_deliver_labels.rs
+++ b/crates/epics-base-rs/tests/enum_link_reads_deliver_labels.rs
@@ -1,0 +1,281 @@
+//! UI-63 (epics-base#183): a link read the record requests as `DBR_STRING`
+//! must deliver an ENUM/MENU source's state LABEL, never its index digits.
+//!
+//! C reads:
+//! - stringin INP  — `dbGetLink(..., DBR_STRING, ...)` (`devSiSoft.c:53`)
+//! - stringin SIOL — same request (`stringinRecord.c:208`)
+//! - lsi INP       — `dbGetLinkLS` (`devLsiSoft.c:32` → `dbLink.c:497-505`):
+//!   CHAR/UCHAR source → the bytes it spells, else `DBR_STRING`
+//! - stringout DOL — `dbGetLink(..., DBR_STRING, ...)` (`stringoutRecord.c:141`)
+//! - lso DOL       — `dbGetLinkLS` (`lsoRecord.c:114`)
+//! - printf `%s`   — `dbGetLink(..., DBR_STRING, ...)` (`printfRecord.c:291`)
+//!
+//! The pre-fix port fetched every one of these natively and let the target
+//! field coerce blind, so a bi/mbbi/menu source stored `"1"` where fixed C
+//! stores `"RUNNING"`. Boundary per read path, plus the numeric printf
+//! conversion that must KEEP the index, and the external-link half (the
+//! label table rides `LinkMetadata::enum_choices` — C `dbCa`'s second
+//! `DBR_STRING` monitor).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::server::database::{LinkMetadata, LinkPutOp, LinkSet, PvDatabase};
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::types::EpicsValue;
+
+async fn build(db_text: &str) -> Arc<PvDatabase> {
+    let (db, _) = IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    db
+}
+
+async fn process(db: &PvDatabase, rec: &str) {
+    let mut v = HashSet::new();
+    db.process_record_with_links(rec, &mut v, 0).await.unwrap();
+}
+
+fn field(db: &PvDatabase, rec: &str, field: &str) -> EpicsValue {
+    let r = db.get_record(rec).unwrap();
+    let v = r.read().record.get_field(field);
+    v.unwrap_or_else(|| panic!("{rec}.{field} missing"))
+}
+
+fn field_str(db: &PvDatabase, rec: &str, name: &str) -> String {
+    match field(db, rec, name) {
+        EpicsValue::String(s) => s.as_str_lossy().into_owned(),
+        EpicsValue::CharArray(b) => String::from_utf8_lossy(&b)
+            .trim_end_matches('\0')
+            .to_string(),
+        other => panic!("{rec}.{name} is not string-shaped: {other:?}"),
+    }
+}
+
+/// stringin INP at a bi VAL: the DBR_STRING request renders ONAM.
+#[epics_macros_rs::epics_test]
+async fn stringin_inp_at_enum_source_delivers_the_label() {
+    let db = build(
+        r#"
+        record(bi, "SRC") { field(ZNAM, "STOPPED") field(ONAM, "RUNNING") field(VAL, "1") }
+        record(stringin, "SI") { field(INP, "SRC") }
+        "#,
+    )
+    .await;
+    process(&db, "SI").await;
+    assert_eq!(
+        field_str(&db, "SI", "VAL"),
+        "RUNNING",
+        "C devSiSoft reads INP with DBR_STRING — the pre-fix port stored \"1\""
+    );
+}
+
+/// stringin INP at a MENU field: the same request renders the menu choice.
+#[epics_macros_rs::epics_test]
+async fn stringin_inp_at_menu_field_delivers_the_choice() {
+    let db = build(
+        r#"
+        record(ai, "SRC2") { field(SCAN, "1 second") }
+        record(stringin, "SI2") { field(INP, "SRC2.SCAN") }
+        "#,
+    )
+    .await;
+    process(&db, "SI2").await;
+    assert_eq!(
+        field_str(&db, "SI2", "VAL"),
+        "1 second",
+        "a DBF_MENU source read as DBR_STRING delivers its choice text"
+    );
+}
+
+/// lsi INP, non-char source: `dbGetLinkLS`'s else-arm is DBR_STRING.
+#[epics_macros_rs::epics_test]
+async fn lsi_inp_at_enum_source_delivers_the_label() {
+    let db = build(
+        r#"
+        record(bi, "SRC3") { field(ZNAM, "STOPPED") field(ONAM, "RUNNING") field(VAL, "1") }
+        record(lsi, "LI") { field(INP, "SRC3") }
+        "#,
+    )
+    .await;
+    process(&db, "LI").await;
+    assert_eq!(field_str(&db, "LI", "VAL"), "RUNNING");
+}
+
+/// lsi INP, CHAR-array source: `dbGetLinkLS`'s CHAR arm reads the bytes the
+/// array spells — the other side of the source-class switch.
+#[epics_macros_rs::epics_test]
+async fn lsi_inp_at_char_array_source_reads_the_bytes() {
+    let db = build(
+        r#"
+        record(waveform, "WFC") { field(FTVL, "CHAR") field(NELM, "16") }
+        record(lsi, "LIC") { field(INP, "WFC") }
+        "#,
+    )
+    .await;
+    {
+        let rec = db.get_record("WFC").unwrap();
+        let mut inst = rec.write();
+        inst.record
+            .put_field_internal("VAL", EpicsValue::CharArray(b"hello".to_vec()))
+            .unwrap();
+    }
+    process(&db, "LIC").await;
+    assert_eq!(
+        field_str(&db, "LIC", "VAL"),
+        "hello",
+        "a DBF_CHAR source goes through the char-array arm, not DBR_STRING"
+    );
+}
+
+/// stringout closed-loop DOL at a bi VAL renders ONAM.
+#[epics_macros_rs::epics_test]
+async fn stringout_dol_at_enum_source_delivers_the_label() {
+    let db = build(
+        r#"
+        record(bi, "SRC4") { field(ZNAM, "STOPPED") field(ONAM, "RUNNING") field(VAL, "1") }
+        record(stringout, "SO") { field(DOL, "SRC4") field(OMSL, "closed_loop") }
+        "#,
+    )
+    .await;
+    process(&db, "SO").await;
+    assert_eq!(field_str(&db, "SO", "VAL"), "RUNNING");
+}
+
+/// lso closed-loop DOL at a bi VAL renders ONAM (`dbGetLinkLS` else-arm).
+#[epics_macros_rs::epics_test]
+async fn lso_dol_at_enum_source_delivers_the_label() {
+    let db = build(
+        r#"
+        record(bi, "SRC5") { field(ZNAM, "STOPPED") field(ONAM, "RUNNING") field(VAL, "1") }
+        record(lso, "LO") { field(DOL, "SRC5") field(OMSL, "closed_loop") }
+        "#,
+    )
+    .await;
+    process(&db, "LO").await;
+    assert_eq!(field_str(&db, "LO", "VAL"), "RUNNING");
+}
+
+/// printf `%s` renders the label; `%d` on the SAME source keeps the index —
+/// the per-conversion request boundary (`printfRecord.c:291` vs `:129`).
+#[epics_macros_rs::epics_test]
+async fn printf_string_conversion_gets_the_label_numeric_keeps_the_index() {
+    let db = build(
+        r#"
+        record(bi, "SRC6") { field(ZNAM, "STOPPED") field(ONAM, "RUNNING") field(VAL, "1") }
+        record(printf, "PFS") { field(FMT, "%s") field(INP0, "SRC6") }
+        record(printf, "PFD") { field(FMT, "%d") field(INP0, "SRC6") }
+        "#,
+    )
+    .await;
+    process(&db, "PFS").await;
+    process(&db, "PFD").await;
+    assert_eq!(
+        field_str(&db, "PFS", "VAL"),
+        "RUNNING",
+        "a %s slot is read with DBR_STRING"
+    );
+    assert_eq!(
+        field_str(&db, "PFD", "VAL"),
+        "1",
+        "a numeric slot keeps the native index"
+    );
+}
+
+/// stringin SIMM=YES: the SIOL read carries the same DBR_STRING request.
+#[epics_macros_rs::epics_test]
+async fn stringin_siol_at_enum_source_delivers_the_label() {
+    let db = build(
+        r#"
+        record(bi, "SRC7") { field(ZNAM, "STOPPED") field(ONAM, "RUNNING") field(VAL, "1") }
+        record(stringin, "SIM") { field(SIMM, "YES") field(SIOL, "SRC7") }
+        "#,
+    )
+    .await;
+    process(&db, "SIM").await;
+    assert_eq!(
+        field_str(&db, "SIM", "VAL"),
+        "RUNNING",
+        "stringinRecord.c:208 reads SIOL with DBR_STRING into SVAL"
+    );
+}
+
+/// An external enum link set: the label table rides
+/// `LinkMetadata::enum_choices` (C `dbCa`'s second DBR_STRING monitor,
+/// `pgetString`) — a bare wire index still renders as its label.
+struct EnumLset {
+    value: EpicsValue,
+    metadata: LinkMetadata,
+    last_put: Arc<Mutex<Option<EpicsValue>>>,
+}
+
+#[epics_base_rs::async_trait]
+impl LinkSet for EnumLset {
+    fn is_connected(&self, _name: &str) -> bool {
+        true
+    }
+    fn get_cached_value(&self, _name: &str) -> Option<EpicsValue> {
+        Some(self.value.clone())
+    }
+    async fn get_value(&self, name: &str) -> Option<EpicsValue> {
+        self.get_cached_value(name)
+    }
+    async fn put_value(
+        &self,
+        _name: &str,
+        value: EpicsValue,
+        _op: LinkPutOp,
+    ) -> Result<(), String> {
+        *self.last_put.lock().unwrap() = Some(value);
+        Ok(())
+    }
+    fn link_metadata(&self, _name: &str) -> Option<LinkMetadata> {
+        Some(self.metadata.clone())
+    }
+}
+
+/// stringin INP at a `ca://` enum channel: the wire value is a bare index;
+/// the cached CTRL label table renders it.
+#[epics_macros_rs::epics_test]
+async fn stringin_inp_at_external_enum_renders_via_cached_choices() {
+    let db = build(r#"record(stringin, "SIX") { field(INP, "ca://EXT:ENUM") }"#).await;
+    db.register_link_set(
+        "ca",
+        Arc::new(EnumLset {
+            value: EpicsValue::Enum(1),
+            metadata: LinkMetadata {
+                enum_choices: Some(vec!["off".into(), "on".into()]),
+                ..Default::default()
+            },
+            last_put: Arc::new(Mutex::new(None)),
+        }),
+    )
+    .await;
+    process(&db, "SIX").await;
+    assert_eq!(
+        field_str(&db, "SIX", "VAL"),
+        "on",
+        "C dbCaGetLink(DBR_STRING) serves the enum label, not the index"
+    );
+}
+
+/// Same external read WITHOUT a cached label table: the index digits are
+/// all that can be rendered (C before its string monitor delivers).
+#[epics_macros_rs::epics_test]
+async fn stringin_inp_at_external_enum_without_choices_falls_back_to_digits() {
+    let db = build(r#"record(stringin, "SIY") { field(INP, "ca://EXT:ENUM2") }"#).await;
+    db.register_link_set(
+        "ca",
+        Arc::new(EnumLset {
+            value: EpicsValue::Enum(1),
+            metadata: LinkMetadata::default(),
+            last_put: Arc::new(Mutex::new(None)),
+        }),
+    )
+    .await;
+    process(&db, "SIY").await;
+    assert_eq!(field_str(&db, "SIY", "VAL"), "1");
+}

--- a/crates/epics-base-rs/tests/link_read_inherits_ms_everywhere.rs
+++ b/crates/epics-base-rs/tests/link_read_inherits_ms_everywhere.rs
@@ -71,7 +71,7 @@ async fn closed_loop_dol_inherits_ms() {
     db.add_record("A1", Box::new(AoRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("A1.DOL", EpicsValue::String("SRC MS".into()))
+    db.put_record_field_from_ca_no_notify("A1", "DOL", EpicsValue::String("SRC MS".into()))
         .await
         .unwrap();
     db.put_pv("A1.OMSL", EpicsValue::String("closed_loop".into()))
@@ -81,7 +81,7 @@ async fn closed_loop_dol_inherits_ms() {
     db.add_record("B1", Box::new(BoRecord::new(0)))
         .await
         .unwrap();
-    db.put_pv("B1.DOL", EpicsValue::String("SRC MS".into()))
+    db.put_record_field_from_ca_no_notify("B1", "DOL", EpicsValue::String("SRC MS".into()))
         .await
         .unwrap();
     db.put_pv("B1.OMSL", EpicsValue::String("closed_loop".into()))
@@ -124,14 +124,14 @@ async fn siml_and_siol_inherit_ms() {
     db.add_record("R3", Box::new(AiRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("R3.SIML", EpicsValue::String("SRC0 MS".into()))
+    db.put_record_field_from_ca_no_notify("R3", "SIML", EpicsValue::String("SRC0 MS".into()))
         .await
         .unwrap();
 
     db.add_record("R4", Box::new(AiRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("R4.SIML", EpicsValue::String("SRC0".into()))
+    db.put_record_field_from_ca_no_notify("R4", "SIML", EpicsValue::String("SRC0".into()))
         .await
         .unwrap();
 
@@ -139,7 +139,7 @@ async fn siml_and_siol_inherit_ms() {
     db.add_record("R2", Box::new(AiRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("R2.SIOL", EpicsValue::String("SRC MS".into()))
+    db.put_record_field_from_ca_no_notify("R2", "SIOL", EpicsValue::String("SRC MS".into()))
         .await
         .unwrap();
     db.put_pv("R2.SIMM", EpicsValue::Short(1)).await.unwrap();
@@ -177,7 +177,7 @@ async fn sdis_and_tsel_inherit_ms() {
     db.add_record("D1", Box::new(AiRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("D1.SDIS", EpicsValue::String("SRC MS".into()))
+    db.put_record_field_from_ca_no_notify("D1", "SDIS", EpicsValue::String("SRC MS".into()))
         .await
         .unwrap();
     // DISV=1 and the source delivers 5, so the record is NOT disabled and its
@@ -187,7 +187,7 @@ async fn sdis_and_tsel_inherit_ms() {
     db.add_record("T2", Box::new(AiRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("T2.TSEL", EpicsValue::String("SRC MS".into()))
+    db.put_record_field_from_ca_no_notify("T2", "TSEL", EpicsValue::String("SRC MS".into()))
         .await
         .unwrap();
 

--- a/crates/epics-base-rs/tests/link_status_waits_for_db_load.rs
+++ b/crates/epics-base-rs/tests/link_status_waits_for_db_load.rs
@@ -223,7 +223,7 @@ async fn runtime_link_re_point_still_classifies_after_a_post_init_load() {
     assert!(db.begin_load().is_err());
 
     // `dbpf CO.INPA "9.5"` — the link becomes a CONSTANT.
-    db.put_pv("CO.INPA", EpicsValue::String("9.5".into()))
+    db.put_record_field_from_ca_no_notify("CO", "INPA", EpicsValue::String("9.5".into()))
         .await
         .unwrap();
     epics_base_rs::runtime::task::sleep(Duration::from_millis(50)).await;

--- a/crates/epics-base-rs/tests/record_tests.rs
+++ b/crates/epics-base-rs/tests/record_tests.rs
@@ -2131,7 +2131,11 @@ fn test_snapshot_bi_enum_strings() {
     let inst = RecordInstance::new("BI:TEST".into(), rec);
 
     let snap = inst.snapshot_for_field("VAL").unwrap();
-    assert!(snap.display.is_none());
+    // bi has no display source beyond dbCommon DESC (UI-106): the block
+    // exists solely to carry `description`, everything else default.
+    let disp = snap.display.as_ref().unwrap();
+    assert!(disp.units.is_empty());
+    assert!(disp.description.is_empty());
     assert!(snap.control.is_none());
     let enums = snap.enums.as_ref().unwrap();
     assert_eq!(enums.strings.len(), 2);
@@ -2475,7 +2479,11 @@ fn test_snapshot_stringin_no_metadata() {
 
     let snap = inst.snapshot_for_field("VAL").unwrap();
     assert_eq!(snap.value, EpicsValue::String("hello".into()));
-    assert!(snap.display.is_none());
+    // stringin has no display source beyond dbCommon DESC (UI-106): the
+    // block carries only `description`, everything else default.
+    let disp = snap.display.as_ref().unwrap();
+    assert!(disp.units.is_empty());
+    assert_eq!(disp.upper_disp_limit, 0.0);
     assert!(snap.control.is_none());
     assert!(snap.enums.is_none());
 }

--- a/crates/epics-base-rs/tests/rset_units_precision_literal_arms.rs
+++ b/crates/epics-base-rs/tests/rset_units_precision_literal_arms.rs
@@ -171,14 +171,15 @@ fn bo_high_serves_the_units_literal_the_wire_can_carry() {
 }
 
 /// bo's only literal is HIGH's. VAL is DBF_ENUM, so `get_units` writes nothing
-/// for it and no display block exists to carry one — the override must not
-/// conjure one into being for a field the rset never answers.
+/// for it — the override must not conjure units into being for a field the
+/// rset never answers. (The display block itself now always exists, carrying
+/// dbCommon DESC — UI-106 — so the assertion is on `units` staying empty.)
 #[test]
 fn bos_units_literal_is_highs_alone() {
     let inst = inst("T:BO", BoRecord::default());
 
     assert!(
-        snap(&inst, "VAL").display.is_none(),
-        "boRecord.c:294-299 answers only HIGH; VAL gets no units and no display block"
+        snap(&inst, "VAL").display.unwrap().units.is_empty(),
+        "boRecord.c:294-299 answers only HIGH; VAL gets no units"
     );
 }

--- a/crates/epics-base-rs/tests/sim_simm_contract.rs
+++ b/crates/epics-base-rs/tests/sim_simm_contract.rs
@@ -614,7 +614,7 @@ async fn w10_e5_busy_failed_siml_read_performs_no_output_write() {
     let mut b = BusyRecord::new();
     b.siml = "NO:SUCH:RECORD".to_string();
     db.add_record("E5BUSY", Box::new(b)).await.unwrap();
-    db.put_pv("E5BUSY.OUT", EpicsValue::String("E5TGT".into()))
+    db.put_record_field_from_ca_no_notify("E5BUSY", "OUT", EpicsValue::String("E5TGT".into()))
         .await
         .unwrap();
     db.put_pv("E5BUSY", EpicsValue::Short(1)).await.unwrap();

--- a/crates/epics-base-rs/tests/sseq_async_machine.rs
+++ b/crates/epics-base-rs/tests/sseq_async_machine.rs
@@ -713,9 +713,13 @@ async fn sseq_link_status_reclassifies_on_special() {
     // A client put to the DOL1 link string re-runs checkLinks via special().
     // The init-time CON refresh and this LOC refresh race; the gate must let
     // the newer LOC classification win.
-    db.put_pv("SSEQ_SP.DOL1", EpicsValue::String("SSEQ_SP_TGT.VAL".into()))
-        .await
-        .unwrap();
+    db.put_record_field_from_ca_no_notify(
+        "SSEQ_SP",
+        "DOL1",
+        EpicsValue::String("SSEQ_SP_TGT.VAL".into()),
+    )
+    .await
+    .unwrap();
     poll_i16(&db, "SSEQ_SP.DOL1V", 2, "DOL1 repointed to local → LOC").await;
 
     // And it must stay LOC — a stale CON post arriving late cannot clobber it.

--- a/crates/epics-base-rs/tests/udf_clear_is_per_record_type.rs
+++ b/crates/epics-base-rs/tests/udf_clear_is_per_record_type.rs
@@ -93,7 +93,7 @@ async fn dfanout_with_closed_loop_dol_is_defined() {
     db.add_record("DF2", Box::new(DfanoutRecord::new(0.0)))
         .await
         .unwrap();
-    db.put_pv("DF2.DOL", EpicsValue::String("SRC".into()))
+    db.put_record_field_from_ca_no_notify("DF2", "DOL", EpicsValue::String("SRC".into()))
         .await
         .unwrap();
     db.put_pv("DF2.OMSL", EpicsValue::String("closed_loop".into()))

--- a/crates/epics-bridge-rs/src/bin/dual_ioc_rs.rs
+++ b/crates/epics-bridge-rs/src/bin/dual_ioc_rs.rs
@@ -192,16 +192,21 @@ async fn main() -> ExitCode {
         .pva_port
         .unwrap_or_else(epics_pva_rs::config::env::pvas_server_port);
 
+    // One live policy cell for both protocol servers, so an ACF
+    // (re)load gates CA and PVA together.
+    let acf = epics_base_rs::server::access_security::new_acf_cell(None);
+
     let ca_handle = if args.no_ca {
         None
     } else {
-        let server = match CaServer::from_parts(db.clone(), ca_port, None, None, None, None).await {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("error binding CA server on port {ca_port}: {e}");
-                return ExitCode::FAILURE;
-            }
-        };
+        let server =
+            match CaServer::from_parts(db.clone(), ca_port, None, acf.clone(), None, None).await {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("error binding CA server on port {ca_port}: {e}");
+                    return ExitCode::FAILURE;
+                }
+            };
         Some(tokio::spawn(async move {
             tracing::info!(port = ca_port, "CA listener starting");
             server.run().await
@@ -211,7 +216,7 @@ async fn main() -> ExitCode {
     let pva_handle = if args.no_pva {
         None
     } else {
-        let server = PvaServer::from_parts(db.clone(), pva_port, None, None, None);
+        let server = PvaServer::from_parts(db.clone(), pva_port, acf, None, None);
         Some(tokio::spawn(async move {
             tracing::info!(port = pva_port, "PVA listener starting");
             server.run().await

--- a/crates/epics-bridge-rs/src/bin/realtime-pva-ioc.rs
+++ b/crates/epics-bridge-rs/src/bin/realtime-pva-ioc.rs
@@ -618,10 +618,12 @@ mod ioc {
         //      finalizes the groups before it returns the store that exposes
         //      them, so the `add_source` below cannot run early.
         //
-        //      `None` for the ACF: this entry point loads no access-security
-        //      file. Passing `None` leaves the provider on `AllowAllAccess`,
-        //      which is what an IOC with no ACF means on the CA side too.
-        let mount: QsrvMount = match block_on_sync(build_qsrv_mount(&db, None, &group_files)) {
+        //      A fresh cell holding no ACF: this entry point loads no
+        //      access-security file, and an empty cell grants like
+        //      `AllowAllAccess` — which is what an IOC with no ACF means
+        //      on the CA side too.
+        let acf = epics_base_rs::server::access_security::new_acf_cell(None);
+        let mount: QsrvMount = match block_on_sync(build_qsrv_mount(&db, acf, &group_files)) {
             Ok(m) => m,
             Err(_) => {
                 eprintln!(

--- a/crates/epics-bridge-rs/src/ca_gateway/downstream.rs
+++ b/crates/epics-bridge-rs/src/ca_gateway/downstream.rs
@@ -310,7 +310,15 @@ impl DownstreamServer {
     /// cannot be bound is reported now rather than from inside the
     /// gateway's server task.
     pub async fn new(shadow_db: Arc<PvDatabase>, port: u16) -> CaResult<Self> {
-        let server = CaServer::from_parts(shadow_db.clone(), port, None, None, None, None).await?;
+        let server = CaServer::from_parts(
+            shadow_db.clone(),
+            port,
+            None,
+            epics_base_rs::server::access_security::new_acf_cell(None),
+            None,
+            None,
+        )
+        .await?;
         Ok(Self {
             server: Mutex::new(Some(server)),
             shadow_db,
@@ -330,8 +338,15 @@ impl DownstreamServer {
         port: u16,
         tls: std::sync::Arc<epics_ca_rs::tls::ServerConfig>,
     ) -> CaResult<Self> {
-        let mut server =
-            CaServer::from_parts(shadow_db.clone(), port, None, None, None, None).await?;
+        let mut server = CaServer::from_parts(
+            shadow_db.clone(),
+            port,
+            None,
+            epics_base_rs::server::access_security::new_acf_cell(None),
+            None,
+            None,
+        )
+        .await?;
         server.set_tls(tls);
         Ok(Self {
             server: Mutex::new(Some(server)),

--- a/crates/epics-bridge-rs/src/pvalink/link.rs
+++ b/crates/epics-bridge-rs/src/pvalink/link.rs
@@ -1565,6 +1565,10 @@ impl PvaLink {
             precision,
             units,
             description,
+            // A pva link's cached value carries its own labels
+            // (`EnumWithChoices`, the NTEnum read path), so the
+            // metadata-side table the CA lset needs is redundant here.
+            enum_choices: None,
         })
     }
 

--- a/crates/epics-bridge-rs/src/qsrv/channel.rs
+++ b/crates/epics-bridge-rs/src/qsrv/channel.rs
@@ -598,7 +598,7 @@ impl BridgeChannel {
         // truth for both the served DBF type and (below) the NT shape,
         // so the advertised descriptor cannot drift from the value the
         // GET path will serialize.
-        let (resolved, nt_type) = if string_view {
+        let (value, nt_type) = if string_view {
             // The `$` modifier is valid only on a `DBF_STRING` or link
             // field; every other field type is `S_dbLib_fieldNotFound` and
             // aborts channel creation, matching `dbChannelCreate`
@@ -615,14 +615,28 @@ impl BridgeChannel {
                     record: record_name.to_string(),
                     field: format!("{field_upper}$"),
                 })?;
-            (Some(v), NtType::LongString)
+            (v, NtType::LongString)
         } else {
             // `client_field_value`, not `resolve_field`: the value projected
             // onto the field's DECLARED type, which is what every delivery
             // path serves. Reading the DBF off the raw stored variant is what
             // advertised `.PROC` (`DBF_UCHAR`) as a signed byte and a
             // `DBF_MENU` field as a short.
-            let resolved = instance.client_field_value(&field_upper);
+            //
+            // `None` means the record does not have the field at all — the
+            // projection is infallible, so this is exactly `resolve_field`
+            // returning `None` — and C aborts channel creation there
+            // (`dbChannelCreate` → `S_dbLib_fieldNotFound`,
+            // `dbChannel.c:456-462`; pvxs renders it `Invalid PV:`,
+            // `ioc/channel.cpp:29-38`). Falling through used to fabricate an
+            // NTScalar double prototype the client would connect to and then
+            // fail every operation against (pvxs#193, server half).
+            let value = instance.client_field_value(&field_upper).ok_or_else(|| {
+                BridgeError::FieldNotFound {
+                    record: record_name.to_string(),
+                    field: field_upper.clone(),
+                }
+            })?;
             // `pvif::nt_type_for_channel` is the single owner of the NT
             // choice (the port's `getChannelValueType`): a record-declared
             // long-string field (`lsi`/`lso` VAL/OVAL, `printf` VAL) AND a
@@ -630,8 +644,8 @@ impl BridgeChannel {
             // QSRV long-string idiom — both resolve to the scalar-string
             // NTScalar, not the byte array the `DBF_CHAR` type alone would
             // select.
-            let nt_type = pvif::nt_type_for_channel(&instance, &field_upper, resolved.as_ref());
-            (resolved, nt_type)
+            let nt_type = pvif::nt_type_for_channel(&instance, &field_upper, Some(&value));
+            (value, nt_type)
         };
 
         // DBF type for the bound field. pvxs serves the type from
@@ -639,20 +653,14 @@ impl BridgeChannel {
         // dbChannel.h:452) — the channel's final field type after lookup,
         // which covers `dbCommon` fields, not only record-specific ones.
         //
-        // `resolved` above is `client_field_value`, i.e. already projected onto
+        // `value` above is `client_field_value`, i.e. already projected onto
         // the field's declared type, so reading the DBF off it IS reading the
         // declaration — and the advertised descriptor agrees with the value the
         // GET path serializes by construction, because both are that one
         // projection. Taking it from the RAW stored variant used to advertise
         // `.PROC` (`DBF_UCHAR`) as a signed byte and every `DBF_MENU` field as
         // a short: agreement with the value, but agreement on the wrong type.
-        //
-        // `Double` remains the backstop for a field that resolves to no value
-        // at all.
-        let value_dbf = resolved
-            .as_ref()
-            .map(|v| v.db_field_type())
-            .unwrap_or(DbFieldType::Double);
+        let value_dbf = value.db_field_type();
 
         Ok(Self {
             db,
@@ -1719,6 +1727,17 @@ mod tests {
             .await
             .expect("unfiltered channel must create");
         assert!(ch.channel_filters.is_empty());
+    }
+
+    /// pvxs#193, server half: a field the record does not declare aborts
+    /// channel creation (C `dbChannelCreate` → `S_dbLib_fieldNotFound`,
+    /// `dbChannel.c:456-462`) instead of fabricating an NTScalar double
+    /// prototype the client connects to and then fails every GET against.
+    #[tokio::test]
+    async fn a_field_the_record_does_not_have_refuses_the_channel() {
+        let db = db_with_rec().await;
+        let res = BridgeChannel::new(db, "REC.NOSUCH").await;
+        assert!(matches!(res, Err(BridgeError::FieldNotFound { .. })));
     }
 
     // ---- Force + block (record[process=true,block=true]) end-to-end wiring ----

--- a/crates/epics-bridge-rs/src/qsrv/channel.rs
+++ b/crates/epics-bridge-rs/src/qsrv/channel.rs
@@ -2,7 +2,7 @@
 //!
 //! Corresponds to C++ QSRV's `PDBSinglePV` / `PDBSingleChannel`.
 
-// RTEMS-EXEC-MODEL-ALLOW(9): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(10): checked - these run and pass in the feature-ON suite.
 
 use std::sync::Arc;
 

--- a/crates/epics-bridge-rs/src/qsrv/channel.rs
+++ b/crates/epics-bridge-rs/src/qsrv/channel.rs
@@ -825,7 +825,22 @@ impl BridgeChannel {
             dbr_type: self.value_dbf as u16,
         };
         super::trap_write::put_with_trap(grant, meta, epics_val, |value| async move {
-            match opts.process {
+            // pvxs sends a DBF link field down the dbPutField path no matter
+            // the requested process mode: a non-wait put splits per-field
+            // (`dbChannelPutField`, and NO doPostProcessing,
+            // singlesource.cpp:374-383) and a blocking put lands in
+            // `dbProcessNotify`'s link special case (write + immediate done,
+            // dbNotify.c:337-353). The port's `put_record_field_from_ca`
+            // family IS that path — its notify body keeps link fields out of
+            // the PACT park — while the `dbPut`-analogue `put_pv` refuses a
+            // link field outright (S_db_badDbrtype, dbAccess.c:1340). So a
+            // link-field put takes the Passive arms regardless of mode.
+            let process = if self.db.is_dbf_link_field(&self.record_name, &self.field) {
+                ProcessMode::Passive
+            } else {
+                opts.process
+            };
+            match process {
                 ProcessMode::Inhibit => {
                     self.db
                         .put_pv(&format!("{}.{}", self.record_name, self.field), value)

--- a/crates/epics-bridge-rs/src/qsrv/provider.rs
+++ b/crates/epics-bridge-rs/src/qsrv/provider.rs
@@ -148,16 +148,20 @@ impl AccessControl for AllowAllAccess {}
 /// (tcp.rs:300).
 pub struct AcfAccessControl {
     db: Arc<epics_base_rs::server::database::PvDatabase>,
-    cfg: Arc<epics_base_rs::server::access_security::AccessSecurityConfig>,
+    /// The live policy cell. When the IOC runner built this control
+    /// ([`AcfAccessControl::adopting`]) it is the same cell the CA/PVA
+    /// servers and the iocsh `asInit` command use, so a runtime ACF
+    /// (re)load reaches the QSRV path too. A cell holding `None` means
+    /// "no policy" and every check grants, matching [`AllowAllAccess`].
+    acf: epics_base_rs::server::access_security::AcfCell,
     /// C `asAddClient` keeps one computed ASGCLIENT per channel and every
     /// put is a bit test; pvxs caches the client's computed access on the
     /// channel at the first PUT (pvxs 3c0154b, issue #176). The Rust QSRV
     /// channel object is rebuilt per operation, so the computed
     /// (level, trap) is cached here on the policy owner instead, keyed by
     /// (channel, full credential identity). Invalidation is by
-    /// construction: an ACF reload swaps in a whole new
-    /// `AcfAccessControl` (`set_access_control`), and a `dbPut
-    /// record.ASG` moves
+    /// generation: both an ACF (re)load (`AcfCell::store`) and a `dbPut
+    /// record.ASG` move
     /// [`asg_change_generation`](epics_base_rs::server::access_security::asg_change_generation)
     /// which every entry
     /// snapshots. The rule walk here never evaluates CALC against live
@@ -212,13 +216,27 @@ struct CachedAccess {
 const GRANT_CACHE_CAP: usize = 4096;
 
 impl AcfAccessControl {
+    /// Build from a fixed config (tests, standalone use): the config is
+    /// wrapped in a fresh cell this control alone observes.
     pub fn new(
         db: Arc<epics_base_rs::server::database::PvDatabase>,
         cfg: epics_base_rs::server::access_security::AccessSecurityConfig,
     ) -> Self {
+        Self::adopting(
+            db,
+            epics_base_rs::server::access_security::new_acf_cell(Some(cfg)),
+        )
+    }
+
+    /// Adopt the IOC's live policy cell — the runner path, so a later
+    /// `asInit`/ACF reload through that cell re-gates QSRV operations.
+    pub fn adopting(
+        db: Arc<epics_base_rs::server::database::PvDatabase>,
+        acf: epics_base_rs::server::access_security::AcfCell,
+    ) -> Self {
         Self {
             db,
-            cfg: Arc::new(cfg),
+            acf,
             grant_cache: parking_lot::RwLock::new(HashMap::new()),
         }
     }
@@ -296,6 +314,17 @@ impl AcfAccessControl {
         {
             return *hit;
         }
+        // No policy in the cell (never loaded, or cleared at runtime):
+        // grant everything, matching [`AllowAllAccess`]. Not cached — a
+        // later `asInit` store moves the generation, but skipping the
+        // cache keeps "no policy" trivially always-current.
+        let Some(cfg) = self.acf.load_full() else {
+            return CachedAccess {
+                asg_generation: generation,
+                level: AccessLevelLite::ReadWrite,
+                write_trap: false,
+            };
+        };
         let (asg, asl, record_known) = self.resolve_asg_and_asl(channel).await;
         let cred_strings = Self::credential_strings(creds);
         // a QSRV access context built through the legacy
@@ -334,7 +363,7 @@ impl AcfAccessControl {
             write_trap: false,
         };
         for cred_user in &cred_strings {
-            let (lvl, trap) = self.cfg.check_access_method_trap(
+            let (lvl, trap) = cfg.check_access_method_trap(
                 &asg,
                 &creds.host,
                 cred_user,

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -2597,9 +2597,13 @@ mod tests {
             .await
             .unwrap();
         // A.FLNK -> B (both default to SCAN=Passive, so FLNK processes B).
-        db.put_pv("FLNK:a.FLNK", EpicsValue::String("FLNK:b".into()))
-            .await
-            .unwrap();
+        db.put_record_field_from_ca_no_notify(
+            "FLNK:a",
+            "FLNK",
+            EpicsValue::String("FLNK:b".into()),
+        )
+        .await
+        .unwrap();
         let provider = Arc::new(BridgeProvider::new(db.clone()));
         let store = QsrvPvStore::new(provider);
 

--- a/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pva_adapter.rs
@@ -1437,10 +1437,11 @@ pub struct QsrvMount {
 /// are built. What the caller still owns is the other half — bind and start
 /// accepting only after `add_source`.
 ///
-/// `acf` is the IOC-wide access-security configuration, or `None`. Passing
-/// `None` leaves the provider on `AllowAllAccess`; passing the same config
-/// the CA server got is what keeps the two protocols on one policy, which
-/// is the documented configuration trap on the host side.
+/// `acf` is the IOC's live access-security policy cell — the SAME cell the
+/// CA/PVA servers and the iocsh `asInit` command use (`IocRunConfig.acf`),
+/// which is what keeps every protocol on one policy and lets a runtime
+/// `asInit`/ACF reload re-gate QSRV operations. A cell holding `None`
+/// behaves as `AllowAllAccess` until a policy is stored.
 ///
 /// `group_files` carries `dbLoadGroup` requests the caller obtained by some
 /// route other than the iocsh command — which on the RTEMS target is the
@@ -1457,7 +1458,7 @@ pub struct QsrvMount {
 /// store already existed.
 pub async fn build_qsrv_mount(
     db: &Arc<epics_base_rs::server::database::PvDatabase>,
-    acf: Option<epics_base_rs::server::access_security::AccessSecurityConfig>,
+    acf: epics_base_rs::server::access_security::AcfCell,
     group_files: &[epics_base_rs::server::ioc_app::GroupLoadRequest],
 ) -> QsrvMount {
     // ── QSRV2 enable gate (pvxs enable2(), iochooks.cpp:401-496) ──
@@ -1470,13 +1471,17 @@ pub async fn build_qsrv_mount(
 
     let provider = Arc::new(BridgeProvider::new_with_serving(db.clone(), enabled));
 
-    // Install the IOC-wide ACF on the QSRV bridge so PVA single-record /
-    // group operations enforce the same policy the CA server does. Without
-    // this, an IOC launched with an ACF would protect CA but leave the PVA
-    // QSRV path on `AllowAllAccess`.
-    if let Some(acf_cfg) = acf {
-        let acf = Arc::new(super::provider::AcfAccessControl::new(db.clone(), acf_cfg));
-        provider.set_access_control(acf);
+    // Install the IOC-wide ACF cell on the QSRV bridge so PVA
+    // single-record / group operations enforce the same policy the CA
+    // server does. Installed unconditionally — a cell holding `None`
+    // grants like `AllowAllAccess`, and installing it even then is what
+    // lets a post-boot `asInit` (which stores into this same cell) turn
+    // access security ON for QSRV without a restart.
+    provider.set_access_control(Arc::new(super::provider::AcfAccessControl::adopting(
+        db.clone(),
+        acf.clone(),
+    )));
+    if acf.load().is_some() {
         tracing::info!("qsrv: ACF installed on BridgeProvider");
     }
 
@@ -1595,9 +1600,10 @@ pub async fn run_ca_pva_qsrv_ioc(
     // — the one owner shared with the RTEMS target IOC, so the two entry
     // points cannot disagree about whether `PVXS_QSRV_ENABLE` was honoured
     // or whether groups were finalized before the first client GET. The ACF
-    // is the same `config.acf` the CA server gets via `CaServer::from_parts`
-    // below; handing the PVA side a different one is the documented
-    // configuration trap.
+    // is the same `config.acf` CELL the CA server adopts via
+    // `CaServer::from_parts` below — one cell for CA, PVA, QSRV and the
+    // iocsh `asInit` command; handing any side a different one is the
+    // documented configuration trap.
     let QsrvMount {
         store,
         enabled: qsrv2_on,

--- a/crates/epics-bridge-rs/src/qsrv/pvif.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pvif.rs
@@ -493,9 +493,13 @@ pub(crate) enum BareLeaf {
     /// A `DBR_CHAR` array whose channel format is `String` — pvxs
     /// `TypeCode::String` (`getChannelValueType`, `iocsource.cpp:634-636`).
     LongString,
-    /// `dbChannelFinalElements() != 1` — pvxs `valueType.arrayOf()`.
+    /// The value is stored as an `*Array` variant ([`nt_type_for_field`])
+    /// — pvxs `valueType.arrayOf()`. Deliberate divergence: pvxs keys
+    /// array-ness on `dbChannelFinalElements() != 1`, so C QSRV serves a
+    /// `NELM=1` waveform as a scalar; the port pins the shape to the
+    /// FTVL storage variant and keeps it NTScalarArray.
     Array(ScalarType),
-    /// A single element — pvxs `fromDbrType(final_field_type)`.
+    /// A scalar-stored value — pvxs `fromDbrType(final_field_type)`.
     Scalar(ScalarType),
 }
 

--- a/crates/epics-bridge-rs/src/qsrv/pvif.rs
+++ b/crates/epics-bridge-rs/src/qsrv/pvif.rs
@@ -768,8 +768,7 @@ pub fn snapshot_to_nt_enum(snapshot: &Snapshot) -> PvStructure {
                 .display
                 .as_ref()
                 .map(|d| d.description.clone())
-                .unwrap_or_default()
-                .into(),
+                .unwrap_or_default(),
         )),
     ));
     pv.fields
@@ -1274,7 +1273,7 @@ fn build_display(disp: &DisplayInfo, scalar_type: ScalarType, numeric: bool) -> 
     }
     d.fields.push((
         "description".into(),
-        PvField::Scalar(ScalarValue::String(disp.description.clone().into())),
+        PvField::Scalar(ScalarValue::String(disp.description.clone())),
     ));
     d.fields.push((
         "units".into(),

--- a/crates/epics-bridge-rs/tests/qsrv_group_blocking_driver.rs
+++ b/crates/epics-bridge-rs/tests/qsrv_group_blocking_driver.rs
@@ -101,7 +101,7 @@ async fn group_flood_starves_neither_the_scalar_monitor_nor_a_fresh_get() {
     write!(group_file, r#"{{ "{GROUP_PV}": {{ {fields} }} }}"#).expect("write group json");
     let mount = build_qsrv_mount(
         &db,
-        None,
+        epics_base_rs::server::access_security::new_acf_cell(None),
         &[GroupLoadRequest {
             filename: group_file.path().to_string_lossy().into_owned(),
             macros: String::new(),

--- a/crates/epics-bridge-rs/tests/testqsingle.rs
+++ b/crates/epics-bridge-rs/tests/testqsingle.rs
@@ -285,9 +285,13 @@ async fn dollar_modifier_serves_link_field_as_string() {
         .await
         .unwrap();
     // Seed the forward link so the `$` view has a non-empty char string.
-    db.put_pv("TEST:lnk.FLNK", EpicsValue::String("TEST:other".into()))
-        .await
-        .expect("seed FLNK");
+    db.put_record_field_from_ca_no_notify(
+        "TEST:lnk",
+        "FLNK",
+        EpicsValue::String("TEST:other".into()),
+    )
+    .await
+    .expect("seed FLNK");
     let provider = Arc::new(BridgeProvider::new(db.clone()));
 
     let any = provider
@@ -1359,5 +1363,60 @@ async fn r17_31_char_waveform_without_qform_stays_a_byte_array() {
     match extract_value(&ch.get(&empty_request()).await.expect("get")).expect("value") {
         PvField::ScalarArray(_) | PvField::ScalarArrayTyped(_) => {}
         other => panic!("expected a byte array, got {other:?}"),
+    }
+}
+
+/// pvxs sends a DBF link field down the dbPutField path no matter the
+/// requested process mode: `doDbPut` splits per-field
+/// (`iocsource.cpp:451-458`) and the single source skips post-processing
+/// for links entirely (`singlesource.cpp:374-383`); a blocking put lands in
+/// `dbProcessNotify`'s link special case (write + immediate done,
+/// `dbNotify.c:337-353`). The port's Force/Inhibit routes used `put_pv`,
+/// the `dbPut` analogue that now refuses link fields (S_db_badDbrtype,
+/// `dbAccess.c:1340`) — a link-field put must re-route, not refuse.
+#[tokio::test]
+async fn link_field_put_succeeds_in_every_process_mode() {
+    use epics_bridge_rs::qsrv::{ProcessMode, PutOptions};
+
+    let db = Arc::new(PvDatabase::new());
+    db.add_record("TEST:lnkmode", Box::new(AiRecord::new(1.0)))
+        .await
+        .unwrap();
+    db.add_record("TEST:lnktgt", Box::new(AiRecord::new(0.0)))
+        .await
+        .unwrap();
+
+    let ch = BridgeChannel::from_cached(
+        db.clone(),
+        "TEST:lnkmode.FLNK".into(),
+        "TEST:lnkmode".into(),
+        "FLNK".into(),
+        NtType::Scalar,
+        DbFieldType::String,
+    );
+
+    for (mode, block, target) in [
+        (ProcessMode::Passive, false, "TEST:lnktgt"),
+        (ProcessMode::Inhibit, false, ""),
+        (ProcessMode::Force, false, "TEST:lnktgt"),
+        (ProcessMode::Force, true, ""),
+    ] {
+        let mut put = PvStructure::new("epics:nt/NTScalar:1.0");
+        put.fields.push((
+            "value".into(),
+            PvField::Scalar(ScalarValue::String(target.into())),
+        ));
+        let opts = PutOptions {
+            process: mode,
+            block,
+        };
+        ch.put_with_options(&put, opts)
+            .await
+            .unwrap_or_else(|e| panic!("{mode:?} block={block}: link-field put must succeed: {e}"));
+        let text = match db.get_pv("TEST:lnkmode.FLNK").unwrap() {
+            EpicsValue::String(s) => s.as_str_lossy().into_owned(),
+            other => panic!("FLNK read back non-string: {other:?}"),
+        };
+        assert_eq!(text, target, "{mode:?} block={block}");
     }
 }

--- a/crates/epics-bridge-rs/tests/testqsingle.rs
+++ b/crates/epics-bridge-rs/tests/testqsingle.rs
@@ -17,7 +17,7 @@
 //! the target's own selection for no reason.
 #![cfg(feature = "qsrv-core")]
 
-// RTEMS-EXEC-MODEL-ALLOW(24): checked - these run and pass in the feature-ON suite.
+// RTEMS-EXEC-MODEL-ALLOW(25): checked - these run and pass in the feature-ON suite.
 
 use std::sync::Arc;
 

--- a/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
+++ b/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
@@ -665,7 +665,7 @@ mod ioc {
         .to_vec();
         let mut name = pv.as_bytes().to_vec();
         name.push(0);
-        while name.len() % 8 != 0 {
+        while !name.len().is_multiple_of(8) {
             name.push(0);
         }
         frame.extend_from_slice(

--- a/crates/epics-ca-rs/src/bin/softioc-rs.rs
+++ b/crates/epics-ca-rs/src/bin/softioc-rs.rs
@@ -443,7 +443,12 @@ async fn main() -> CaResult<()> {
                 zone: args.dns_update_zone.clone().unwrap(),
                 instance: args.dns_update_instance.clone().unwrap(),
                 host,
-                port: args.port,
+                // Advertise the port the server will actually bind: an
+                // omitted --port defers to the EPICS environment, same
+                // as the builder's own seeding above.
+                port: args
+                    .port
+                    .unwrap_or_else(epics_base_rs::runtime::net::ca_server_port),
                 txt: Vec::new(),
                 ttl: std::time::Duration::from_secs(args.dns_update_ttl),
                 keepalive: std::time::Duration::from_secs(args.dns_update_keepalive),

--- a/crates/epics-ca-rs/src/calink/resolver.rs
+++ b/crates/epics-ca-rs/src/calink/resolver.rs
@@ -915,6 +915,21 @@ fn build_link_metadata(
         if let Some(c) = snap.control.as_ref() {
             md.control_limits = Some((c.lower_ctrl_limit, c.upper_ctrl_limit));
         }
+        // An enum channel's CTRL reply is `DBR_CTRL_ENUM`, whose metadata IS
+        // the state-label table. Cached so a `DBR_STRING`-requesting reader
+        // (stringin/lsi INP, printf `%s`) renders the remote index as its
+        // label — C `dbCa` keeps a second `DBR_STRING` monitor (`pgetString`)
+        // for that read; here the labels ride the attribute fetch.
+        if let Some(e) = snap.enums.as_ref()
+            && !e.strings.is_empty()
+        {
+            md.enum_choices = Some(
+                e.strings
+                    .iter()
+                    .map(|s| s.as_str_lossy().into_owned())
+                    .collect(),
+            );
+        }
     }
     md
 }
@@ -1428,6 +1443,28 @@ mod tests {
         assert_eq!(md.alarm_limits, None);
         assert_eq!(md.precision, None);
         assert_eq!(md.units, None);
+    }
+
+    /// an enum channel's `DBR_CTRL_ENUM` reply carries the state-label
+    /// table; it lands in `enum_choices` so a `DBR_STRING`-requesting
+    /// reader (stringin/lsi INP, printf `%s`) can render the remote index
+    /// as its label — C `dbCa`'s `pgetString` monitor equivalent. An empty
+    /// table stays `None` (nothing to render through).
+    #[test]
+    fn build_link_metadata_enum_ctrl_carries_the_choices() {
+        use epics_base_rs::server::snapshot::EnumInfo;
+        let mut snap = Snapshot::new(EpicsValue::Enum(1), 0, 0, std::time::SystemTime::UNIX_EPOCH);
+        snap.enums = Some(EnumInfo::new(vec!["off".into(), "on".into()]));
+        let md = build_link_metadata(Some(DbFieldType::Enum), Some(1), Some(&snap));
+        assert_eq!(md.dbf_type, Some(LinkDbfType::Enum));
+        assert_eq!(
+            md.enum_choices,
+            Some(vec!["off".to_string(), "on".to_string()])
+        );
+
+        let empty = Snapshot::new(EpicsValue::Enum(0), 0, 0, std::time::SystemTime::UNIX_EPOCH);
+        let md = build_link_metadata(Some(DbFieldType::Enum), Some(1), Some(&empty));
+        assert_eq!(md.enum_choices, None);
     }
 
     /// when the channel info fetch failed (`None` dbf /

--- a/crates/epics-ca-rs/src/calink/resolver.rs
+++ b/crates/epics-ca-rs/src/calink/resolver.rs
@@ -909,7 +909,8 @@ fn build_link_metadata(
                 md.units = Some(d.units.as_str_lossy().into_owned());
             }
             if !d.description.is_empty() {
-                md.description = Some(d.description.clone());
+                // Same lossy `String` cache rendering as `units` above.
+                md.description = Some(d.description.as_str_lossy().into_owned());
             }
         }
         if let Some(c) = snap.control.as_ref() {

--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -795,15 +795,13 @@ impl CaClient {
         let sni_overrides: std::collections::HashMap<SocketAddr, String> = {
             let mut map: std::collections::HashMap<SocketAddr, String> = nameserver_entries
                 .iter()
-                .filter_map(|(addr, host)| host.clone().map(|h| (*addr, h)))
+                .filter_map(|e| e.hostname.clone().map(|h| (e.sock, h)))
                 .collect();
             for (addr, host) in parse_tls_sni_map() {
                 map.insert(addr, host);
             }
             map
         };
-        let nameserver_addrs: Vec<SocketAddr> =
-            nameserver_entries.iter().map(|(a, _)| *a).collect();
 
         let (search_tx, search_rx) = mpsc::unbounded_channel();
         let (search_resp_tx, search_resp_rx) = mpsc::unbounded_channel();
@@ -834,7 +832,7 @@ impl CaClient {
         // gate — a target IOC's `ca://` links now resolve the way a C IOC's do.
         let search_task = epics_base_rs::runtime::task::spawn(search::run_search_engine(
             addr_list,
-            nameserver_addrs,
+            nameserver_entries,
             search_rx,
             search_resp_tx,
             search_attempts.clone(),
@@ -5376,7 +5374,7 @@ fn parse_tls_sni_map() -> Vec<(SocketAddr, String)> {
 /// SNI / cert-verification name for that specific server, so multi-IOC TLS
 /// deployments with hostname-bound certs work without a single global
 /// `EPICS_CA_TLS_SERVER_NAME` override.
-pub(crate) fn parse_nameserver_list() -> Vec<(SocketAddr, Option<String>)> {
+pub(crate) fn parse_nameserver_list() -> Vec<AddrEntry> {
     let Some(list) = epics_base_rs::runtime::env_table::EPICS_CA_NAME_SERVERS.get() else {
         return Vec::new();
     };
@@ -5392,20 +5390,25 @@ pub(crate) fn parse_nameserver_list() -> Vec<(SocketAddr, Option<String>)> {
     // C `cac.cpp:259` — the SAME tokenizer the client address list is built
     // with, which is why a bad token here is reported in exactly the same two
     // lines, naming this variable.
-    let out: Vec<(SocketAddr, Option<String>)> =
-        crate::iocinf::add_addr_to_channel_access_address_list(
-            &list,
-            "EPICS_CA_NAME_SERVERS",
-            default_server_port,
-        )
-        .into_iter()
-        .map(|tok| (tok.sock, tok.hostname))
-        .collect();
+    // `AddrEntry`, not a bare `SocketAddr`: the hostname must survive to
+    // the per-nameserver circuit so its redial path can re-resolve DNS
+    // (the same Launchpad-#488 family `EPICS_CA_ADDR_LIST` already
+    // handles via `AddrEntry::refresh_dns`). The resolved port carries
+    // over — explicit `host:port` entries keep it, bare hostnames got
+    // `default_server_port` above.
+    let out: Vec<AddrEntry> = crate::iocinf::add_addr_to_channel_access_address_list(
+        &list,
+        "EPICS_CA_NAME_SERVERS",
+        default_server_port,
+    )
+    .into_iter()
+    .map(|tok| AddrEntry::new(tok.sock, tok.hostname, tok.sock.port()))
+    .collect();
     // C `cac.cpp:260`: `removeDuplicateAddresses ( &dest, &tmpList, 0 )` — the
     // name-server list is deduped by the SAME helper as `EPICS_CA_ADDR_LIST`,
     // and warns about what it drops for the same reason: a repeated entry
     // otherwise buys a second TCP circuit to that name server.
-    crate::iocinf::remove_duplicate_addresses(out, |(addr, _)| *addr)
+    crate::iocinf::remove_duplicate_addresses(out, |e| e.sock)
 }
 
 // Legacy `parse_addr_list() -> Vec<SocketAddr>`

--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -779,8 +779,11 @@ impl CaClient {
         }
 
         let nameserver_entries = parse_nameserver_list();
-        // Build the per-address SNI map. Two sources:
-        // 1. EPICS_CA_NAME_SERVERS hostnames.
+        // Build the per-address SNI registry. Two sources:
+        // 1. EPICS_CA_NAME_SERVERS hostnames — live rows, re-keyed by
+        //    each entry's own `refresh_dns` so a nameserver that moves
+        //    behind a stable DNS name keeps its SNI override
+        //    (epics-base#488 residual).
         // 2. EPICS_CA_TLS_SNI_MAP for IPs reached via UDP search
         //   . The CA SEARCH wire protocol carries no
         //    hostname, so a UDP-discovered TLS IOC otherwise has to
@@ -792,16 +795,17 @@ impl CaClient {
         // Per-address overrides win over the global
         // EPICS_CA_TLS_SERVER_NAME (config.tls_server_name).
         #[cfg(feature = "experimental-rust-tls")]
-        let sni_overrides: std::collections::HashMap<SocketAddr, String> = {
-            let mut map: std::collections::HashMap<SocketAddr, String> = nameserver_entries
+        let sni_overrides = std::sync::Arc::new(SniOverrides::new(
+            parse_tls_sni_map().into_iter().collect(),
+            nameserver_entries
                 .iter()
-                .filter_map(|e| e.hostname.clone().map(|h| (e.sock, h)))
-                .collect();
-            for (addr, host) in parse_tls_sni_map() {
-                map.insert(addr, host);
-            }
-            map
-        };
+                .filter_map(|e| e.hostname.clone().map(|h| (h, e.sock))),
+        ));
+        #[cfg(feature = "experimental-rust-tls")]
+        let nameserver_entries: Vec<AddrEntry> = nameserver_entries
+            .into_iter()
+            .map(|e| e.with_sni(sni_overrides.clone()))
+            .collect();
 
         let (search_tx, search_rx) = mpsc::unbounded_channel();
         let (search_resp_tx, search_resp_rx) = mpsc::unbounded_channel();
@@ -4795,6 +4799,11 @@ pub(crate) struct AddrEntry {
     pub sock: SocketAddr,
     pub hostname: Option<String>,
     pub port: u16,
+    /// TLS-only: SNI registry this entry publishes fresh resolutions
+    /// into. Attached ([`AddrEntry::with_sni`]) only to
+    /// `EPICS_CA_NAME_SERVERS` entries; `None` for addr-list entries.
+    #[cfg(feature = "experimental-rust-tls")]
+    sni: Option<std::sync::Arc<SniOverrides>>,
 }
 
 impl AddrEntry {
@@ -4803,7 +4812,18 @@ impl AddrEntry {
             sock,
             hostname,
             port,
+            #[cfg(feature = "experimental-rust-tls")]
+            sni: None,
         }
+    }
+
+    /// Publish this entry's future [`refresh_dns`](Self::refresh_dns)
+    /// resolutions into `sni`, so a TLS data circuit to the re-resolved
+    /// address still finds the operator-supplied hostname.
+    #[cfg(feature = "experimental-rust-tls")]
+    pub fn with_sni(mut self, sni: std::sync::Arc<SniOverrides>) -> Self {
+        self.sni = Some(sni);
+        self
     }
 
     /// Re-resolve the hostname (if any) and return the freshened
@@ -4821,6 +4841,12 @@ impl AddrEntry {
         };
         let new_sock = resolve_host(host, self.port)?;
         self.sock = new_sock;
+        // The one place a tracked hostname is ever resolved, so the SNI
+        // registry row can never lag the address actually being dialed.
+        #[cfg(feature = "experimental-rust-tls")]
+        if let Some(sni) = &self.sni {
+            sni.record_resolution(host, new_sock);
+        }
         Ok(new_sock)
     }
 }
@@ -5303,6 +5329,66 @@ fn expand_shell_vars(s: &str) -> String {
     out
 }
 
+/// Live SNI / cert-verification-name registry, shared between the
+/// transport manager (reader, one [`SniOverrides::lookup`] per TLS
+/// connect) and every nameserver [`AddrEntry::refresh_dns`] (writer,
+/// one [`SniOverrides::record_resolution`] per successful re-resolve).
+///
+/// Two layers, one meaning each:
+/// - `static_map` — operator-pinned `EPICS_CA_TLS_SNI_MAP` rows,
+///   immutable for the client's lifetime (exact `ip:port` keys plus
+///   `port == 0` wildcard rows).
+/// - `nameservers` — hostname → *current* DNS resolution, one row per
+///   `EPICS_CA_NAME_SERVERS` entry given by name. Keyed by hostname,
+///   not by resolved address, so a nameserver that moves behind a
+///   stable DNS name cannot leave a stale address key behind: the same
+///   `refresh_dns` that redials the new address rewrites the row.
+///   (Replaces the startup-frozen `SocketAddr`-keyed snapshot — the
+///   epics-base#488 residual that lost a moved nameserver's SNI
+///   override until client restart.)
+#[cfg(feature = "experimental-rust-tls")]
+#[derive(Debug, Default)]
+pub(crate) struct SniOverrides {
+    static_map: std::collections::HashMap<SocketAddr, String>,
+    nameservers: parking_lot::Mutex<std::collections::HashMap<String, SocketAddr>>,
+}
+
+#[cfg(feature = "experimental-rust-tls")]
+impl SniOverrides {
+    fn new(
+        static_map: std::collections::HashMap<SocketAddr, String>,
+        nameservers: impl IntoIterator<Item = (String, SocketAddr)>,
+    ) -> Self {
+        Self {
+            static_map,
+            nameservers: parking_lot::Mutex::new(nameservers.into_iter().collect()),
+        }
+    }
+
+    /// Resolve the SNI name for `addr`. Precedence is that of the
+    /// snapshot map this replaces: exact `EPICS_CA_TLS_SNI_MAP` row,
+    /// then a nameserver whose current resolution is `addr`, then the
+    /// wildcard (`port == 0`) map row.
+    pub(crate) fn lookup(&self, addr: SocketAddr) -> Option<String> {
+        if let Some(h) = self.static_map.get(&addr) {
+            return Some(h.clone());
+        }
+        if let Some((host, _)) = self
+            .nameservers
+            .lock()
+            .iter()
+            .find(|(_, sock)| **sock == addr)
+        {
+            return Some(host.clone());
+        }
+        self.static_map.get(&SocketAddr::new(addr.ip(), 0)).cloned()
+    }
+
+    fn record_resolution(&self, hostname: &str, sock: SocketAddr) {
+        self.nameservers.lock().insert(hostname.to_string(), sock);
+    }
+}
+
 /// Parse `EPICS_CA_TLS_SNI_MAP` — whitespace-separated `IP[:port]=hostname`
 /// entries. Returns a vec of `(SocketAddr, hostname)` pairs ready to
 /// merge into the per-server SNI override map.
@@ -5652,6 +5738,60 @@ mod tls_sni_config_tests {
         assert!(cfg.tls_server_name.is_none(), "default must be None");
         cfg.tls_server_name = Some("ioc.example.com".into());
         assert_eq!(cfg.tls_server_name.as_deref(), Some("ioc.example.com"));
+    }
+
+    /// epics-base#488 residual: the SNI row must follow the hostname,
+    /// not the address it resolved to at startup. `refresh_dns` — the
+    /// one place a tracked hostname is resolved — rewrites the row, so
+    /// a TLS circuit to the moved nameserver's new address still gets
+    /// its hostname and the stale address stops matching.
+    #[cfg(feature = "experimental-rust-tls")]
+    #[test]
+    fn a_moved_nameserver_keeps_its_sni_override() {
+        let stale: SocketAddr = "192.0.2.1:5064".parse().unwrap();
+        let sni = std::sync::Arc::new(SniOverrides::new(
+            std::collections::HashMap::new(),
+            [("localhost".to_string(), stale)],
+        ));
+        assert_eq!(sni.lookup(stale).as_deref(), Some("localhost"));
+
+        // The nameserver task's redial path: refresh through the entry.
+        let mut entry = AddrEntry::new(stale, Some("localhost".into()), 5064).with_sni(sni.clone());
+        let fresh = entry.refresh_dns().expect("localhost resolves");
+        assert_ne!(fresh, stale, "precondition: the resolution moved");
+        assert_eq!(sni.lookup(fresh).as_deref(), Some("localhost"));
+        assert_eq!(
+            sni.lookup(stale),
+            None,
+            "hostname-keyed row must not leave the startup address behind"
+        );
+    }
+
+    /// Precedence of the snapshot map this registry replaces: exact
+    /// static row, then live nameserver binding, then wildcard row.
+    #[cfg(feature = "experimental-rust-tls")]
+    #[test]
+    fn static_sni_rows_win_and_wildcard_comes_last() {
+        let pinned: SocketAddr = "10.0.0.1:5064".parse().unwrap();
+        let sni = SniOverrides::new(
+            [
+                (pinned, "pin.example.com".to_string()),
+                (
+                    "10.0.0.1:0".parse().unwrap(),
+                    "wild.example.com".to_string(),
+                ),
+            ]
+            .into(),
+            [("ns.example.com".to_string(), pinned)],
+        );
+        // Exact static row beats the nameserver binding for the same addr.
+        assert_eq!(sni.lookup(pinned).as_deref(), Some("pin.example.com"));
+        // No exact row, no binding at this port → wildcard row.
+        assert_eq!(
+            sni.lookup("10.0.0.1:5065".parse().unwrap()).as_deref(),
+            Some("wild.example.com")
+        );
+        assert_eq!(sni.lookup("10.0.0.2:5064".parse().unwrap()), None);
     }
 }
 

--- a/crates/epics-ca-rs/src/client/search.rs
+++ b/crates/epics-ca-rs/src/client/search.rs
@@ -660,8 +660,10 @@ impl SearchTransport {
     /// fanned to nobody, and retried forever. That is a configuration error
     /// and it fails here — before any task is spawned — rather than
     /// presenting as every channel timing out.
-    fn name_servers_only(nameserver_addrs: &[SocketAddr]) -> epics_base_rs::error::CaResult<Self> {
-        if nameserver_addrs.is_empty() {
+    fn name_servers_only(
+        nameserver_entries: &[super::AddrEntry],
+    ) -> epics_base_rs::error::CaResult<Self> {
+        if nameserver_entries.is_empty() {
             return Err(epics_base_rs::error::CaError::InvalidValue(
                 "name-servers-only search engine requires a non-empty \
                  EPICS_CA_NAME_SERVERS: with no UDP socket and no name server \
@@ -907,7 +909,7 @@ impl SearchTransport {
 /// silently never resolved one reachable by broadcast alone.
 pub(crate) async fn run_search_engine(
     addr_list: Vec<super::AddrEntry>,
-    nameserver_addrs: Vec<SocketAddr>,
+    nameserver_entries: Vec<super::AddrEntry>,
     request_rx: mpsc::UnboundedReceiver<SearchRequest>,
     response_tx: mpsc::UnboundedSender<SearchResponse>,
     attempts: SearchAttempts,
@@ -917,7 +919,7 @@ pub(crate) async fn run_search_engine(
     };
     run_engine(
         transport,
-        nameserver_addrs,
+        nameserver_entries,
         request_rx,
         response_tx,
         attempts,
@@ -965,15 +967,15 @@ pub(crate) async fn run_search_engine(
     )
 )]
 pub(crate) fn name_servers_only_search_engine(
-    nameserver_addrs: Vec<SocketAddr>,
+    nameserver_entries: Vec<super::AddrEntry>,
     request_rx: mpsc::UnboundedReceiver<SearchRequest>,
     response_tx: mpsc::UnboundedSender<SearchResponse>,
     attempts: SearchAttempts,
 ) -> epics_base_rs::error::CaResult<impl std::future::Future<Output = ()> + Send + 'static> {
-    let transport = SearchTransport::name_servers_only(&nameserver_addrs)?;
+    let transport = SearchTransport::name_servers_only(&nameserver_entries)?;
     Ok(run_engine(
         transport,
-        nameserver_addrs,
+        nameserver_entries,
         request_rx,
         response_tx,
         attempts,
@@ -982,7 +984,7 @@ pub(crate) fn name_servers_only_search_engine(
 
 async fn run_engine(
     mut transport: SearchTransport,
-    nameserver_addrs: Vec<SocketAddr>,
+    nameserver_entries: Vec<super::AddrEntry>,
     mut request_rx: mpsc::UnboundedReceiver<SearchRequest>,
     response_tx: mpsc::UnboundedSender<SearchResponse>,
     attempts: SearchAttempts,
@@ -1007,12 +1009,12 @@ async fn run_engine(
         .unwrap_or(256)
         .max(8);
     let mut nameserver_send_txs: Vec<mpsc::Sender<Vec<u8>>> = Vec::new();
-    for addr in nameserver_addrs {
+    for entry in nameserver_entries {
         let (tx, rx) = mpsc::channel::<Vec<u8>>(ns_queue_cap);
         nameserver_send_txs.push(tx);
         let resp_tx = tcp_response_tx.clone();
         epics_base_rs::runtime::task::spawn(async move {
-            run_nameserver_connection(addr, rx, resp_tx).await;
+            run_nameserver_connection(entry, rx, resp_tx).await;
         });
     }
 
@@ -1144,12 +1146,47 @@ async fn run_engine(
 /// port's 5 s connect cap plus 1→30 s exponential backoff diverged in
 /// both directions: it abandoned a slow-but-live name server C would have
 /// reached, and it hammered a down one far harder than C does.
+///
+/// One deliberate deviation from that rule: C redials the address it
+/// resolved at startup forever, so a name server that moves behind a
+/// stable DNS name is lost until client restart (the epics-base#488
+/// family, which C fixed for neither list). The entry arrives here as an
+/// [`AddrEntry`](super::AddrEntry) and every redial re-resolves its
+/// hostname first — the same deviation, same primitive, and same
+/// keep-cached-IP-on-failure policy as the `EPICS_CA_ADDR_LIST` refresh
+/// (`SearchTransport::refresh_dns`). Literal-IP entries re-resolve to
+/// themselves; the extra lookup per redial is bounded by the CONN_TMO
+/// cadence.
 async fn run_nameserver_connection(
-    addr: SocketAddr,
+    mut entry: super::AddrEntry,
     mut outgoing_rx: mpsc::Receiver<Vec<u8>>,
     response_tx: mpsc::UnboundedSender<ParsedDatagram>,
 ) {
     loop {
+        let prev_sock = entry.sock;
+        let addr = match entry.refresh_dns() {
+            Ok(new_sock) => {
+                if new_sock != prev_sock {
+                    tracing::info!(
+                        target: "epics_ca_rs::client::search",
+                        hostname = ?entry.hostname,
+                        old = %prev_sock,
+                        new = %new_sock,
+                        "ca-rs: EPICS_CA_NAME_SERVERS entry re-resolved"
+                    );
+                }
+                new_sock
+            }
+            Err(e) => {
+                tracing::debug!(
+                    target: "epics_ca_rs::client::search",
+                    hostname = ?entry.hostname,
+                    error = %e,
+                    "ca-rs: name-server DNS refresh failed; keeping cached IP"
+                );
+                entry.sock
+            }
+        };
         // The client's one dial (`transport::dial_ca`), which is also what
         // decides the transport: on a target with no reactor this circuit
         // comes up on the same two pump threads an upstream circuit does. The
@@ -2161,6 +2198,12 @@ fn build_search_payload(cid: u32, pv_name: &str) -> Vec<u8> {
 mod tests {
     use super::*;
 
+    /// A literal-IP name-server entry — what every test here configures;
+    /// `refresh_dns` is a no-op for it.
+    fn ns_entry(addr: SocketAddr) -> crate::client::AddrEntry {
+        crate::client::AddrEntry::new(addr, None, addr.port())
+    }
+
     /// C `getNTimers` (`udpiiu.cpp:96-111`) caps the search-timer ladder at 18
     /// rungs, so the effective ceiling on `EPICS_CA_MAX_SEARCH_PERIOD` is
     /// `(1 << 17) * 32e-3 == 4194.304 s` and the boundary sits at
@@ -2388,7 +2431,8 @@ mod tests {
     fn name_servers_only_drops_address_list_mutations() {
         let mut state = SearchEngineState::new();
         let ns: SocketAddr = "127.0.0.1:5064".parse().unwrap();
-        let mut transport = SearchTransport::name_servers_only(&[ns]).expect("non-empty NS list");
+        let mut transport =
+            SearchTransport::name_servers_only(&[ns_entry(ns)]).expect("non-empty NS list");
         let a: SocketAddr = "10.0.0.7:5064".parse().unwrap();
 
         handle_request_or_addr(&mut state, &mut transport, SearchRequest::AddAddress(a));
@@ -3107,6 +3151,37 @@ mod tests {
     /// type and is additionally covered by
     /// `name_servers_only_drops_address_list_mutations`, which runs in both
     /// configurations.
+    /// epics-base#488 for `EPICS_CA_NAME_SERVERS`: the dial must use the
+    /// entry's *current* DNS resolution, not the one cached at startup.
+    /// The entry's cached sock points at TEST-NET-1 (unroutable), the
+    /// hostname still names this host — only a redial that re-resolves
+    /// can reach the listener. Pre-fix, the circuit redialled the cached
+    /// `SocketAddr` forever and this accept times out.
+    #[cfg(not(feature = "rtems-exec-model"))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_nameserver_dial_uses_the_fresh_dns_resolution() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener bind");
+        let port = listener.local_addr().expect("listener addr").port();
+        let stale = crate::client::AddrEntry::new(
+            SocketAddr::from(([192, 0, 2, 1], port)),
+            Some("localhost".into()),
+            port,
+        );
+        let (_out_tx, out_rx) = mpsc::channel::<Vec<u8>>(8);
+        let (resp_tx, _resp_rx) = mpsc::unbounded_channel();
+        let circuit = tokio::spawn(run_nameserver_connection(stale, out_rx, resp_tx));
+        let accepted =
+            tokio::time::timeout(std::time::Duration::from_secs(10), listener.accept()).await;
+        circuit.abort();
+        assert!(
+            accepted.is_ok(),
+            "the name-server circuit dialled the stale startup resolution \
+             instead of re-resolving the hostname"
+        );
+    }
+
     #[cfg(not(feature = "rtems-exec-model"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[serial_test::serial]
@@ -3147,7 +3222,7 @@ mod tests {
         let ns_addr = ns_listener.local_addr().expect("mock name-server addr");
 
         assert!(
-            SearchTransport::name_servers_only(&[ns_addr])
+            SearchTransport::name_servers_only(&[ns_entry(ns_addr)])
                 .expect("non-empty name-server list")
                 .bound_udp_addrs()
                 .is_empty(),
@@ -3185,7 +3260,7 @@ mod tests {
         let (req_tx, req_rx) = mpsc::unbounded_channel();
         let (resp_tx, mut resp_rx) = mpsc::unbounded_channel();
         let engine = name_servers_only_search_engine(
-            vec![ns_addr],
+            vec![ns_entry(ns_addr)],
             req_rx,
             resp_tx,
             std::sync::Arc::new(dashmap::DashMap::new()),
@@ -3295,7 +3370,7 @@ mod tests {
         let (_req_tx, req_rx) = mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = mpsc::unbounded_channel();
         let engine = name_servers_only_search_engine(
-            vec![ns_addr],
+            vec![ns_entry(ns_addr)],
             req_rx,
             resp_tx,
             std::sync::Arc::new(dashmap::DashMap::new()),
@@ -3381,7 +3456,7 @@ mod tests {
         let (_req_tx, req_rx) = mpsc::unbounded_channel();
         let (resp_tx, _resp_rx) = mpsc::unbounded_channel();
         let engine = name_servers_only_search_engine(
-            vec![ns_addr],
+            vec![ns_entry(ns_addr)],
             req_rx,
             resp_tx,
             std::sync::Arc::new(dashmap::DashMap::new()),
@@ -3479,7 +3554,7 @@ mod tests {
         let (req_tx, req_rx) = mpsc::unbounded_channel();
         let (resp_tx, mut resp_rx) = mpsc::unbounded_channel();
         let engine = name_servers_only_search_engine(
-            vec![ns_addr],
+            vec![ns_entry(ns_addr)],
             req_rx,
             resp_tx,
             std::sync::Arc::new(dashmap::DashMap::new()),
@@ -3588,7 +3663,7 @@ mod tests {
         // that path actually uses — and binds no socket for a pure
         // state-ordering test.
         let mut transport =
-            SearchTransport::name_servers_only(&[server_a]).expect("non-empty NS list");
+            SearchTransport::name_servers_only(&[ns_entry(server_a)]).expect("non-empty NS list");
         let (resp_tx, mut resp_rx) = mpsc::unbounded_channel::<SearchResponse>();
         let (req_tx, mut req_rx) = mpsc::unbounded_channel::<SearchRequest>();
 

--- a/crates/epics-ca-rs/src/client/transport.rs
+++ b/crates/epics-ca-rs/src/client/transport.rs
@@ -1268,13 +1268,14 @@ pub(crate) async fn run_transport_manager(
     client_identity: super::types::ClientIdentitySlot,
     #[cfg(feature = "experimental-rust-tls")] tls: Option<ClientTlsConfig>,
     #[cfg(feature = "experimental-rust-tls")] tls_server_name: Option<String>,
-    // Per-server SNI / cert-verification overrides built from the
-    // hostname half of EPICS_CA_NAME_SERVERS=host:port entries.
-    // Looked up per connect_server call so each TLS handshake uses
-    // the operator-supplied DNS name for that specific peer; falls
-    // back to tls_server_name (the global override), then the IP
-    // literal. Empty when no name servers were given by hostname.
-    #[cfg(feature = "experimental-rust-tls")] sni_overrides: HashMap<SocketAddr, String>,
+    // Per-server SNI / cert-verification overrides: the static
+    // EPICS_CA_TLS_SNI_MAP rows plus the *live* resolution of every
+    // EPICS_CA_NAME_SERVERS hostname (re-keyed by each entry's own
+    // `refresh_dns`). Looked up per connect_server call so each TLS
+    // handshake uses the operator-supplied DNS name for that specific
+    // peer; falls back to tls_server_name (the global override), then
+    // the IP literal.
+    #[cfg(feature = "experimental-rust-tls")] sni_overrides: std::sync::Arc<super::SniOverrides>,
 ) {
     // circuits are keyed by `(SocketAddr, priority)`, so two
     // channels to the same IOC at different priorities own independent
@@ -1317,25 +1318,21 @@ pub(crate) async fn run_transport_manager(
     let (circuit_dead_tx, mut circuit_dead_rx) = mpsc::unbounded_channel::<CircuitKey>();
 
     // Helper: resolve the right SNI / cert-verification name for a
-    // particular target address. Lookup order:
-    //   1. Exact (ip:port) match — EPICS_CA_NAME_SERVERS hostname or
-    //      EPICS_CA_TLS_SNI_MAP "ip:port=host" entry.
-    //   2. Wildcard (ip:0) match — EPICS_CA_TLS_SNI_MAP "ip=host"
+    // particular target address. Lookup order (`SniOverrides::lookup`):
+    //   1. Exact (ip:port) EPICS_CA_TLS_SNI_MAP "ip:port=host" row.
+    //   2. An EPICS_CA_NAME_SERVERS hostname whose *current* DNS
+    //      resolution is this address.
+    //   3. Wildcard (ip:0) match — EPICS_CA_TLS_SNI_MAP "ip=host"
     //      entry (any port). lets operators map an IOC's IP
     //      once and have it apply to every port the search engine
     //      finds it on.
-    //   3. Global EPICS_CA_TLS_SERVER_NAME fallback.
-    //   4. (Caller's last fallback) IP literal as SNI.
+    //   4. Global EPICS_CA_TLS_SERVER_NAME fallback.
+    //   5. (Caller's last fallback) IP literal as SNI.
     #[cfg(feature = "experimental-rust-tls")]
     let pick_sni = |addr: SocketAddr| -> Option<String> {
-        if let Some(h) = sni_overrides.get(&addr) {
-            return Some(h.clone());
-        }
-        let wildcard = SocketAddr::new(addr.ip(), 0);
-        if let Some(h) = sni_overrides.get(&wildcard) {
-            return Some(h.clone());
-        }
-        tls_server_name.clone()
+        sni_overrides
+            .lookup(addr)
+            .or_else(|| tls_server_name.clone())
     };
 
     loop {
@@ -5542,7 +5539,7 @@ mod priority_circuit_tests {
             identity,
             None,
             None,
-            HashMap::new(),
+            std::sync::Arc::new(crate::client::SniOverrides::default()),
         ));
         (cmd_tx, event_rx, observable)
     }
@@ -5844,7 +5841,7 @@ mod circuit_retirement_tests {
             identity,
             None,
             None,
-            std::collections::HashMap::new(),
+            std::sync::Arc::new(crate::client::SniOverrides::default()),
         ));
         (cmd_tx, event_rx, observable)
     }

--- a/crates/epics-ca-rs/src/discovery/mod.rs
+++ b/crates/epics-ca-rs/src/discovery/mod.rs
@@ -47,7 +47,7 @@ pub use dns_update::{DnsRegistration, DnsUpdater, TsigAlgo, TsigKey};
 #[cfg(feature = "discovery")]
 pub use dnssd::DnsSdBackend;
 #[cfg(feature = "discovery")]
-pub use mdns::MdnsBackend;
+pub use mdns::{MdnsAnnouncer, MdnsBackend};
 #[cfg(feature = "discovery")]
 pub use zone::ZoneSnippet;
 

--- a/crates/epics-ca-rs/src/server/ca_server.rs
+++ b/crates/epics-ca-rs/src/server/ca_server.rs
@@ -512,6 +512,12 @@ impl CaServer {
     /// TCP override (`EPICS_CAS_SERVER_PORT`); pass `None` to share the
     /// UDP discovery port with the TCP listener.
     ///
+    /// `acf` is the IOC's live policy cell, ADOPTED rather than
+    /// re-created: the runner passes `IocRunConfig.acf` so this server,
+    /// the sibling PVA/QSRV servers, and the iocsh `asInit` command all
+    /// gate on one cell. A standalone caller creates its own with
+    /// [`epics_base_rs::server::access_security::new_acf_cell`].
+    ///
     /// Binds the TCP and UDP sockets, exactly as
     /// [`CaServerBuilder::build`] does — the returned server is already
     /// listening, and a bind failure is reported here rather than from
@@ -520,7 +526,7 @@ impl CaServer {
         db: Arc<PvDatabase>,
         port: u16,
         tcp_port: Option<u16>,
-        acf: Option<access_security::AccessSecurityConfig>,
+        acf: epics_base_rs::server::access_security::AcfCell,
         autosave_config: Option<autosave::SaveSetConfig>,
         autosave_manager: Option<Arc<autosave::AutosaveManager>>,
     ) -> CaResult<Self> {
@@ -540,7 +546,7 @@ impl CaServer {
             tcp,
             udp,
             stats,
-            acf: epics_base_rs::server::access_security::new_acf_cell(acf),
+            acf,
             acf_source_path: std::sync::Mutex::new(None),
             acf_reload_tx,
             autosave_config,
@@ -787,6 +793,7 @@ impl CaServer {
         F: FnOnce(&iocsh::IocShell) + Send + 'static,
     {
         let db = self.db.clone();
+        let acf = self.acf.clone();
         let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
 
         let autosave_cmds = self
@@ -802,7 +809,9 @@ impl CaServer {
 
         let (tx, rx) = epics_base_rs::runtime::sync::oneshot::channel();
         std::thread::spawn(move || {
-            let shell = iocsh::IocShell::new(db, bridge);
+            // The shell administers this server's live policy cell so an
+            // interactive `asInit` is a real ACF (re)load, not a dead-end.
+            let shell = iocsh::IocShell::new_with_acf(db, bridge, acf);
             register_fn(&shell);
             if let Some(cmds) = autosave_cmds {
                 for cmd in cmds {
@@ -1413,9 +1422,16 @@ mod access_notifier_tests {
 
     async fn empty_server() -> CaServer {
         let db = Arc::new(PvDatabase::new());
-        CaServer::from_parts(db, 0, None, None, None, None)
-            .await
-            .expect("bind ephemeral server")
+        CaServer::from_parts(
+            db,
+            0,
+            None,
+            epics_base_rs::server::access_security::new_acf_cell(None),
+            None,
+            None,
+        )
+        .await
+        .expect("bind ephemeral server")
     }
 
     // The detachable handle must keep firing after the CaServer value is

--- a/crates/epics-ca-rs/tests/acf_hot_reload.rs
+++ b/crates/epics-ca-rs/tests/acf_hot_reload.rs
@@ -38,9 +38,16 @@ async fn reload_acf_swaps_in_new_rules() {
 
     // No source path → reload_acf_from must work but reload_acf would
     // fail on a server constructed without acf_file.
-    let bare = CaServer::from_parts(server.database().clone(), 0, None, None, None, None)
-        .await
-        .expect("build bare server");
+    let bare = CaServer::from_parts(
+        server.database().clone(),
+        0,
+        None,
+        epics_base_rs::server::access_security::new_acf_cell(None),
+        None,
+        None,
+    )
+    .await
+    .expect("build bare server");
     assert!(bare.reload_acf().await.is_err());
     assert!(
         bare.reload_acf_from(acf_path.to_str().unwrap())

--- a/crates/epics-oracle-rs/src/bin/oracle_ioc.rs
+++ b/crates/epics-oracle-rs/src/bin/oracle_ioc.rs
@@ -144,7 +144,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Port 0 => the kernel assigns; `from_parts` binds first and reports the
     // port it actually bound. This is the bind-and-read-back the harness
     // requires, not a probe-then-rebind.
-    let server = CaServer::from_parts(db, 0, None, None, None, None).await?;
+    let server = CaServer::from_parts(
+        db,
+        0,
+        None,
+        epics_base_rs::server::access_security::new_acf_cell(None),
+        None,
+        None,
+    )
+    .await?;
     let port = server.udp_port();
 
     // Announce only after the sockets exist. The harness blocks on this line,
@@ -176,7 +184,13 @@ async fn serve_pva(
     // Same reasoning as the CA path: scanning is core-owned (C iocInit),
     // not the PVA server's — the harness's Scanned drive records need it.
     let _scan_owner = epics_base_rs::server::scan::ScanOwner::start(db.clone());
-    let server = PvaServer::from_parts(db, 0, None, None, None);
+    let server = PvaServer::from_parts(
+        db,
+        0,
+        epics_base_rs::server::access_security::new_acf_cell(None),
+        None,
+        None,
+    );
 
     // Announce from a side task rather than by racing the server future: a
     // healthy `run_reporting` never returns, and selecting on it would drop

--- a/crates/epics-pva-rs/src/client_native/channel.rs
+++ b/crates/epics-pva-rs/src/client_native/channel.rs
@@ -815,19 +815,19 @@ impl Channel {
                     // otherwise this is a fresh resolve and `Initial`
                     // earns the immediate broadcast for fast first-attempt
                     // latency.
-                    let reason = if self
+                    let reason = if researched_after_refusal {
+                        // A refused CREATE_CHANNEL usually recurs on retry, so
+                        // the re-search parks in the furthest future bucket —
+                        // one ring revolution, ~30 s — instead of riding the
+                        // ≤1 s tick (pvxs 084336bb, `clientconn.cpp:376-381`).
+                        // With the previous Reconnect placement a server that
+                        // answered SEARCH instantly and then refused CREATE was
+                        // re-asked about once a second, forever.
+                        super::search_engine::SearchReason::CreateRefused
+                    } else if self
                         .has_been_active
                         .load(std::sync::atomic::Ordering::Relaxed)
-                        || researched_after_refusal
                     {
-                        // Force the bucket-paced Reconnect search once we have
-                        // re-searched after a refusal, even on a channel that was
-                        // never Active: pvxs re-pushes the refused channel into the
-                        // current search bucket (clientconn.cpp:373-377), so the
-                        // re-search rides the ≤1 s tick instead of an immediate
-                        // Initial broadcast. Otherwise a server that answers SEARCH
-                        // instantly and then refuses CREATE would spin this loop
-                        // with no pacing.
                         super::search_engine::SearchReason::Reconnect
                     } else {
                         super::search_engine::SearchReason::Initial
@@ -981,9 +981,9 @@ impl Channel {
             // Every candidate failed. A searched CREATE_CHANNEL refusal is a
             // channel-state transition back to Searching, not a terminal op error:
             // re-enter the search ring and keep the waiting operation pending
-            // (pvxs clientconn.cpp:368-378). The next pass clears nothing extra —
-            // `alternatives` is already drained — and issues a Reconnect search
-            // that rides the ≤1 s bucket tick.
+            // (pvxs clientconn.cpp:368-381). The next pass clears nothing extra —
+            // `alternatives` is already drained — and issues a CreateRefused
+            // search parked one full ring revolution out (pvxs 084336bb).
             if refusal_reenters_search(last_failure, saw_connect_failure, is_direct) {
                 researched_after_refusal = true;
                 continue;

--- a/crates/epics-pva-rs/src/client_native/search_engine.rs
+++ b/crates/epics-pva-rs/src/client_native/search_engine.rs
@@ -165,6 +165,14 @@ pub enum SearchReason {
     /// server sent CMD_DESTROY_CHANNEL). pvxs-equivalent recovery
     /// path — see the type-level comment.
     Reconnect,
+    /// The server answered the SEARCH and then refused CREATE_CHANNEL.
+    /// The refusal will often recur on retry (a QSRV field that cannot
+    /// be served, an ACL deny), so the re-search is parked in the
+    /// furthest future bucket — one full ring revolution, ~30 s — rather
+    /// than the current one (pvxs 084336bb, `clientconn.cpp:376-381`).
+    /// Riding the current bucket here is what produced a ~1 s
+    /// SEARCH → CREATE → refuse loop against the same server, forever.
+    CreateRefused,
 }
 
 pub enum SearchCommand {
@@ -1252,6 +1260,11 @@ fn placement_bucket(current_bucket: usize, reason: SearchReason) -> usize {
     match reason {
         SearchReason::Initial => (current_bucket + 1) % N_SEARCH_BUCKETS,
         SearchReason::Reconnect => current_bucket,
+        // pvxs 084336bb: `laterBucket = currentBucket ? currentBucket - 1
+        // : nBuckets - 1` — the furthest future bucket, so a refusal that
+        // will recur is retried once per ring revolution (~30 s), not
+        // once per tick.
+        SearchReason::CreateRefused => (current_bucket + N_SEARCH_BUCKETS - 1) % N_SEARCH_BUCKETS,
     }
 }
 
@@ -4393,6 +4406,27 @@ mod tests {
             0,
             "wrap-around at ring boundary"
         );
+    }
+
+    /// pvxs 084336bb: a refused CREATE_CHANNEL parks the re-search in
+    /// the furthest future bucket (`currentBucket ? currentBucket - 1 :
+    /// nBuckets - 1`) — a full ring revolution, ~30 s — so a refusal
+    /// that recurs is not re-asked once per tick. Wrap-around at
+    /// bucket 0 is the boundary the pvxs ternary exists for.
+    #[test]
+    fn placement_create_refused_is_the_furthest_bucket_with_wraparound() {
+        assert_eq!(
+            placement_bucket(0, SearchReason::CreateRefused),
+            N_SEARCH_BUCKETS - 1,
+            "wrap-around at ring boundary"
+        );
+        for current in 1..N_SEARCH_BUCKETS {
+            assert_eq!(
+                placement_bucket(current, SearchReason::CreateRefused),
+                current - 1,
+                "CreateRefused must park one full revolution out (got {current})"
+            );
+        }
     }
 
     /// pvxs `tickSearch` (client.cpp:1193-1196) escalates the retry

--- a/crates/epics-pva-rs/src/format.rs
+++ b/crates/epics-pva-rs/src/format.rs
@@ -1374,7 +1374,7 @@ fn tree_show(
         || (!sv && matches!(desc, FieldDesc::UnionArray { .. }));
 
     if inline {
-        tree_show_inline(out, desc, value, fmt, depth);
+        tree_show_inline(out, desc, value, member, fmt, depth);
     } else if braced {
         tree_show_braced(out, desc, value, member, fmt, depth);
     } else {
@@ -1406,16 +1406,21 @@ fn tree_show_value(out: &mut String, value: &PvField, fmt: &ValueFmt) {
 }
 
 /// pvxs Tree inline branch (datafmt.cpp:214-238): `any NAME = VAL` /
-/// `union NAME.MEM TYPE = VAL`. `member` and the type name have already been
-/// emitted by [`tree_show`].
+/// `union NAME.MEM TYPE = VAL`. The type name (and id) have already been
+/// emitted by [`tree_show`]; `member` is emitted here, before the union
+/// selector (datafmt.cpp:224-230).
 fn tree_show_inline(
     out: &mut String,
     desc: &FieldDesc,
     value: Option<&PvField>,
-    member_already_emitted: &ValueFmt,
+    member: &str,
+    fmt: &ValueFmt,
     depth: usize,
 ) {
-    let fmt = member_already_emitted;
+    if !member.is_empty() {
+        out.push(' ');
+        out.push_str(member);
+    }
     match desc {
         // (showValue is implied true for the Union inline branch.)
         FieldDesc::Union { variants, .. } => match value {
@@ -1855,6 +1860,89 @@ fn array_elements(desc: &FieldDesc, value: Option<&PvField>) -> Vec<(FieldDesc, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pvdata::VariantValue;
+
+    /// pvxs#46 residue: the Tree inline branch (`any` / `any[]` /
+    /// valued `union`) must emit the member name before the union
+    /// selector and value (datafmt.cpp:224-230). Pre-fix `pvinfo-rs`
+    /// printed `any` where pvxs prints `any parameters`.
+    #[test]
+    fn tree_inline_branch_keeps_the_member_name() {
+        let desc = FieldDesc::Structure {
+            struct_id: String::new(),
+            fields: vec![
+                ("parameters".into(), FieldDesc::Variant),
+                ("history".into(), FieldDesc::VariantArray),
+                (
+                    "u".into(),
+                    FieldDesc::Union {
+                        struct_id: String::new(),
+                        variants: vec![
+                            ("d".into(), FieldDesc::Scalar(ScalarType::Double)),
+                            ("i".into(), FieldDesc::Scalar(ScalarType::Int)),
+                        ],
+                    },
+                ),
+            ],
+        };
+
+        // Describe mode (show_value=false, pvinfo): `any`/`any[]` are
+        // inline; the union renders braced and is not asserted here.
+        let describe = ValueFmt {
+            format: ValueFormat::Tree,
+            array_limit: 0,
+            show_value: false,
+        };
+        let out = format_value(&desc, None, &describe, None, 0);
+        assert!(out.contains("any parameters\n"), "got: {out:?}");
+        assert!(out.contains("any[] history\n"), "got: {out:?}");
+
+        // Value mode (show_value=true): `any` and the valued `union`
+        // are inline; the union adds `.MEM` after the member name.
+        let mut s = PvStructure::new("");
+        s.set(
+            "parameters",
+            PvField::Variant(Box::new(VariantValue {
+                desc: Some(FieldDesc::Scalar(ScalarType::Int)),
+                value: PvField::Scalar(ScalarValue::Int(5)),
+            })),
+        );
+        s.set("history", PvField::VariantArray(Vec::new()));
+        s.set(
+            "u",
+            PvField::Union {
+                selector: 1,
+                variant_name: "i".into(),
+                value: Box::new(PvField::Scalar(ScalarValue::Int(7))),
+            },
+        );
+        let value_mode = ValueFmt {
+            format: ValueFormat::Tree,
+            array_limit: 0,
+            show_value: true,
+        };
+        let out = format_value(
+            &desc,
+            Some(&PvField::Structure(s.clone())),
+            &value_mode,
+            None,
+            0,
+        );
+        assert!(out.contains("any parameters int32_t = 5\n"), "got: {out:?}");
+        assert!(out.contains("union u.i int32_t = 7\n"), "got: {out:?}");
+
+        // Null-union boundary: member name, no selector, ` null`.
+        s.set(
+            "u",
+            PvField::Union {
+                selector: -1,
+                variant_name: String::new(),
+                value: Box::new(PvField::Null),
+            },
+        );
+        let out = format_value(&desc, Some(&PvField::Structure(s)), &value_mode, None, 0);
+        assert!(out.contains("union u null\n"), "got: {out:?}");
+    }
 
     fn nt_scalar_double(value: f64, sec: i64, nsec: i32) -> (FieldDesc, PvField) {
         let desc = FieldDesc::Structure {

--- a/crates/epics-pva-rs/src/server/native_source.rs
+++ b/crates/epics-pva-rs/src/server/native_source.rs
@@ -220,7 +220,7 @@ fn fill_nt_scalar(desc: &FieldDesc, snap: &Snapshot) -> PvField {
         set_leaf(
             &mut v,
             "display.description",
-            PvField::Scalar(ScalarValue::String(d.description.clone().into())),
+            PvField::Scalar(ScalarValue::String(d.description.clone())),
         );
         set_leaf(
             &mut v,
@@ -384,7 +384,7 @@ fn build_nt_enum(index: i32, snap: &Snapshot) -> PvField {
         .unwrap_or_default();
     display.fields.push((
         "description".into(),
-        PvField::Scalar(ScalarValue::String(description.into())),
+        PvField::Scalar(ScalarValue::String(description)),
     ));
 
     let mut s = PvStructure::new("epics:nt/NTEnum:1.0");

--- a/crates/epics-pva-rs/src/server/pva_server.rs
+++ b/crates/epics-pva-rs/src/server/pva_server.rs
@@ -117,17 +117,22 @@ impl PvaServer {
         PvaServerBuilder::new()
     }
 
+    /// `acf` is the IOC's live policy cell, ADOPTED rather than
+    /// re-created: a protocol runner passes `IocRunConfig.acf` so this
+    /// server, the sibling CA/QSRV servers, and the iocsh `asInit`
+    /// command all gate on one cell. A standalone caller creates its
+    /// own with [`epics_base_rs::server::access_security::new_acf_cell`].
     pub fn from_parts(
         db: Arc<PvDatabase>,
         port: u16,
-        acf: Option<access_security::AccessSecurityConfig>,
+        acf: epics_base_rs::server::access_security::AcfCell,
         autosave_config: Option<autosave::SaveSetConfig>,
         autosave_manager: Option<Arc<autosave::AutosaveManager>>,
     ) -> Self {
         Self {
             db,
             port: Some(port),
-            acf: epics_base_rs::server::access_security::new_acf_cell(acf),
+            acf,
             acl_version: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             autosave_config,
             autosave_manager,
@@ -295,6 +300,7 @@ impl PvaServer {
         F: FnOnce(&iocsh::IocShell) + Send + 'static,
     {
         let db = self.db.clone();
+        let acf = self.acf.clone();
         let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
 
         let autosave_cmds = self
@@ -312,7 +318,9 @@ impl PvaServer {
 
         let (tx, rx) = epics_base_rs::runtime::sync::oneshot::channel();
         std::thread::spawn(move || {
-            let shell = iocsh::IocShell::new(db, bridge);
+            // Administer this server's live policy cell so an interactive
+            // `asInit` is a real ACF (re)load, not a dead-end.
+            let shell = iocsh::IocShell::new_with_acf(db, bridge, acf);
             register_fn(&shell);
             if let Some(cmds) = autosave_cmds {
                 for cmd in cmds {
@@ -352,6 +360,7 @@ impl PvaServer {
         F: FnOnce(&iocsh::IocShell) + Send + 'static,
     {
         let db = self.db.clone();
+        let acf = self.acf.clone();
         let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
 
         let autosave_cmds = self
@@ -371,7 +380,9 @@ impl PvaServer {
 
         let (tx, rx) = epics_base_rs::runtime::sync::oneshot::channel();
         std::thread::spawn(move || {
-            let shell = iocsh::IocShell::new(db, bridge);
+            // Same as `run_with_shell`: the shell administers this
+            // server's live policy cell.
+            let shell = iocsh::IocShell::new_with_acf(db, bridge, acf);
             register_fn(&shell);
             if let Some(cmds) = autosave_cmds {
                 for cmd in cmds {
@@ -422,7 +433,13 @@ mod tests {
     #[tokio::test]
     async fn ephemeral_port_zero_reports_both_bound_ports() {
         let db = Arc::new(PvDatabase::new());
-        let server = PvaServer::from_parts(db, 0, None, None, None);
+        let server = PvaServer::from_parts(
+            db,
+            0,
+            epics_base_rs::server::access_security::new_acf_cell(None),
+            None,
+            None,
+        );
 
         let (tx, mut rx) = watch::channel(None);
         let run = tokio::spawn(async move { server.run_reporting(Some(tx)).await });

--- a/crates/epics-pva-rs/src/server_native/accept.rs
+++ b/crates/epics-pva-rs/src/server_native/accept.rs
@@ -166,14 +166,23 @@ pub async fn run_tcp_server_on_listener(
                     // detection. We add OS keepalive (CA-libca style) so a
                     // pre-handshake half-open peer still gets reaped even
                     // before the application timer arms.
-                    {
+                    // Read `SO_SNDBUF` here, while the raw stream is still in
+                    // scope (the TLS accept below consumes it): the byte cap
+                    // on the connection's writer queue is
+                    // `SO_SNDBUF × TCP_TX_LIMIT_MULT`, pvxs `tcp_tx_limit`
+                    // (`serverconn.cpp:20,61`).
+                    let tx_limit_bytes = {
                         let sock = socket2::SockRef::from(&stream);
                         let keepalive = socket2::TcpKeepalive::new()
                             .with_time(std::time::Duration::from_secs(15))
                             .with_interval(std::time::Duration::from_secs(5));
                         let _ = sock.set_keepalive(true);
                         let _ = sock.set_tcp_keepalive(&keepalive);
-                    }
+                        match sock.send_buffer_size() {
+                            Ok(sz) if sz > 0 => sz.saturating_mul(super::tcp::TCP_TX_LIMIT_MULT),
+                            _ => super::tcp::TX_LIMIT_FALLBACK,
+                        }
+                    };
 
                     // TLS-NAMESERVER: peek the first byte to dispatch
                     // TLS vs plain PVA on a single port.
@@ -295,6 +304,7 @@ pub async fn run_tcp_server_on_listener(
                                             peer_entry: peer_entry.clone(),
                                             x509_identity: x509_id,
                                             channel_invalidator: conn_invalidator,
+                                            tx_limit_bytes,
                                         },
                                     )
                                     .await
@@ -327,6 +337,7 @@ pub async fn run_tcp_server_on_listener(
                                     peer_entry: peer_entry.clone(),
                                     x509_identity: None,
                                     channel_invalidator: conn_invalidator,
+                                    tx_limit_bytes,
                                 },
                             )
                             .await

--- a/crates/epics-pva-rs/src/server_native/blocking.rs
+++ b/crates/epics-pva-rs/src/server_native/blocking.rs
@@ -172,7 +172,7 @@ use super::search_engine::{
     Origin, SearchOutput, filter_inbound, process_search_datagram, random_guid,
 };
 use super::source::{ChannelInvalidator, DynSource};
-use super::tcp::{ConnInit, handle_connection_io};
+use super::tcp::{ConnInit, TCP_TX_LIMIT_MULT, TX_LIMIT_FALLBACK, handle_connection_io};
 use crate::error::{PvaError, PvaResult};
 
 /// The EPICS priority every PVA server thread runs at.
@@ -930,6 +930,7 @@ impl BlockingPvaServer {
             peer_entry,
             x509_identity: None,
             channel_invalidator: invalidator,
+            tx_limit_bytes: tx_limit_bytes(&stream),
         };
         conn_worker.run_detached(format!("PVA connection {peer}"), move || {
             let _lease = lease;
@@ -1032,6 +1033,39 @@ const UDP_RECV_BUF: usize = 64 * 1024;
 /// listing (`pvxlist`) that sees exactly the expected server.
 pub fn bind_udp_search(addr: SocketAddrV4) -> io::Result<UdpSocket> {
     bind_udp_search_socket(addr)
+}
+
+/// `SO_SNDBUF × TCP_TX_LIMIT_MULT` for an accepted socket — the byte cap
+/// pvxs applies to a connection's queued TX (`tcp_tx_limit`,
+/// `serverconn.cpp:20,61`). Raw `libc` rather than `socket2` for the same
+/// RTEMS reason as [`bind_udp_search`]; on a failed read the connection is
+/// served under [`TX_LIMIT_FALLBACK`] instead of refused as pvxs does.
+#[cfg(unix)]
+fn tx_limit_bytes(stream: &TcpStream) -> usize {
+    use std::os::fd::AsRawFd;
+    let mut val: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    // SAFETY: the fd is a valid open socket borrowed from `stream`; `val`
+    // and `len` outlive the call and `len` matches `val`'s size.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &mut val as *mut libc::c_int as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc == 0 && val > 0 {
+        (val as usize).saturating_mul(TCP_TX_LIMIT_MULT)
+    } else {
+        TX_LIMIT_FALLBACK
+    }
+}
+
+#[cfg(not(unix))]
+fn tx_limit_bytes(_stream: &TcpStream) -> usize {
+    TX_LIMIT_FALLBACK
 }
 
 #[cfg(unix)]
@@ -1498,6 +1532,7 @@ mod tests {
                         peer_entry: PeerEntry::new(false),
                         x509_identity: None,
                         channel_invalidator: ChannelInvalidator::new(),
+                        tx_limit_bytes: TX_LIMIT_FALLBACK,
                     },
                     &registry,
                 )
@@ -1813,6 +1848,7 @@ mod tests {
                 peer_entry: PeerEntry::new(false),
                 x509_identity: None,
                 channel_invalidator: ChannelInvalidator::new(),
+                tx_limit_bytes: TX_LIMIT_FALLBACK,
             },
             &ConnRegistry::new(),
         )

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -2955,18 +2955,160 @@ fn parse_client_credentials(
 /// and TLS-wrapped streams.
 type SrvRead = Box<dyn tokio::io::AsyncRead + Unpin + Send>;
 type SrvWrite = Box<dyn tokio::io::AsyncWrite + Unpin + Send>;
+/// pvxs bounds a connection's queued TX by *bytes*, not frames:
+/// `tcp_tx_limit = SO_SNDBUF × tcp_tx_limit_mult` with
+/// `tcp_tx_limit_mult = 2` (`serverconn.cpp:20,61`), and monitor
+/// replies are deferred once the output buffer reaches that limit
+/// (`servermon.cpp:123`, pvxs#161). The multiplier is shared with the
+/// drivers that read `SO_SNDBUF` at accept time.
+pub(super) const TCP_TX_LIMIT_MULT: usize = 2;
+
+/// Byte limit used when `SO_SNDBUF` cannot be read at accept time.
+/// pvxs throws and refuses the connection there; serving under a
+/// conservative fixed budget (2 × 256 KiB) is the deliberate
+/// deviation — a failed `getsockopt` is not worth a lost client.
+pub(super) const TX_LIMIT_FALLBACK: usize = TCP_TX_LIMIT_MULT * 256 * 1024;
+
+/// Byte budget for one connection's writer queue — the port of pvxs
+/// `tcp_tx_limit`. Producers acquire `clamp(len, 1..=limit)` permits
+/// before a frame may enter the queue; the writer task releases the
+/// same amount after the frame is written (or the connection dies).
+/// The clamp keeps a frame larger than the whole limit admissible —
+/// it charges the full budget and travels alone, exactly how pvxs
+/// admits one oversized monitor reply before suspending the rest.
+#[derive(Clone)]
+struct TxBudget {
+    sem: Arc<tokio::sync::Semaphore>,
+    limit: usize,
+}
+
+impl TxBudget {
+    /// Largest representable charge: `acquire_many` takes `u32`, and the
+    /// semaphore itself caps permits at `Semaphore::MAX_PERMITS`
+    /// (smaller than `u32::MAX` on 32-bit targets — this file compiles
+    /// for armv7 RTEMS through the blocking driver).
+    const MAX_CHARGE: usize = {
+        let sem_max = tokio::sync::Semaphore::MAX_PERMITS;
+        if sem_max < u32::MAX as usize {
+            sem_max
+        } else {
+            u32::MAX as usize
+        }
+    };
+
+    fn new(limit_bytes: usize) -> Self {
+        let limit = limit_bytes.clamp(1, Self::MAX_CHARGE);
+        Self {
+            sem: Arc::new(tokio::sync::Semaphore::new(limit)),
+            limit,
+        }
+    }
+
+    fn charge(&self, len: usize) -> u32 {
+        // ≤ self.limit ≤ MAX_CHARGE ≤ u32::MAX, so the cast is lossless.
+        len.clamp(1, self.limit) as u32
+    }
+
+    /// Take `len` bytes of budget, waiting while the queue is full.
+    /// `Err` means the budget was closed — the writer task is gone and
+    /// the frame can never be written.
+    async fn acquire(&self, len: usize) -> Result<(), ()> {
+        match self.sem.clone().acquire_many_owned(self.charge(len)).await {
+            Ok(permits) => {
+                permits.forget();
+                Ok(())
+            }
+            Err(_closed) => Err(()),
+        }
+    }
+
+    fn release(&self, len: usize) {
+        self.sem.add_permits(self.charge(len) as usize);
+    }
+}
+
+/// Closes the budget when the writer task's future is dropped — whether
+/// the loop broke on a write error/timeout or `AbortOnDrop` cancelled it
+/// at an await point. Without this, producers blocked in
+/// `TxBudget::acquire` would wait forever once the writer is gone: the
+/// mpsc receiver closing fails only senders that reach `tx.send`, not
+/// senders parked on the semaphore in front of it.
+struct TxBudgetCloseGuard(TxBudget);
+
+impl Drop for TxBudgetCloseGuard {
+    fn drop(&mut self) {
+        self.0.sem.close();
+    }
+}
+
 /// Per-connection write side. Producers (the main read loop — including
 /// its heartbeat arm — and the monitor subscribers) push fully-framed
 /// PVA messages into the
 /// channel; a single dedicated writer task drains it in arrival order.
 /// Replaces `Arc<Mutex<SrvWrite>>` so a slow client cannot block other
-/// producers waiting for the lock. The channel is *bounded* —
-/// `await`-style sends propagate backpressure all the way back to the
-/// monitor subscribers / read loop, so memory cannot grow unbounded
-/// when the client is slow. Errors on the write side drop the
-/// receiver; subsequent sends fail and the read loop independently
-/// observes the dead socket and tears down.
-type SrvTx = tokio::sync::mpsc::Sender<Vec<u8>>;
+/// producers waiting for the lock. The channel is bounded twice —
+/// by frame count (`write_queue_depth`) and by bytes ([`TxBudget`],
+/// pvxs `tcp_tx_limit`) — and `await`-style sends propagate
+/// backpressure all the way back to the monitor subscribers / read
+/// loop, so memory cannot grow unbounded when the client is slow.
+/// The frame-count bound alone was the defect: 1024 queued frames of
+/// arbitrary size is not a memory bound at all. Errors on the write
+/// side drop the receiver and close the budget; subsequent sends fail
+/// and the read loop independently observes the dead socket and tears
+/// down.
+#[derive(Clone)]
+struct SrvTx {
+    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+    budget: TxBudget,
+}
+
+impl SrvTx {
+    /// Build the writer-queue pair plus the budget handle the writer
+    /// task releases into.
+    fn channel(
+        depth: usize,
+        tx_limit_bytes: usize,
+    ) -> (Self, tokio::sync::mpsc::Receiver<Vec<u8>>, TxBudget) {
+        let (tx, rx) = tokio::sync::mpsc::channel(depth);
+        let budget = TxBudget::new(tx_limit_bytes);
+        (
+            Self {
+                tx,
+                budget: budget.clone(),
+            },
+            rx,
+            budget,
+        )
+    }
+
+    async fn send(&self, buf: Vec<u8>) -> Result<(), tokio::sync::mpsc::error::SendError<Vec<u8>>> {
+        if self.budget.acquire(buf.len()).await.is_err() {
+            return Err(tokio::sync::mpsc::error::SendError(buf));
+        }
+        let len = buf.len();
+        match self.tx.send(buf).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // The frame never entered the queue; hand its budget back
+                // so any producer racing the shutdown is not stuck short.
+                self.budget.release(len);
+                Err(e)
+            }
+        }
+    }
+
+    fn capacity(&self) -> usize {
+        self.tx.capacity()
+    }
+
+    fn max_capacity(&self) -> usize {
+        self.tx.max_capacity()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.tx.is_closed()
+    }
+}
 
 /// Connection writer handle bound to one channel's byte accounting.
 ///
@@ -3073,6 +3215,11 @@ pub(super) struct ConnInit {
     /// currently serves under that name with a server-initiated
     /// DESTROY_CHANNEL.
     pub(super) channel_invalidator: ChannelInvalidator,
+    /// Byte cap on this connection's queued-but-unwritten TX — pvxs
+    /// `tcp_tx_limit` (`serverconn.cpp:20,61`: `SO_SNDBUF ×`
+    /// [`TCP_TX_LIMIT_MULT`]). The driver reads the accepted socket's
+    /// `SO_SNDBUF` and multiplies; [`TX_LIMIT_FALLBACK`] when it cannot.
+    pub(super) tx_limit_bytes: usize,
 }
 
 pub(super) async fn handle_connection_io(
@@ -3087,6 +3234,7 @@ pub(super) async fn handle_connection_io(
         peer_entry,
         x509_identity,
         channel_invalidator,
+        tx_limit_bytes,
     } = init;
     let op_timeout = config.op_timeout;
     let idle_timeout = config.idle_timeout;
@@ -3107,10 +3255,14 @@ pub(super) async fn handle_connection_io(
     //    fails fast. Mirrors the parallel guard in `epics-ca-rs`'s
     //    server-side dispatch wrap (the CA G1 audit fix).
     let send_tmo = config.send_timeout;
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(config.write_queue_depth);
+    let (tx, mut rx, writer_budget) = SrvTx::channel(config.write_queue_depth, tx_limit_bytes);
     let writer_peer = peer;
     let peer_entry_writer = peer_entry.clone();
     let writer_task = epics_base_rs::runtime::task::spawn(async move {
+        // Dropping this guard — loop break OR abort at the `recv` await —
+        // closes the byte budget so producers parked in `TxBudget::acquire`
+        // fail instead of waiting on a writer that no longer exists.
+        let _budget_guard = TxBudgetCloseGuard(writer_budget.clone());
         while let Some(frame) = rx.recv().await {
             match epics_base_rs::runtime::task::timeout(send_tmo, writer_raw.write_all(&frame))
                 .await
@@ -3118,6 +3270,9 @@ pub(super) async fn handle_connection_io(
                 Ok(Ok(())) => {
                     // bytes_out counter for PvaServer::report().
                     peer_entry_writer.touch_tx(frame.len());
+                    // The frame left the queue for the socket buffer;
+                    // return its bytes to the TX budget.
+                    writer_budget.release(frame.len());
                 }
                 Ok(Err(e)) => {
                     debug!(peer = ?writer_peer, error = %e, "writer task: TCP write failed, dropping connection");
@@ -8223,6 +8378,19 @@ fn now_nanos() -> u64 {
         .unwrap_or(0)
 }
 
+/// Test-only writer-queue pair with an effectively unlimited byte
+/// budget, so the existing frame-count-oriented tests keep their exact
+/// semantics; the byte bound has its own dedicated tests. Defined at
+/// module level so every `#[cfg(test)]` sub-module reaches it via
+/// `super::*` — and *below* all production code, because the peer_buf
+/// source guard treats everything before the file's first column-0
+/// `#[cfg(test)]` as the production text it scans.
+#[cfg(test)]
+fn test_srv_tx(depth: usize) -> (SrvTx, tokio::sync::mpsc::Receiver<Vec<u8>>) {
+    let (tx, rx, _budget) = SrvTx::channel(depth, TxBudget::MAX_CHARGE);
+    (tx, rx)
+}
+
 /// A fixed-order outbound cell for `handle_op` calls in tests that do not
 /// renegotiate the connection byte order mid-stream. Production threads the
 /// read loop's live cell; these tests latch it once to the handler's `order`
@@ -10020,7 +10188,7 @@ mod tests {
                     intro_wire: None,
                 },
             );
-            let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+            let (tx, _rx) = test_srv_tx(16);
             let config = PvaServerConfig::default();
             let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -10117,7 +10285,7 @@ mod tests {
                     intro_wire: None,
                 },
             );
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+            let (tx, mut rx) = test_srv_tx(16);
             let config = PvaServerConfig::default();
             let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -10213,7 +10381,7 @@ mod tests {
                 intro_wire: None,
             },
         );
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -10310,7 +10478,7 @@ mod tests {
                     intro_wire: None,
                 },
             );
-            let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+            let (tx, _rx) = test_srv_tx(16);
             let config = PvaServerConfig::default();
             let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -10976,7 +11144,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11088,7 +11256,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11183,7 +11351,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11443,7 +11611,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11716,7 +11884,7 @@ mod tests {
         let (sid, ioid) = (1u32, 700u32);
         let intro = three_field_intro();
         let (mut channels, _source, pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11789,7 +11957,7 @@ mod tests {
         let (sid, ioid) = (2u32, 701u32);
         let intro = three_field_intro();
         let (mut channels, _source, pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11857,7 +12025,7 @@ mod tests {
         let (sid, ioid) = (3u32, 702u32);
         let intro = three_field_intro();
         let (mut channels, _source, _pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11910,7 +12078,7 @@ mod tests {
         let (sid, ioid) = (4u32, 703u32);
         let intro = three_field_intro();
         let (mut channels, _source, pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -11968,7 +12136,7 @@ mod tests {
         let (sid, ioid) = (5u32, 704u32);
         let intro = three_field_intro();
         let (mut channels, _source, pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12069,7 +12237,7 @@ mod tests {
         let (sid, ioid) = (6u32, 705u32);
         let intro = three_field_intro();
         let (mut channels, _source, _pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12133,7 +12301,7 @@ mod tests {
         let (sid, ioid) = (7u32, 706u32);
         let intro = three_field_intro();
         let (mut channels, _source, _pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12180,7 +12348,7 @@ mod tests {
         let (sid, ioid) = (11u32, 710u32);
         let intro = three_field_intro();
         let (mut channels, _source, pusher) = pvx61_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12382,7 +12550,7 @@ mod tests {
         let (sid, ioid) = (8u32, 707u32);
         let intro = three_field_intro();
         let (mut channels, _source, raw_tx) = pvx61_raw_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12450,7 +12618,7 @@ mod tests {
         let (sid, ioid) = (9u32, 708u32);
         let intro = three_field_intro();
         let (mut channels, _source, raw_tx) = pvx61_raw_channels(sid, &intro);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12600,7 +12768,7 @@ mod tests {
                 intro_wire: None,
             },
         );
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12769,7 +12937,7 @@ mod tests {
                 intro_wire: None,
             },
         );
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12867,7 +13035,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -12995,7 +13163,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         assert_ne!(
             config.monitor_queue_depth, 2,
@@ -13098,7 +13266,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13306,7 +13474,7 @@ mod tests {
         let window = Arc::new(AtomicU32::new(0));
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
         let mut channels = ack_test_channels(sid, ioid, window.clone(), source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13359,7 +13527,7 @@ mod tests {
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
         let mut channels = ack_test_channels(sid, ioid, window.clone(), source.clone());
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13412,7 +13580,7 @@ mod tests {
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
         let mut channels = ack_test_channels(sid, ioid, window.clone(), source.clone());
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13602,7 +13770,7 @@ mod tests {
         );
         log.lock().clear();
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13678,7 +13846,7 @@ mod tests {
         );
         log.lock().clear(); // drop the build-time "start:true" edge
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13753,7 +13921,7 @@ mod tests {
         );
         log.lock().clear();
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -13873,7 +14041,7 @@ mod tests {
         // --- (a) no MustReply: the real match alone must produce a reply. ---
         let body = build_search_body(order, 7, 0x00, &["tls"], &[(42, "MY:PV")]);
         let frame = synth_frame(Command::Search, order, body);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         handle_tcp_search(&source, &frame, &tx, &config, peer)
             .await
             .expect("handle_tcp_search must succeed");
@@ -13894,7 +14062,7 @@ mod tests {
         // --- (b) MustReply: the same match must still carry the CID. ---
         let body = build_search_body(order, 9, 0x01, &["tls"], &[(43, "MY:PV")]);
         let frame = synth_frame(Command::Search, order, body);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         handle_tcp_search(&source, &frame, &tx, &config, peer)
             .await
             .expect("handle_tcp_search must succeed");
@@ -13933,7 +14101,7 @@ mod tests {
 
         let body = build_search_body(order, 11, 0x00, &["tls"], &[(50, "OTHER:PV")]);
         let frame = synth_frame(Command::Search, order, body);
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         handle_tcp_search(&source, &frame, &tx, &config, peer)
             .await
             .expect("handle_tcp_search must succeed");
@@ -15028,7 +15196,7 @@ mod tests {
         let cid: u32 = 7;
 
         let mut channels: HashMap<u32, ChannelState> = HashMap::new();
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
 
         let mut payload = Vec::new();
         payload.put_u32(unknown_sid, order);
@@ -15083,7 +15251,7 @@ mod tests {
                 intro_wire: None,
             },
         );
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
 
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
@@ -15143,7 +15311,7 @@ mod tests {
                 intro_wire: None,
             },
         );
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
 
         // Payload encoded big-endian; header flagged big-endian.
         let mut payload = Vec::new();
@@ -15190,7 +15358,7 @@ mod tests {
         let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
         let mut channels = ack_test_channels(sid, ioid, window.clone(), source.clone());
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -15297,7 +15465,7 @@ mod tests {
                 intro_wire: None,
             },
         );
-        let (tx, mut _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut _rx) = test_srv_tx(8);
 
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
@@ -15445,7 +15613,7 @@ mod tests {
         });
 
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let (cc_tx, mut cc_rx) = tokio::sync::mpsc::channel::<CreateChannelCompletion>(8);
         let mut channels: HashMap<u32, ChannelState> = HashMap::new();
         let mut pending = 0usize;
@@ -15557,7 +15725,7 @@ mod tests {
             },
         );
 
-        let (tx, mut _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut _rx) = test_srv_tx(8);
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
         payload.put_u32(cid, order);
@@ -15621,7 +15789,7 @@ mod tests {
             },
         );
 
-        let (tx, mut _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut _rx) = test_srv_tx(8);
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let peer_entry = crate::server_native::peers::PeerEntry::new(false);
         let teardown = ChannelTeardownCtx {
@@ -15696,7 +15864,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = crate::server_native::runtime::PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -15779,7 +15947,7 @@ mod tests {
             2
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let teardown = ChannelTeardownCtx {
             tx: &tx,
@@ -15847,7 +16015,7 @@ mod tests {
         );
         peer_entry.channel_opened(1, stat);
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let teardown = ChannelTeardownCtx {
             tx: &tx,
@@ -15927,7 +16095,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -16062,7 +16230,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -16222,7 +16390,7 @@ mod tests {
         // Last request: subcmd = 0x50 (0x40 | 0x10).
         let mut channels = make_channels();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let (exec_fin_tx, mut exec_fin_rx) = mpsc::unbounded_channel::<ExecFinished>();
         handle_op(
             &exec_frame(0x50),
@@ -16283,7 +16451,7 @@ mod tests {
         // completion, never removed.
         let mut channels = make_channels();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let (exec_fin_tx, mut exec_fin_rx) = mpsc::unbounded_channel::<ExecFinished>();
         handle_op(
             &exec_frame(0x00),
@@ -16369,7 +16537,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -16877,7 +17045,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -17010,7 +17178,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -17715,7 +17883,7 @@ mod tests {
         let source: DynSource = std::sync::Arc::new(src);
 
         let mut channels = primed_process_channels(sid, ioid, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
 
@@ -17775,7 +17943,7 @@ mod tests {
         let source: DynSource = std::sync::Arc::new(src);
 
         let mut channels = primed_process_channels(sid, ioid, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
 
@@ -17872,7 +18040,7 @@ mod tests {
 
         // IOID initialised as a GET, not a PROCESS.
         let mut channels = primed_channels_with_kind(sid, ioid, OpKind::Get, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, _rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
 
@@ -17917,7 +18085,7 @@ mod tests {
         let source: DynSource = std::sync::Arc::new(src);
 
         let mut channels = primed_channels_with_kind(sid, ioid, OpKind::Monitor, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, _rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
 
@@ -18000,7 +18168,7 @@ mod tests {
     ) -> (bool, bool, Option<bool>) {
         let source: DynSource = std::sync::Arc::new(AuthorityGatedSource::new());
         let mut channels = process_channels_no_op(sid, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let peer: SocketAddr = "127.0.0.1:5076".parse().unwrap();
         let frame = process_init_frame(sid, ioid, pv_request, order);
@@ -18156,7 +18324,7 @@ mod tests {
     ) -> (bool, bool, bool) {
         let source: DynSource = std::sync::Arc::new(AuthorityGatedSource::new());
         let mut channels = process_channels_no_op(sid, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5076".parse().unwrap();
@@ -18219,7 +18387,7 @@ mod tests {
         let source: DynSource = std::sync::Arc::new(AuthorityGatedSource::new());
 
         let mut channels = primed_channels_with_kind(sid, ioid, OpKind::Get, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, _rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -18273,7 +18441,7 @@ mod tests {
         let source: DynSource = std::sync::Arc::new(AuthorityGatedSource::new());
 
         let mut channels = primed_channels_with_kind(sid, ioid, OpKind::Put, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, _rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -18357,7 +18525,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -18444,7 +18612,7 @@ mod tests {
         let source: DynSource = std::sync::Arc::new(src);
 
         let mut channels = primed_process_channels(sid, ioid, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let (exec_fin_tx, mut exec_fin_rx) = mpsc::unbounded_channel::<ExecFinished>();
         let config = PvaServerConfig::default();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -18546,7 +18714,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let (exec_fin_tx, mut exec_fin_rx) = mpsc::unbounded_channel::<ExecFinished>();
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
@@ -18687,7 +18855,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (tx, mut rx) = test_srv_tx(4);
 
         // GET_FIELD payload: sid + ioid + subfield string.
         let mut payload = Vec::new();
@@ -18749,7 +18917,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (tx, mut rx) = test_srv_tx(4);
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
         payload.put_u32(ioid, order);
@@ -18818,7 +18986,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (tx, mut rx) = test_srv_tx(4);
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
         payload.put_u32(ioid, order);
@@ -18927,7 +19095,7 @@ mod tests {
             let peer_entry = crate::server_native::peers::PeerEntry::new(false);
             peer_entry.channel_opened(sid, stat.clone());
 
-            let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+            let (tx, mut rx) = test_srv_tx(4);
             let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
             let teardown = ChannelTeardownCtx {
                 tx: &tx,
@@ -19003,7 +19171,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (tx, mut rx) = test_srv_tx(4);
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
         payload.put_u32(ioid, order);
@@ -19089,7 +19257,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (tx, mut rx) = test_srv_tx(4);
         let mut payload = Vec::new();
         payload.put_u32(sid, order);
         payload.put_u32(ioid, order);
@@ -19197,7 +19365,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         let build = || {
             let mut payload = Vec::new();
             payload.put_u32(sid, order);
@@ -19788,7 +19956,7 @@ mod tests {
             keep: Arc::new(parking_lot::Mutex::new(Some(keep_rx))),
         });
 
-        let (wire_tx, _wire_rx) = mpsc::channel::<Vec<u8>>(64);
+        let (wire_tx, _wire_rx) = test_srv_tx(64);
         let (mon_fin_tx, _mon_fin_rx) = mpsc::unbounded_channel::<MonitorFinished>();
         let (_join, start_ctl) = spawn_monitor_subscriber(MonitorSubscriberArgs {
             sid: 1,
@@ -19981,7 +20149,7 @@ mod tests {
             },
         );
 
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(64);
+        let (tx, mut rx) = test_srv_tx(64);
         let (mon_fin_tx, mut mon_fin_rx) = mpsc::unbounded_channel::<MonitorFinished>();
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
@@ -20201,7 +20369,7 @@ mod tests {
         let (sid, ioid) = (1u32, 700u32);
         let source: DynSource = Arc::new(Bfr13FailSource);
         let mut channels = bfr13_channels(Some(three_field_intro()), source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -20316,7 +20484,7 @@ mod tests {
             ),
         );
 
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, _rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -20397,7 +20565,7 @@ mod tests {
         let (sid, ioid) = (1u32, 701u32);
         let source: DynSource = Arc::new(Bfr13FailSource);
         let mut channels = bfr13_channels(Some(three_field_intro()), source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -20481,7 +20649,7 @@ mod tests {
         let source: DynSource = Arc::new(Bfr13FailSource);
         // No prototype on the channel → INIT fails "must provide prototype".
         let mut channels = bfr13_channels(None, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -20615,7 +20783,7 @@ mod tests {
         };
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let peer_entry = crate::server_native::peers::PeerEntry::new(false);
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         let mut cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         // One connection-scope inbound decode cache shared across both
         // validation frames, mirroring the read loop's single `rx_type_cache`.
@@ -20753,7 +20921,7 @@ mod tests {
         };
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
         let peer_entry = crate::server_native::peers::PeerEntry::new(false);
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         let mut cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
         let mut decode_cache = TypeCache::new();
 
@@ -20922,7 +21090,7 @@ mod autoexec_tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(16);
+        let (tx, mut rx) = test_srv_tx(16);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let peer: SocketAddr = "127.0.0.1:5075".parse().unwrap();
@@ -21143,7 +21311,7 @@ mod r14_tests {
             },
         );
 
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
 
         // Build a GET EXEC frame (subcmd = 0x00, no INIT bit).
         let mut payload = Vec::new();
@@ -21431,7 +21599,7 @@ mod bfr15_tests {
             block_put: false,
         });
         let mut channels = channels_with_op(sid, ioid, OpKind::Get, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
@@ -21524,7 +21692,7 @@ mod bfr15_tests {
             block_put: true,
         });
         let mut channels = channels_with_op(sid, ioid, OpKind::Put, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
@@ -21612,7 +21780,7 @@ mod bfr15_tests {
             block_put: false,
         });
         let mut channels = channels_with_op(sid, ioid, OpKind::Get, source.clone());
-        let (tx, _rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, _rx) = test_srv_tx(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
@@ -21668,7 +21836,7 @@ mod bfr15_tests {
             block_put: false,
         });
         let mut channels = channels_with_op(sid, ioid, OpKind::Get, source.clone());
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (tx, mut rx) = test_srv_tx(8);
         let config = PvaServerConfig::default();
         let mut encode_cache = crate::pvdata::encode::EncodeTypeCache::new();
         let cred = Arc::new(ClientCredentials::anonymous(TEST_PEER));
@@ -22005,5 +22173,86 @@ mod inbound_message_cap_tests {
             err.to_string().contains("client closed"),
             "an unbounded reader must not refuse on size: {err}"
         );
+    }
+}
+
+/// The writer queue's byte budget (pvxs#161 / `tcp_tx_limit`,
+/// `serverconn.cpp:20,61`): one case per invariant boundary — bytes
+/// exhausted while frame slots remain, a frame larger than the whole
+/// limit, and a parked sender when the budget closes.
+#[cfg(test)]
+mod tx_byte_budget_tests {
+    use super::*;
+
+    /// `write_queue_depth` alone bounded frames, not memory: 1024 slots
+    /// of arbitrary `Vec<u8>` is no bound at all. The byte budget must
+    /// park a 1-byte frame while slots are free, and the writer's
+    /// release must re-admit it.
+    #[epics_macros_rs::epics_test]
+    async fn bytes_not_frames_bound_the_writer_queue() {
+        let (tx, mut rx, budget) = SrvTx::channel(1024, 1024);
+        tx.send(vec![0u8; 1024])
+            .await
+            .expect("the first frame exactly fills the byte budget");
+        assert!(
+            futures_util::future::poll_immediate(tx.send(vec![0u8; 1]))
+                .await
+                .is_none(),
+            "1023 frame slots are free; only the byte budget can be parking this send"
+        );
+        // Act as the writer task: drain one frame, return its bytes.
+        let frame = rx.recv().await.expect("the queued frame");
+        budget.release(frame.len());
+        tx.send(vec![0u8; 1])
+            .await
+            .expect("the released budget must re-admit the parked size");
+    }
+
+    /// A frame larger than the whole limit charges `limit` and travels
+    /// alone — the clamp in [`TxBudget::charge`]. Refusing it outright
+    /// would wedge the connection; letting it charge its true size
+    /// would park it forever.
+    #[epics_macros_rs::epics_test]
+    async fn an_oversized_frame_is_admitted_alone() {
+        let (tx, mut rx, budget) = SrvTx::channel(1024, 8);
+        tx.send(vec![0u8; 100])
+            .await
+            .expect("a frame larger than the whole limit must still be admitted");
+        assert!(
+            futures_util::future::poll_immediate(tx.send(vec![0u8; 1]))
+                .await
+                .is_none(),
+            "the oversized frame holds the entire budget until written"
+        );
+        let frame = rx.recv().await.expect("the oversized frame");
+        budget.release(frame.len());
+        tx.send(vec![0u8; 1])
+            .await
+            .expect("releasing the oversized frame frees the whole budget");
+    }
+
+    /// The writer-death path: closing the budget (what
+    /// [`TxBudgetCloseGuard`] does when the writer task ends or is
+    /// aborted) must fail a sender parked in `TxBudget::acquire` — the
+    /// mpsc receiver closing alone cannot reach it there.
+    #[epics_macros_rs::epics_test]
+    async fn a_closed_budget_fails_parked_senders() {
+        let (tx, _rx, budget) = SrvTx::channel(1024, 8);
+        tx.send(vec![0u8; 8]).await.expect("fill the budget");
+        let mut parked = std::pin::pin!(tx.send(vec![0u8; 1]));
+        assert!(
+            futures_util::future::poll_immediate(parked.as_mut())
+                .await
+                .is_none(),
+            "the sender must be parked on the exhausted budget"
+        );
+        drop(TxBudgetCloseGuard(budget));
+        match futures_util::future::poll_immediate(parked.as_mut()).await {
+            Some(Err(tokio::sync::mpsc::error::SendError(frame))) => {
+                assert_eq!(frame.len(), 1, "the unsent frame comes back to the caller");
+            }
+            Some(Ok(())) => panic!("a closed budget must not admit new frames"),
+            None => panic!("closing the budget must wake and fail the parked sender"),
+        }
     }
 }

--- a/crates/epics-tools-rs/src/procserv/child.rs
+++ b/crates/epics-tools-rs/src/procserv/child.rs
@@ -25,7 +25,7 @@ use nix::pty::ForkptyResult;
 use nix::sys::resource::{Resource, getrlimit, setrlimit};
 use nix::sys::signal::Signal;
 use nix::sys::wait::{WaitStatus, waitpid};
-use nix::unistd::{Pid, chdir, execvp};
+use nix::unistd::Pid;
 use tokio::io::unix::AsyncFd;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -107,9 +107,16 @@ impl ChildHandle {
     /// 2. **Reaper** — blocking `waitpid` on a `spawn_blocking` thread,
     ///    emits the final `Exited` event and flips `alive` to false
     pub fn spawn(spec: &ChildSpec) -> ProcServResult<(Self, mpsc::Receiver<ChildEvent>)> {
+        // Everything the child needs after the fork — CStrings, the
+        // argv pointer vector, failure messages — is allocated here,
+        // BEFORE forkpty (epics-base#211 fork-safety class; see
+        // `ChildExecImage`).
+        let image = ChildExecImage::prepare(spec)?;
         // SAFETY: forkpty is unsafe because between fork and exec we
-        // may only call async-signal-safe functions. We do exactly
-        // that: setsid + chdir (libc syscalls, both AS-safe) + execvp.
+        // may only call async-signal-safe functions. The child arm
+        // calls exactly those: signal/pthread_sigmask, setrlimit,
+        // chdir, execvp, write, _exit — no malloc, no stdio locks
+        // (`in_child_setup_and_exec`).
         let result = unsafe { nix::pty::forkpty(None, None) }
             .map_err(|e| ProcServError::Forkpty(e.to_string()))?;
 
@@ -144,9 +151,9 @@ impl ChildHandle {
             ForkptyResult::Child => {
                 // We're in the child. Exec the target program.
                 // `in_child_setup_and_exec` returns `!` — either
-                // execvp succeeds (we never return) or it logs the
-                // error and `process::exit`s.
-                in_child_setup_and_exec(spec);
+                // execvp succeeds (we never return) or it reports via
+                // raw `write(2)` and `_exit`s.
+                in_child_setup_and_exec(spec, &image);
             }
         }
     }
@@ -297,16 +304,116 @@ fn restore_c_child_signal_environment() {
     let _ = blocked.thread_block();
 }
 
+/// Everything the post-fork child path needs, built in the parent
+/// BEFORE `forkpty` (upstream fork-safety class, epics-base#211).
+/// Respawns run from the live multi-threaded tokio supervisor, so at
+/// fork time another thread can hold the malloc arena or the stdio
+/// lock; a child-side `CString::new` or `eprintln!` can then deadlock
+/// before ever reaching `execvp`. `argv_ptrs` is the NULL-terminated
+/// `execvp` vector; it borrows `_argv`'s heap buffers, which stay put
+/// when the struct moves.
+struct ChildExecImage {
+    cwd: Option<CString>,
+    exec: CString,
+    _argv: Vec<CString>,
+    argv_ptrs: Vec<*const libc::c_char>,
+    /// Pre-formatted failure lines ending in ` errno=`; the child
+    /// appends the digits from a stack buffer (`write_child_failure`).
+    chdir_fail: Vec<u8>,
+    exec_fail: Vec<u8>,
+}
+
+impl ChildExecImage {
+    fn prepare(spec: &ChildSpec) -> ProcServResult<Self> {
+        let cstr = |bytes: &[u8], what: &str| {
+            CString::new(bytes).map_err(|_| ProcServError::Config(format!("{what} contains NUL")))
+        };
+        let cwd = match &spec.cwd {
+            Some(p) => Some(cstr(p.as_os_str().as_encoded_bytes(), "chdir path")?),
+            None => None,
+        };
+        // argv[0] presented to the child is always the positional command
+        // (`spec.program`), so a `--exec` override runs a different binary
+        // under the original command line. C `childExec` (procServ.cc:62,
+        // 459-462); C's argv[0]-is-the-prior-token quirk is not reproduced.
+        let arg0 = cstr(spec.program.as_os_str().as_encoded_bytes(), "program name")?;
+        // The binary actually exec'd: the `--exec` override if set, else the
+        // command itself. `execvp` PATH-searches a slashless name, like C.
+        let exec = match &spec.child_exec {
+            Some(exe) => cstr(exe.as_os_str().as_encoded_bytes(), "exec path")?,
+            None => arg0.clone(),
+        };
+        let mut argv: Vec<CString> = Vec::with_capacity(1 + spec.args.len());
+        argv.push(arg0);
+        for a in &spec.args {
+            argv.push(cstr(a.as_bytes(), "argument")?);
+        }
+        let mut argv_ptrs: Vec<*const libc::c_char> = argv.iter().map(|c| c.as_ptr()).collect();
+        argv_ptrs.push(std::ptr::null());
+
+        let chdir_fail = match &spec.cwd {
+            Some(p) => {
+                format!("procserv child: chdir to {} failed, errno=", p.display()).into_bytes()
+            }
+            None => Vec::new(),
+        };
+        let exec_fail = format!(
+            "procserv child: execvp({}) failed, errno=",
+            spec.child_exec.as_ref().unwrap_or(&spec.program).display()
+        )
+        .into_bytes();
+
+        Ok(Self {
+            cwd,
+            exec,
+            _argv: argv,
+            argv_ptrs,
+            chdir_fail,
+            exec_fail,
+        })
+    }
+}
+
+/// Async-signal-safe failure report: `write(2)` the pre-built message,
+/// then the decimal errno and a newline formatted in a stack buffer.
+/// No allocation, no stdio lock — callable between fork and exec.
+fn write_child_failure(msg: &[u8], errno: i32) {
+    let mut buf = [0u8; 12];
+    let mut i = buf.len() - 1;
+    buf[i] = b'\n';
+    let mut n = errno.unsigned_abs();
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
+        }
+    }
+    unsafe {
+        let _ = libc::write(2, msg.as_ptr().cast(), msg.len());
+        let _ = libc::write(2, buf[i..].as_ptr().cast(), buf.len() - i);
+    }
+}
+
 /// In-child path of `forkpty` — optional chdir, then `execvp` the
-/// target program. Never returns on success; on failure prints to
-/// stderr (which goes back through the PTY to the parent) and exits
-/// with [`CHILD_LAUNCH_FAILURE_EXIT`].
+/// target program. Never returns on success; on failure reports via raw
+/// `write(2)` (back through the PTY to the parent) and `_exit`s with
+/// [`CHILD_LAUNCH_FAILURE_EXIT`].
+///
+/// Everything here must be async-signal-safe: the supervisor forks from
+/// the multi-threaded tokio runtime, so the child can inherit a held
+/// malloc arena or stdio lock. All allocation and formatting happened in
+/// [`ChildExecImage::prepare`] before the fork; this path is limited to
+/// signal/sigmask restoration, `setrlimit`, `chdir(2)`, `execvp(3)`
+/// (whose PATH walk uses stack buffers in modern glibc/musl — the same
+/// post-fork call C procServ makes), `write(2)`, and `_exit(2)`.
 ///
 /// Note: `forkpty(3)` already calls `setsid()` internally and
 /// connects the slave fd as the controlling terminal, so we MUST
 /// NOT call `setsid` here again — it would return `EPERM` because
 /// we're already a session leader.
-fn in_child_setup_and_exec(spec: &ChildSpec) -> ! {
+fn in_child_setup_and_exec(spec: &ChildSpec, image: &ChildExecImage) -> ! {
     // R6-75: hand the child C's signal environment, not the Rust runtime's.
     restore_c_child_signal_environment();
 
@@ -321,66 +428,16 @@ fn in_child_setup_and_exec(spec: &ChildSpec) -> ! {
         let _ = setrlimit(Resource::RLIMIT_CORE, core, hard);
     }
 
-    if let Some(ref cwd) = spec.cwd {
-        let c_cwd = match CString::new(cwd.as_os_str().as_encoded_bytes()) {
-            Ok(c) => c,
-            Err(_) => {
-                eprintln!("procserv child: invalid chdir path");
-                std::process::exit(CHILD_LAUNCH_FAILURE_EXIT);
-            }
-        };
-        if let Err(e) = chdir(c_cwd.as_c_str()) {
-            eprintln!("procserv child: chdir to {} failed: {e}", cwd.display());
-            std::process::exit(CHILD_LAUNCH_FAILURE_EXIT);
-        }
+    if let Some(cwd) = &image.cwd
+        && unsafe { libc::chdir(cwd.as_ptr()) } != 0
+    {
+        write_child_failure(&image.chdir_fail, nix::errno::Errno::last_raw());
+        unsafe { libc::_exit(CHILD_LAUNCH_FAILURE_EXIT) };
     }
 
-    // argv[0] presented to the child is always the positional command
-    // (`spec.program`), so a `--exec` override runs a different binary
-    // under the original command line. C `childExec` (procServ.cc:62,
-    // 459-462); C's argv[0]-is-the-prior-token quirk is not reproduced.
-    let arg0 = match CString::new(spec.program.as_os_str().as_encoded_bytes()) {
-        Ok(c) => c,
-        Err(_) => {
-            eprintln!("procserv child: program name contains NUL");
-            std::process::exit(CHILD_LAUNCH_FAILURE_EXIT);
-        }
-    };
-    // The binary actually exec'd: the `--exec` override if set, else the
-    // command itself. `execvp` PATH-searches a slashless name, like C.
-    let exec_target = match &spec.child_exec {
-        Some(exe) => match CString::new(exe.as_os_str().as_encoded_bytes()) {
-            Ok(c) => c,
-            Err(_) => {
-                eprintln!("procserv child: exec path contains NUL");
-                std::process::exit(CHILD_LAUNCH_FAILURE_EXIT);
-            }
-        },
-        None => arg0.clone(),
-    };
-    let mut argv: Vec<CString> = Vec::with_capacity(1 + spec.args.len());
-    argv.push(arg0);
-    for a in &spec.args {
-        match CString::new(a.as_bytes()) {
-            Ok(c) => argv.push(c),
-            Err(_) => {
-                eprintln!("procserv child: argument contains NUL: {a:?}");
-                std::process::exit(CHILD_LAUNCH_FAILURE_EXIT);
-            }
-        }
-    }
-
-    let argv_refs: Vec<&std::ffi::CStr> = argv.iter().map(|c| c.as_c_str()).collect();
-    match execvp(exec_target.as_c_str(), &argv_refs) {
-        Ok(infallible) => match infallible {},
-        Err(e) => {
-            eprintln!(
-                "procserv child: execvp({}) failed: {e}",
-                spec.child_exec.as_ref().unwrap_or(&spec.program).display()
-            );
-            std::process::exit(CHILD_LAUNCH_FAILURE_EXIT);
-        }
-    }
+    unsafe { libc::execvp(image.exec.as_ptr(), image.argv_ptrs.as_ptr()) };
+    write_child_failure(&image.exec_fail, nix::errno::Errno::last_raw());
+    unsafe { libc::_exit(CHILD_LAUNCH_FAILURE_EXIT) }
 }
 
 /// Set `O_NONBLOCK` on a borrowed fd. Required before wrapping in

--- a/crates/mca-rs/src/record/dbd_generated.rs
+++ b/crates/mca-rs/src/record/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -4516,11 +4519,26 @@ pub static MCA_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(mca)` — the `DBF_NOACCESS` internal names dropped from
+/// [`MCA_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static MCA_NOACCESS: &[&str] = &["BPTR", "PBG", "PSTATUS"];
+
 /// The record-own field table for a record type name, or `None` for a type
 /// no vendored `.dbd` declares.
 pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
     Some(match record_type {
         "mca" => MCA_FIELDS,
+        _ => return None,
+    })
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
+    Some(match record_type {
+        "mca" => MCA_NOACCESS,
         _ => return None,
     })
 }

--- a/crates/mca-rs/src/record/mod.rs
+++ b/crates/mca-rs/src/record/mod.rs
@@ -502,6 +502,10 @@ impl Record for McaRecord {
         dbd_generated::MCA_FIELDS
     }
 
+    fn declared_noaccess_fields(&self) -> &'static [&'static str] {
+        dbd_generated::MCA_NOACCESS
+    }
+
     fn get_field(&self, name: &str) -> Option<EpicsValue> {
         if let Some((i, member)) = roi_field(name) {
             let r = &self.roi[i];

--- a/crates/motor-rs/src/record/dbd_generated.rs
+++ b/crates/motor-rs/src/record/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -1874,11 +1877,26 @@ pub static MOTOR_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(motor)` — the `DBF_NOACCESS` internal names dropped from
+/// [`MOTOR_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static MOTOR_NOACCESS: &[&str] = &["CBAK"];
+
 /// The record-own field table for a record type name, or `None` for a type
 /// no vendored `.dbd` declares.
 pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
     Some(match record_type {
         "motor" => MOTOR_FIELDS,
+        _ => return None,
+    })
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
+    Some(match record_type {
+        "motor" => MOTOR_NOACCESS,
         _ => return None,
     })
 }

--- a/crates/motor-rs/src/record/mod.rs
+++ b/crates/motor-rs/src/record/mod.rs
@@ -395,6 +395,10 @@ impl Record for MotorRecord {
         dbd_generated::MOTOR_FIELDS
     }
 
+    fn declared_noaccess_fields(&self) -> &'static [&'static str] {
+        dbd_generated::MOTOR_NOACCESS
+    }
+
     /// C `special()` pass-0 blink (motorRecord.cc:2582-2608): "Someone
     /// wrote to drive field. Blink .dmov unless record is disabled."
     /// Every database put to a drive field drops DMOV before the record

--- a/crates/mqtt-rs/src/z2m.rs
+++ b/crates/mqtt-rs/src/z2m.rs
@@ -37,7 +37,13 @@ struct RecordDef {
 }
 
 /// Generate a .db string from record definitions and load it via db_loader.
-fn load_records(prefix: &str, dev: &str, port: &str, records: &[RecordDef], ctx: &CommandContext) {
+fn load_records(
+    prefix: &str,
+    dev: &str,
+    port: &str,
+    records: &[RecordDef],
+    ctx: &CommandContext,
+) -> Result<(), String> {
     let mut db_string = String::new();
     for r in records {
         let pv_name = format!("{prefix}{dev}:{}", r.suffix);
@@ -61,38 +67,52 @@ fn load_records(prefix: &str, dev: &str, port: &str, records: &[RecordDef], ctx:
     }
 
     let macros = HashMap::new();
-    match db_loader::parse_db(&db_string, &macros) {
-        Ok(defs) => {
-            for def in defs {
-                match db_loader::create_record(&def.record_type) {
-                    Ok(mut record) => {
-                        let mut common_fields = Vec::new();
-                        if let Err(e) =
-                            db_loader::apply_fields(&mut record, &def.fields, &mut common_fields)
-                        {
-                            eprintln!("z2m: apply_fields for {}: {e}", def.name);
-                            continue;
-                        }
-                        // Record + loaded common fields in one call: the sink
-                        // runs the `iocInit` passes against the final field
-                        // set, not a pre-load one (see `ioc.rs`).
-                        let load = epics_base_rs::server::database::RecordLoad::from_common_fields(
-                            common_fields,
-                        );
-                        ctx.block_on(async {
-                            if let Err(e) =
-                                ctx.db().add_loaded_record(&def.name, record, load).await
-                            {
-                                eprintln!("z2m: register '{}' skipped: {e}", def.name);
-                            }
-                        });
-                    }
-                    Err(e) => eprintln!("z2m: create_record({}): {e}", def.record_type),
+    // Per-record failures are printed and accumulated so the command ends
+    // in Err and `on error` sees a device whose records did not land
+    // (epics-base#498 / UI-105).
+    let mut deferred: Vec<String> = Vec::new();
+    let defs = db_loader::parse_db(&db_string, &macros)
+        .map_err(|e| format!("z2m: parse_db failed: {e}"))?;
+    for def in defs {
+        match db_loader::create_record(&def.record_type) {
+            Ok(mut record) => {
+                let mut common_fields = Vec::new();
+                if let Err(e) =
+                    db_loader::apply_fields(&mut record, &def.fields, &mut common_fields)
+                {
+                    let msg = format!("z2m: apply_fields for {}: {e}", def.name);
+                    eprintln!("{msg}");
+                    deferred.push(msg);
+                    continue;
                 }
+                // Record + loaded common fields in one call: the sink
+                // runs the `iocInit` passes against the final field
+                // set, not a pre-load one (see `ioc.rs`).
+                let load =
+                    epics_base_rs::server::database::RecordLoad::from_common_fields(common_fields);
+                ctx.block_on(async {
+                    if let Err(e) = ctx.db().add_loaded_record(&def.name, record, load).await {
+                        let msg = format!("z2m: register '{}' skipped: {e}", def.name);
+                        eprintln!("{msg}");
+                        deferred.push(msg);
+                    }
+                });
+            }
+            Err(e) => {
+                let msg = format!("z2m: create_record({}): {e}", def.record_type);
+                eprintln!("{msg}");
+                deferred.push(msg);
             }
         }
-        Err(e) => eprintln!("z2m: parse_db failed: {e}"),
     }
+    if let Some(first) = deferred.first() {
+        return Err(if deferred.len() == 1 {
+            first.clone()
+        } else {
+            format!("{first} (+{} more)", deferred.len() - 1)
+        });
+    }
+    Ok(())
 }
 
 /// Register a Z2M JSON topic and return its canonical drvInfo (param name).
@@ -243,7 +263,7 @@ pub fn cmd_z2m_plug() -> CommandDef {
                     scan_io_intr: false,
                 },
             ];
-            load_records(&prefix, &dev, &port, &records, ctx);
+            load_records(&prefix, &dev, &port, &records, ctx)?;
             Ok(CommandOutcome::Continue)
         },
     )
@@ -291,7 +311,7 @@ pub fn cmd_z2m_temp_sensor() -> CommandDef {
                     scan_io_intr: true,
                 },
             ];
-            load_records(&prefix, &dev, &port, &records, ctx);
+            load_records(&prefix, &dev, &port, &records, ctx)?;
             Ok(CommandOutcome::Continue)
         },
     )
@@ -364,7 +384,7 @@ pub fn cmd_z2m_light() -> CommandDef {
                     scan_io_intr: false,
                 },
             ];
-            load_records(&prefix, &dev, &port, &records, ctx);
+            load_records(&prefix, &dev, &port, &records, ctx)?;
             Ok(CommandOutcome::Continue)
         },
     )
@@ -407,7 +427,7 @@ pub fn cmd_z2m_switch() -> CommandDef {
                     scan_io_intr: false,
                 },
             ];
-            load_records(&prefix, &dev, &port, &records, ctx);
+            load_records(&prefix, &dev, &port, &records, ctx)?;
             Ok(CommandOutcome::Continue)
         },
     )
@@ -445,7 +465,7 @@ pub fn cmd_z2m_motion() -> CommandDef {
                     scan_io_intr: true,
                 },
             ];
-            load_records(&prefix, &dev, &port, &records, ctx);
+            load_records(&prefix, &dev, &port, &records, ctx)?;
             Ok(CommandOutcome::Continue)
         },
     )
@@ -483,7 +503,7 @@ pub fn cmd_z2m_remote2() -> CommandDef {
                     scan_io_intr: true,
                 },
             ];
-            load_records(&prefix, &dev, &port, &records, ctx);
+            load_records(&prefix, &dev, &port, &records, ctx)?;
             Ok(CommandOutcome::Continue)
         },
     )

--- a/crates/optics-rs/src/records/dbd_generated.rs
+++ b/crates/optics-rs/src/records/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -2569,6 +2572,17 @@ pub static TABLE_FIELDS: &[FieldDesc] = &[
 pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
     Some(match record_type {
         "table" => TABLE_FIELDS,
+        _ => return None,
+    })
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
+    Some(match record_type {
+        "table" => &[],
         _ => return None,
     })
 }

--- a/crates/scaler-rs/src/records/dbd_generated.rs
+++ b/crates/scaler-rs/src/records/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -4842,11 +4845,26 @@ pub static SCALER_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(scaler)` — the `DBF_NOACCESS` internal names dropped from
+/// [`SCALER_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static SCALER_NOACCESS: &[&str] = &["RPVT"];
+
 /// The record-own field table for a record type name, or `None` for a type
 /// no vendored `.dbd` declares.
 pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
     Some(match record_type {
         "scaler" => SCALER_FIELDS,
+        _ => return None,
+    })
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
+    Some(match record_type {
+        "scaler" => SCALER_NOACCESS,
         _ => return None,
     })
 }

--- a/crates/scaler-rs/src/records/scaler.rs
+++ b/crates/scaler-rs/src/records/scaler.rs
@@ -1209,6 +1209,10 @@ impl Record for ScalerRecord {
         dbd_generated::SCALER_FIELDS
     }
 
+    fn declared_noaccess_fields(&self) -> &'static [&'static str] {
+        dbd_generated::SCALER_NOACCESS
+    }
+
     /// C `scalerRecord.c:471,770-787`: `process()` calls `monitor()` only
     /// while `ss == SCALER_STATE_IDLE`, and `monitor()` re-posts every
     /// active channel `S1..Snch` with a literal `DBE_LOG` regardless of

--- a/crates/std-rs/src/records/dbd_generated.rs
+++ b/crates/std-rs/src/records/dbd_generated.rs
@@ -18,8 +18,11 @@
 //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).
 //!   These are C-internal pointers with no CA/PVA representation — C's
 //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses
-//!   a channel on them. A Rust port has no pointer to expose, so they are
-//!   dropped rather than invented; the count is reported by the generator.
+//!   a channel on them. A Rust port has no pointer to expose, so their
+//!   *descriptors* are dropped rather than invented — but their NAMES are
+//!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so
+//!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel
+//!   creation, and the search gate needs the names to do the same.
 
 #![allow(clippy::all)]
 
@@ -786,6 +789,10 @@ pub static EPID_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(epid)` — the `DBF_NOACCESS` internal names dropped from
+/// [`EPID_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static EPID_NOACCESS: &[&str] = &["CT", "CTP"];
+
 /// `recordtype(throttle)` — 21 CA-visible own fields from `dbd/throttleRecord.dbd` (1 `DBF_NOACCESS` internals dropped).
 pub static THROTTLE_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -1084,6 +1091,10 @@ pub static THROTTLE_FIELDS: &[FieldDesc] = &[
     },
 ];
 
+/// `recordtype(throttle)` — the `DBF_NOACCESS` internal names dropped from
+/// [`THROTTLE_FIELDS`]: resolvable (a SEARCH is answered), never servable.
+pub static THROTTLE_NOACCESS: &[&str] = &["RPVT"];
+
 /// `recordtype(timestamp)` — 4 CA-visible own fields from `dbd/timestampRecord.dbd` (0 `DBF_NOACCESS` internals dropped).
 pub static TIMESTAMP_FIELDS: &[FieldDesc] = &[
     FieldDesc {
@@ -1151,6 +1162,19 @@ pub fn record_fields(record_type: &str) -> Option<&'static [FieldDesc]> {
         "epid" => EPID_FIELDS,
         "throttle" => THROTTLE_FIELDS,
         "timestamp" => TIMESTAMP_FIELDS,
+        _ => return None,
+    })
+}
+
+/// The record-own `DBF_NOACCESS` internal names for a record type — fields
+/// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is
+/// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type
+/// declaring none, `None` for a type no vendored `.dbd` declares.
+pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {
+    Some(match record_type {
+        "epid" => EPID_NOACCESS,
+        "throttle" => THROTTLE_NOACCESS,
+        "timestamp" => &[],
         _ => return None,
     })
 }

--- a/crates/std-rs/src/records/epid.rs
+++ b/crates/std-rs/src/records/epid.rs
@@ -1031,6 +1031,10 @@ impl Record for EpidRecord {
         dbd_generated::EPID_FIELDS
     }
 
+    fn declared_noaccess_fields(&self) -> &'static [&'static str] {
+        dbd_generated::EPID_NOACCESS
+    }
+
     fn as_any_mut(&mut self) -> Option<&mut dyn Any> {
         Some(self)
     }

--- a/crates/std-rs/src/records/throttle.rs
+++ b/crates/std-rs/src/records/throttle.rs
@@ -746,6 +746,10 @@ impl Record for ThrottleRecord {
         dbd_generated::THROTTLE_FIELDS
     }
 
+    fn declared_noaccess_fields(&self) -> &'static [&'static str] {
+        dbd_generated::THROTTLE_NOACCESS
+    }
+
     /// C `throttleRecord.c:308` keeps `recGblFwdLink(prec)` commented
     /// out in `process()` — the forward link is fired ONLY from
     /// `valuePut`'s non-CONSTANT branch (`throttleRecord.c:580`), i.e.

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -347,6 +347,18 @@ re-resolution that rebuilds the hag map and republishes through
 connected clients re-evaluate automatically. Default mode (claimed
 HOST_NAME string match) involves no DNS and is unaffected.
 
+— CLEARED. `AccessSecurityConfig` now keeps the raw HAG spellings
+(`hag_raw`; the resolved `hag` stores `hag_members` *output*, which a
+DNS move makes unre-resolvable), `with_refreshed_hags` re-runs
+`hag_members` — still the single resolution owner — and returns a
+refreshed config only on change, and `spawn_hag_refresh` (wired in
+`ioc_app` right after `new_acf_cell`) republishes it every 60 s
+(`HAG_DNS_REFRESH`, the CA-side `refresh_dns` cadence) via
+`AcfCell::store`, the same client-notification path `asInit` uses.
+Gated on `asCheckClientIP`; the task holds a `Weak` and ends with the
+IOC. Tests: stale-quad re-resolve, unchanged → `None`, name-mode
+no-op.
+
 ### UI-108 dbLoadTemplate silently ignores `file "x.template" {}`
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/db_loader/substitution.rs:285-289`, `:449-476`. Upstream: epics-base#666 (C dbLoadTemplate half reproduced; msi's parse-error half absent).
 The docs call the subs block optional, but an empty body loads zero

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -388,6 +388,20 @@ on script entry, restore the outer value when a nested script exits,
 keep the top-level value after boot. Verify the exact C set sites
 against the reference before implementing.
 
+— CLEARED. The reference overturned the assumed save/restore design:
+upstream already landed #469's fix (48eed22f3, in R7.0.10) as
+*set-once* — `iocshLoad` sets the variable only when `getenv` finds
+nothing, so the first script (or an inherited environment value) wins
+and nested loads never overwrite. Ported as
+`set_startup_script_once`, called from `execute_script_with_macros`
+(the `iocshLoad` mirror; the top-level st.cmd load in `ioc_app` now
+routes through it, matching C `iocsh(pathname)` ≡
+`iocshLoad(pathname, NULL)`) and set before the file is opened, like
+C. `execute_script` is the `iocshBody` level — `<` includes land
+there and never set it, also like C. Test:
+`startup_script_env_is_first_load_only` (nested-load no-overwrite,
+include no-set, inherited-value kept).
+
 ## Parity findings (upstream wart reproduced deliberately — document, do not fix)
 
 - **UI-2** camonitor-rs `-S` renders an emptied char waveform as `0`

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -284,7 +284,7 @@ Structurally our port lacks the suspected upstream hazard (separate
 client search socket; lo-mcast re-forward ported), but no live
 same-process repro under the issue's exact env config was run.
 
-### UI-105 iocsh db* failure paths return Ok — invisible to `on error`
+### UI-105 iocsh db* failure paths return Ok — invisible to `on error` — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/iocsh/commands.rs:795-810`, `:1222-1227`, `:1278`; port-original family `commands.rs:92`, `:667-716`, `crates/mqtt-rs/src/z2m.rs:73-94`. Upstream: epics-base#498 (db* family worse than current C).
 Current C base routes exactly these failures through `iocshSetError`
 (`dbStaticIocRegister.c:282-310`, `dbIocRegister.c:56,73`): a bad
@@ -295,6 +295,17 @@ past a database that did not load. Same print-then-Ok shape in the
 port-original commands with no C constraint (dbDeleteRecord,
 pushd/popd, mqttZ2m*). Module commands whose C callFuncs are void
 (autosave, asyn, areaDetector, astac) mirror C and stay as parity.
+CLEARED: every reachable failure arm in the two families now returns
+Err — dbCreateRecord's four rejections, dbDeleteRecord's missing
+record, all pushd/popd failures — and the two non-fatal dbLoadRecords
+loops (alias reject, merge put_common_field) accumulate into a final
+Err after the load completes, matching C's parse-recover-then-return
+non-zero. mqtt z2m's `load_records` returns Result with the same
+accumulation; all six mqttZ2m* commands propagate. Unreachable
+missing-arg arms (parse_args rejects first) left as-is. Tests: the
+three dbCreateRecord rejection tests now assert Err, and
+`on_error_break_stops_at_a_failed_db_command` pins that a real command
+failure (not just an unknown command) trips `on error break`.
 
 ### UI-106 qsrv serves an always-empty `display.description` — pvxs fills it from DESC
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/record/record_instance.rs` (`populate_display_info`), `crates/epics-bridge-rs/src/qsrv/pvif.rs:763-776`, `:1275-1278`. Upstream: epics-base#785 (the port is behind the pvxs half).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -1,0 +1,275 @@
+# Upstream-issue audit — 2026-08-09
+
+Sweep of the epics-base and pvxs GitHub issue trackers for problems that
+could also exist in epics-rs. Surface: 149+37 open and 139+52
+recently-closed issues; ~80 triaged as plausibly applicable (the rest
+are C-toolchain/build/docs/platform-specific) and checked against the
+port by six parallel read-only agents (areas: CA, PVA wire,
+QSRV/pvalink/discovery, DB links/events, record types,
+libcom/access-security/iocsh). Closed upstream issues were checked
+against the upstream FIX (did we port the corrected behavior?); open
+ones against the reported defect. Baseline for already-known deliberate
+deviations: doc/upstream-c-bugs.md.
+
+Verdict legend: SAME-PROBLEM (defect exists here), NOT-PRESENT (area
+implemented, defect absent — with evidence), NOT-APPLICABLE (feature
+not ported / C-specific), SUSPECTED (not fully proven), PARITY
+(deliberate byte/behavior parity with an upstream wart that upstream
+has not fixed).
+
+## Open Findings
+
+### UI-100 iocsh `asInit` never reaches the live AccessGate — enforcement silently fails open
+Severity: HIGH. epics-rs: `crates/epics-base-rs/src/server/iocsh/access_commands.rs:220`. Upstream: adjacent to epics-base#667.
+A script-driven IOC doing `asSetFilename` + `asInit` gets a success
+message and working `astac`/`asdbdump`, but the parsed config lands only
+in `as_state()` — nothing bridges it to the servers' `AcfCell`, which
+stays `None` = permissive. Access security is silently OFF while
+appearing loaded. The live cell is fed exclusively by the programmatic
+`IocApplication::acf()` path.
+
+### UI-20 Server outbound queue bounded in frames, not bytes
+Severity: HIGH. epics-rs: `crates/epics-pva-rs/src/server_native/config.rs:414`, `tcp.rs:3110`, `tcp.rs:2997-3003`. Upstream: pvxs#161.
+Per-connection writer queue admits by frame count (default 1024) with no
+byte watermark; ~10 MB NTNDArray monitor frames to a slow client can pin
+~10 GiB per connection before `send_timeout` evicts. pvxs fixed this
+with a byte-denominated `tcp_tx_limit` (2 × socket send buffer). The
+per-op squash FIFO bounds staleness, not writer-queue bytes. Static
+analysis; not measured live.
+
+### UI-1 EPICS_CA_NAME_SERVERS entries never re-resolve DNS
+Severity: MED. epics-rs: `crates/epics-ca-rs/src/client/mod.rs:805-806`, `client/search.rs:1147-1191`. Upstream: epics-base#488 (partial).
+The `EPICS_CA_ADDR_LIST` half of #488 is deliberately fixed (periodic
+`refresh_dns`), but name-server entries are resolved once at startup and
+the per-nameserver task redials the same stale `SocketAddr` forever
+(hostname survives only into the TLS SNI map). A nameserver/gateway that
+moves behind a stable DNS name is lost until client restart; worst on
+`name_servers_only` embedded search and the ca_gateway.
+
+### UI-21 QSRV single-record path admits unresolvable fields as a fabricated NTScalar double
+Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/mod.rs:1853-1879` (`has_name_no_resolve`), `crates/epics-bridge-rs/src/qsrv/channel.rs:625-655`, `qsrv/pvif.rs:421`. Upstream: pvxs#193 (server half).
+The search/CREATE gate tests only the record name (field suffix
+discarded) and `BridgeChannel::new` backstops an unresolvable field
+(`REC.TIME`, any typo) with `DbFieldType::Double`/NTScalar — the client
+connects and is taught a fantasy prototype, then every GET fails at op
+level (debug-only log). C refuses the channel. The group path already
+has the gate (`resolve_db_channel`); the single-record path never calls
+it.
+
+### UI-22 Client retries a refused CREATE_CHANNEL at ~1 s forever
+Severity: MED. epics-rs: `crates/epics-pva-rs/src/client_native/channel.rs:987-989`, `client_native/search_engine.rs:1251-1256`, `:1514-1525`. Upstream: pvxs#193 (client half; fixed upstream in 084336bb).
+Refusal → re-search → current bucket (≤1 s) → refusal, indefinitely,
+attempt counter reset each pass — the pre-fix pvxs loop. Upstream now
+drops the channel into the furthest search bucket (~30 s).
+
+### UI-63 Enum/menu sources read as string over links deliver index digits, not labels
+Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/links.rs:1353-1357`, `processing.rs:2517-2536`, `types/value.rs:99,1150`; CA half `crates/epics-ca-rs/src/calink/resolver.rs:553`. Upstream: epics-base#183 (closed-fixed), #855 (mechanism).
+`stringin`/`lsi` INP at a DBF_MENU/DBF_ENUM field stores `"2"` where
+fixed C stores `"INVALID"`. The correct renderer exists
+(`field_as_dbr_string` → choice tables) but only sseq requests
+`LinkReadAs::String`; the single-INP soft path fetches native and
+coerces via field-blind `convert_to`. Same outcome over CA links (calink
+subscribes native; no string subscription).
+
+### UI-64 DB-link puts to link fields are accepted where C's dbPut refuses
+Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/field_io.rs:653-707` (`put_pv_body`), reached from `links.rs:1504`. Upstream: epics-base#876 (the C guard is dbAccess.c:1340).
+C's `dbPut` refuses writes to DBF_INLINK/OUTLINK/FWDLINK
+(`field_type > DBF_DEVICE` → S_db_badDbrtype); only `dbPutField`
+(CA/dbpf) routes link fields through `dbPutFieldLink`. Our DB OUT-link
+write path lands in `put_pv_body` with no such guard: a local DB link
+can silently rewire another record's link field every process — a
+semantics divergence and lock-model hazard C deliberately forbids.
+
+### UI-101 `iocshLoad`/`<` recursion has no depth guard — self-including script aborts the IOC
+Severity: MED. epics-rs: `crates/epics-base-rs/src/server/iocsh/mod.rs:103-113`, `:84-88`. Upstream: epics-base#499 (worse than C).
+C survives via the incidental fd limit; our `read_to_string` closes the
+fd, so recursion is bounded only by the thread stack → Rust
+stack-overflow abort at boot. The only depth guard in iocsh
+(`max_include_depth: 32`) covers DB-file includes, not scripts.
+
+### UI-104 procserv-rs allocates and locks stdio between forkpty and exec
+Severity: MED. epics-rs: `crates/epics-tools-rs/src/procserv/child.rs:309-384`. Upstream: epics-base#211 (fork-safety class).
+`in_child_setup_and_exec` builds `CString`s/`Vec` (malloc) and uses
+`eprintln!` (stdio lock) after fork; respawns run from the live tokio
+supervisor (multi-threaded), so an arena/stdio lock held by another
+thread at fork time deadlocks the child pre-exec. The SAFETY comment at
+child.rs:110-112 claims async-signal-safe-only. (The daemonize fork is
+safe: pre-runtime, single-threaded.)
+
+### UI-24 Tree formatter drops the member name for `any`/union inline fields
+Severity: LOW. epics-rs: `crates/epics-pva-rs/src/format.rs:1376-1377`, `:1411-1417`. Upstream: pvxs#46 residue.
+The #46 fix proper is ported, but upstream's inline branch emits
+`' ' << member` and ours never does: `pvinfo-rs` prints `any` instead of
+`any parameters`; value mode omits the member path prefix. No test
+covers union/any/struct[] tree rendering.
+
+### UI-65 DBF_ULONG string puts lack C's via-double fallback
+Severity: LOW. epics-rs: `crates/epics-base-rs/src/types/c_parse.rs:107-135,180-259`. Upstream: epics-base#564 (the fallback is quoted in its comments; dbConvert.c:1044-1057).
+C re-parses via double when the integer parse stops at `.`/`e`/`E`:
+`1.0e3` → 1000, `".5"` → 0. Ours stores 1 for `1.0e3` (longest integer
+prefix — accepted, wrong value) and refuses `".5"`. GET direction
+unaffected. The negative-wrap behavior #564 complained about is
+correctly reproduced (upstream wontfix).
+
+### UI-80 lso/lsi `field(VAL, ...)` load failure carries a misleading diagnostic
+Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/db_loader/mod.rs:1529-1560`. Upstream: epics-base#548.
+Load is refused as in C, but for an accidental reason: the loader parses
+VAL as scalar `Char` and reports a value-syntax error, steering the
+operator toward "malformed string" instead of "field not settable from a
+.db". `Record::long_string_fields()` exists but the loader never
+consults it.
+
+### UI-103 Out-of-quote backslash diverges from C `split()`; `lint_line` disagrees with the splitters
+Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/iocsh/registry.rs:418-420` vs `:449-456`. Upstream: adjacent to epics-base#362 (the reported in-quote defect is fixed here).
+C consumes `\` as an escape outside quotes (`echo \"hello\"` →
+`"hello"`); our splitters only honor backslash inside quotes (→
+`\hello"`), while `lint_line` honors it everywhere — the lint passes
+lines the splitters then mis-parse.
+
+### UI-25 Same-host/same-process discovery (pvxs#200) not live-verified
+Severity: LOW/SUSPECTED. Upstream: pvxs#200 (open, cause undiagnosed upstream).
+Structurally our port lacks the suspected upstream hazard (separate
+client search socket; lo-mcast re-forward ported), but no live
+same-process repro under the issue's exact env config was run.
+
+## Parity findings (upstream wart reproduced deliberately — document, do not fix)
+
+- **UI-2** camonitor-rs `-S` renders an emptied char waveform as `0`
+  (`cli.rs:620-628`; epics-base#829 open, tied to CA's
+  scalar-vs-length-1 ambiguity; byte-parity with C tool_lib).
+- **UI-23** Q:group members sorted putorder-then-alphabetical,
+  declaration order destroyed (`group_config.rs:536-553`; pvxs#87 open;
+  parity with groupconfigprocessor.cpp; `+putorder` is the workaround).
+- **UI-60** SDIS read wraps to i16 → unexpected disable every 65536
+  counts (`processing.rs:1660-1668`; epics-base#906 open; C dbGetLink
+  DBR_SHORT parity).
+- **UI-61** Event-queue replace threshold copies C's disputed
+  `rngSpace <= EVENTSPERQUE` condition (`event_queue.rs:449`;
+  epics-base#868 open; upstream itself split on code-vs-comment).
+- **UI-62** calc/calcout go INVALID when an UNUSED input link is broken
+  (`calc.rs:93-98,406`; epics-base#823 open; upstream declined to
+  change — existing sites rely on it).
+- **UI-102** Trailing `#` comments parsed as command arguments, extra
+  args silently dropped (`iocsh/mod.rs:79`, `registry.rs:579-606`;
+  epics-base#414 open; faithful C parity).
+- **UI-81** seq record: all-zero-delay link groups run synchronously
+  under the record gate (C uses the callback task per group) —
+  deliberate deviation, previously documented only in a code comment
+  (`links.rs:2528-2578`; epics-base#784 context).
+
+## Classification (per issue)
+
+### CA (epics-base) — agent A
+- #943 — NOT-PRESENT — server accepts libca's truncated scalar DBR_STRING put, matching upstream PR #944's corrected behavior; bounds-checked (`types/value.rs:249-266`, `server/tcp.rs:4337-4396`).
+- #936 — NOT-PRESENT — teardown aborts tasks; blocking driver shuts the socket down before join (`blocking_io.rs:626-644`).
+- #426 — NOT-PRESENT — circuit minor version set only by the TCP VERSION frame; zero-count requests gated on CA_V413(peer); unsolicited VERSION greeting on accept (`transport.rs:1995-1999`, `server/tcp.rs:1795-1802`).
+- #402 — NOT-PRESENT — every reply datagram reseeds a VERSION placeholder patched at flush (`server/udp.rs:694-711`, `:936-948`).
+- #266 — NOT-PRESENT — extended-header threshold matches libca implementation (`protocol.rs:699-737`); upstream resolved as spec-doc error.
+- #488 — SAME-PROBLEM (partial) — UI-1.
+- #455 — NOT-PRESENT — pre-1990 clock saturates to 0 (`types/codec.rs:48-53`); monotonic timers; no warning-printer spin.
+- #477 — NOT-PRESENT — no 30 s exitWait analog; socket shutdown precedes the only I/O-thread join.
+- #515 — NOT-APPLICABLE — no RSRV_SERVER_PORT export; our env parsing is full-width with range check (`runtime/env.rs:145-162`).
+- #128 — NOT-PRESENT — port-scan garbage refused via ECA_DEFUNCT with no console noise, rate-limited (`server/tcp.rs:2045-2128`).
+- #829 — PARITY — UI-2.
+- #190 — NOT-APPLICABLE — upstream closed as local misconfiguration; same echo design as C (`transport.rs:2000-2016`).
+- #223 — NOT-PRESENT — infallible chrono rendering with explicit fallback (`cli.rs:352-358`).
+- #554 — NOT-PRESENT — loopback appended only when broadcast enumeration is empty, as upstream by-design (`client/mod.rs:4906-4928`).
+- #209 — NOT-APPLICABLE — upstream closed as documented flush behavior; our client frames subscribe immediately (`transport.rs:1718-1760`).
+
+### PVA (pvxs) — agent B
+- #200 — SUSPECTED — UI-25.
+- #193 — SAME-PROBLEM — UI-21 (server half) + UI-22 (client half); the CRIT+backtrace log itself is absent (refusal is quiet wire-parity, `tcp.rs:3441-3459`).
+- #161 — SAME-PROBLEM — UI-20.
+- #156 — NOT-PRESENT — parser accepts both dialects, normalizes identically (`pv_request.rs:1092-1176`); pvDataCPP getField/putField sections unsupported same as pvxs.
+- #136 — NOT-PRESENT — read side never gates on TX watermark; stuck client evicted by send_timeout (`tcp.rs:3094-3117`) — post-4249885 design.
+- #135 — NOT-PRESENT — DESTROY_CHANNEL removes channel + report entry through the single teardown owner (`tcp.rs:5701,5717`).
+- #119 — NOT-PRESENT — every data-phase exit reports through RAII ExecFinishGuard → apply_exec_finish (`tcp.rs:1053-1141`).
+- #93 — NOT-PRESENT — nameserver dial failure enters the same 10 s retry arm as disconnect (`search_engine.rs:2916-2984`).
+- #84 — NOT-PRESENT — no persistent per-channel attempt counter; fresh Pending per search with regression test (`search_engine.rs:1514-1525`, `:4920-4980`).
+- #32 — NOT-PRESENT — type cache stores decoded subtrees per 0xFD key, resolved in wire order in the reader task (`pvdata/encode.rs:760-774`, `decode.rs:362-391`).
+- #192 — NOT-PRESENT — callbacks moved into owning task or Arc-cloned out of locks before invocation (`shared_pv.rs:725-1112`).
+- #44 — NOT-PRESENT — pvput-rs special-cases enum_t via choices with integer fallback (`ops_v2.rs:5133-5227`).
+- #46 — NOT-PRESENT for the cited defect (fix ported, `format.rs:1366-1374`); residue filed as UI-24.
+- #87 — PARITY — UI-23.
+- #55 — NOT-PRESENT — display.precision from PREC served (`record_instance.rs:2007-2028`, `pvif.rs:1279-1286`); adjacent nesting defect is CBUG-G1.
+- #69 — NOT-PRESENT — scalar-vs-array keys on FTVL-pinned storage variant, not count (`pvif.rs:401-423`); NELM=1 waveform stays NTScalarArray (wire-visible divergence from C QSRV's max-count==1 rule; the stale doc comment at pvif.rs:496 still describes the C rule).
+
+### QSRV / pvalink / discovery (pvxs) — agent C (all clean)
+- #148 — NOT-PRESENT — pruned-delta presence ≡ fixed isMarked(true,true) (`group.rs:702-707`, `encode.rs:2316-2374`); no-putorder warning also present (`group.rs:1640-1644`).
+- #105 — NOT-PRESENT — `record._options.block` parsed; single-record PUT awaits put-notify completion (`channel.rs:350-368`, `:828-883`); group not waiting matches pvxs.
+- #97 — NOT-PRESENT — DBE value-class mask keeps ARCHIVE|LOG; post-#98 event promotion (`channel.rs:69-77`, `monitor.rs:201-217`).
+- #177 — NOT-PRESENT — time=true adopts userTag (`pvalink/link.rs:1441-1446`, `processing.rs:3214-3230`; regression test).
+- #107 — NOT-PRESENT — no cached field reference; every read re-selects and derefs Union/Variant (`link.rs:1871-1904`).
+- #187 — NOT-PRESENT — no update-seq barrier exists; cache written before scan trigger enqueue (`link.rs:428-437`, `integration.rs:1010-1104`).
+- #152 — NOT-PRESENT — remote String into CHAR-array dest exempted from scalar parse, carried via CharArray (`record_trait.rs:3606-3610`, `value.rs:1168-1178`).
+- #59 — NOT-PRESENT — self-trigger default applied silently, no per-group WARN (`group_config.rs:136-165`).
+- #137 — NOT-PRESENT — pvput-rs JSON-parses bracketed values against the descriptor (pvAccessCPP pvput semantics, `ops_v2.rs:5530-5670`).
+- #138 — NOT-APPLICABLE — upstream not-a-bug; our config carries auto_beacon with env override (`config/env.rs:740-757`).
+- #139 — NOT-PRESENT — tools don't share the UDPManager refactor that broke mcast; origSrc/replyDest distinction ported (`udp.rs:1348-1385`, `pvxvct-rs.rs:71-79`).
+- #31 — NOT-PRESENT — dedicated AF_INET lo-mcast socket, join failure degrades to local answering instead of black-holing (`loopback_mcast.rs:54-93`, `search_engine.rs:273-399`).
+
+### DB links / events (epics-base) — agent D
+- #906 — PARITY — UI-60.
+- #868 — PARITY — UI-61.
+- #867 — NOT-PRESENT — documented deviation keeps the incoming event on collapse (newest survives; `event_queue.rs:440-448`, module doc `:133-141`).
+- #855 — NOT-PRESENT — calink opens exactly one native subscription (`resolver.rs:553`); the label-delivery gap is UI-63.
+- #823 — PARITY — UI-62.
+- #657 — NOT-PRESENT — link re-classification re-reads the stored string post-put; no late-installed lset to lie (`calcout.rs:1321-1354`).
+- #692 — NOT-PRESENT — raw-soft mbbi converts INP through the ULong coercion owner; 0xFFFFFFFF preserved (`mbbi.rs:378-384`).
+- #564 — NOT-PRESENT for the reported wrap (reproduced as upstream intends); adjacent gap is UI-65.
+- #521 — NOT-PRESENT — matches C's current sdef/RVAL-as-index/65535 behavior (`mbbi.rs:183-215`, `mbbo.rs:198-312`).
+- #183 — SAME-PROBLEM (variant) — UI-63.
+- #567 — NOT-PRESENT — upstream fix d0cf47cd6 ported: MSS propagates stat+sevr+AMSG (`links.rs:198-219`).
+- #442 — NOT-PRESENT — UTAG kept out of the timestamp as upstream decided; separate u64 carried through (`common_fields.rs:81-85`).
+- #324 — NOT-PRESENT — no eventsRemaining-deferred flush; outbox drains independent of callbacks (`monitor.rs:52-66`).
+- #423 — NOT-PRESENT — cancel is idempotent Drop, no flush-semaphore analog (`event_queue.rs:600-610`).
+- #557 — NOT-PRESENT — upstream fix a4bc0db6e ported: CP target mid-process sets RPRO (`processing.rs:5158-5166`).
+- #876 — SAME-PROBLEM (inverted: the C guard is missing) — UI-64.
+
+### Record types (epics-base) — agent E
+- #548 — SAME-PROBLEM — UI-80.
+- #485 — NOT-PRESENT — SIZV clamped [16, 0x7fff] mirroring upstream e5b4829 (`lsi.rs:262`, `lso.rs:260`, `printf.rs:589`).
+- #187 — NOT-PRESENT — PACT framework-owned; visited-set + PACT guards (`record_instance.rs:1330-1345`, `processing.rs:1359-1623`).
+- #174 — NOT-APPLICABLE — upstream closed without change; port matches current C init-alarm behavior.
+- #97 — NOT-PRESENT — aai init loads constant links only; compress reads are nuse-clamped Vec indexing (`compress.rs:497-514`).
+- #9 — NOT-PRESENT — rem_euclid LIFO / modulo FIFO with the fixed read-out formula (`compress.rs:257-273`, `:504-510`).
+- #258 — NOT-PRESENT — posts built after apply_timestamp; snapshot reads common.time at post time.
+- #280 — NOT-PRESENT — one framework epilogue; single NORD post owner per path (`field_io.rs:426-461`).
+- #361 — NOT-PRESENT — `%%` emits literal `%` (`printf.rs:235-238`).
+- #555 — NOT-PRESENT — `%s` stringifies CharArray (deliberate improvement; upstream wontfix).
+- #846 — NOT-APPLICABLE — open feature request; port matches current C (32 bit fields, no names).
+- #874 — NOT-APPLICABLE — open enhancement; current MS/MSI/MSS/NMS semantics matched (`links.rs:198-219`).
+- #784 — SUSPECTED/PARITY-deviation — UI-81.
+
+### libcom / access security / iocsh (epics-base) — agent F
+- #865 — NOT-APPLICABLE — no signal handler triggers an event (only SIG_IGN + tokio self-pipe).
+- #495 — NOT-APPLICABLE — priority applied by the thread itself at band entry; no cross-thread cell.
+- #667 — NOT-PRESENT for the reported stall; adjacent HIGH defect UI-100.
+- #438 — NOT-PRESENT — no asCaTask worker; per-gate async resolver into the local DB.
+- #328 — NOT-PRESENT — HAG resolves to IPv4 at parse and peer IP is the identity (`access_security.rs:1688-1719`, `server/tcp.rs:821`).
+- #474 — NOT-PRESENT — typed immutable trap-write messages, Drop-handle unregister; all four upstream complaints structurally absent.
+- #362 — NOT-PRESENT for the reported defect (in-quote escapes work; C still broken); adjacent divergence UI-103.
+- #414 — PARITY — UI-102.
+- #499 — SAME-PROBLEM (worse than C) — UI-101.
+- #369 — NOT-APPLICABLE — no errPrintf port; single_line owns framing.
+- #106 — NOT-PRESENT — monotonic deadlines, no quantum/2 adjustment (`delayed_timer.rs:94-163`).
+- #241 — NOT-APPLICABLE — no foreign-thread OSD attach registry.
+- #596 — NOT-PRESENT — stats are instance-owned atomics; pre-start reads are zeros (`ca_server.rs:780`).
+- #709 — NOT-APPLICABLE — no epicsThreadOSD::attr analog.
+- #718 — NOT-PRESENT — pool count usize clamped `.max(1)` (`callback_executor.rs:272-274`).
+- #211 — SAME-PROBLEM (scoped to procserv-rs) — UI-104.
+
+## Review Log
+
+- 2026-08-09 — initial sweep, 6 agents, ~80 issues. 17 findings: 2 HIGH
+  (UI-100 asInit unwired, UI-20 byte-unbounded TX queue), 7 MED (UI-1,
+  UI-21, UI-22, UI-63, UI-64, UI-101, UI-104), 8 LOW/PARITY. Thematic
+  clusters: (1) "the port fixed the famous half and missed the sibling
+  half" — UI-1 (ADDR_LIST fixed, NAME_SERVERS not), UI-63 (renderer
+  exists, only sseq uses it), UI-100 (programmatic ACF path works, iocsh
+  path unwired) — suggests auditing every dual-entry feature for the
+  second entry point; (2) deliberate C-parity reproductions of open
+  upstream warts were undocumented outside code comments (UI-2, UI-23,
+  UI-60, UI-61, UI-62, UI-81, UI-102) — this doc now records them;
+  (3) resource-exhaustion bounds denominated in the wrong unit (UI-20
+  frames-vs-bytes).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -243,12 +243,26 @@ before iocInit()" (measured on the reference softIoc: `Can't set
 value`). Tests in `db_load_refuses_long_string_val.rs` cover lso VAL,
 printf VAL, and the ordinary-field control (lso SIZV still loads).
 
-### UI-103 Out-of-quote backslash diverges from C `split()`; `lint_line` disagrees with the splitters
+### UI-103 Out-of-quote backslash diverges from C `split()`; `lint_line` disagrees with the splitters — CLEARED
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/iocsh/registry.rs:418-420` vs `:449-456`. Upstream: adjacent to epics-base#362 (the reported in-quote defect is fixed here).
 C consumes `\` as an escape outside quotes (`echo \"hello\"` →
 `"hello"`); our splitters only honor backslash inside quotes (→
 `\hello"`), while `lint_line` honors it everywhere — the lint passes
 lines the splitters then mis-parse.
+CLEARED: `split_space_args`, `split_comma_args`, and
+`find_closing_paren` now apply lint_line's rules — out-of-quote `\X`
+is a literal X (neither separator, quote, nor closing paren), and the
+paren scanner tracks `'` quotes like the rest. Two family members
+found by the sweep and fixed in the same change: the comma splitter's
+second pass re-processed escapes (`"a\\\\b"` collapsed twice) — it is
+now trim+strip only, gated on a functional-outer-quote flag so an
+escape-produced quote is never stripped — and `find_closing_paren`
+took an escaped `\)` or a `)` inside single quotes as the call's end.
+All expectations measured on the reference softIoc (`echo \"hello\"`→
+`"hello"`, `a\ b`→`a b`, `echo(a\,b)`→`a,b`, `echo(\"hi\")`→`"hi"`,
+`echo(a\))`→`a)`, `echo('a)b')`→`a)b`). Tests
+`registry::tests::out_of_quote_backslash_escapes_like_c_split`,
+`registry::tests::call_syntax_escapes_are_not_double_processed`.
 
 ### UI-25 Same-host/same-process discovery (pvxs#200) not live-verified
 Severity: LOW/SUSPECTED. Upstream: pvxs#200 (open, cause undiagnosed upstream).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -94,11 +94,18 @@ level (debug-only log). C refuses the channel. The group path already
 has the gate (`resolve_db_channel`); the single-record path never calls
 it.
 
-### UI-22 Client retries a refused CREATE_CHANNEL at ~1 s forever
+### UI-22 Client retries a refused CREATE_CHANNEL at ~1 s forever — CLEARED
 Severity: MED. epics-rs: `crates/epics-pva-rs/src/client_native/channel.rs:987-989`, `client_native/search_engine.rs:1251-1256`, `:1514-1525`. Upstream: pvxs#193 (client half; fixed upstream in 084336bb).
 Refusal → re-search → current bucket (≤1 s) → refusal, indefinitely,
 attempt counter reset each pass — the pre-fix pvxs loop. Upstream now
 drops the channel into the furthest search bucket (~30 s).
+CLEARED: new `SearchReason::CreateRefused` selected when
+`researched_after_refusal`; `placement_bucket` parks it at
+`(current + N_SEARCH_BUCKETS - 1) % N_SEARCH_BUCKETS` (pvxs
+`laterBucket`), and the immediate-broadcast fast path stays gated on
+`SearchReason::Initial`, so a refused channel waits one full ring
+revolution (~30 s) by construction. Placement unit test covers the
+wrap-at-0 boundary and every non-zero bucket.
 
 ### UI-63 Enum/menu sources read as string over links deliver index digits, not labels
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/links.rs:1353-1357`, `processing.rs:2517-2536`, `types/value.rs:99,1150`; CA half `crates/epics-ca-rs/src/calink/resolver.rs:553`. Upstream: epics-base#183 (closed-fixed), #855 (mechanism).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -39,7 +39,7 @@ stays `None` = permissive. Access security is silently OFF while
 appearing loaded. The live cell is fed exclusively by the programmatic
 `IocApplication::acf()` path.
 
-### UI-20 Server outbound queue bounded in frames, not bytes
+### UI-20 Server outbound queue bounded in frames, not bytes — CLEARED
 Severity: HIGH. epics-rs: `crates/epics-pva-rs/src/server_native/config.rs:414`, `tcp.rs:3110`, `tcp.rs:2997-3003`. Upstream: pvxs#161.
 Per-connection writer queue admits by frame count (default 1024) with no
 byte watermark; ~10 MB NTNDArray monitor frames to a slow client can pin
@@ -47,6 +47,14 @@ byte watermark; ~10 MB NTNDArray monitor frames to a slow client can pin
 with a byte-denominated `tcp_tx_limit` (2 × socket send buffer). The
 per-op squash FIFO bounds staleness, not writer-queue bytes. Static
 analysis; not measured live.
+CLEARED: `SrvTx` is now a struct carrying a `TxBudget` semaphore of
+`SO_SNDBUF × 2` bytes (pvxs `tcp_tx_limit`, `serverconn.cpp:20,61`),
+read per-connection by both drivers (`accept.rs` via socket2,
+`blocking.rs` via raw libc) and threaded through `ConnInit`. Every send
+acquires `clamp(len, 1..=limit)` permits; the writer task releases them
+after the frame is written and closes the budget on exit so parked
+senders fail instead of waiting forever. Boundary tests in
+`tx_byte_budget_tests`.
 
 ### UI-1 EPICS_CA_NAME_SERVERS entries never re-resolve DNS
 Severity: MED. epics-rs: `crates/epics-ca-rs/src/client/mod.rs:805-806`, `client/search.rs:1147-1191`. Upstream: epics-base#488 (partial).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -159,12 +159,22 @@ and tested, unchanged. Boundary tests:
 `tests/dbput_refuses_link_fields.rs` (6),
 `testqsingle.rs::link_field_put_succeeds_in_every_process_mode`.
 
-### UI-101 `iocshLoad`/`<` recursion has no depth guard — self-including script aborts the IOC
+### UI-101 `iocshLoad`/`<` recursion has no depth guard — self-including script aborts the IOC — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/iocsh/mod.rs:103-113`, `:84-88`. Upstream: epics-base#499 (worse than C).
 C survives via the incidental fd limit; our `read_to_string` closes the
 fd, so recursion is bounded only by the thread stack → Rust
 stack-overflow abort at boot. The only depth guard in iocsh
 (`max_include_depth: 32`) covers DB-file includes, not scripts.
+CLEARED: `IocShell` now carries a `script_depth` cell; both script
+executors (`execute_script`, `execute_script_with_macros`) take a
+Drop-released `ScriptDepthGuard` via `enter_script`, refusing past
+`MAX_SCRIPT_DEPTH = 32` (matching the db_loader `max_include_depth`
+convention). At the cap the include line errors and unwinds through
+normal `on error` semantics — the explicit form of C's fd-exhaustion
+failure. Tests:
+`iocsh::tests::self_including_script_errors_at_the_depth_cap` (both
+`<` and `iocshLoad` entries, ticket unwinds to 0),
+`iocsh::tests::nested_include_under_the_cap_still_runs`.
 
 ### UI-104 procserv-rs allocates and locks stdio between forkpty and exec
 Severity: MED. epics-rs: `crates/epics-tools-rs/src/procserv/child.rs:309-384`. Upstream: epics-base#211 (fork-safety class).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -330,7 +330,7 @@ same-process repro under the issue's exact env config was run.
 - #46 — NOT-PRESENT for the cited defect (fix ported, `format.rs:1366-1374`); residue filed as UI-24.
 - #87 — PARITY — UI-23.
 - #55 — NOT-PRESENT — display.precision from PREC served (`record_instance.rs:2007-2028`, `pvif.rs:1279-1286`); adjacent nesting defect is CBUG-G1.
-- #69 — NOT-PRESENT — scalar-vs-array keys on FTVL-pinned storage variant, not count (`pvif.rs:401-423`); NELM=1 waveform stays NTScalarArray (wire-visible divergence from C QSRV's max-count==1 rule; the stale doc comment at pvif.rs:496 still describes the C rule).
+- #69 — NOT-PRESENT — scalar-vs-array keys on FTVL-pinned storage variant, not count (`pvif.rs:401-423`); NELM=1 waveform stays NTScalarArray (wire-visible divergence from C QSRV's max-count==1 rule; the stale doc comment at pvif.rs:496 now states the port's rule and the divergence — fixed in this fix phase).
 
 ### QSRV / pvalink / discovery (pvxs) — agent C (all clean)
 - #148 — NOT-PRESENT — pruned-delta presence ≡ fixed isMarked(true,true) (`group.rs:702-707`, `encode.rs:2316-2374`); no-putorder warning also present (`group.rs:1640-1644`).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -176,7 +176,7 @@ failure. Tests:
 `<` and `iocshLoad` entries, ticket unwinds to 0),
 `iocsh::tests::nested_include_under_the_cap_still_runs`.
 
-### UI-104 procserv-rs allocates and locks stdio between forkpty and exec
+### UI-104 procserv-rs allocates and locks stdio between forkpty and exec — CLEARED
 Severity: MED. epics-rs: `crates/epics-tools-rs/src/procserv/child.rs:309-384`. Upstream: epics-base#211 (fork-safety class).
 `in_child_setup_and_exec` builds `CString`s/`Vec` (malloc) and uses
 `eprintln!` (stdio lock) after fork; respawns run from the live tokio
@@ -184,6 +184,16 @@ supervisor (multi-threaded), so an arena/stdio lock held by another
 thread at fork time deadlocks the child pre-exec. The SAFETY comment at
 child.rs:110-112 claims async-signal-safe-only. (The daemonize fork is
 safe: pre-runtime, single-threaded.)
+CLEARED: `ChildExecImage::prepare` builds every allocation before
+`forkpty` — cwd/exec `CString`s, the NULL-terminated `argv_ptrs`
+vector, and pre-formatted failure lines; NUL validation now surfaces
+as a parent-side `ProcServError::Config` instead of a child exit. The
+post-fork path is syscall-only: `libc::chdir`/`libc::execvp` on the
+pre-built pointers, `write_child_failure` (raw `write(2)` + stack
+errno digits) instead of `eprintln!`, and `libc::_exit` instead of
+`std::process::exit` (no atexit/stdio flush in the forked image).
+Existing regressions `missing_child_binary_exits_255_not_127` /
+`failed_chdir_exits_255_not_126` exercise the new failure path.
 
 ### UI-24 Tree formatter drops the member name for `any`/union inline fields
 Severity: LOW. epics-rs: `crates/epics-pva-rs/src/format.rs:1376-1377`, `:1411-1417`. Upstream: pvxs#46 residue.

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -56,8 +56,16 @@ after the frame is written and closes the budget on exit so parked
 senders fail instead of waiting forever. Boundary tests in
 `tx_byte_budget_tests`.
 
-### UI-1 EPICS_CA_NAME_SERVERS entries never re-resolve DNS
+### UI-1 EPICS_CA_NAME_SERVERS entries never re-resolve DNS — CLEARED
 Severity: MED. epics-rs: `crates/epics-ca-rs/src/client/mod.rs:805-806`, `client/search.rs:1147-1191`. Upstream: epics-base#488 (partial).
+CLEARED: `parse_nameserver_list` now yields `AddrEntry` (the #488
+primitive) and the entry rides to `run_nameserver_connection`, which
+calls `refresh_dns()` before every dial — same keep-cached-IP-on-failure
+policy as the ADDR_LIST refresh. Regression test
+`a_nameserver_dial_uses_the_fresh_dns_resolution`. Residual: the
+`experimental-rust-tls` SNI override map is still keyed by the
+startup-resolved `SocketAddr`, so a moved nameserver loses its SNI
+override until restart.
 The `EPICS_CA_ADDR_LIST` half of #488 is deliberately fixed (periodic
 `refresh_dns`), but name-server entries are resolved once at startup and
 the per-nameserver task redials the same stale `SocketAddr` forever

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -19,8 +19,19 @@ has not fixed).
 
 ## Open Findings
 
-### UI-100 iocsh `asInit` never reaches the live AccessGate — enforcement silently fails open
+### UI-100 iocsh `asInit` never reaches the live AccessGate — enforcement silently fails open — CLEARED
 Severity: HIGH. epics-rs: `crates/epics-base-rs/src/server/iocsh/access_commands.rs:220`. Upstream: adjacent to epics-base#667.
+**Cleared**: one `AcfCell` per IOC, created by `IocApplication::run`
+before the startup script, administered by every shell
+(`IocShell::new_with_acf`) and adopted (never re-wrapped) by
+`CaServer::from_parts` / `PvaServer::from_parts` /
+`build_qsrv_mount`; `AcfCell` is now a newtype whose `store` fires
+`notify_asg_field_changed`, so a post-boot `asInit` also re-gates
+live connections and drops the gate/grant caches. Same family closed
+alongside: the bridge runner previously wrapped `config.acf` into
+THREE independent cells, and the QSRV `AcfAccessControl` froze a
+boot-time snapshot no reload could reach. Regression tests:
+`crates/epics-base-rs/tests/asinit_reaches_live_gate.rs`.
 A script-driven IOC doing `asSetFilename` + `asInit` gets a success
 message and working `astac`/`asdbdump`, but the parsed config lands only
 in `as_state()` — nothing bridges it to the servers' `AcfCell`, which

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -368,6 +368,15 @@ a doc change, so semantics stay; the missing piece is the diagnostic:
 warn when a `file` entry contributes zero loads, the same move
 upstream made for CP/CPP-on-OUTLINK discards.
 
+— CLEARED. `parse_file` snapshots `loads.len()` around the body and
+emits one `tracing::warn!` (filename + entry line) when the entry
+contributed nothing — covering all three row-less shapes (empty
+`{}`, row-less `pattern`, globals-only body) with one uniform check
+rather than special-casing the empty-body early return. Semantics
+unchanged; `parse_empty_file_body` still pins the zero-load parse,
+`zero_load_file_entry_warns` pins the diagnostic for all three
+shapes plus the no-warn case.
+
 ### UI-109 `IOCSH_STARTUP_SCRIPT` never set
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/iocsh/mod.rs` (no producer). Upstream: epics-base#469 (C's setter leaks scope; the port lacks the variable entirely).
 C sets `IOCSH_STARTUP_SCRIPT` when a script starts; #469's bug is that

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -73,8 +73,19 @@ the per-nameserver task redials the same stale `SocketAddr` forever
 moves behind a stable DNS name is lost until client restart; worst on
 `name_servers_only` embedded search and the ca_gateway.
 
-### UI-21 QSRV single-record path admits unresolvable fields as a fabricated NTScalar double
+### UI-21 QSRV single-record path admits unresolvable fields as a fabricated NTScalar double — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/mod.rs:1853-1879` (`has_name_no_resolve`), `crates/epics-bridge-rs/src/qsrv/channel.rs:625-655`, `qsrv/pvif.rs:421`. Upstream: pvxs#193 (server half).
+CLEARED: `BridgeChannel::new` refuses an unresolvable field with
+`FieldNotFound` (C `S_dbLib_fieldNotFound`) instead of fabricating an
+NTScalar double, and `has_name_no_resolve` validates an explicit field
+suffix the way `dbChannelTest` does — declared-name existence, `$`
+eligibility, plus the `dbCommon` `DBF_NOACCESS` names
+(`DBCOMMON_NOACCESS`) that C resolves and pvxs answers SEARCH for
+(measured `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`).
+Residual: record-own `DBF_NOACCESS` names (`BPTR` family) were dropped
+by dbd-codegen with their descs, so a SEARCH for them stays silent where
+C would answer then refuse the create; restoring them needs the
+generator to emit the dropped names.
 The search/CREATE gate tests only the record name (field suffix
 discarded) and `BridgeChannel::new` backstops an unresolvable field
 (`REC.TIME`, any typo) with `DbFieldType::Double`/NTScalar — the client

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -209,13 +209,25 @@ wrong assumption is gone. Test
 inline boundaries: `any`/`any[]` describe mode, valued `any`, valued
 `union u.i`, and the null union.
 
-### UI-65 DBF_ULONG string puts lack C's via-double fallback
+### UI-65 DBF_ULONG string puts lack C's via-double fallback — CLEARED
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/types/c_parse.rs:107-135,180-259`. Upstream: epics-base#564 (the fallback is quoted in its comments; dbConvert.c:1044-1057).
 C re-parses via double when the integer parse stops at `.`/`e`/`E`:
 `1.0e3` → 1000, `".5"` → 0. Ours stores 1 for `1.0e3` (longest integer
 prefix — accepted, wrong value) and refuses `".5"`. GET direction
 unaffected. The negative-wrap behavior #564 complained about is
 correctly reproduced (upstream wontfix).
+CLEARED: `parse_ulong_via_double` ports `putStringUlong` exactly, keyed
+on `scan_int`'s new `end` index (`strtoul`'s `*endp`): fallback on
+noConversion or a `.`/`e`/`E` stop, double stored only inside
+`0..=UINT_MAX`, out-of-band double keeps the integer prefix, integer
+overflow gets no fallback. All expectations measured via `dbpf B.SVAL`
+on the reference softIoc (`1.0e3`→1000, `.5`→0, `1.5e20`→1, `-1.5`→
+4294967295, `1e999`→error, `-.5`→C silent no-write). Two documented
+deviations, both from the port's atomic-put shape: `-.5`-class inputs
+(no digits, double out of band) are refused where C reports success
+writing nothing, and `1e999` refuses without C's partial prefix write.
+Test `c_parse::tests::ulong_string_put_falls_back_via_double`
+(includes the UInt64 no-fallback control).
 
 ### UI-80 lso/lsi `field(VAL, ...)` load failure carries a misleading diagnostic
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/db_loader/mod.rs:1529-1560`. Upstream: epics-base#548.

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -195,12 +195,19 @@ errno digits) instead of `eprintln!`, and `libc::_exit` instead of
 Existing regressions `missing_child_binary_exits_255_not_127` /
 `failed_chdir_exits_255_not_126` exercise the new failure path.
 
-### UI-24 Tree formatter drops the member name for `any`/union inline fields
+### UI-24 Tree formatter drops the member name for `any`/union inline fields — CLEARED
 Severity: LOW. epics-rs: `crates/epics-pva-rs/src/format.rs:1376-1377`, `:1411-1417`. Upstream: pvxs#46 residue.
 The #46 fix proper is ported, but upstream's inline branch emits
 `' ' << member` and ours never does: `pvinfo-rs` prints `any` instead of
 `any parameters`; value mode omits the member path prefix. No test
 covers union/any/struct[] tree rendering.
+CLEARED: `tree_show_inline` now takes `member` and emits it first,
+before the union `.MEM` selector and value (datafmt.cpp:224-230); the
+misnamed `member_already_emitted` fmt parameter that documented the
+wrong assumption is gone. Test
+`format::tests::tree_inline_branch_keeps_the_member_name` covers the
+inline boundaries: `any`/`any[]` describe mode, valued `any`, valued
+`union u.i`, and the null union.
 
 ### UI-65 DBF_ULONG string puts lack C's via-double fallback
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/types/c_parse.rs:107-135,180-259`. Upstream: epics-base#564 (the fallback is quoted in its comments; dbConvert.c:1044-1057).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -107,7 +107,7 @@ CLEARED: new `SearchReason::CreateRefused` selected when
 revolution (~30 s) by construction. Placement unit test covers the
 wrap-at-0 boundary and every non-zero bucket.
 
-### UI-63 Enum/menu sources read as string over links deliver index digits, not labels
+### UI-63 Enum/menu sources read as string over links deliver index digits, not labels — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/links.rs:1353-1357`, `processing.rs:2517-2536`, `types/value.rs:99,1150`; CA half `crates/epics-ca-rs/src/calink/resolver.rs:553`. Upstream: epics-base#183 (closed-fixed), #855 (mechanism).
 `stringin`/`lsi` INP at a DBF_MENU/DBF_ENUM field stores `"2"` where
 fixed C stores `"INVALID"`. The correct renderer exists
@@ -115,6 +115,22 @@ fixed C stores `"INVALID"`. The correct renderer exists
 `LinkReadAs::String`; the single-INP soft path fetches native and
 coerces via field-blind `convert_to`. Same outcome over CA links (calink
 subscribes native; no string subscription).
+CLEARED: every framework input read (single-INP soft, DOL, multi-input
+loop, SIOL) now consults `Record::input_link_read_as` through one
+conversion owner (`apply_link_read_as`); stringin/stringout declare
+`DBR_STRING` for INP/SIOL/DOL, lsi/lso the `dbGetLinkLS` source switch,
+printf the per-conversion request (`%s` → String, FMT-walked). printf's
+A..J slots store raw (they are C locals, not DBF fields — the previous
+Double-typed coercion turned EVERY string delivery into `atof` = 0.0).
+External half: `LinkMetadata::enum_choices` carries the label table
+(calink fills it from the `DBR_CTRL_ENUM` attribute fetch — C `dbCa`'s
+`pgetString` monitor equivalent; pvalink values already arrive as
+`EnumWithChoices`), rendered in `dbr_string_of`'s external arm.
+Residuals: printf's slot↔conversion map is classified unshifted — after
+a failed `*`-width link C's format-time slot inheritance can consume a
+slot under a different conversion than it was fetched with (that
+directive already emits IVLS); lsi's disconnected-source silent-success
+(`dbGetLinkLS` dtyp<0 → status 0) keeps our failed-read LINK alarm.
 
 ### UI-64 DB-link puts to link fields are accepted where C's dbPut refuses
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/field_io.rs:653-707` (`put_pv_body`), reached from `links.rs:1504`. Upstream: epics-base#876 (the C guard is dbAccess.c:1340).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -85,10 +85,16 @@ suffix the way `dbChannelTest` does — declared-name existence, `$`
 eligibility, plus the `dbCommon` `DBF_NOACCESS` names
 (`DBCOMMON_NOACCESS`) that C resolves and pvxs answers SEARCH for
 (measured `pvxget ORACLE:AI.MLOK` → `Refused to create Channel`).
-Residual: record-own `DBF_NOACCESS` names (`BPTR` family) were dropped
-by dbd-codegen with their descs, so a SEARCH for them stays silent where
-C would answer then refuse the create; restoring them needs the
-generator to emit the dropped names.
+Residual closed: record-own `DBF_NOACCESS` names (`BPTR` family) were
+dropped by dbd-codegen with their descs, so a SEARCH for them stayed
+silent where C answers then refuses the create. The generator now
+keeps the dropped names (`record_noaccess_fields`, per-target), the
+gate consults them through one predicate
+(`RecordInstance::resolves_noaccess_name`, which also carries the
+`dbCommon` list — now generated as `DB_COMMON_NOACCESS` instead of
+hand-kept), and downstream record types route theirs via
+`Record::declared_noaccess_fields` (motor `CBAK`, mca, scaler, epid,
+throttle).
 The search/CREATE gate tests only the record name (field suffix
 discarded) and `BridgeChannel::new` backstops an unresolvable field
 (`REC.TIME`, any typo) with `DbFieldType::Double`/NTScalar — the client

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -229,13 +229,19 @@ writing nothing, and `1e999` refuses without C's partial prefix write.
 Test `c_parse::tests::ulong_string_put_falls_back_via_double`
 (includes the UInt64 no-fallback control).
 
-### UI-80 lso/lsi `field(VAL, ...)` load failure carries a misleading diagnostic
+### UI-80 lso/lsi `field(VAL, ...)` load failure carries a misleading diagnostic — CLEARED
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/db_loader/mod.rs:1529-1560`. Upstream: epics-base#548.
 Load is refused as in C, but for an accidental reason: the loader parses
 VAL as scalar `Char` and reports a value-syntax error, steering the
 operator toward "malformed string" instead of "field not settable from a
 .db". `Record::long_string_fields()` exists but the loader never
 consults it.
+CLEARED: the owned-field arm asks `Record::long_string_fields` before
+parsing and refuses with C's real constraint — "can't set array field
+before iocInit()" (measured on the reference softIoc: `Can't set
+'L.VAL' to 'hello' Can't set array field before iocInit() : Bad Field
+value`). Tests in `db_load_refuses_long_string_val.rs` cover lso VAL,
+printf VAL, and the ordinary-field control (lso SIZV still loads).
 
 ### UI-103 Out-of-quote backslash diverges from C `split()`; `lint_line` disagrees with the splitters
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/iocsh/registry.rs:418-420` vs `:449-456`. Upstream: adjacent to epics-base#362 (the reported in-quote defect is fixed here).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -132,7 +132,7 @@ slot under a different conversion than it was fetched with (that
 directive already emits IVLS); lsi's disconnected-source silent-success
 (`dbGetLinkLS` dtyp<0 → status 0) keeps our failed-read LINK alarm.
 
-### UI-64 DB-link puts to link fields are accepted where C's dbPut refuses
+### UI-64 DB-link puts to link fields are accepted where C's dbPut refuses — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/field_io.rs:653-707` (`put_pv_body`), reached from `links.rs:1504`. Upstream: epics-base#876 (the C guard is dbAccess.c:1340).
 C's `dbPut` refuses writes to DBF_INLINK/OUTLINK/FWDLINK
 (`field_type > DBF_DEVICE` → S_db_badDbrtype); only `dbPutField`
@@ -140,6 +140,24 @@ C's `dbPut` refuses writes to DBF_INLINK/OUTLINK/FWDLINK
 write path lands in `put_pv_body` with no such guard: a local DB link
 can silently rewire another record's link field every process — a
 semantics divergence and lock-model hazard C deliberately forbids.
+
+CLEARED: `check_not_link_field` (new `CaError::BadDbrType`, C
+S_db_badDbrtype) refuses link fields in both `dbPut`-analogue bodies
+(`put_pv_body`, `put_pv_and_post_with_origin`); the OUT-link route now
+lands the refusal on the writer as LINK/INVALID exactly like C
+`setLinkAlarm`. The dbPutField-analogue paths keep their link writes:
+`put_record_field_from_ca*` (re-parse via `put_common_field`),
+`put_pv_no_process` (autosave; C `reboot_restore` = dbPutField), and
+autosave's Process mode routes link entries through the no-process
+write. QSRV single-source Force/Inhibit puts re-route link fields down
+the Passive/CA path per pvxs `doDbPut`'s per-field split
+(iocsource.cpp:451-458, singlesource.cpp:374-383);
+`PvDatabase::is_dbf_link_field` is the one classification owner. QSRV
+GROUP puts keep refusing link members in the preparation pass ("Links
+not supported for put", groupsource.cpp:603-606) — already implemented
+and tested, unchanged. Boundary tests:
+`tests/dbput_refuses_link_fields.rs` (6),
+`testqsingle.rs::link_field_put_succeeds_in_every_process_mode`.
 
 ### UI-101 `iocshLoad`/`<` recursion has no depth guard — self-including script aborts the IOC
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/iocsh/mod.rs:103-113`, `:84-88`. Upstream: epics-base#499 (worse than C).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -135,11 +135,16 @@ External half: `LinkMetadata::enum_choices` carries the label table
 (calink fills it from the `DBR_CTRL_ENUM` attribute fetch — C `dbCa`'s
 `pgetString` monitor equivalent; pvalink values already arrive as
 `EnumWithChoices`), rendered in `dbr_string_of`'s external arm.
-Residuals: printf's slot↔conversion map is classified unshifted — after
-a failed `*`-width link C's format-time slot inheritance can consume a
-slot under a different conversion than it was fetched with (that
-directive already emits IVLS); lsi's disconnected-source silent-success
-(`dbGetLinkLS` dtyp<0 → status 0) keeps our failed-read LINK alarm.
+Residuals closed as deliberate deviations, documented at the owning
+code: printf's fetch-time slot↔conversion map stays unshifted — after a
+failed `*`-width link C's `goto bad_format` skips the conversion's
+`plink++` so later directives re-read shifted slots under their own DBR
+types; `apply_fmt` reproduces the slot shift, and correcting the
+shifted slot's fetch conversion would need a second fetch (double-
+processing a PP source) or C's lazy read-during-format model
+(`printf.rs::plain_string_slots`). lsi keeps its failed-read LINK alarm
+where C's `dbGetLinkLS` silently succeeds without writing on a
+disconnected source (`dbLink.c:504-505`; `lsi.rs::input_link_read_as`).
 
 ### UI-64 DB-link puts to link fields are accepted where C's dbPut refuses — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/database/field_io.rs:653-707` (`put_pv_body`), reached from `links.rs:1504`. Upstream: epics-base#876 (the C guard is dbAccess.c:1340).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -284,6 +284,62 @@ Structurally our port lacks the suspected upstream hazard (separate
 client search socket; lo-mcast re-forward ported), but no live
 same-process repro under the issue's exact env config was run.
 
+### UI-105 iocsh db* failure paths return Ok — invisible to `on error`
+Severity: MED. epics-rs: `crates/epics-base-rs/src/server/iocsh/commands.rs:795-810`, `:1222-1227`, `:1278`; port-original family `commands.rs:92`, `:667-716`, `crates/mqtt-rs/src/z2m.rs:73-94`. Upstream: epics-base#498 (db* family worse than current C).
+Current C base routes exactly these failures through `iocshSetError`
+(`dbStaticIocRegister.c:282-310`, `dbIocRegister.c:56,73`): a bad
+record name, duplicate record, unknown type, or dbLoadRecords parse
+failure makes `on error break|halt|wait` fire. The port's handlers
+print the failure and return `Ok(Continue)`, so a startup script sails
+past a database that did not load. Same print-then-Ok shape in the
+port-original commands with no C constraint (dbDeleteRecord,
+pushd/popd, mqttZ2m*). Module commands whose C callFuncs are void
+(autosave, asyn, areaDetector, astac) mirror C and stay as parity.
+
+### UI-106 qsrv serves an always-empty `display.description` — pvxs fills it from DESC
+Severity: MED. epics-rs: `crates/epics-base-rs/src/server/record/record_instance.rs` (`populate_display_info`), `crates/epics-bridge-rs/src/qsrv/pvif.rs:763-776`, `:1275-1278`. Upstream: epics-base#785 (the port is behind the pvxs half).
+The NTScalar/NTEnum builders emit the `display.description` leaf and
+`qsrv_marks::property_leaves` marks it, but no producer ever assigns
+`DisplayInfo::description`, so the served description is always the
+empty string. pvxs QSRV fills it from dbCommon DESC at channel
+initialize (`iocsource.cpp:307-310`). The C-defect half of #785 — no
+DBE_PROPERTY on a DESC write because DESC lacks `prop(YES)` — is exact
+parity (pinned at `record_instance.rs:5523`) and stays: posting it
+would be a wire-visible divergence upstream has not decided to make.
+
+### UI-107 HAG hostnames frozen at ACF parse under asCheckClientIP — stale after DNS change
+Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/access_security.rs:1717-1748`, `:1518`. Upstream: epics-base#863 (AS half; C parity; upstream PR #862 in flight).
+With `EPICS_CA_AS_CHECK_CLIENT_IP` set, `hag_members` resolves each
+HAG hostname exactly once during `parse_acf` and stores the frozen
+dotted quad; a DNS move leaves stale IPs until an operator re-runs
+`asInit`. Byte-for-byte the C behavior (`asLibRoutines.c:1227-1265`),
+and the sibling of the CA half this port already closed as the UI-1
+family deviation (60 s `refresh_dns` cadence). Fix direction: periodic
+re-resolution that rebuilds the hag map and republishes through
+`AcfCell::store` — the same notification path `cmd_as_init` uses, so
+connected clients re-evaluate automatically. Default mode (claimed
+HOST_NAME string match) involves no DNS and is unaffected.
+
+### UI-108 dbLoadTemplate silently ignores `file "x.template" {}`
+Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/db_loader/substitution.rs:285-289`, `:449-476`. Upstream: epics-base#666 (C dbLoadTemplate half reproduced; msi's parse-error half absent).
+The docs call the subs block optional, but an empty body loads zero
+instances with no diagnostic — pinned as intended by
+`parse_empty_file_body`. Upstream is undecided between expand-once and
+a doc change, so semantics stay; the missing piece is the diagnostic:
+warn when a `file` entry contributes zero loads, the same move
+upstream made for CP/CPP-on-OUTLINK discards.
+
+### UI-109 `IOCSH_STARTUP_SCRIPT` never set
+Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/iocsh/mod.rs` (no producer). Upstream: epics-base#469 (C's setter leaks scope; the port lacks the variable entirely).
+C sets `IOCSH_STARTUP_SCRIPT` when a script starts; #469's bug is that
+`iocshLoad` overwrites the global value without restoring it, so after
+st.cmd finishes the variable names the last nested script. The port
+never sets it at all, so a C-compatible st.cmd reading the variable
+gets nothing. Port it with the corrected scoping upstream wants: set
+on script entry, restore the outer value when a nested script exits,
+keep the top-level value after boot. Verify the exact C set sites
+against the reference before implementing.
+
 ## Parity findings (upstream wart reproduced deliberately — document, do not fix)
 
 - **UI-2** camonitor-rs `-S` renders an emptied char waveform as `0`
@@ -411,6 +467,35 @@ same-process repro under the issue's exact env config was run.
 - #718 — NOT-PRESENT — pool count usize clamped `.max(1)` (`callback_executor.rs:272-274`).
 - #211 — SAME-PROBLEM (scoped to procserv-rs) — UI-104.
 
+### epics-base uncovered delta (second sweep — agents G–J + inline)
+- #498 — SAME-PROBLEM (db* family worse than current C) — UI-105.
+- #785 — SAME-PROBLEM (port behind pvxs on the description half) — UI-106; the missing-prop(YES) half is parity.
+- #863 — split verdict: CA half NOT-PRESENT — already closed as the UI-1 family deviation (60 s `refresh_dns` cadence, per-redial nameserver re-resolution; `search.rs:1040-1117`, `client/mod.rs:4838-4863`); AS half SAME-PROBLEM — UI-107.
+- #666 — SAME-PROBLEM (silent zero-load `file` entry, pinned by test) — UI-108.
+- #469 — PARITY-GAP — UI-109 (variable absent entirely; C's setter has the scope leak).
+- #378 — NOT-PRESENT — the repeater-registered socket discards everything but beacons (`beacon_monitor.rs:546-559`) and the search socket never registers (`search.rs:626`), so a forwarded SEARCH request cannot reach the response parser. Caveat: the parse itself, like C, sanity-checks nothing (`search.rs:1784-1800`) — reachable only by direct unicast to the ephemeral search port.
+- #372 — NOT-PRESENT — HashMap channel tables + 30-bucket retry ring touch only due entries per tick (`search.rs:112`, `:383-460`, `:1981-2049`).
+- #576 — NOT-PRESENT — single-coordinator subscribe; registry insert precedes EVENT_ADD; every disconnect path flags `needs_restore`, every connect restores (`client/mod.rs:3458-3567`, `:3943-4033`, `:4408-4477`).
+- #380 — NOT-PRESENT — `cmd_astac` is a stateless query over the loaded config; no client-registration surface exists to leak (`access_commands.rs:468-503`).
+- #333 — NOT-PRESENT — no narrow-integer timestamp diff anywhere; camonitor's `secs_between` goes through `Duration` (`camonitor-rs.rs:695-702`), wire u32 widened before arithmetic (`codec.rs:47-54`).
+- #368 — NOT-APPLICABLE — mingw-libc defect; the port formats in Rust with `%F`/`%lx` mapped (`printf.rs:248`, `:399-415`, `:510`).
+- #549 — NOT-PRESENT — load errors are values printed once (`commands.rs:1062`, `softioc-rs.rs:340`); latent double-print only for an external binary that prints both the script-line echo and `run()`'s Err (`iocsh/mod.rs:366`, `ioc_app.rs:740`).
+- #683 — NOT-APPLICABLE — no lockset machinery; per-record gates in a leaked static registry (`record_lock.rs:30-58`, `:244-255`).
+- #529 — NOT-PRESENT — template resolver bypasses the include-path search only on `is_absolute()`, matching the current C fix (`substitution.rs:480-511`).
+- #537 — NOT-APPLICABLE — open enhancement; `-m p` parsed but the subscription type stays TIME-class, matching current C camonitor (`camonitor-rs.rs:518-552`, `client/mod.rs:203-216`).
+- #428 — NOT-PRESENT — modern dbParseLink parity including the CP/CPP discard warning (`link.rs:1153-1258`, `record_instance.rs:2872-2879`).
+- #836 — NOT-PRESENT — no pool-space probe in either search-reply driver (`server/udp.rs:643-700`, `blocking.rs:707-724` records the deliberate admission design).
+- #643 — NOT-PRESENT — filter chains are Arc-owned by channel/monitor objects; the only global is a leaked static; no teardown ordering exists to violate (`filters/mod.rs:119`, `qsrv/channel.rs:489`).
+- #256 — NOT-PRESENT — parse errors propagate as Results; in-parse warnings go through the synchronous console subscriber; both end at line-atomic `eprintln!` from the loading thread (`db_loader/mod.rs:77-82`, `log.rs:106-108`).
+- #911 — NOT-PRESENT — `erl_warning()` gates ANSI on isatty + non-empty TERM (`log.rs:332-340`); no unconditional escapes in port output.
+- #858 — NOT-PRESENT — `on error wait` parses through a checked Result (`iocsh/mod.rs:534-539`); the C inversion has no counterpart.
+- #761 — NOT-APPLICABLE — no cantProceed/epicsEventMustTrigger suspension model in the port.
+- #416 — NOT-APPLICABLE — no errlog localEcho/atExit console gate; port logging is the tracing pipeline.
+- #775 — NOT-APPLICABLE — unmerged upstream proposal (bi/bo ZRVL/ONVL); pre-adoption would be a DBD-visible deviation.
+
+The remaining 91 uncovered open issues were title-triaged as
+toolchain/build/CI/docs/platform items with no port surface.
+
 ## Review Log
 
 - 2026-08-09 — initial sweep, 6 agents, ~80 issues. 17 findings: 2 HIGH
@@ -425,3 +510,13 @@ same-process repro under the issue's exact env config was run.
   UI-60, UI-61, UI-62, UI-81, UI-102) — this doc now records them;
   (3) resource-exhaustion bounds denominated in the wrong unit (UI-20
   frames-vs-bytes).
+- 2026-08-09 — second sweep over the 115 open epics-base issues the
+  initial round only surface-classified: title triage → 24 candidates
+  → 4 read-only agents + inline checks. 5 findings: UI-105..UI-109
+  (2 MED, 3 LOW), 19 clean verdicts with evidence. Themes: (1) round
+  1's "fixed half / missed sibling half" recurs — #863's CA DNS
+  refresh was already shipped, its access-security sibling was not
+  (UI-107); (2) signals dropped while porting the mechanism — error
+  status to the shell (UI-105), the zero-load warning (UI-108), the
+  startup-script env var (UI-109); (3) metadata leaf emitted but never
+  produced (UI-106, empty display.description).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -307,7 +307,7 @@ three dbCreateRecord rejection tests now assert Err, and
 `on_error_break_stops_at_a_failed_db_command` pins that a real command
 failure (not just an unknown command) trips `on error break`.
 
-### UI-106 qsrv serves an always-empty `display.description` — pvxs fills it from DESC
+### UI-106 qsrv serves an always-empty `display.description` — pvxs fills it from DESC — CLEARED
 Severity: MED. epics-rs: `crates/epics-base-rs/src/server/record/record_instance.rs` (`populate_display_info`), `crates/epics-bridge-rs/src/qsrv/pvif.rs:763-776`, `:1275-1278`. Upstream: epics-base#785 (the port is behind the pvxs half).
 The NTScalar/NTEnum builders emit the `display.description` leaf and
 `qsrv_marks::property_leaves` marks it, but no producer ever assigns
@@ -317,6 +317,22 @@ initialize (`iocsource.cpp:307-310`). The C-defect half of #785 — no
 DBE_PROPERTY on a DESC write because DESC lacks `prop(YES)` — is exact
 parity (pinned at `record_instance.rs:5523`) and stays: posting it
 would be a wire-visible divergence upstream has not decided to make.
+CLEARED: `populate_display_info` ends with a uniform epilogue filling
+`display.description` from `common.desc` for every record type (the
+builders always emit the leaf, so a newly-Some display changes leaf
+values, never wire shape). `DisplayInfo::description` became
+`PvString` for the same byte-preservation reason as `units`. Cache
+freshness is owned by the DESC arm of `put_common_field` — the single
+writer of `common.desc` — which invalidates the metadata cache on a
+real change WITHOUT posting DBE_PROPERTY, exactly pvxs's fresh-on-
+rebuild/no-event behavior; DESC stays out of `is_metadata_field`
+(both invariant doc comments updated). Field channels inherit the
+record's DESC through the shared per-record cache, matching pvxs's
+`dbChannelRecord(pChannel)->desc`. Three tests that pinned
+`display.is_none()` for no-display-arm record types now assert
+empty-units/default limits; new boundary tests
+`desc_reaches_display_description_and_a_write_refreshes_it` and
+`an_idempotent_desc_put_keeps_the_cache`.
 
 ### UI-107 HAG hostnames frozen at ACF parse under asCheckClientIP — stale after DNS change
 Severity: LOW. epics-rs: `crates/epics-base-rs/src/server/access_security.rs:1717-1748`, `:1518`. Upstream: epics-base#863 (AS half; C parity; upstream PR #862 in flight).

--- a/doc/upstream-issue-audit-2026-08-09.md
+++ b/doc/upstream-issue-audit-2026-08-09.md
@@ -62,10 +62,13 @@ CLEARED: `parse_nameserver_list` now yields `AddrEntry` (the #488
 primitive) and the entry rides to `run_nameserver_connection`, which
 calls `refresh_dns()` before every dial — same keep-cached-IP-on-failure
 policy as the ADDR_LIST refresh. Regression test
-`a_nameserver_dial_uses_the_fresh_dns_resolution`. Residual: the
-`experimental-rust-tls` SNI override map is still keyed by the
-startup-resolved `SocketAddr`, so a moved nameserver loses its SNI
-override until restart.
+`a_nameserver_dial_uses_the_fresh_dns_resolution`. Residual closed:
+the `experimental-rust-tls` SNI override map was keyed by the
+startup-resolved `SocketAddr` (a moved nameserver lost its SNI
+override until restart); `SniOverrides` now keeps nameserver rows
+keyed by hostname and `AddrEntry::refresh_dns` — the one resolution
+owner — rewrites the row, so the stale-key state is unconstructable
+(`a_moved_nameserver_keeps_its_sni_override`).
 The `EPICS_CA_ADDR_LIST` half of #488 is deliberately fixed (periodic
 `refresh_dns`), but name-server entries are resolved once at startup and
 the per-nameserver task redials the same stale `SocketAddr` forever

--- a/examples/qsrv-ioc/src/main.rs
+++ b/examples/qsrv-ioc/src/main.rs
@@ -96,8 +96,12 @@ async fn main() -> CaResult<()> {
     let _scan_owner = epics_base_rs::server::scan::ScanOwner::start(db.clone());
 
     // ── Build both servers from the same database ──
-    let ca_server = CaServer::from_parts(db.clone(), ca_port, None, None, None, None).await?;
-    let pva_server = PvaServer::from_parts(db, pva_port, None, None, None);
+    // One policy cell for both protocols, so an `asInit` from the shell
+    // (or a future ACF reload) gates CA and PVA together.
+    let acf = epics_base_rs::server::access_security::new_acf_cell(None);
+    let ca_server =
+        CaServer::from_parts(db.clone(), ca_port, None, acf.clone(), None, None).await?;
+    let pva_server = PvaServer::from_parts(db, pva_port, acf, None, None);
 
     // CA runs in background, PVA runs with iocsh (shell exit stops everything)
     let ca_handle = epics_base_rs::runtime::task::spawn(async move { ca_server.run().await });

--- a/examples/regression-ioc/src/lib.rs
+++ b/examples/regression-ioc/src/lib.rs
@@ -120,7 +120,15 @@ impl RegressionIoc {
         // CA server on a kernel-assigned port: `from_parts` binds the
         // sockets and reports the port it got, so nothing can take the
         // number in between.
-        let ca_server = CaServer::from_parts(db.clone(), 0, None, None, None, None).await?;
+        let ca_server = CaServer::from_parts(
+            db.clone(),
+            0,
+            None,
+            epics_base_rs::server::access_security::new_acf_cell(None),
+            None,
+            None,
+        )
+        .await?;
         let ca_port = ca_server.udp_port();
         let _ca_task = tokio::spawn(async move { ca_server.run().await });
 

--- a/examples/rt-probe/src/probe.rs
+++ b/examples/rt-probe/src/probe.rs
@@ -192,7 +192,15 @@ async fn boot_ioc_on(ca_port: u16) -> Result<Ioc, Box<dyn std::error::Error>> {
         .build()
         .await?;
     let scan = ScanOwner::start(db.clone());
-    let ca_server = CaServer::from_parts(db.clone(), ca_port, None, None, None, None).await?;
+    let ca_server = CaServer::from_parts(
+        db.clone(),
+        ca_port,
+        None,
+        epics_base_rs::server::access_security::new_acf_cell(None),
+        None,
+        None,
+    )
+    .await?;
     let ca_port = ca_server.udp_port();
     let _ca_task = tokio::spawn(async move { ca_server.run().await });
     let source = Arc::new(PvDatabaseSource::new(db.clone()));

--- a/tools/dbd-codegen/src/emit.rs
+++ b/tools/dbd-codegen/src/emit.rs
@@ -266,8 +266,11 @@ pub fn emit(input: &Input<'_>) -> Result<String, String> {
          //! * **`DBF_NOACCESS` fields** (`RSET`, `DPVT`, `MLOK`, `BPTR`, `PPN`, ...).\n\
          //!   These are C-internal pointers with no CA/PVA representation — C's\n\
          //!   `mapDBFToDBR` sends them to `DBR_NOACCESS` and `dbChannelCreate` refuses\n\
-         //!   a channel on them. A Rust port has no pointer to expose, so they are\n\
-         //!   dropped rather than invented; the count is reported by the generator.\n",
+         //!   a channel on them. A Rust port has no pointer to expose, so their\n\
+         //!   *descriptors* are dropped rather than invented — but their NAMES are\n\
+         //!   kept (`record_noaccess_fields`): C's `dbNameToAddr` resolves them, so\n\
+         //!   a SEARCH for `REC.BPTR` is answered and the refusal lands at channel\n\
+         //!   creation, and the search gate needs the names to do the same.\n",
         input.dbd_dir
     )
     .unwrap();
@@ -366,6 +369,7 @@ pub fn emit(input: &Input<'_>) -> Result<String, String> {
     );
 
     let mut record_consts: Vec<(String, String)> = Vec::new();
+    let mut noaccess_consts: Vec<(String, String)> = Vec::new();
     for rec in input.records {
         let konst = fields_const(&rec.name);
         let own: Vec<&Field> = rec
@@ -373,19 +377,21 @@ pub fn emit(input: &Input<'_>) -> Result<String, String> {
             .iter()
             .filter(|f| !f.from_common && !is_internal(f))
             .collect();
-        let dropped = rec
+        let internal: Vec<&str> = rec
             .fields
             .iter()
             .filter(|f| !f.from_common && is_internal(f))
-            .count();
+            .map(|f| f.name.as_str())
+            .collect();
 
         writeln!(
             out,
             "/// `recordtype({})` — {} CA-visible own fields from `dbd/{}` \
-             ({dropped} `DBF_NOACCESS` internals dropped).",
+             ({} `DBF_NOACCESS` internals dropped).",
             rec.name,
             own.len(),
-            rec.source
+            rec.source,
+            internal.len()
         )
         .unwrap();
         writeln!(out, "pub static {konst}: &[FieldDesc] = &[").unwrap();
@@ -399,7 +405,30 @@ pub fn emit(input: &Input<'_>) -> Result<String, String> {
             )?);
         }
         out.push_str("];\n\n");
-        record_consts.push((rec.name.clone(), konst));
+        record_consts.push((rec.name.clone(), konst.clone()));
+
+        // The dropped internals keep their NAMES: C's `dbNameToAddr`
+        // resolves a `DBF_NOACCESS` field, so a SEARCH for it is answered
+        // and the refusal lands at channel creation. The search gate
+        // consults this list to answer the same way.
+        if !internal.is_empty() {
+            let na_konst = format!("{}_NOACCESS", konst.trim_end_matches("_FIELDS"));
+            writeln!(
+                out,
+                "/// `recordtype({})` — the `DBF_NOACCESS` internal names dropped from\n\
+                 /// [`{konst}`]: resolvable (a SEARCH is answered), never servable.",
+                rec.name
+            )
+            .unwrap();
+            writeln!(out, "pub static {na_konst}: &[&str] = &[").unwrap();
+            for name in &internal {
+                writeln!(out, "    {},", rust_str(name)).unwrap();
+            }
+            out.push_str("];\n\n");
+            noaccess_consts.push((rec.name.clone(), na_konst));
+        } else {
+            noaccess_consts.push((rec.name.clone(), "&[]".to_string()));
+        }
     }
 
     // Every `cvt_dbaddr.types` row must name a field that really is
@@ -455,6 +484,25 @@ pub fn emit(input: &Input<'_>) -> Result<String, String> {
             )?);
         }
         out.push_str("];\n\n");
+
+        let common_internal: Vec<&str> = input
+            .common
+            .iter()
+            .filter(|f| is_internal(f))
+            .map(|f| f.name.as_str())
+            .collect();
+        if !common_internal.is_empty() {
+            out.push_str(
+                "/// The `DBF_NOACCESS` internals of `dbCommon.dbd`, dropped from\n\
+                 /// [`DB_COMMON_FIELDS`]: resolvable (a SEARCH is answered), never\n\
+                 /// servable — see `record_noaccess_fields` for the record-own twins.\n",
+            );
+            out.push_str("pub static DB_COMMON_NOACCESS: &[&str] = &[\n");
+            for name in &common_internal {
+                writeln!(out, "    {},", rust_str(name)).unwrap();
+            }
+            out.push_str("];\n\n");
+        }
     }
 
     if !input.devices.is_empty() {
@@ -471,6 +519,22 @@ pub fn emit(input: &Input<'_>) -> Result<String, String> {
         &mut out,
         "record_type",
         record_consts.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+    );
+    out.push_str("}\n\n");
+
+    out.push_str(
+        "/// The record-own `DBF_NOACCESS` internal names for a record type — fields\n\
+         /// C's `dbNameToAddr` resolves (a SEARCH is answered) but whose channel is\n\
+         /// refused at creation (`mapDBFToDBR` -> `DBR_NOACCESS`). Empty for a type\n\
+         /// declaring none, `None` for a type no vendored `.dbd` declares.\n\
+         pub fn record_noaccess_fields(record_type: &str) -> Option<&'static [&'static str]> {\n",
+    );
+    emit_str_lookup(
+        &mut out,
+        "record_type",
+        noaccess_consts
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str())),
     );
     out.push_str("}\n\n");
 


### PR DESCRIPTION
Sweeps every open epics-base and pvxs issue for defects this port shares and fixes each confirmed finding, one commit apiece. Verdicts and evidence for all candidates — including the clean ones — are in doc/upstream-issue-audit-2026-08-09.md; each fixed finding's section there carries a CLEARED note naming the implementation.