### PR TITLE
fix(ca-client): convert a native-typed put's value before encoding the payload

### DIFF
--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -1476,6 +1476,31 @@ impl Drop for CaClient {
             fwd.abort();
         }
 
+        // Drop must be infallible in ANY thread context. On the tokio
+        // backend `runtime::task::spawn` panics without an ambient
+        // reactor — which is exactly the state of a sync caller
+        // unwinding on its own thread, where the panic would mask the
+        // error that triggered the unwind. Without a reactor the
+        // graceful drain cannot be polled: send the shutdown request
+        // (unbounded, sync) and abort the tasks directly —
+        // `AbortHandle::abort` is thread-safe and runtime-free. The
+        // server reclaims the circuit on TCP close, the same path as a
+        // client that dies without `ca_context_destroy`. The guard is
+        // tokio-only: on the RTEMS exec backend the executor always
+        // exists, and design doc §5.1 forbids silently skipping the
+        // drain there.
+        #[cfg(tokio_backend)]
+        if tokio::runtime::Handle::try_current().is_err() {
+            let (tx, _rx) = oneshot::channel();
+            let _ = coord_tx.send(CoordRequest::Shutdown { reply: tx });
+            coord_abort.abort();
+            transport_abort.abort();
+            search_abort.abort();
+            #[cfg(ca_beacon_monitor)]
+            beacon_abort.abort();
+            return;
+        }
+
         // Spawn the graceful drain through the `runtime::task` seam so it
         // runs on the RTEMS exec backend too — a bare `tokio::spawn`
         // behind a `Handle::try_current()` guard silently skipped it on

--- a/crates/epics-ca-rs/src/client/mod.rs
+++ b/crates/epics-ca-rs/src/client/mod.rs
@@ -2661,12 +2661,25 @@ impl CaChannel {
 
     pub async fn put(&self, value: &EpicsValue) -> CaResult<()> {
         let snap = self.snapshot()?;
+        // The frame is stamped with the channel's NATIVE type below, so
+        // the payload must be the native encoding. A caller variant that
+        // differs (e.g. `Long` on an ENUM field) would otherwise ship a
+        // native-typed header over foreign bytes, and the server —
+        // which decodes strictly against the header type — would read
+        // the first two bytes of the big-endian i32 as the enum index:
+        // `Long(1)` landed as 0, silently. `convert_to` is the single
+        // value-coercion owner (C cast semantics), so the header/payload
+        // pairing holds for every variant. Menu labels still go through
+        // `put_string`, which the server resolves against its menu.
+        let value = value.convert_to(snap.native_type);
         // C `nciu::write` rejects countIn > channel count with
         // ECA_BADCOUNT before queueing the request. Pre-fix Rust sent
         // an oversized write that the server would either accept past
-        // its array bound or reject asynchronously.
+        // its array bound or reject asynchronously. Validated on the
+        // converted value — the count of the actual wire request, which
+        // conversion can change (String → CHAR-array on a CHAR field).
         validate_put_count(&snap, value.count())?;
-        validate_put_strings(value)?;
+        validate_put_strings(&value)?;
 
         let ioid = self.in_flight.alloc_ioid();
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -2692,8 +2705,10 @@ impl CaChannel {
     /// Write with completion callback and configurable timeout.
     pub async fn put_with_timeout(&self, value: &EpicsValue, timeout: Duration) -> CaResult<()> {
         let snap = self.snapshot()?;
+        // Native encoding to match the native-typed header; see `put`.
+        let value = value.convert_to(snap.native_type);
         validate_put_count(&snap, value.count())?;
-        validate_put_strings(value)?;
+        validate_put_strings(&value)?;
 
         let ioid = self.in_flight.alloc_ioid();
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -2721,8 +2736,10 @@ impl CaChannel {
     /// which monitors DMOV for completion instead.
     pub async fn put_nowait(&self, value: &EpicsValue) -> CaResult<()> {
         let snap = self.snapshot()?;
+        // Native encoding to match the native-typed header; see `put`.
+        let value = value.convert_to(snap.native_type);
         validate_put_count(&snap, value.count())?;
-        validate_put_strings(value)?;
+        validate_put_strings(&value)?;
 
         let payload = value.to_bytes();
         let count = value.count() as u32;

--- a/crates/epics-ca-rs/tests/client_drop_outside_runtime.rs
+++ b/crates/epics-ca-rs/tests/client_drop_outside_runtime.rs
@@ -1,0 +1,44 @@
+//! Regression test: dropping a `CaClient` from a thread with no ambient
+//! tokio reactor must not panic.
+//!
+//! `CaClient::drop` routes its graceful drain through
+//! `runtime::task::spawn`, which on the tokio backend calls
+//! `tokio::spawn` and panics without a reactor context. That is exactly
+//! the state of a sync `main` unwinding on an error: the drop panic
+//! aborts the unwind and masks the error that caused it (observed as a
+//! robot daemon dying with "there is no reactor running" instead of its
+//! real bring-up failure). Post-fix the drop degrades to a sync
+//! shutdown send plus task aborts; the panic-free property is the test.
+
+// Host/tokio-only: constructs the async `CaClient`, which needs a tokio
+// reactor at build time (see caget_dbr_type.rs).
+#![cfg(not(feature = "rtems-exec-model"))]
+
+use epics_ca_rs::client::CaClient;
+use serial_test::serial;
+
+/// SAFETY: `#[serial]` — no other test mutates the environment
+/// concurrently, and the env is set before `CaClient::new()` snapshots
+/// its resolver configuration. The address list points at loopback so
+/// the client never probes the live network.
+fn pin_env_to_loopback() {
+    unsafe {
+        std::env::set_var("EPICS_CA_ADDR_LIST", "127.0.0.1");
+        std::env::set_var("EPICS_CA_AUTO_ADDR_LIST", "NO");
+    }
+}
+
+#[test]
+#[serial]
+fn client_drop_outside_runtime_does_not_panic() {
+    pin_env_to_loopback();
+    let rt = tokio::runtime::Runtime::new().expect("runtime");
+    let client = rt.block_on(async { CaClient::new().await.expect("client") });
+    // The dropping thread has no reactor context — `Handle::try_current`
+    // fails here. Pre-fix this line panicked inside `CaClient::drop`.
+    drop(client);
+    // The runtime is still alive, so the coordinator can observe the
+    // sync-sent Shutdown before its abort lands; either way the drop
+    // above must have returned normally.
+    drop(rt);
+}

--- a/crates/epics-ca-rs/tests/put_native_type_conversion.rs
+++ b/crates/epics-ca-rs/tests/put_native_type_conversion.rs
@@ -1,0 +1,128 @@
+//! Regression tests: the native-typed put family (`put`,
+//! `put_with_timeout`, `put_nowait`) must CONVERT the caller's value to
+//! the channel's native type before encoding the payload.
+//!
+//! Those functions stamp `snap.native_type` on the frame header, so the
+//! payload bytes must be the native encoding. Pre-fix they encoded the
+//! caller's variant verbatim: `put(&EpicsValue::Long(1))` on an ENUM
+//! field (`bi`) shipped a DBR_ENUM header over a 4-byte big-endian i32,
+//! and the server — decoding strictly against the header type — read
+//! the first two bytes (`0x0000`) as the enum index. `Long(1)` landed
+//! as 0 with a successful completion callback; every write of 0 "worked"
+//! by accident, which is what hid the defect.
+//!
+//! C has no such seam: `ca_array_put(type, ...)` takes the caller's
+//! DBR type and buffer together, and the SERVER converts to the field
+//! type. The Rust native-typed API's equivalent obligation is client-
+//! side conversion through `convert_to`, the value-coercion owner.
+
+// Host/tokio-only: builds the async `CaClient`/`CaServer` stack in
+// process, which needs a tokio reactor (see caget_dbr_type.rs).
+#![cfg(not(feature = "rtems-exec-model"))]
+
+use std::time::{Duration, Instant};
+
+use epics_base_rs::server::records::bi::BiRecord;
+use epics_ca_rs::EpicsValue;
+use epics_ca_rs::client::CaClient;
+use epics_ca_rs::server::CaServer;
+use serial_test::serial;
+
+/// Point a soon-to-be-constructed `CaClient` at exactly this server so
+/// it skips UDP search.
+///
+/// SAFETY: every test in this file is `#[serial]`, so no other test
+/// mutates the environment concurrently, and the env is set before
+/// `CaClient::new()` snapshots its resolver configuration.
+fn point_client_at(port: u16) {
+    unsafe {
+        std::env::set_var("EPICS_CA_ADDR_LIST", format!("127.0.0.1:{port}"));
+        std::env::set_var("EPICS_CA_AUTO_ADDR_LIST", "NO");
+        std::env::set_var("EPICS_CA_SERVER_PORT", port.to_string());
+    }
+}
+
+/// Bring up a server holding one `bi` record (native ENUM, VAL=0),
+/// returning a connected client channel.
+async fn server_with_bi(pv: &'static str) -> (CaClient, epics_ca_rs::client::CaChannel) {
+    let mut rec = BiRecord::new(0);
+    rec.znam = "Off".into();
+    rec.onam = "On".into();
+    let server = CaServer::builder()
+        .port(0)
+        .record(pv, rec)
+        .build()
+        .await
+        .expect("build CA server");
+    let port = server.udp_port();
+    let _h = tokio::spawn(async move { server.run().await });
+
+    point_client_at(port);
+    let client = CaClient::new().await.expect("client");
+    let ch = client.create_channel(pv);
+    ch.wait_connected(Duration::from_secs(3))
+        .await
+        .expect("connect");
+    (client, ch)
+}
+
+/// Native readback as a plain integer, whatever ENUM carrier comes back.
+async fn read_index(ch: &epics_ca_rs::client::CaChannel) -> i64 {
+    let (_t, v) = ch.get().await.expect("readback");
+    match v {
+        EpicsValue::Enum(i) => i as i64,
+        EpicsValue::EnumWithChoices { index, .. } => index as i64,
+        other => panic!("unexpected readback variant: {other:?}"),
+    }
+}
+
+/// Owner path: a variant already matching the native type is encoded
+/// verbatim — conversion is the identity.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn matching_enum_put_lands_index() {
+    let (_client, ch) = server_with_bi("PNC:BI:ENUM").await;
+    ch.put(&EpicsValue::Enum(1)).await.expect("put");
+    assert_eq!(read_index(&ch).await, 1);
+}
+
+/// Formerly-corrupted path: `Long(1)` on the ENUM-native `bi` must land
+/// as index 1. Pre-fix the DBR_ENUM header over Long bytes decoded to 0.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn long_put_on_enum_native_converts() {
+    let (_client, ch) = server_with_bi("PNC:BI:LONG").await;
+    ch.put_with_timeout(&EpicsValue::Long(1), Duration::from_secs(3))
+        .await
+        .expect("put");
+    assert_eq!(read_index(&ch).await, 1);
+}
+
+/// Float source takes the `putDoubleEnum` wrapping-cast lane of
+/// `convert_to` rather than the integer view — same header/payload
+/// invariant, different coercion path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn double_put_on_enum_native_converts() {
+    let (_client, ch) = server_with_bi("PNC:BI:DBL").await;
+    ch.put(&EpicsValue::Double(1.0)).await.expect("put");
+    assert_eq!(read_index(&ch).await, 1);
+}
+
+/// Fire-and-forget lane: `put_nowait` shares the encoding seam but has
+/// no completion callback, so poll the readback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn nowait_long_put_on_enum_native_converts() {
+    let (_client, ch) = server_with_bi("PNC:BI:NOWAIT").await;
+    ch.put_nowait(&EpicsValue::Long(1)).await.expect("put");
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if read_index(&ch).await == 1 {
+            break;
+        }
+        assert!(Instant::now() < deadline, "put_nowait value never landed");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}


### PR DESCRIPTION
put, put_with_timeout and put_nowait stamp the channel's native type on the frame but encoded the caller's variant verbatim, so Long(1) on an ENUM field shipped an ENUM header over i32 bytes and the server decoded the leading zero bytes as index 0 — a silent wrong-value write with a successful callback (found live: a sequencer daemon's bi puts of 1 landed as 0 while its 0-writes "worked"). Routing the value through convert_to(native_type) makes the header/payload pairing hold for every variant, calink cross-typed link puts included; validation now sees the converted request, as C nciu::write does.

The second commit keeps CaClient::drop panic-free on threads with no ambient reactor — the drop panic was masking the daemon's real bring-up error during unwind. Both fixes carry fail-before/pass-after regression tests.