### PR TITLE
fix: port six upstream fixes (base #871/#856/#934/#853, pvxs #189, asyn #217)

### DIFF
--- a/crates/asyn-rs/src/port.rs
+++ b/crates/asyn-rs/src/port.rs
@@ -692,6 +692,14 @@ impl PortDriverBase {
     /// (the port is not yet registered, so no listeners exist).
     pub fn set_auto_connect(&mut self, yes: bool) {
         self.auto_connect = yes;
+        // asyn PR #217 (asynManager.c:2322-2324): flipping auto-connect ON
+        // while the port is down starts the connect timer, so the flip
+        // alone brings the port up. Pre-fix, the only autonomous attempt
+        // was the one exception-wake pass — one try, then silence until
+        // traffic or a disconnect edge armed the timer.
+        if yes && !self.connected.get() {
+            self.connect_retry_at = Some(Instant::now() + CONNECT_RETRY_INITIAL);
+        }
         self.announce_exception(AsynException::AutoConnect, -1);
     }
 
@@ -700,7 +708,17 @@ impl PortDriverBase {
     /// device pasynUser hits the device's dpc, otherwise the port's
     /// dpc (asynManager.c:2314 + findDpCommon).
     pub fn set_auto_connect_addr(&mut self, addr: i32, yes: bool) {
-        self.device_state(addr).auto_connect = yes;
+        let device_down = {
+            let dev = self.device_state(addr);
+            dev.auto_connect = yes;
+            !dev.connected
+        };
+        // Same PR #217 arm as `set_auto_connect`: C keys the check on the
+        // dpCommon `findDpCommon` resolved — the DEVICE's — while the
+        // timer it starts is the port's (asynManager.c:2322-2324).
+        if yes && device_down {
+            self.connect_retry_at = Some(Instant::now() + CONNECT_RETRY_INITIAL);
+        }
         self.announce_exception(AsynException::AutoConnect, addr);
     }
 
@@ -3440,6 +3458,47 @@ mod tests {
         base.set_auto_connect(false);
         base.set_auto_connect(false);
         assert_eq!(hits.load(Ordering::Relaxed), 3);
+    }
+
+    /// asyn PR #217 (asynManager.c:2322-2324): enabling auto-connect on a
+    /// down port/device arms the connect timer; a connected port, or a
+    /// flip to OFF, arms nothing. Pre-fix no flip armed the timer, so a
+    /// never-connected port enabled late made one exception-wake attempt
+    /// and then sat silent.
+    #[test]
+    fn auto_connect_enable_arms_connect_timer_boundaries() {
+        // dropped while auto-connect was OFF (the disconnect edge arms
+        // nothing then, port.rs sync_connection_edge), enabled late →
+        // the flip itself must arm
+        let mut base = PortDriverBase::new("act", 1, PortFlags::default());
+        base.set_auto_connect(false);
+        base.set_connected(false);
+        assert!(base.connect_retry_at.is_none());
+        base.set_auto_connect(true);
+        assert!(base.connect_retry_at.is_some());
+
+        // down + OFF → untouched (C's timer callback no-ops on
+        // !autoConnect; the flip itself must not arm)
+        let mut base = PortDriverBase::new("act2", 1, PortFlags::default());
+        base.set_auto_connect(false);
+        base.set_connected(false);
+        base.set_auto_connect(false);
+        assert!(base.connect_retry_at.is_none());
+
+        // connected + ON → nothing to retry (a fresh base is born
+        // `Connection::Own(true)`)
+        let mut base = PortDriverBase::new("act3", 1, PortFlags::default());
+        base.set_auto_connect(true);
+        assert!(base.connect_retry_at.is_none());
+
+        // device down + ON via the addr variant → the PORT timer arms,
+        // keyed on the device's dpCommon exactly as C's findDpCommon
+        // resolution is; the port itself stays connected
+        let mut base = PortDriverBase::new("act4", 2, PortFlags::default());
+        base.device_state(1).connected = false;
+        assert!(base.connect_retry_at.is_none());
+        base.set_auto_connect_addr(1, true);
+        assert!(base.connect_retry_at.is_some());
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/access_security.rs
+++ b/crates/epics-base-rs/src/server/access_security.rs
@@ -832,7 +832,9 @@ impl AccessSecurityConfig {
         for name in uags {
             out.push_str(&format!("UAG({name})\n"));
             for m in &self.uag[name] {
-                out.push_str(&format!("\t{m}\n"));
+                out.push('\t');
+                dump_quoted(&mut out, m);
+                out.push('\n');
             }
         }
         let mut hags: Vec<_> = self.hag.keys().collect();
@@ -840,7 +842,9 @@ impl AccessSecurityConfig {
         for name in hags {
             out.push_str(&format!("HAG({name})\n"));
             for h in &self.hag[name] {
-                out.push_str(&format!("\t{h}\n"));
+                out.push('\t');
+                dump_quoted(&mut out, h);
+                out.push('\n');
             }
         }
         let mut asgs: Vec<_> = self.asg.keys().collect();
@@ -1548,6 +1552,17 @@ pub fn subscribe_asg_changes() -> tokio::sync::broadcast::Receiver<()> {
 }
 
 /// Parse an ACF (Access Control File).
+/// C `asDumpQuoted` (asLibRoutines.c:660-666, epics-base #871): print a
+/// UAG/HAG member as `"` + `epicsStrPrintEscaped` + `"`. C passes
+/// `strlen(s)`, so the escape never runs past a NUL byte.
+fn dump_quoted(out: &mut String, s: &str) {
+    let bytes = s.as_bytes();
+    let len = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    out.push('"');
+    out.push_str(&crate::runtime::epics_string::print_escaped(&bytes[..len]));
+    out.push('"');
+}
+
 pub fn parse_acf(content: &str) -> CaResult<AccessSecurityConfig> {
     let mut config = AccessSecurityConfig {
         uag: HashMap::new(),
@@ -2672,6 +2687,23 @@ ASG(DEFAULT) {
             config.check_access("DEFAULT", "", ""),
             AccessLevel::ReadWrite
         );
+    }
+
+    /// epics-base #871 (7e18b8cff): `asDump*` quotes every UAG and HAG
+    /// member through `asDumpQuoted` — `"` + `epicsStrPrintEscaped` + `"`
+    /// — so a member that needed ACF quoting (`"role/op"`, an embedded
+    /// `"`) survives the dump unambiguously instead of printing raw.
+    #[test]
+    fn dump_report_quotes_uag_and_hag_members() {
+        let cfg =
+            parse_acf("UAG(special) { someone, \"role/op\", \"a\\\"b\" }\nHAG(hosts) { HostA }\n")
+                .unwrap();
+        let dump = cfg.dump_report();
+        assert!(dump.contains("\t\"someone\"\n"), "{dump}");
+        assert!(dump.contains("\t\"role/op\"\n"), "{dump}");
+        assert!(dump.contains("\t\"a\\\"b\"\n"), "{dump}");
+        // HAG members are stored lowercased; quoted the same way.
+        assert!(dump.contains("\t\"hosta\"\n"), "{dump}");
     }
 
     // ----- epics-base PR #563/#618: METHOD / AUTHORITY -----

--- a/crates/epics-base-rs/src/server/database/link_set.rs
+++ b/crates/epics-base-rs/src/server/database/link_set.rs
@@ -249,6 +249,21 @@ pub trait LinkSet: Send + Sync {
     /// record's advisory write gate. MUST NOT perform I/O.
     fn is_connected(&self, name: &str) -> bool;
 
+    /// True iff `name` has completed every post-connect init action
+    /// iocInit's external-link wait holds for — C `testInitReady`
+    /// (dbCa.c:835-845, epics-base #856 "dbCa: iocInit wait for all
+    /// conditions"): connected with the first monitor event cached AND
+    /// the attribute (metadata) fetch complete. Distinct from
+    /// [`Self::is_connected`], which is C's lset `isConnected` and keeps
+    /// its readable-cache semantics.
+    ///
+    /// Synchronous and non-blocking like `is_connected`; polled only by
+    /// the iocInit wait. Default: `is_connected` — right for an lset
+    /// with no post-connect init actions.
+    fn init_ready(&self, name: &str) -> bool {
+        self.is_connected(name)
+    }
+
     /// Read the current value of `name`. Returns None when the
     /// upstream isn't yet connected or the lset has no cache for
     /// this name.

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -971,8 +971,10 @@ impl PvDatabase {
     }
 
     /// Wait for the CA links to local records to report
-    /// `is_connected() == true`. Mirrors `dbCa: iocInit wait for local CA
-    /// links to connect` (epics-base PR #768/#856). The working set is
+    /// `init_ready() == true` — connected, first monitor event cached,
+    /// attribute fetch complete. Mirrors `dbCa: iocInit wait for local CA
+    /// links to connect` (epics-base PR #768) as extended by #856's
+    /// `testInitReady` all-conditions gate. The working set is
     /// exactly `Self::external_link_targets`: only the CA facility's
     /// local-target links — `pva://` links and non-local CA links connect
     /// in the background and are never waited on (pvxs parity).
@@ -1010,7 +1012,11 @@ impl PvDatabase {
         loop {
             let mut connected = 0usize;
             for (lset, name) in &targets {
-                if lset.is_connected(name) {
+                // `init_ready`, not `is_connected`: C `testInitReady`
+                // (dbCa.c:835, epics-base #856) releases iocInit only when
+                // the link's monitor AND attribute-fetch actions have all
+                // completed, not on the bare connection edge.
+                if lset.init_ready(name) {
                     connected += 1;
                 }
             }
@@ -1069,7 +1075,9 @@ impl PvDatabase {
     pub async fn unconnected_external_links(&self) -> Vec<String> {
         let mut names = Vec::new();
         for (lset, name) in self.external_link_targets().await {
-            if !lset.is_connected(&name) {
+            // Same predicate as the wait loop, so the M/N accounting and
+            // this diagnostic agree on which links held iocInit.
+            if !lset.init_ready(&name) {
                 names.push(name);
             }
         }
@@ -2393,6 +2401,56 @@ mod tests {
         );
         // And it is reported as unconnected by neither path (silent, like C).
         assert!(db.unconnected_external_links().await.is_empty());
+    }
+
+    /// Lset that is connected but whose post-connect init actions (the
+    /// metadata fetch) never complete: `init_ready` stays false.
+    struct ConnectedMetaPendingLset {
+        names: Vec<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl link_set::LinkSet for ConnectedMetaPendingLset {
+        fn is_connected(&self, _: &str) -> bool {
+            true
+        }
+        fn init_ready(&self, _: &str) -> bool {
+            false
+        }
+        fn get_cached_value(&self, _: &str) -> Option<EpicsValue> {
+            None
+        }
+        async fn get_value(&self, name: &str) -> Option<EpicsValue> {
+            self.get_cached_value(name)
+        }
+        fn link_names(&self) -> Vec<String> {
+            self.names.clone()
+        }
+    }
+
+    /// epics-base #856 (ef4829829, "dbCa: iocInit wait for all
+    /// conditions"): a connected link whose attribute fetch has not
+    /// completed still holds iocInit — the wait polls `init_ready`
+    /// (C `testInitReady`'s three-bit gate), not `is_connected` alone,
+    /// and the timeout diagnostic names the link it proceeded without.
+    #[epics_macros_rs::epics_test]
+    async fn wait_for_external_links_holds_until_init_ready() {
+        let db = PvDatabase::new();
+        db.add_pv("meta:pending", EpicsValue::Long(0))
+            .await
+            .unwrap();
+        let lset = Arc::new(ConnectedMetaPendingLset {
+            names: vec!["meta:pending".to_string()],
+        });
+        db.register_link_set("ca", lset).await;
+        let (c, t) = db
+            .wait_for_external_links(std::time::Duration::from_millis(250))
+            .await;
+        assert_eq!((c, t), (0, 1));
+        assert_eq!(
+            db.unconnected_external_links().await,
+            vec!["meta:pending".to_string()]
+        );
     }
 
     // epics-base PR #336 — alias parsing + lookup integration tests.

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -1864,6 +1864,22 @@ impl RecordInstance {
         // the CA create-channel path announced from `client_field_value` and
         // the same one the monitor path posts.
         let value = self.client_field_value(field)?;
+        Some(self.finish_field_snapshot(field, value))
+    }
+
+    /// The one finishing pipeline behind both `Snapshot` producers
+    /// ([`Self::snapshot_for_field`] for GET, [`Self::make_monitor_snapshot`]
+    /// for updates). Every step that shapes a served snapshot — alarm/utag
+    /// carry, the metadata cache, per-field routing and RSET overrides, menu
+    /// enums, property support, the `Q:time:tag` nsec split — runs here, so
+    /// the two paths cannot drift apart. Upstream pvxs PR #189 is exactly
+    /// that drift: its subscription callback served unmasked nanoseconds
+    /// while its GET path applied the nsec mask.
+    fn finish_field_snapshot(
+        &self,
+        field: &str,
+        value: EpicsValue,
+    ) -> super::super::snapshot::Snapshot {
         let mut snap = super::super::snapshot::Snapshot::new(
             value,
             self.common.stat,
@@ -1928,7 +1944,7 @@ impl RecordInstance {
         // gate is.
         crate::server::snapshot::apply_nsec_mask(&mut snap, self.qtime_nsec_mask());
 
-        Some(snap)
+        snap
     }
 
     /// Resolve `info(Q:time:tag)` to pvxs's `MappingInfo::nsecMask`.
@@ -4457,40 +4473,7 @@ impl RecordInstance {
         // CA create-channel path use, or a client that was told `DBR_ENUM` at
         // create time would be posted a `DBR_SHORT` update.
         let value = self.project_to_declared_type(field, value);
-        let mut snap = super::super::snapshot::Snapshot::new(
-            value,
-            self.common.stat,
-            self.common.sevr as u16,
-            self.common.time,
-        );
-        // Carry the record's `utag` into the monitor update's
-        // `timeStamp.userTag`, same as the GET path
-        // (`snapshot_for_field`) and pvxs `iocsource.cpp:245`. Narrows
-        // the 64-bit `epicsUTag` to the int32 wire field by low-32-bit
-        // truncation.
-        snap.user_tag = self.common.utag as i32;
-        // Same amsg carry as the GET path (`snapshot_for_field`): a monitor
-        // update serves the record's own `common.amsg`, so PVA
-        // `alarm.message` matches a read of the same channel.
-        snap.alarm.amsg = self.common.amsg.clone();
-        let meta = self.cached_metadata();
-        snap.display = meta.display;
-        snap.control = meta.control;
-        snap.enums = meta.enums;
-        // Same per-field routing owner as the GET path — a monitor update must
-        // carry the same metadata a read of that field would.
-        self.route_field_metadata(field, &mut snap);
-        // Per-field RSET metadata, same as the GET path
-        // (`snapshot_for_field`) — a monitor update for VELO must carry
-        // VELO's limits, not the record-level VAL limits.
-        self.apply_field_metadata_override(field, &mut snap);
-        // A monitored DBF_MENU field carries the same DBR_ENUM value and
-        // choice labels as the GET path, so a `camonitor`/`pvmonitor`
-        // update shows the menu label, not a bare index.
-        self.attach_menu_enum(field, &mut snap);
-        // Same owner, same settled value, same mask as the GET path.
-        self.assign_property_support(field, &mut snap);
-        snap
+        self.finish_field_snapshot(field, value)
     }
 
     /// Apply a record's per-field metadata override (C RSET
@@ -5700,6 +5683,28 @@ mod metadata_cache_tests {
         assert_eq!(snap.user_tag, 123_456_700);
         assert_eq!(snap.timestamp.subsec_nanos(), 0);
         assert_eq!(snap.timestamp.unix_secs(), 42);
+    }
+
+    /// The monitor path applies the same `Q:time:tag` nsec split as GET.
+    /// Pre-fix, `make_monitor_snapshot` skipped `apply_nsec_mask`, so a
+    /// monitor update on a `nsec:lsb:N` record posted the raw nanoseconds
+    /// and the record utag while a GET of the same channel served the
+    /// split — upstream pvxs PR #189 is the same defect in its
+    /// `subscriptionCallback`.
+    #[test]
+    fn qtime_nsec_mask_applies_on_the_monitor_path() {
+        use std::time::{Duration, SystemTime};
+        let mut inst = ai_instance();
+        // 100 ns-multiple so the subsec_nanos assertion holds on Windows too;
+        // see qtime_nsec_lsb_31_is_served_not_ignored for the FILETIME reason.
+        inst.common.time = SystemTime::UNIX_EPOCH + Duration::new(42, 123_456_700);
+        inst.common.utag = 5;
+        inst.set_info("Q:time:tag", "nsec:lsb:31");
+
+        let mon = inst.make_monitor_snapshot("VAL", EpicsValue::Double(1.0));
+        assert_eq!(mon.user_tag, 123_456_700);
+        assert_eq!(mon.timestamp.subsec_nanos(), 0);
+        assert_eq!(mon.timestamp.unix_secs(), 42);
     }
 
     /// The mirror boundary: a tag pvxs's `strncmp` rejects must leave the

--- a/crates/epics-ca-rs/src/calink/resolver.rs
+++ b/crates/epics-ca-rs/src/calink/resolver.rs
@@ -370,7 +370,7 @@ impl CaLink {
     /// `testInitReady` (dbCa.c:835-845, epics-base #856 "dbCa: iocInit
     /// wait for all conditions"): servable (connected with the first
     /// monitor event cached — C's NATIVE wait bit) AND the attribute
-    /// fetch complete (the ATTRIB bit; [`fetch_link_metadata`] stores
+    /// fetch complete (the ATTRIB bit; `fetch_link_metadata` stores
     /// `Some` even when the CTRL get failed, exactly the
     /// action-completed edge `getAttribEventCallback` clears the bit
     /// on). C's STRING bit has no twin here: this port keeps one native

--- a/crates/epics-ca-rs/src/calink/resolver.rs
+++ b/crates/epics-ca-rs/src/calink/resolver.rs
@@ -366,6 +366,19 @@ impl CaLink {
         self.with_servable(|_| ()).is_some()
     }
 
+    /// The iocInit wait's all-conditions gate for this link — C
+    /// `testInitReady` (dbCa.c:835-845, epics-base #856 "dbCa: iocInit
+    /// wait for all conditions"): servable (connected with the first
+    /// monitor event cached — C's NATIVE wait bit) AND the attribute
+    /// fetch complete (the ATTRIB bit; [`fetch_link_metadata`] stores
+    /// `Some` even when the CTRL get failed, exactly the
+    /// action-completed edge `getAttribEventCallback` clears the bit
+    /// on). C's STRING bit has no twin here: this port keeps one native
+    /// monitor and renders strings from it.
+    pub fn init_ready(&self) -> bool {
+        self.is_connected() && self.meta.load().is_some()
+    }
+
     /// Current cached value, or `None` when the link is not servable: no
     /// event yet, the circuit is down, READ access is denied, or the cached
     /// snapshot's type/count no longer matches the channel after an
@@ -970,6 +983,14 @@ impl LinkSet for CaLinkResolver {
             Some(link) => link.is_connected(),
             // Not opened yet — report not connected. `open` /
             // `get_value` open it lazily.
+            None => false,
+        }
+    }
+
+    fn init_ready(&self, name: &str) -> bool {
+        let name = strip_ca_scheme(name);
+        match self.links.read().get(name) {
+            Some(link) => link.init_ready(),
             None => false,
         }
     }

--- a/crates/epics-ca-rs/src/server/blocking.rs
+++ b/crates/epics-ca-rs/src/server/blocking.rs
@@ -3546,6 +3546,210 @@ mod tests {
         );
     }
 
+    /// Build a WRITE / WRITE_NOTIFY frame with an explicit wire count and
+    /// payload, for the epics-base #934 cross-check tests below.
+    fn put_frame(
+        cmmd: u16,
+        data_type: u16,
+        count: u32,
+        sid: u32,
+        ioid: u32,
+        payload: &[u8],
+    ) -> Vec<u8> {
+        let mut h = CaHeader::new(cmmd);
+        h.data_type = data_type;
+        h.cid = sid;
+        h.available = ioid;
+        h.set_payload_size(payload.len(), count, CA_MINOR_VERSION)
+            .expect("modern peer accepts the extended header");
+        let mut f = h.to_bytes().to_vec();
+        f.extend_from_slice(payload);
+        f
+    }
+
+    /// Session helper for the #934 write tests: VERSION + CREATE_CHAN for
+    /// `pv` (-> sid 1), outbox drained of the create replies.
+    fn write_test_session(
+        pv: &str,
+        seed: EpicsValue,
+    ) -> (Arc<PvDatabase>, ClientState, outbox::Outbox, OutboxDrain) {
+        let db = seed_db(&[(pv, seed)]);
+        let acf = new_acf();
+        let mut state = ClientState::new(acf, 5064, db.clone());
+        let peer: SocketAddr = "127.0.0.1:5064".parse().unwrap();
+        state.apply_connection_identity(peer, None, None);
+        let (outbox, mut drain) = outbox::channel();
+        for frame in [version_frame(), create_chan_frame(0x1234, pv)] {
+            let (hdr, hdr_size) =
+                CaHeader::from_bytes_for_peer(&frame, state.client_minor_version()).unwrap();
+            let payload = frame[hdr_size..].to_vec();
+            block_on_sync(dispatch_message(
+                &hdr, &payload, &mut state, &db, &outbox, peer, None,
+            ))
+            .unwrap()
+            .unwrap();
+        }
+        while drain.try_next().is_some() {}
+        (db, state, outbox, drain)
+    }
+
+    /// epics-base #934 (4128a7c07): `write_notify_action` cross-checks
+    /// `dbr_size_n(m_dataType, m_count)` against `m_postsize` AFTER the
+    /// access gate — a declared count whose DBR size exceeds the received
+    /// payload is RSRV_ERROR with NO reply frame. Pre-fix the payload was
+    /// silently truncated by `from_bytes_array` and the put proceeded.
+    #[test]
+    fn write_notify_payload_shorter_than_declared_count_drops_silently() {
+        let (db, mut state, outbox, mut drain) =
+            write_test_session("WR:ARR", EpicsValue::DoubleArray(vec![1.0, 2.0]));
+        let peer: SocketAddr = "127.0.0.1:5064".parse().unwrap();
+
+        // count=2 doubles declared, 8-byte payload (one double).
+        let f = put_frame(
+            CA_PROTO_WRITE_NOTIFY,
+            DBR_DOUBLE_MON,
+            2,
+            1,
+            0x51,
+            &9.0f64.to_be_bytes(),
+        );
+        let (hdr, hdr_size) =
+            CaHeader::from_bytes_for_peer(&f, state.client_minor_version()).unwrap();
+        let payload = f[hdr_size..].to_vec();
+        let res = block_on_sync(dispatch_message(
+            &hdr, &payload, &mut state, &db, &outbox, peer, None,
+        ))
+        .unwrap();
+        assert!(
+            res.is_err(),
+            "short WRITE_NOTIFY payload must be RSRV_ERROR (C size > m_postsize)"
+        );
+        assert!(
+            drain.try_next().is_none(),
+            "C write_notify_action sends nothing before this RSRV_ERROR"
+        );
+        // The put never ran.
+        assert_eq!(
+            simple_pv(&db, "WR:ARR").get(),
+            EpicsValue::DoubleArray(vec![1.0, 2.0])
+        );
+    }
+
+    /// epics-base #934 (4128a7c07): both write actions clamp `m_count` to
+    /// `dbChannelFinalElements` BEFORE sizing and putting, so an oversized
+    /// count writes the channel's real capacity and the put-callback reply
+    /// echoes the CLAMPED count. Pre-fix the full wire count was decoded
+    /// (an array landed in a scalar channel) and echoed back.
+    #[test]
+    fn write_notify_count_above_capacity_clamps_to_channel_elements() {
+        let (db, mut state, outbox, mut drain) =
+            write_test_session("WR:CLAMP", EpicsValue::Double(1.0));
+        let peer: SocketAddr = "127.0.0.1:5064".parse().unwrap();
+
+        // count=4 doubles on a scalar channel, payload fully present.
+        let mut payload = Vec::new();
+        for v in [9.0f64, 8.0, 7.0, 6.0] {
+            payload.extend_from_slice(&v.to_be_bytes());
+        }
+        let f = put_frame(CA_PROTO_WRITE_NOTIFY, DBR_DOUBLE_MON, 4, 1, 0x52, &payload);
+        let (hdr, hdr_size) =
+            CaHeader::from_bytes_for_peer(&f, state.client_minor_version()).unwrap();
+        let payload = f[hdr_size..].to_vec();
+        block_on_sync(dispatch_message(
+            &hdr, &payload, &mut state, &db, &outbox, peer, None,
+        ))
+        .unwrap()
+        .unwrap();
+
+        // The scalar channel holds the FIRST element, not a 4-element array.
+        assert_eq!(simple_pv(&db, "WR:CLAMP").get(), EpicsValue::Double(9.0));
+
+        // The WRITE_NOTIFY reply echoes the clamped count (C echoes the
+        // mutated mp->m_count).
+        let reply = loop {
+            let f = drain.try_next().expect("a WRITE_NOTIFY reply frame");
+            if u16::from_be_bytes([f[0], f[1]]) == CA_PROTO_WRITE_NOTIFY {
+                break f.to_vec();
+            }
+        };
+        let (rh, _) = CaHeader::from_bytes_for_peer(&reply, state.client_minor_version()).unwrap();
+        assert_eq!(rh.actual_count(), 1, "reply must echo the clamped count");
+    }
+
+    /// epics-base #934 (4128a7c07): the size cross-check covers
+    /// DBR_PUT_ACKT/ACKS too — `dbr_size_n(DBR_PUT_ACKT, m_count)` = 2
+    /// bytes against an empty payload is RSRV_ERROR before the access
+    /// gate (write_action order). Pre-fix the missing u16 defaulted to 0
+    /// and the alarm-ack path ran with a value the peer never sent.
+    #[test]
+    fn write_put_ackt_with_empty_payload_drops_silently() {
+        let (db, mut state, outbox, mut drain) =
+            write_test_session("WR:ACK", EpicsValue::Double(1.0));
+        let peer: SocketAddr = "127.0.0.1:5064".parse().unwrap();
+
+        let f = put_frame(
+            CA_PROTO_WRITE,
+            epics_base_rs::types::DBR_PUT_ACKT,
+            1,
+            1,
+            0x53,
+            &[],
+        );
+        let (hdr, hdr_size) =
+            CaHeader::from_bytes_for_peer(&f, state.client_minor_version()).unwrap();
+        let payload = f[hdr_size..].to_vec();
+        let res = block_on_sync(dispatch_message(
+            &hdr, &payload, &mut state, &db, &outbox, peer, None,
+        ))
+        .unwrap();
+        assert!(
+            res.is_err(),
+            "PUT_ACKT with no payload must be RSRV_ERROR (C size > m_postsize)"
+        );
+        assert!(
+            drain.try_next().is_none(),
+            "C write_action sends nothing before this RSRV_ERROR"
+        );
+    }
+
+    /// epics-base PR #944 (regression #943): a scalar DBR_STRING put is
+    /// exempt from the `dbr_size_n` check — libca frames it as
+    /// `CA_MESSAGE_ALIGN(strlen+1)`, not 40 bytes — but the payload must
+    /// be NUL-terminated within `m_postsize`
+    /// (`epicsStrnLen >= m_postsize` → RSRV_ERROR). The accept arm is
+    /// covered end-to-end by the CLI tests (real `caput` framing).
+    #[test]
+    fn write_scalar_string_without_nul_drops_silently() {
+        let (db, mut state, outbox, mut drain) =
+            write_test_session("WR:STR", EpicsValue::Double(1.0));
+        let peer: SocketAddr = "127.0.0.1:5064".parse().unwrap();
+
+        let f = put_frame(
+            CA_PROTO_WRITE,
+            epics_base_rs::types::DBR_STRING,
+            1,
+            1,
+            0x54,
+            b"AAAAAAAA",
+        );
+        let (hdr, hdr_size) =
+            CaHeader::from_bytes_for_peer(&f, state.client_minor_version()).unwrap();
+        let payload = f[hdr_size..].to_vec();
+        let res = block_on_sync(dispatch_message(
+            &hdr, &payload, &mut state, &db, &outbox, peer, None,
+        ))
+        .unwrap();
+        assert!(
+            res.is_err(),
+            "scalar string with no NUL in the payload must be RSRV_ERROR (PR #944)"
+        );
+        assert!(
+            drain.try_next().is_none(),
+            "C write_action sends nothing before this RSRV_ERROR"
+        );
+        assert_eq!(simple_pv(&db, "WR:STR").get(), EpicsValue::Double(1.0));
+    }
+
     fn events_off_frame() -> Vec<u8> {
         CaHeader::new(CA_PROTO_EVENTS_OFF).to_bytes().to_vec()
     }
@@ -3968,6 +4172,23 @@ mod tests {
         f
     }
 
+    /// A deprecated `CA_PROTO_WRITE` carrying `DBR_CLASS_NAME` with its
+    /// full 40-byte (`dbr_size_n`) payload — post-#934 the server
+    /// cross-checks `dbr_size_n(type, count)` against the postsize, so a
+    /// shorter frame would be dropped before reaching `dbChannel_put`.
+    fn class_name_write_frame(sid: u32) -> Vec<u8> {
+        let mut h = CaHeader::new(CA_PROTO_WRITE);
+        h.data_type = epics_base_rs::types::DBR_CLASS_NAME;
+        h.count = 1;
+        h.cid = sid;
+        h.available = 0;
+        h.set_payload_size(40, 1, CA_MINOR_VERSION)
+            .expect("modern peer");
+        let mut f = h.to_bytes().to_vec();
+        f.extend_from_slice(&[0u8; 40]);
+        f
+    }
+
     /// Alarm status a compound-put test injects — a value the record must NOT
     /// end up carrying.
     const INJECTED_STATUS: u16 = 3;
@@ -4313,12 +4534,7 @@ mod tests {
 
         let (mut c, sid) = connected_client(addr, "BLK:MDO");
 
-        c.write_all(&plain_write_frame(
-            sid,
-            epics_base_rs::types::DBR_CLASS_NAME,
-            7.5,
-        ))
-        .unwrap();
+        c.write_all(&class_name_write_frame(sid)).unwrap();
         let rb_ioid = 0x0000_5A5C;
         c.write_all(&read_notify_frame(sid, rb_ioid, DBR_DOUBLE_MON))
             .unwrap();
@@ -4401,12 +4617,7 @@ mod tests {
             "the compound WRITE_NOTIFY is still a failed put"
         );
 
-        c.write_all(&plain_write_frame(
-            sid,
-            epics_base_rs::types::DBR_CLASS_NAME,
-            7.5,
-        ))
-        .unwrap();
+        c.write_all(&class_name_write_frame(sid)).unwrap();
         let err = read_until_cmmd(&mut c, crate::protocol::CA_PROTO_ERROR);
         assert_eq!(
             u32::from_be_bytes([err[12], err[13], err[14], err[15]]),
@@ -4453,10 +4664,10 @@ mod tests {
     }
 
     /// The other side of the same boundary: ABOVE `LAST_BUFFER_TYPE` there is no
-    /// such tolerance. C's `caNetConvert` (`ca/src/client/convert.cpp:1421`)
-    /// answers ECA_BADTYPE and `write_action` returns RSRV_ERROR, so the circuit
-    /// goes down. Guards the compound tolerance above from widening into
-    /// "accept anything".
+    /// such tolerance. Post-#934, `write_action`'s `INVALID_DB_REQ` gate runs
+    /// before anything else and answers with `log_header` only — no error
+    /// frame — then RSRV_ERROR, so the circuit goes down silently. Guards the
+    /// compound tolerance above from widening into "accept anything".
     #[test]
     fn dbr_type_above_last_buffer_type_still_drops_the_circuit() {
         let db = seed_db(&[("BLK:BADT", EpicsValue::Double(0.0))]);
@@ -4471,19 +4682,12 @@ mod tests {
         let over = epics_base_rs::types::LAST_BUFFER_TYPE + 1;
         c.write_all(&plain_write_frame(sid, over, 7.5)).unwrap();
 
-        let err = read_until_cmmd(&mut c, crate::protocol::CA_PROTO_ERROR);
-        assert_eq!(
-            u32::from_be_bytes([err[12], err[13], err[14], err[15]]),
-            crate::protocol::ECA_BADTYPE,
-            "past C's protocol bound the answer is ECA_BADTYPE, not ECA_PUTFAIL"
-        );
-
-        // ... and the circuit goes down: a read returns EOF rather than blocking.
+        // The circuit goes down with no frame first: EOF, not ECA_BADTYPE.
         c.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
         let mut probe = [0u8; 1];
         match c.read(&mut probe) {
             Ok(0) => { /* RSRV_ERROR: the circuit is torn down, as C does */ }
-            Ok(_) => panic!("unexpected extra frame bytes after the ECA_BADTYPE reply"),
+            Ok(_) => panic!("C sends no frame for a bad-type WRITE (log_header only)"),
             Err(e) if is_read_timeout(e.kind()) => {
                 panic!("circuit stayed open; C drops it (write_action RSRV_ERROR)")
             }

--- a/crates/epics-ca-rs/src/server/blocking.rs
+++ b/crates/epics-ca-rs/src/server/blocking.rs
@@ -3483,6 +3483,69 @@ mod tests {
         f
     }
 
+    /// epics-base #934 (4128a7c07): `event_add_action` refuses a truncated
+    /// `struct mon_info` — `m_postsize < sizeof(*pmi)` (16 bytes) joins the
+    /// INVALID_DB_REQ pre-lookup gate and returns RSRV_ERROR with NO reply
+    /// frame. Pre-fix a short payload was accepted with a defaulted
+    /// DBE_VALUE|DBE_ALARM mask C never applies.
+    #[test]
+    fn event_add_with_truncated_mon_info_drops_silently() {
+        let db = seed_db(&[("SHORT:MON", EpicsValue::Double(1.0))]);
+        let acf = new_acf();
+        let mut state = ClientState::new(acf, 5064, db.clone());
+        let peer: SocketAddr = "127.0.0.1:5064".parse().unwrap();
+        state.apply_connection_identity(peer, None, None);
+        let (outbox, mut drain) = outbox::channel();
+
+        let run = |state: &mut ClientState, frame: Vec<u8>| {
+            let (hdr, hdr_size) =
+                CaHeader::from_bytes_for_peer(&frame, state.client_minor_version()).unwrap();
+            let payload = frame[hdr_size..].to_vec();
+            block_on_sync(dispatch_message(
+                &hdr, &payload, state, &db, &outbox, peer, None,
+            ))
+            .unwrap()
+            .unwrap();
+        };
+        run(&mut state, version_frame());
+        run(&mut state, create_chan_frame(0x1234, "SHORT:MON")); // -> sid 1
+        while drain.try_next().is_some() {} // shed the create_chan replies
+
+        // 8-byte payload: two dead-band floats, mask and pad missing.
+        let mut h = CaHeader::new(CA_PROTO_EVENT_ADD);
+        h.data_type = DBR_DOUBLE_MON;
+        h.count = 1;
+        h.cid = 1;
+        h.available = 77;
+        h.set_payload_size(8, 1, CA_MINOR_VERSION).unwrap();
+        let mut f = h.to_bytes().to_vec();
+        f.extend_from_slice(&0f32.to_be_bytes());
+        f.extend_from_slice(&0f32.to_be_bytes());
+
+        let (hdr, hdr_size) =
+            CaHeader::from_bytes_for_peer(&f, state.client_minor_version()).unwrap();
+        let payload = f[hdr_size..].to_vec();
+        let outcome = block_on_sync(register_subscription(
+            &hdr,
+            &payload,
+            &state,
+            &outbox,
+            SubscriptionDelivery::HandOff,
+            || 0usize,
+            false,
+        ))
+        .expect("blockable");
+        assert!(
+            outcome.is_err(),
+            "truncated mon_info must be RSRV_ERROR, not an installed subscription"
+        );
+        // Silent, like C: no CA_PROTO_ERROR (or any) frame precedes the drop.
+        assert!(
+            drain.try_next().is_none(),
+            "C event_add_action sends nothing before RSRV_ERROR"
+        );
+    }
+
     fn events_off_frame() -> Vec<u8> {
         CaHeader::new(CA_PROTO_EVENTS_OFF).to_bytes().to_vec()
     }

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -3952,6 +3952,37 @@ pub(crate) async fn serve_write_head(
                 )));
             }
         };
+        // epics-base #934 (4128a7c07): both write actions clamp `m_count`
+        // to `dbChannelFinalElements`, then cross-check
+        // `dbr_size_n(m_dataType, m_count)` against `m_postsize` — a short
+        // frame is a silent RSRV_ERROR. The size check runs BEFORE the
+        // access gate on the deprecated WRITE (`write_action`) and AFTER
+        // it on WRITE_NOTIFY (`write_notify_action`).
+        // `dbr_size_n(PUT_ACKT/ACKS, n)` is the bare u16 array; C's
+        // `COUNT<=0` arm sizes one element.
+        let mut ack_count = hdr.actual_count();
+        if ack_count > entry.final_element_count {
+            ack_count = entry.final_element_count;
+        }
+        let ack_size = epics_base_rs::types::dbr_buffer_size(
+            hdr.data_type,
+            epics_base_rs::types::DbFieldType::Short,
+            ack_count.max(1) as usize,
+        );
+        let ack_size_check = || -> CaResult<()> {
+            if ack_size > payload.len() {
+                return Err(epics_base_rs::error::CaError::Protocol(format!(
+                    "WRITE (ACKT/ACKS) payload {} bytes < dbr_size_n {} \
+                     (matches C size > m_postsize silent RSRV_ERROR)",
+                    payload.len(),
+                    ack_size
+                )));
+            }
+            Ok(())
+        };
+        if !is_notify {
+            ack_size_check()?;
+        }
         // Alarm-acknowledge PUTs travel
         // the same WRITE wire opcodes but pre-fix bypassed
         // the access_rights check that the regular WRITE
@@ -3971,7 +4002,7 @@ pub(crate) async fn serve_write_head(
                     send_put_notify_response(
                         writer,
                         hdr.data_type,
-                        hdr.actual_count(),
+                        ack_count,
                         denied.eca_code(),
                         ioid,
                         ReplyContext {
@@ -4005,11 +4036,15 @@ pub(crate) async fn serve_write_head(
                 return Ok(WriteHeadOutcome::Done);
             }
         };
-        let value_u16 = if payload.len() >= 2 {
-            u16::from_be_bytes([payload[0], payload[1]])
-        } else {
-            0
-        };
+        // WRITE_NOTIFY runs the size cross-check here — after the access
+        // gate — matching C `write_notify_action`'s order (a denied peer
+        // gets ECA_NOWTACCESS; the size check never runs for it).
+        if is_notify {
+            ack_size_check()?;
+        }
+        // The size gate guarantees the u16 is present; pre-fix a missing
+        // value silently defaulted to 0.
+        let value_u16 = u16::from_be_bytes([payload[0], payload[1]]);
         // C dispatches alarm acknowledgement on the DBR *request type*
         // inside `dbPut` (`dbAccess.c:1331-1335`), ABOVE the SPC_NOMOD
         // gate that refuses an ordinary put to ACKT/ACKS — the client
@@ -4059,7 +4094,7 @@ pub(crate) async fn serve_write_head(
             send_put_notify_response(
                 writer,
                 hdr.data_type,
-                hdr.actual_count(),
+                ack_count,
                 eca.eca(),
                 ioid,
                 ReplyContext {
@@ -4132,6 +4167,9 @@ pub(crate) async fn serve_write_head(
     // error header. Captured here as a Copy so the error sites
     // below can use it after the `entry` borrow ends.
     let entry_cid = entry.cid;
+    // The #934 count clamp's bound, captured as a Copy for the same
+    // borrow-lifetime reason as `entry_cid` above.
+    let final_element_count = entry.final_element_count;
     // Clone the per-channel put-callback slot (Arc-backed) so the
     // supersede gate and the async-completion install below use it
     // without holding the `entry` borrow across them.
@@ -4146,42 +4184,35 @@ pub(crate) async fn serve_write_head(
         }
     };
 
-    // The DBR-type gate and the write-access gate run in
-    // OPPOSITE orders for the two write opcodes, and the order is
-    // observable when BOTH fail: a bad type tears the connection
-    // down (RSRV_ERROR), denied access keeps it (RSRV_OK), and
-    // only the gate that runs FIRST reports its error.
+    // Post-#934 (epics-base 4128a7c07) BOTH opcodes gate the TYPE first,
+    // then clamp `m_count` to `dbChannelFinalElements`, then cross-check
+    // `dbr_size_n(m_dataType, m_count)` against `m_postsize`; only the
+    // reply shapes and the size-vs-access order still differ:
     //
-    // * `write_notify_action` (camessage.c:1647-1656): TYPE first
-    //   (ECA_BADTYPE → RSRV_ERROR/drop), THEN access
-    //   (ECA_NOWTACCESS → RSRV_OK/keep).
-    // * `write_action` (camessage.c:741-766): ACCESS first
-    //   (ECA_NOWTACCESS → RSRV_OK/keep). There is NO standalone
-    //   type pre-check — the type is validated only by
-    //   `caNetConvert` (camessage.c:753) AFTER access passes
-    //   (ECA_BADTYPE → RSRV_ERROR/drop).
+    // * `write_notify_action`: type (`putNotifyErrorReply` ECA_BADTYPE →
+    //   RSRV_ERROR/drop), clamp, access (ECA_NOWTACCESS → RSRV_OK/keep),
+    //   size cross-check (silent RSRV_ERROR/drop).
+    // * `write_action`: type (`log_header` only — SILENT RSRV_ERROR/drop;
+    //   #934 moved this ahead of the access gate, which pre-#934 ran
+    //   first with no standalone type check), clamp, size cross-check
+    //   (silent RSRV_ERROR/drop), access (ECA_NOWTACCESS → RSRV_OK/keep).
     //
-    // So a deprecated CA_PROTO_WRITE carrying an unsupported DBR
-    // type to a channel the peer cannot write must reply
-    // ECA_NOWTACCESS and KEEP the connection — not ECA_BADTYPE +
-    // drop. Pre-fix Rust ran the type gate first for both
-    // opcodes, inverting `write_action`. Each gate's witness type
-    // (`write_type`, `write_grant`) flows to the write below.
+    // The observable both-fail case therefore inverted with #934: a
+    // deprecated WRITE carrying a bad type to a channel the peer cannot
+    // write is now a silent drop, not ECA_NOWTACCESS + keep.
     //
-    // A type-state WRITE gate: `lookup_access` is the only path
-    // to the cache; the witness ensures the matching ECA code
-    // reaches the wire.
-    let (wire_type, write_grant) = if is_notify {
-        let wire_type = match AcceptedWriteType::classify(hdr.data_type) {
-            Some(t) => t,
-            None => {
+    // A type-state WRITE gate: `lookup_access` is the only path to the
+    // cache; the witness ensures the matching ECA code reaches the wire.
+    let wire_type = match AcceptedWriteType::classify(hdr.data_type) {
+        Some(t) => t,
+        None => {
+            // A peer sending a DBR above `LAST_BUFFER_TYPE` has a
+            // corrupted dispatcher or is probing, so C drops. A compound
+            // type is BELOW that bound and therefore never reaches here.
+            if is_notify {
                 // C `putNotifyErrorReply` (camessage.c:1482-1501)
-                // preserves `m_dataType`/`m_count` from the
-                // request, then returns RSRV_ERROR (drop) — a
-                // peer sending a DBR above `LAST_BUFFER_TYPE` has
-                // a corrupted dispatcher or is probing, so C
-                // drops. A compound type is BELOW that bound and
-                // therefore never reaches here.
+                // preserves `m_dataType`/`m_count` from the request —
+                // the count is pre-clamp here, as in C.
                 send_put_notify_response(
                     writer,
                     hdr.data_type,
@@ -4193,12 +4224,64 @@ pub(crate) async fn serve_write_head(
                         client_minor: state.client_minor_version,
                     },
                 )?;
+            }
+            // `write_action` sends nothing: C logs "bad put data type"
+            // and returns RSRV_ERROR without a frame.
+            return Err(epics_base_rs::error::CaError::Protocol(format!(
+                "{} with unsupported DBR type {} (matches C INVALID_DB_REQ RSRV_ERROR)",
+                if is_notify { "WRITE_NOTIFY" } else { "WRITE" },
+                hdr.data_type
+            )));
+        }
+    };
+
+    // #934 count clamp. C mutates `mp->m_count` in place, so the size
+    // cross-check, the payload decode, the DB put and every later reply
+    // echo all see the clamped count.
+    let mut write_count = hdr.actual_count();
+    if write_count > final_element_count {
+        write_count = final_element_count;
+    }
+
+    // `dbr_size_n(m_dataType, m_count)` vs `m_postsize` (`payload` is
+    // the postsize-long buffer). C's `COUNT<=0` arm sizes one element.
+    //
+    // Scalar DBR_STRING is exempt: libca frames it as
+    // `CA_MESSAGE_ALIGN(strlen + 1)` (comQueSend.cpp:332-341), not the
+    // 40-byte `dbr_size[DBR_STRING]`, so #934 as merged drops every
+    // default-mode `caput` (upstream regression #943; the exemption is
+    // PR #944's fix: require a NUL within `m_postsize` instead).
+    let size_check = || -> CaResult<()> {
+        if hdr.data_type == epics_base_rs::types::DBR_STRING && write_count == 1 {
+            if !payload.contains(&0) {
                 return Err(epics_base_rs::error::CaError::Protocol(format!(
-                    "WRITE_NOTIFY with unsupported DBR type {} (matches C write_notify_action RSRV_ERROR)",
-                    hdr.data_type
+                    "WRITE scalar string payload {} bytes with no NUL terminator \
+                     (matches C epicsStrnLen >= m_postsize silent RSRV_ERROR, PR #944)",
+                    payload.len()
                 )));
             }
-        };
+            return Ok(());
+        }
+        let native = epics_base_rs::types::native_type_for_dbr(hdr.data_type)?;
+        let size = epics_base_rs::types::dbr_buffer_size(
+            hdr.data_type,
+            native,
+            write_count.max(1) as usize,
+        );
+        if size > payload.len() {
+            return Err(epics_base_rs::error::CaError::Protocol(format!(
+                "WRITE payload {} bytes < dbr_size_n {} for type {} count {} \
+                 (matches C size > m_postsize silent RSRV_ERROR)",
+                payload.len(),
+                size,
+                hdr.data_type,
+                write_count
+            )));
+        }
+        Ok(())
+    };
+
+    let write_grant = if is_notify {
         let write_grant = match state.lookup_access(sid).require_write() {
             Ok(g) => g,
             Err(denied) => {
@@ -4207,13 +4290,12 @@ pub(crate) async fn serve_write_head(
                 // the extended-form count instead of the u16
                 // marker. The echoed type is the REQUEST's
                 // (`putNotifyErrorReply` preserves `m_dataType`,
-                // camessage.c:1482-1501) — identical to the
-                // native code for a native put, and the only
-                // available answer for a compound one.
+                // camessage.c:1482-1501); the count is the CLAMPED
+                // one — C reads the mutated `mp->m_count`.
                 send_put_notify_response(
                     writer,
                     hdr.data_type,
-                    hdr.actual_count(),
+                    write_count,
                     denied.eca_code(),
                     ioid,
                     ReplyContext {
@@ -4225,16 +4307,17 @@ pub(crate) async fn serve_write_head(
                 return Ok(WriteHeadOutcome::Done);
             }
         };
-        (wire_type, write_grant)
+        size_check()?;
+        write_grant
     } else {
-        // C `write_action` (camessage.c:741-750) emits
-        // `send_err(mp, ECA_NOWTACCESS, ...)` and returns RSRV_OK
-        // (keep) BEFORE any type handling. Without surfacing this
-        // the Rust server dropped denied PROTO_WRITEs silently —
-        // libca's `cac::exception` never fired, so a `caput` from
-        // a read-only peer looked like it had succeeded even
-        // though the value never reached the DB.
-        let write_grant = match state.lookup_access(sid).require_write() {
+        size_check()?;
+        // C `write_action` emits `send_err(mp, ECA_NOWTACCESS, ...)` and
+        // returns RSRV_OK (keep). Without surfacing this the Rust server
+        // dropped denied PROTO_WRITEs silently — libca's
+        // `cac::exception` never fired, so a `caput` from a read-only
+        // peer looked like it had succeeded even though the value never
+        // reached the DB.
+        match state.lookup_access(sid).require_write() {
             Ok(g) => g,
             Err(denied) => {
                 send_ca_error(
@@ -4248,30 +4331,7 @@ pub(crate) async fn serve_write_head(
                 state.audit("caput", &audit_pv, "", "denied");
                 return Ok(WriteHeadOutcome::Done);
             }
-        };
-        // Type validated only after access passes (C
-        // `caNetConvert`, camessage.c:753) — a type ABOVE
-        // `LAST_BUFFER_TYPE` is a protocol violation →
-        // RSRV_ERROR/drop. A compound type converts fine in C and
-        // so passes here too; it fails later, at the put.
-        let wire_type = match AcceptedWriteType::classify(hdr.data_type) {
-            Some(t) => t,
-            None => {
-                send_ca_error(
-                    writer,
-                    hdr,
-                    ECA_BADTYPE,
-                    entry_cid,
-                    "bad data type",
-                    state.client_minor_version,
-                )?;
-                return Err(epics_base_rs::error::CaError::Protocol(format!(
-                    "WRITE with unsupported DBR type {} (matches C write_action RSRV_ERROR)",
-                    hdr.data_type
-                )));
-            }
-        };
-        (wire_type, write_grant)
+        }
     };
 
     // the write-trap mask of the ACF rule that
@@ -4305,12 +4365,11 @@ pub(crate) async fn serve_write_head(
         supersede_put_notify(prev, writer, state.client_minor_version)?;
     }
 
-    let count = hdr.actual_count() as usize;
-    // Echo the FULL 32-bit count
-    // (`hdr.actual_count()`); pre-fix used `hdr.count`
-    // which is the 0 marker for extended requests and
-    // therefore lost the count on large array put-callbacks.
-    let write_count = hdr.actual_count();
+    // The CLAMPED full 32-bit count flows to the decode, the put and the
+    // reply echo (pre-fix the echo used `hdr.count`, which is the 0
+    // marker for extended requests and therefore lost the count on large
+    // array put-callbacks; then the raw wire count, which #934 clamps).
+    let count = write_count as usize;
 
     // Whatever the buffer type carries, only the value reaches the
     // record. The metadata a compound put brings along is discarded —
@@ -4339,11 +4398,12 @@ pub(crate) async fn serve_write_head(
             return decoded;
         }
         if is_notify {
-            // Same `putNotifyErrorReply` shape.
+            // Same `putNotifyErrorReply` shape; count post-clamp, as C's
+            // mutated `mp->m_count` is at this point.
             send_put_notify_response(
                 writer,
                 hdr.data_type,
-                hdr.actual_count(),
+                write_count,
                 ECA_BADTYPE,
                 ioid,
                 ReplyContext {
@@ -8592,14 +8652,15 @@ mod write_gate_order_tests {
         read_create_chan_sid(client, Duration::from_secs(3)).await
     }
 
-    /// Deprecated `CA_PROTO_WRITE`, access-denied AND bad type: C
-    /// `write_action` checks access FIRST → ECA_NOWTACCESS + RSRV_OK
-    /// (keep). The error rides a `CA_PROTO_ERROR` reply (`m_available` =
-    /// ECA status). Pre-fix the type-first path replied ECA_BADTYPE and
-    /// dropped the connection.
+    /// Deprecated `CA_PROTO_WRITE`, access-denied AND bad type: post-#934
+    /// (epics-base 4128a7c07) C `write_action` checks the TYPE first —
+    /// `INVALID_DB_REQ` is `log_header` + RSRV_ERROR with NO frame, so
+    /// the access gate (and its ECA_NOWTACCESS reply) is never reached.
+    /// Pre-#934 C ran access first and replied ECA_NOWTACCESS + keep,
+    /// which the pre-fix code mirrored.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn deprecated_write_denied_reports_nowtaccess_and_keeps_conn() {
-        let (mut client, handle, _acf_reload_tx) = spawn_read_only_server(55330).await;
+    async fn deprecated_write_bad_type_drops_silently_before_access() {
+        let (mut client, mut handle, _acf_reload_tx) = spawn_read_only_server(55330).await;
         let sid = handshake(&mut client).await;
 
         client
@@ -8608,23 +8669,27 @@ mod write_gate_order_tests {
             .expect("write");
         client.flush().await.expect("flush write");
 
-        let err = read_frame_of_cmmd(&mut client, CA_PROTO_ERROR, Duration::from_secs(3)).await;
-        assert_eq!(
-            err.available, ECA_NOWTACCESS,
-            "deprecated WRITE must report access denial first (ECA_NOWTACCESS), \
-             not the type error (ECA_BADTYPE={ECA_BADTYPE}); got {}",
-            err.available
-        );
-
-        // RSRV_OK after ECA_NOWTACCESS — the connection must stay up.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        // RSRV_ERROR with no reply — the connection drops without a frame.
+        let res = tokio::time::timeout(Duration::from_secs(2), &mut handle)
+            .await
+            .expect("handle_client completes after WRITE bad type")
+            .expect("join ok");
         assert!(
-            !handle.is_finished(),
-            "deprecated WRITE access-denied must KEEP the connection (C write_action RSRV_OK)"
+            res.is_err(),
+            "deprecated WRITE bad type must DROP the connection \
+             (C write_action INVALID_DB_REQ RSRV_ERROR), got {res:?}"
+        );
+        let mut rest = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut client, &mut rest)
+            .await
+            .expect("read to EOF");
+        assert!(
+            rest.is_empty(),
+            "C write_action sends nothing before this RSRV_ERROR, got {} bytes",
+            rest.len()
         );
 
         drop(client);
-        handle.abort();
     }
 
     /// `CA_PROTO_WRITE_NOTIFY`, same access-denied + bad type: C

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -4870,11 +4870,20 @@ pub(crate) async fn register_subscription(
         }
     };
 
-    let mask = if payload.len() >= 14 {
-        u16::from_be_bytes([payload[12], payload[13]])
-    } else {
-        DBE_VALUE | DBE_ALARM
-    };
+    // C `event_add_action` (epics-base #934, 4128a7c07):
+    // `INVALID_DB_REQ(m_dataType) || m_postsize < sizeof(*pmi)` is ONE
+    // silent pre-lookup gate — a truncated `struct mon_info` (16 bytes:
+    // three f32 dead-band fields, u16 mask, u16 pad) is RSRV_ERROR with
+    // no reply frame, exactly like the bad-type arm above. Pre-fix a
+    // short payload was accepted with a DBE_VALUE|DBE_ALARM default
+    // mask C never applies.
+    if payload.len() < 16 {
+        return Err(epics_base_rs::error::CaError::Protocol(format!(
+            "EVENT_ADD with truncated mon_info payload ({} < 16 bytes; matches C event_add_action silent drop)",
+            payload.len()
+        )));
+    }
+    let mask = u16::from_be_bytes([payload[12], payload[13]]);
     let entry = match state.channels.get(&sid) {
         Some(e) => e,
         None => {

--- a/crates/epics-ca-rs/tests/calink.rs
+++ b/crates/epics-ca-rs/tests/calink.rs
@@ -113,6 +113,49 @@ async fn ca_link_resolves_remote_value() {
     assert_eq!(resolver.link_count(), 1);
 }
 
+/// epics-base #856 (`dbCa: iocInit wait for all conditions`): the
+/// iocInit gate `init_ready` is satisfied only once the detached CTRL
+/// attribute fetch has completed too, and it does flip true on a live
+/// link — a connected, value-serving link is necessary but not
+/// sufficient.
+#[tokio::test(flavor = "multi_thread")]
+#[serial(epics_env)]
+async fn ca_link_init_ready_flips_after_metadata_fetch() {
+    let server = CaServer::builder()
+        .port(0)
+        .pv("CALINK:INITREADY", EpicsValue::Double(1.0))
+        .build()
+        .await
+        .expect("CA server");
+    let port = server.udp_port();
+    let _server = tokio::spawn(async move { server.run().await });
+
+    let client = Arc::new(pinned_client(port).await);
+    let resolver = CaLinkResolver::with_client(client);
+
+    use epics_base_rs::server::database::LinkSet;
+    // Unopened link: not init-ready.
+    assert!(!LinkSet::init_ready(&resolver, "CALINK:INITREADY"));
+
+    let connected = resolver
+        .wait_for_link_connected("CALINK:INITREADY", Duration::from_secs(5))
+        .await;
+    assert!(connected, "CA link must connect to the upstream CA server");
+
+    // The attribute fetch is detached from the monitor path, so poll
+    // for the flip; a connected link whose fetch never completes would
+    // hold iocInit, and this assert names that failure.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !LinkSet::init_ready(&resolver, "CALINK:INITREADY") {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "metadata fetch never completed: init_ready stayed false on a connected link"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(LinkSet::is_connected(&resolver, "CALINK:INITREADY"));
+}
+
 /// Gap 2 — the `ca://` scheme prefix is accepted: `epics-base-rs`
 /// stores a `ca://X` link verbatim in `ParsedLink::Ca`, so the
 /// resolver must strip it.

--- a/crates/epics-libcom-rs/src/runtime/epics_string.rs
+++ b/crates/epics-libcom-rs/src/runtime/epics_string.rs
@@ -6,6 +6,10 @@
 //! every caller that must turn a source-text escape into the byte it denotes
 //! goes through it —
 //!
+//! [`print_escaped`] is the opposite direction — `epicsStrPrintEscaped`
+//! (epicsString.c:230-262), which `asDumpQuoted` (asLibRoutines.c, epics-base
+//! PR #871) escapes UAG/HAG members through before printing them quoted.
+//!
 //! * the `.db` loader, for field and info VALUES (`dbLexRoutines.c:1398-1403`
 //!   and `:1435-1440`, both `dbTranslateEscape(value, value)`), and
 //! * iocsh `echo` (`libComRegister.c:84-91`).
@@ -110,8 +114,51 @@ pub fn raw_from_escaped_bytes(src: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Escape bytes for display — C `epicsStrPrintEscaped` (epicsString.c:230-262),
+/// the `FILE *` form, returning the text instead of writing a stream.
+///
+/// * `\a \b \f \n \r \t \v \\ \' \"` — the named escapes.
+/// * Printable ASCII (C-locale `isprint`) — the byte itself.
+/// * Anything else — `\xNN`, lower-case hex.
+/// * NUL — `\0`. C's `switch` here forgot the NUL case (so C prints `\x00`)
+///   while its sibling `epicsStrnEscapedFromRaw` has a deliberate `case '\0'`
+///   (`:145`); the port refuses that divergence (CBUG-D4, same refusal as
+///   `asyn-rs`'s private copy of this table) and renders `\0` — the form
+///   [`raw_from_escaped`]'s `case '0'` decodes back to NUL.
+/// * C guards on `strlen(s) == 0` (`:236-237`) despite taking an explicit
+///   length: a buffer whose FIRST byte is NUL prints nothing at all, however
+///   many bytes follow it. Kept.
+pub fn print_escaped(src: &[u8]) -> String {
+    if src.first().is_none_or(|&c| c == 0) {
+        return String::new();
+    }
+    let mut out = String::with_capacity(src.len());
+    for &c in src {
+        match c {
+            0x07 => out.push_str("\\a"),
+            0x08 => out.push_str("\\b"),
+            0x0c => out.push_str("\\f"),
+            b'\n' => out.push_str("\\n"),
+            b'\r' => out.push_str("\\r"),
+            b'\t' => out.push_str("\\t"),
+            0x0b => out.push_str("\\v"),
+            b'\\' => out.push_str("\\\\"),
+            b'\'' => out.push_str("\\'"),
+            b'"' => out.push_str("\\\""),
+            0 => out.push_str("\\0"),
+            0x20..=0x7e => out.push(c as char),
+            _ => {
+                use std::fmt::Write;
+                let _ = write!(out, "\\x{c:02x}");
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
+    use super::print_escaped;
     use super::raw_from_escaped;
 
     /// The softIoc transcripts quoted in the module docs.
@@ -176,5 +223,34 @@ mod tests {
     #[test]
     fn plain_text_is_untouched() {
         assert_eq!(raw_from_escaped("@asyn(PORT,0)"), b"@asyn(PORT,0)");
+    }
+
+    /// `epicsStrPrintEscaped`'s table: named escapes, isprint passthrough,
+    /// lower-case `\xNN` for the rest, and NUL as `\0` (CBUG-D4 refused — C
+    /// prints `\x00` from this function but `\0` from
+    /// `epicsStrnEscapedFromRaw`; the port renders the decodable form from
+    /// both). Round-trips through [`raw_from_escaped`].
+    #[test]
+    fn print_escaped_renders_the_c_table() {
+        assert_eq!(
+            print_escaped(b"\x07\x08\x0c\n\r\t\x0b\\'\""),
+            r#"\a\b\f\n\r\t\v\\\'\""#
+        );
+        assert_eq!(print_escaped(b" ~OK"), " ~OK");
+        assert_eq!(print_escaped(b"\x03\x1b\x7f\xff"), r"\x03\x1b\x7f\xff");
+        assert_eq!(print_escaped(b"a\0b"), r"a\0b");
+
+        let raw = b"a\"b\\c\td";
+        assert_eq!(raw_from_escaped(&print_escaped(raw)), raw);
+    }
+
+    /// R17-49: C guards on `strlen(s) == 0` (epicsString.c:236-237), so a
+    /// buffer whose first byte is NUL prints nothing — only the FIRST byte;
+    /// a later NUL escapes normally.
+    #[test]
+    fn print_escaped_prints_nothing_when_the_first_byte_is_nul() {
+        assert_eq!(print_escaped(b"\0a"), "");
+        assert_eq!(print_escaped(b""), "");
+        assert_eq!(print_escaped(b"x\0y"), r"x\0y");
     }
 }

--- a/crates/epics-rtems-boot/csrc/rtems_init.c
+++ b/crates/epics-rtems-boot/csrc/rtems_init.c
@@ -1,8 +1,9 @@
 /*
  * POSIX_Init — the RTEMS entry task for an epics-rs IOC.
  *
- * Brings up the console, the clock, libbsd and DHCP, then calls the Rust
- * `main`. Derived from EPICS base's POSIX arm,
+ * Brings up the console, the clock, libbsd and the network — DHCP, or a
+ * compile-time static address — then calls the Rust `main`. Derived from
+ * EPICS base's POSIX arm,
  * `modules/libcom/RTEMS/posix/rtems_init.c`; each step cites the base line it
  * comes from, and `doc/rtems-boot-shim-design.md` §1.1 records what base does
  * here that we deliberately drop (NFS/TFTP mounts, iocsh registration and the
@@ -19,10 +20,15 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <net/route.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
+#include <sysexits.h>
 #include <termios.h>
 #include <time.h>
 #include <unistd.h>
@@ -187,6 +193,136 @@ static void start_dhcpcd(void)
     }
 }
 
+/*
+ * Static network configuration (base #853: posix/rtems_init.c:1095-1131,
+ * setBootConfigFromNVRAM.c `applyNetConfig`).
+ *
+ * Base discovers the addresses in motload/PPCBUG NVRAM at run time; this shim
+ * has no NVRAM contract (§1.1 drops the NVRAM boot path), so the same values
+ * arrive as compile-time defines instead. Build with
+ *
+ *     -DEPICS_RTEMS_STATIC_IP=\"10.0.0.5\"
+ *     -DEPICS_RTEMS_STATIC_NETMASK=\"255.255.255.0\"
+ *     -DEPICS_RTEMS_STATIC_GATEWAY=\"10.0.0.1\"   (optional)
+ *
+ * (via `CFLAGS_armv7-rtems-eabihf`; the `cc` crate forwards them) to configure
+ * the first hardware interface statically. With the first two undefined the
+ * image keeps its DHCP path, and — matching base, where a bad NVRAM config
+ * returns -1 and `try_dhcp` takes over — a static setup that fails at run
+ * time also falls back to DHCP rather than booting unreachable.
+ */
+#if defined(EPICS_RTEMS_STATIC_IP) && defined(EPICS_RTEMS_STATIC_NETMASK)
+
+/*
+ * Block until `ifname` reports link up via an RTM_IFINFO routing message, or
+ * until `timeout_secs` elapses (base #853 `wait_for_link_up`, modeled there on
+ * dhcpcd's `manage_link`). The static path needs this explicit wait because,
+ * unlike DHCP — whose BOUND hook fires only once the link carries traffic —
+ * `rtems_bsd_ifconfig` returns before the PHY negotiates.
+ *
+ * `route_sock` must already be open from before the interface was configured,
+ * so no RTM_IFINFO event can be missed.
+ */
+static int wait_for_link_up(int route_sock, const char *ifname, int timeout_secs)
+{
+    struct timeval tv = {.tv_sec = timeout_secs, .tv_usec = 0};
+    char buf[sizeof(struct if_msghdr) + sizeof(struct sockaddr_dl)];
+
+    printf("rtems-boot: waiting for link on %s (timeout %d s)\n", ifname,
+           timeout_secs);
+    setsockopt(route_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    while (recv(route_sock, buf, sizeof(buf), 0) > 0) {
+        struct rt_msghdr *rtm = (struct rt_msghdr *)(void *)buf;
+        if (rtm->rtm_type == RTM_IFINFO) {
+            struct if_msghdr *ifm = (struct if_msghdr *)(void *)buf;
+            char name[IFNAMSIZ];
+            if (if_indextoname(ifm->ifm_index, name) != NULL &&
+                strcmp(name, ifname) == 0 &&
+                ifm->ifm_data.ifi_link_state == LINK_STATE_UP) {
+                return 0;
+            }
+        }
+    }
+
+    /* recv returned <= 0: SO_RCVTIMEO expired (EAGAIN) or socket error. */
+    printf("rtems-boot: ***** link did not come up on %s within %d s *****\n",
+           ifname, timeout_secs);
+    return -1;
+}
+
+/*
+ * Configure the interface at index 1 — the index base's `applyNetConfig` and
+ * `wait_for_link_up` both hard-code for "the first hardware interface" —
+ * with the compiled-in address. Returns 1 when the interface is configured,
+ * 0 to fall back to DHCP.
+ */
+static int configure_static_network(void)
+{
+    /* Writable copies: `rtems_bsd_ifconfig` takes `char *`. */
+    static char ip[] = EPICS_RTEMS_STATIC_IP;
+    static char netmask[] = EPICS_RTEMS_STATIC_NETMASK;
+#ifdef EPICS_RTEMS_STATIC_GATEWAY
+    static char gateway_buf[] = EPICS_RTEMS_STATIC_GATEWAY;
+    char *gateway = gateway_buf;
+#else
+    char *gateway = NULL;
+#endif
+    char ifnamebuf[IF_NAMESIZE];
+    char *ifname = if_indextoname(1, ifnamebuf);
+    int route_sock;
+    int exit_code;
+
+    if (ifname == NULL) {
+        printf("rtems-boot: no network interface found; trying DHCP\n");
+        return 0;
+    }
+
+    /*
+     * Open the route socket before configuring the interface, so the
+     * RTM_IFINFO that reports link-up cannot be missed (base #853,
+     * rtems_init.c:1102-1106).
+     */
+    route_sock = socket(PF_ROUTE, SOCK_RAW, 0);
+    if (route_sock < 0) {
+        printf("rtems-boot: cannot open PF_ROUTE socket: %s\n",
+               strerror(errno));
+    }
+
+    printf("rtems-boot: static ifconfig %s ip=%s netmask=%s gateway=%s\n",
+           ifname, ip, netmask, gateway != NULL ? gateway : "none");
+    exit_code = rtems_bsd_ifconfig(ifname, ip, netmask, gateway);
+    if (exit_code != EX_OK) {
+        printf("rtems-boot: rtems_bsd_ifconfig failed (exit code %d); trying "
+               "DHCP\n",
+               exit_code);
+        if (route_sock >= 0) {
+            close(route_sock);
+        }
+        return 0;
+    }
+
+    /*
+     * Block until the physical link comes up, analogous to the DHCP BOUND
+     * wait; on timeout continue loudly, as the DHCP path does. Base's
+     * timeout: 30 s (rtems_init.c:1148).
+     */
+    if (route_sock >= 0) {
+        wait_for_link_up(route_sock, ifname, 30);
+        close(route_sock);
+    }
+    return 1;
+}
+
+#else /* !EPICS_RTEMS_STATIC_IP || !EPICS_RTEMS_STATIC_NETMASK */
+
+static int configure_static_network(void)
+{
+    return 0;
+}
+
+#endif
+
 void *POSIX_Init(void *argument)
 {
     struct timespec now;
@@ -279,18 +415,26 @@ void *POSIX_Init(void *argument)
      */
     rtems_bsd_ifconfig_lo0();
 
-    /* 10. DHCP, bounded — boot anyway on timeout, loudly (base :1050-1072). */
-    rtems_dhcpcd_add_hook(&dhcpcd_hook);
-    start_dhcpcd();
-    for (waited = 0; !dhcp_bound && waited < EPICS_RTEMS_DHCP_TIMEOUT_SECONDS;
-         ++waited) {
-        rtems_task_wake_after(rtems_clock_get_ticks_per_second());
-    }
-    if (!dhcp_bound) {
-        printf("rtems-boot: ***** DHCP did not bind in %d s; continuing with no "
-               "address. Server ports will bind but nothing off-board can reach "
-               "them. *****\n",
-               EPICS_RTEMS_DHCP_TIMEOUT_SECONDS);
+    /*
+     * 10. Network configuration (base #853, :1095-1160): static when the
+     * image was built with an address — see configure_static_network above —
+     * otherwise DHCP, bounded: boot anyway on timeout, loudly (base
+     * :1050-1072).
+     */
+    if (!configure_static_network()) {
+        rtems_dhcpcd_add_hook(&dhcpcd_hook);
+        start_dhcpcd();
+        for (waited = 0;
+             !dhcp_bound && waited < EPICS_RTEMS_DHCP_TIMEOUT_SECONDS;
+             ++waited) {
+            rtems_task_wake_after(rtems_clock_get_ticks_per_second());
+        }
+        if (!dhcp_bound) {
+            printf("rtems-boot: ***** DHCP did not bind in %d s; continuing "
+                   "with no address. Server ports will bind but nothing "
+                   "off-board can reach them. *****\n",
+                   EPICS_RTEMS_DHCP_TIMEOUT_SECONDS);
+        }
     }
 
     /*

--- a/crates/epics-rtems-boot/src/lib.rs
+++ b/crates/epics-rtems-boot/src/lib.rs
@@ -624,6 +624,45 @@ mod tests {
         assert!(link_args("/p", DEFAULT_BSP).contains(&ENTRY_SYMBOL.to_string()));
     }
 
+    /// Base #853's invariant: the PF_ROUTE socket must be open before
+    /// `rtems_bsd_ifconfig` runs, or the RTM_IFINFO that reports link-up can
+    /// fire into nothing and `wait_for_link_up` waits out its full timeout on
+    /// a link that is already up.
+    #[test]
+    fn the_route_socket_opens_before_the_interface_is_configured() {
+        let init = include_str!("../csrc/rtems_init.c");
+        let sock = init
+            .find("socket(PF_ROUTE, SOCK_RAW, 0)")
+            .expect("the static path opens a route socket");
+        let ifconfig = init
+            .find("rtems_bsd_ifconfig(")
+            .expect("the static path configures the interface");
+        assert!(
+            sock < ifconfig,
+            "the route socket must open before rtems_bsd_ifconfig"
+        );
+    }
+
+    /// The static path is opt-in per image and total in its fallback: with
+    /// the two defines absent the stub returns 0, and every run-time failure
+    /// inside the configured path also returns 0 — so an image never boots
+    /// networkless when DHCP could still have reached it (base #853's
+    /// `try_dhcp = status != 0`).
+    #[test]
+    fn the_static_path_is_gated_and_falls_back_to_dhcp() {
+        let init = include_str!("../csrc/rtems_init.c");
+        assert!(
+            init.contains(
+                "#if defined(EPICS_RTEMS_STATIC_IP) && defined(EPICS_RTEMS_STATIC_NETMASK)"
+            )
+        );
+        assert!(init.contains("if (!configure_static_network()) {"));
+        // The DHCP machinery stays compiled unconditionally — it is the
+        // fallback, not an #else.
+        assert!(init.contains("rtems_dhcpcd_add_hook(&dhcpcd_hook);"));
+        assert!(init.contains("start_dhcpcd();"));
+    }
+
     /// The shim's whole purpose is to reach Rust; base's own contract is the
     /// `main(argc, argv)` call at `rtems_init.c:1183`.
     #[test]

--- a/doc/rtems-boot-shim-design.md
+++ b/doc/rtems-boot-shim-design.md
@@ -154,6 +154,15 @@ in §1.1's dropped table.
 Keep base's two `ifconfig`/`netstat` dumps (`:1084-1087`) — they cost nothing
 and rung 3's diagnosis depends on knowing the guest's address.
 
+Step 10 gained a second arm after this design was written: base #853 added a
+libbsd static-IP path (`rtems_bsd_ifconfig` + a PF_ROUTE link-up wait, with
+DHCP as the fallback), and the shim carries it as
+`configure_static_network()`. Base sources the addresses from motload/PPCBUG
+NVRAM at run time; the shim has no NVRAM contract (§1.1 drops that path), so
+they arrive as the compile-time defines `EPICS_RTEMS_STATIC_IP` /
+`EPICS_RTEMS_STATIC_NETMASK` / `EPICS_RTEMS_STATIC_GATEWAY` instead — see the
+comment block in `rtems_init.c`.
+
 `delayedPanic` (`:145-150`) is worth carrying: two 1-second waits before
 `rtems_panic` so the console actually flushes the message. On a serial-scrape
 acceptance ladder, a panic that loses its own message is a wasted boot.


### PR DESCRIPTION
The 2026-08-11 upstream triage's six PORT-now items, one commit each (plus a second #934 commit). The #934 port deliberately includes upstream's still-open PR #944: merged #934 alone silently drops every default-mode caput (libca frames scalar strings as ALIGN(strlen+1), not 40 bytes) — reproduced live against a rebuilt C softIoc, tracked upstream as epics-base#943. The #853 static-IP arm was compile- and boot-verified on the bring-up box (cgem0 takes the compiled-in address, no dhcpcd, caget/caput through guest-IP-pinned hostfwd).