### PR TITLE
build(release): bump workspace to 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,102 @@
 # Changelog
 
+## v0.26.0 — 2026-08-11
+
+Minor release. The upstream-issue audit lands its fix wave across the CA
+client/server, iocsh, db links, and access security; the QSRV PUT path is
+measured past pvxs QSRV2 on both server CPU and throughput; and the CA client
+no longer silently writes a wrong value on a cross-typed put. Five breaking
+API changes (epics-ca-rs, epics-base-rs, epics-pva-rs, epics-bridge-rs).
+Workspace version 0.25.4 -> 0.26.0, internal `[workspace.dependencies]` pins
+move to 0.26.0 in lockstep.
+
+### Breaking
+
+- **epics-ca-rs: `protocol::check_write_element_count` is renamed
+  `check_write_request`** and now owns the DBR-type bound as well as the
+  element-count bound, in C's order (`comQueSend.cpp:323/330`): a scalar
+  `put_as_dbr_*` with a type past `LAST_BUFFER_TYPE` is refused client-side
+  instead of reaching the server, which answers ECA_BADTYPE and drops the
+  circuit.
+
+- **epics-base-rs: `AcfCell` is a newtype, and `IocApplication.acf` holds
+  one** in place of `Option<AccessSecurityConfig>`. The cell is the IOC's
+  single live Access Security policy — every server built from the app must
+  share it so a later `asInit`/ACF reload reaches all of them. The old alias
+  invited re-wrapping the config in a fresh cell, which left the interactive
+  shell storing into a copy the servers never read.
+
+- **epics-base-rs: the record snapshot's `description` is `PvString`, not
+  `String`.** A non-UTF-8 DESC must reach the client byte-preserved, the
+  same rule `units` already follows.
+
+- **epics-pva-rs: the native server's per-op credential fields
+  (`account`/`method`/`host`/`authority`/`roles`) collapse into one shared
+  `ClientCreds`,** handed to access checks by reference instead of
+  re-cloning five strings per check.
+
+- **epics-bridge-rs: `AccessContext` carries `access` plus
+  `creds: Arc<ClientCreds>`** in place of its five owned string fields, for
+  the same reason.
+
+### The CA client writes the value you asked for
+
+`put`, `put_with_timeout` and `put_nowait` stamp the channel's native type on
+the frame but encoded the caller's variant verbatim, so `Long(1)` to an ENUM
+field shipped an ENUM header over i32 bytes and the server decoded the leading
+zero bytes as index 0 — a silent wrong-value write with a successful callback,
+found live under a sequencer daemon. The value now routes through
+`convert_to(native_type)` before encoding, as C's `nciu::write` does.
+`CaClient::drop` no longer panics on a thread without a tokio runtime (that
+unwind panic was masking the daemon's real bring-up error), and
+`EPICS_CA_NAME_SERVERS` entries are re-resolved through DNS on every redial
+instead of once at startup, with a nameserver's TLS SNI row keyed by hostname
+rather than its startup address.
+
+### QSRV PUT overtakes pvxs QSRV2
+
+Back-to-back on the same host, db and client (20,000 puts, 3 runs each), the
+shipped `qsrv-rs` reads 99.0–102.0 µs of server CPU per put at 3,781–3,842
+puts/s against pvxs `softIocPVX`'s 103.5–104.0 µs at 3,693–3,724 — every Rust
+run beats every pvxs run on both metrics (`doc/qsrv-put-perf.md`). What got it
+there: the server bins serve from one tokio worker (an idle multi-worker pool
+costs ~30 µs/put in wake/steal churn while one client's traffic is a single
+runnable task); per-peer channel resolution and the ACF grant per
+(channel, credential) are cached; a RULE's CALC compiles once at ACF parse; the
+INIT reply's inline type encoding is memoized; the negotiated `FieldDesc` and
+peer credentials are shared by `Arc`; a PUT delta decodes into the channel's
+scratch value; and a ready EXEC body runs inline instead of spawning a task.
+
+### The upstream-issue audit lands its fixes
+
+The 2026-08-09 sweep (`doc/upstream-issue-audit-2026-08-09.md`, 115 open
+epics-base issues triaged) turned into fixes across the workspace:
+
+- Framework link reads honor the record's declared DBR type, and
+  dbPut-analogue writes to DBF link fields are refused, as C refuses them.
+- iocsh: `<`/`iocshLoad` nesting is bounded at 32 levels; out-of-quote
+  backslash is honored in every line scanner; `db*` and directory-stack
+  failures return `Err` instead of printing and continuing;
+  `IOCSH_STARTUP_SCRIPT` is recorded on the first script load; `asInit`
+  stores into the IOC's live `AcfCell`.
+- Access security: HAG hostnames are re-resolved periodically under
+  `asCheckClientIP`, so a DHCP-moved client host does not keep its old grant.
+- db: SEARCH answers for record-own DBF_NOACCESS names as C does; a
+  substitutions-file entry that yields no template loads warns;
+  `putStringUlong`'s via-double fallback is ported for DBF_ULONG.
+- CA server: a compound DBR put (`DBR_STS_*`, `DBR_TIME_*`, …) no longer
+  drops the circuit (`doc/ca-compound-dbr-put.md`).
+- PVA: the server writer queue is bounded in bytes, not frames; qsrv refuses
+  a channel on a field the record does not have and serves
+  `display.description` from DESC as pvxs does; a refused CREATE_CHANNEL's
+  re-search parks a full ring out; the client emits the member name in the
+  `Tree` inline branch.
+- procServ: child exec allocations move before `forkpty`, off the
+  post-fork async-signal-unsafe window.
+
+The `--all-features` build of epics-ca-rs compiles again (`MdnsAnnouncer` is
+re-exported beside `MdnsBackend`, whose `announce_helper` returns it).
+
 ## v0.25.4 — 2026-08-04
 
 Patch release. The IPv6 SEARCH socket now builds on the embedded targets too,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -994,7 +994,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "cc",
  "libc",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2241,7 +2241,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3209,7 +3209,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3828,7 +3828,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,30 +29,30 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.25.4"
+version = "0.26.0"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.25.0" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.25.0" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.25.0" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.25.0" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.25.0" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.25.0" }
-epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.25.0" }
-epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.25.0" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.25.0" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.25.0" }
-motor-rs = { path = "crates/motor-rs", version = "0.25.0" }
-std-rs = { path = "crates/std-rs", version = "0.25.0" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.25.0" }
-optics-rs = { path = "crates/optics-rs", version = "0.25.0" }
-mca-rs = { path = "crates/mca-rs", version = "0.25.0" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.25.0" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.25.0", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.25.0" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.26.0" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.26.0" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.26.0" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.26.0" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.26.0" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.26.0" }
+epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.26.0" }
+epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.26.0" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.26.0" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.26.0" }
+motor-rs = { path = "crates/motor-rs", version = "0.26.0" }
+std-rs = { path = "crates/std-rs", version = "0.26.0" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.26.0" }
+optics-rs = { path = "crates/optics-rs", version = "0.26.0" }
+mca-rs = { path = "crates/mca-rs", version = "0.26.0" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.26.0" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.26.0", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.26.0" }
 
 # Deployable-image profile for the embedded targets (RTEMS / VxWorks), where
 # image size is a real resource: `cargo build --profile release-embedded ...`

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -205,7 +205,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # host-facing feature that pulls this dependency — `qsrv`, `pvalink`,
 # `pva-gateway`, `dual-ioc` — so host builds resolve exactly as before. Only
 # `qsrv-core`, the RTEMS selection, gets the reduced set.
-epics-pva-rs = { path = "../epics-pva-rs", version = "0.25.0", optional = true, default-features = false }
+epics-pva-rs = { path = "../epics-pva-rs", version = "0.26.0", optional = true, default-features = false }
 # `epics-ca-rs` stays inherited, but NOT because its defaults are empty — they
 # stopped being empty at `274a734b`, which introduced the `client-core`/`client`
 # split and made `default = ["client"]`. The reason is narrower and is a fact


### PR DESCRIPTION
v0.25.4..main carries five public API breaks that no commit flagged with a BREAKING footer — the check_write_request rename, the AcfCell newtype (IocApplication.acf holds it), the snapshot DESC as PvString, and the credential collapse into a shared ClientCreds on the PVA/qsrv side — so this is a minor bump, not the patch the commit subjects suggest. Dependency pins move to 0.26.0 in lockstep; the CHANGELOG section is written from the 54-commit log.