### PR TITLE
build(release): bump workspace to 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## v0.26.1 — 2026-08-20
+
+Patch release. `ad-plugins-rs` moves to rust-hdf5 0.5.1, which brings that
+crate's 0.4/0.5 read overhaul to the HDF5 file plugin. An asyn parameter batch
+now fires an interrupt for every address list it wrote, an NTNDArray frame no
+longer boxes its pixels one `ScalarValue` at a time on the PVA path, and the
+merged-upstream fix wave for epics-base #853/#856/#871/#934/#944 and asyn #217
+is in. Workspace version 0.26.0 -> 0.26.1, internal `[workspace.dependencies]`
+pins move to 0.26.1 in lockstep.
+
+### `ad-plugins-rs` reads and writes HDF5 through rust-hdf5 0.5.1
+
+The jump from 0.3.2 picks up that crate's read-path rewrite — a typed full
+read landing in the vector it returns rather than a second buffer of the same
+size, a hyperslab of an unfiltered chunked dataset reading only the byte
+ranges the selection intersects, a per-dataset cache of partly-consumed
+filtered chunk images, and `zlib-rs` inflating what `flate2` compressed.
+rust-hdf5's own probes against libhdf5 1.14.6 put a 128 MiB contiguous read at
+0.89x of its time where it was 1.79x, and opening plus reading 2000 small
+datasets at 0.29x where it was 2.52x. Stored bytes are unchanged.
+
+One thing on this side had to move. 0.5.1 resolves a dataset's path against
+the groups that already exist — libhdf5's rule with
+`H5Pset_create_intermediate_group` off — so `Hdf5Writer::open_swmr` builds the
+layout group tree before creating the streaming dataset that carries the
+nested layout path as its name. The group that path names is now the dataset's
+placement, and the `assign_dataset_to_group` call that used to re-parent it
+afterwards is gone: one owner rather than a create followed by a move.
+
+### An asyn parameter batch flushes every address list it wrote
+
+`callParamCallbacks` consumes one address list's changed flags, and a C driver
+calls it once per list it wrote. `RequestOp::CallParamCallbacks` bundles the
+sets and the flush, so flushing the request address alone stored the other
+lists' values while firing no interrupt for them: a multi-device driver
+publishing six joint angles at addresses 0..6 in one call left five records at
+UDF for the life of the IOC, while the array parameter carrying the same six
+numbers updated normally. Found in the ur-robot RTDE receive driver.
+
+### An NTNDArray frame no longer costs 24x its pixels on the PVA path
+
+`NdArrayBuffer::into_scalar_array` boxed every element into a `ScalarValue`,
+24 bytes wide because the enum carries a `String(PvString)` variant, so a
+640x480 RGB8 frame turned 0.9 MB of pixels into a 22 MB `Vec<ScalarValue>`
+that the encoder then walked element by element. It now returns the
+`PvField::ScalarArrayTyped` variant the encoder bulk-copies, and
+`nt_nd_array_value` borrows the pixel buffer instead of cloning it first. On a
+RealSense D405 IOC serving colour and depth at 640x480 @ 15 fps, the two PVA
+plugins' CPU increment falls from 135.3% to 14.3% of one core. The wire format
+does not change.
+
+### The merged-upstream fix wave
+
+- **CA server:** both write actions clamp `m_count` to the channel's final
+  element count and cross-check `dbr_size_n` against the postsize before
+  access (epics-base #934), carrying #944's scalar-`DBR_STRING` exemption —
+  without it every default-mode `caput` drops, since libca frames a scalar
+  string as `ALIGN(strlen+1)` rather than 40 bytes. An `EVENT_ADD` whose
+  `mon_info` payload is truncated is now dropped instead of defaulted to a
+  `DBE_VALUE|DBE_ALARM` mask C never applies.
+
+- **CA links:** the iocInit link wait is gated on `init_ready` — monitor and
+  attribute fetch both complete — instead of `is_connected`, which the first
+  monitor event satisfies before the detached CTRL fetch lands, so records
+  could init against absent metadata (epics-base #856).
+
+- **Access security:** `dump_report` quotes UAG and HAG members C's
+  `asDumpQuoted` way, via `epicsStrPrintEscaped` ported into
+  `epics-libcom-rs` (epics-base #871).
+
+- **asyn:** enabling auto-connect while the port or addressed device is down
+  arms `connect_retry_at`, so the flip alone brings the link up (asyn #217).
+
+- **QSRV:** `make_monitor_snapshot` applies the `Q:time:tag` nsec split that
+  `snapshot_for_field` ends with, so a monitor and a GET of the same channel
+  no longer disagree; both producers share one `finish_field_snapshot` tail
+  (the same drift as pvxs #189).
+
+- **RTEMS:** an opt-in static-IP arm in the network bring-up — first interface
+  through `rtems_bsd_ifconfig`, link-up waited on a `PF_ROUTE` socket opened
+  before it, addresses from `EPICS_RTEMS_STATIC_IP`/`_NETMASK`/`_GATEWAY`
+  compile-time defines, falling back to DHCP on any failure (epics-base #853).
+
 ## v0.26.0 — 2026-08-11
 
 Minor release. The upstream-issue audit lands its fix wave across the CA

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bitflags",
  "chrono",
@@ -994,7 +994,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "cc",
  "libc",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2241,7 +2241,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3209,7 +3209,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3829,7 +3829,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "rust-hdf5"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d9a3a248d812fc26bb6342fa6c978bf08ff3c801418608854678d462b7c52c"
+checksum = "d6944dd9a338f0cc79d1b291f2216765669cc129ab5713451a7e6295d5c240a1"
 dependencies = [
  "bzip2",
  "flate2",
@@ -3286,6 +3286,7 @@ dependencies = [
  "rayon",
  "rust-zstd",
  "snap",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5146,6 +5147,12 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,30 +29,30 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.26.0" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.26.0" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.26.0" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.26.0" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.26.0" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.26.0" }
-epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.26.0" }
-epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.26.0" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.26.0" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.26.0" }
-motor-rs = { path = "crates/motor-rs", version = "0.26.0" }
-std-rs = { path = "crates/std-rs", version = "0.26.0" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.26.0" }
-optics-rs = { path = "crates/optics-rs", version = "0.26.0" }
-mca-rs = { path = "crates/mca-rs", version = "0.26.0" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.26.0" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.26.0", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.26.0" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.26.1" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.26.1" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.26.1" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.26.1" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.26.1" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.26.1" }
+epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.26.1" }
+epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.26.1" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.26.1" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.26.1" }
+motor-rs = { path = "crates/motor-rs", version = "0.26.1" }
+std-rs = { path = "crates/std-rs", version = "0.26.1" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.26.1" }
+optics-rs = { path = "crates/optics-rs", version = "0.26.1" }
+mca-rs = { path = "crates/mca-rs", version = "0.26.1" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.26.1" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.26.1", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.26.1" }
 
 # Deployable-image profile for the embedded targets (RTEMS / VxWorks), where
 # image size is a real resource: `cargo build --profile release-embedded ...`

--- a/crates/ad-plugins-rs/Cargo.toml
+++ b/crates/ad-plugins-rs/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 netcdf3 = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif", "tiff"] }
 rayon = { version = "1", optional = true }
-rust-hdf5 = { version = "0.3.2", features = ["threadsafe", "all_filters", "parallel"] }
+rust-hdf5 = { version = "0.5.1", features = ["threadsafe", "all_filters", "parallel"] }
 epics-pva-rs = { workspace = true, optional = true }
 epics-bridge-rs = { workspace = true, features = ["qsrv"], optional = true }
 

--- a/crates/ad-plugins-rs/src/file_hdf5.rs
+++ b/crates/ad-plugins-rs/src/file_hdf5.rs
@@ -1175,16 +1175,23 @@ impl Hdf5Writer {
     /// Ordering mirrors C `NDFileHDF5::openFile` (`NDFileHDF5.cpp:264`-`335`):
     /// the file layout tree and datasets are created, then `createHardLinks`
     /// (`NDFileHDF5.cpp:320`-`321`) runs, and only then `startSWMR`
-    /// (`NDFileHDF5.cpp:324`-`326`). The new rust-hdf5 0.2.17 `SwmrFileWriter`
-    /// exposes `create_group` / `assign_dataset_to_group` / `create_hard_link`
-    /// callable before `start_swmr()`; a group or link created before
-    /// `start_swmr()` is visible to SWMR readers for the whole streaming
-    /// window. So here the image dataset is placed at the layout's nested
-    /// `resolved_dataset_path` and the layout `<hardlink>` elements are
+    /// (`NDFileHDF5.cpp:324`-`326`). `SwmrFileWriter` exposes `create_group` /
+    /// `create_hard_link` callable before `start_swmr()`; a group or link
+    /// created before `start_swmr()` is visible to SWMR readers for the whole
+    /// streaming window. So here the image dataset is placed at the layout's
+    /// nested `resolved_dataset_path` and the layout `<hardlink>` elements are
     /// materialised before SWMR mode is entered — not on the close path.
+    ///
+    /// The layout groups are built first because the dataset carries its full
+    /// nested path as its name, and rust-hdf5 resolves that path against the
+    /// groups that already exist (libhdf5's rule: the default link creation
+    /// property list has `H5Pset_create_intermediate_group` off). The parent
+    /// group the path names is therefore also the dataset's single placement
+    /// owner — nothing re-parents it afterwards.
     fn open_swmr(&mut self, path: &Path, array: &NDArray) -> ADResult<()> {
         let mut swmr = SwmrFileWriter::create(path)
             .map_err(|e| ADError::UnsupportedConversion(format!("SWMR create error: {}", e)))?;
+        self.build_swmr_layout_groups(&mut swmr)?;
 
         let usize_frame_dims: Vec<usize> = array.dims.iter().rev().map(|d| d.size).collect();
         let frame_dims: Vec<u64> = usize_frame_dims.iter().map(|&d| d as u64).collect();
@@ -1214,15 +1221,10 @@ impl Hdf5Writer {
 
         // The streaming dataset is created with its full nested layout path
         // as the dataset name (default flat `data` without a layout). The
-        // `SwmrFileWriter` emits a path-named dataset that is also assigned to
-        // a group under that group with just the leaf, while keeping the full
-        // name addressable so a layout `<hardlink target="/entry/.../data">`
-        // resolves against it. `ds_group_path` is the parent group the
-        // dataset is re-parented into via `assign_dataset_to_group` below.
-        let ds_group_path: Option<String> = self
-            .resolved_dataset_path
-            .rsplit_once('/')
-            .map(|(group_path, _leaf)| group_path.to_string());
+        // `SwmrFileWriter` links it into the group that path names — built
+        // just above — under just the leaf, while keeping the full name
+        // addressable so a layout `<hardlink target="/entry/.../data">`
+        // resolves against it.
         let ds_name = self.resolved_dataset_path.clone();
 
         macro_rules! create_ds {
@@ -1276,25 +1278,10 @@ impl Hdf5Writer {
             NDDataType::Float64 => create_ds!(f64)?,
         };
 
-        // Build the layout group tree, place the image dataset inside its
-        // nested layout group, materialise its constant attributes and the
-        // layout `<hardlink>` elements — all BEFORE `start_swmr()` so SWMR
-        // readers see the nested paths and aliases for the whole streaming
-        // window. C `NDFileHDF5.cpp:320`-`326`: `createHardLinks` then
-        // `startSWMR`.
-        self.build_swmr_layout_groups(&mut swmr)?;
-        if let Some(ref group_path) = ds_group_path {
-            // `SwmrFileWriter` keys groups by their absolute path (leading
-            // `/`); `resolved_dataset_path` is stored stripped, so re-add it.
-            let abs_group = format!("/{}", group_path);
-            swmr.assign_dataset_to_group(&abs_group, ds_index)
-                .map_err(|e| {
-                    ADError::UnsupportedConversion(format!(
-                        "SWMR assign dataset to group '{}': {}",
-                        abs_group, e
-                    ))
-                })?;
-        }
+        // Materialise the image dataset's constant attributes and the layout
+        // `<hardlink>` elements — all BEFORE `start_swmr()` so SWMR readers
+        // see the nested paths and aliases for the whole streaming window.
+        // C `NDFileHDF5.cpp:320`-`326`: `createHardLinks` then `startSWMR`.
         self.write_swmr_layout_dataset_attrs(&mut swmr, ds_index)?;
         self.write_swmr_ndarray_default_attrs(&mut swmr, ds_index, array)?;
         self.build_swmr_layout_hardlinks(&mut swmr)?;

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -205,7 +205,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # host-facing feature that pulls this dependency — `qsrv`, `pvalink`,
 # `pva-gateway`, `dual-ioc` — so host builds resolve exactly as before. Only
 # `qsrv-core`, the RTEMS selection, gets the reduced set.
-epics-pva-rs = { path = "../epics-pva-rs", version = "0.26.0", optional = true, default-features = false }
+epics-pva-rs = { path = "../epics-pva-rs", version = "0.26.1", optional = true, default-features = false }
 # `epics-ca-rs` stays inherited, but NOT because its defaults are empty — they
 # stopped being empty at `274a734b`, which introduced the `client-core`/`client`
 # split and made `default = ["client"]`. The reason is narrower and is a fact

--- a/crates/epics-ca-rs/src/client/search.rs
+++ b/crates/epics-ca-rs/src/client/search.rs
@@ -3309,6 +3309,51 @@ mod tests {
         }
     }
 
+    /// Shrink the circuit's timers so a test that drives a real loopback peer
+    /// can run on the real clock, and prove the shrink took.
+    ///
+    /// `EPICS_CA_CONN_TMO` sets both halves these tests wait on:
+    /// `CircuitWatchdog::retire_bound()` is `echo_idle_secs()` — the timeout
+    /// itself, floored at 1 s — plus the fixed `ECHO_TIMEOUT_SECS`, and the
+    /// per-name-server redial waits one more `connection_timeout()`. At the
+    /// compiled 30 s default that is 65 s of waiting, which is why these two
+    /// tests used to ask for a paused clock instead.
+    ///
+    /// A paused clock is the wrong tool here. Tokio auto-advances it whenever
+    /// the runtime idles, and it idles while the OS still owes the test an
+    /// `accept` — the park polls I/O once with a zero timeout and, finding
+    /// nothing ready, jumps straight to the next timer
+    /// (`tokio::runtime::time::Driver::park_thread_timeout`; only in-flight
+    /// `spawn_blocking` work inhibits it, never pending I/O). A few such park
+    /// cycles cover the whole 65 s budget in microseconds of wall clock, so a
+    /// virtual deadline around a real accept measures the machine's socket
+    /// latency and not the property under test. That is what made
+    /// `a_silent_name_server_is_retired_on_the_circuit_bound` fail under a
+    /// loaded `--workspace` run and pass alone.
+    ///
+    /// `connection_timeout()` caches its resolution for the life of the
+    /// process, so the value has to be in the environment before anything
+    /// resolves it — one test per process under nextest, and `#[serial]` for
+    /// `cargo test`. The assertion is the point: a cache that was already
+    /// warm would leave the test running the 30 s default, passing slowly
+    /// rather than failing, and that is exactly the kind of silence these
+    /// tests exist to break.
+    ///
+    /// SAFETY: `std::env::set_var` in a multi-threaded process; every caller
+    /// is `#[serial_test::serial]`, the same key `conn_tmo_env_tests` uses.
+    fn shrink_circuit_timers(secs: u64) -> Duration {
+        // SAFETY: as above — every caller is `#[serial_test::serial]`.
+        unsafe { std::env::set_var("EPICS_CA_CONN_TMO", secs.to_string()) };
+        let resolved = crate::client::transport::connection_timeout();
+        assert_eq!(
+            resolved,
+            Duration::from_secs(secs),
+            "EPICS_CA_CONN_TMO was already resolved in this process, so the \
+             shrink did not take; this test must own the resolution"
+        );
+        resolved
+    }
+
     /// An `EPICS_CA_NAME_SERVERS` peer that accepts, keeps reading and never
     /// answers is retired on the bound every CA TCP connection is held to —
     /// `CircuitWatchdog::retire_bound()`, i.e. `echo_idle_secs()` of quiet plus
@@ -3327,16 +3372,22 @@ mod tests {
     /// waits. Against the pre-fix reader the first accept is the only one there
     /// will ever be, so this test times out instead of passing.
     ///
-    /// Virtual time (`start_paused`), because the bound is built from
-    /// `EPICS_CA_CONN_TMO` and defaults to 30 s + 5 s, with another 30 s before
-    /// the redial. Real sockets under a paused clock still work — tokio
-    /// auto-advances only while nothing is runnable, which is precisely what a
-    /// silent peer produces.
+    /// Real time on shrunk timers ([`shrink_circuit_timers`]), not a paused
+    /// clock: the bound is built from `EPICS_CA_CONN_TMO`, and a peer that is
+    /// real enough to accept a connection is real enough that its `accept`
+    /// cannot be measured on tokio's virtual clock.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
+    #[serial_test::serial]
     async fn a_silent_name_server_is_retired_on_the_circuit_bound() {
         use tokio::io::AsyncReadExt;
         use tokio::net::TcpListener;
+
+        // 1 s floors `echo_idle_secs()`, so the bound is the 5 s echo probe
+        // plus one second and the redial one second more: ~7 s of real
+        // waiting for a property whose failure mode is "no second accept
+        // ever", which needs no tight margin.
+        let conn_tmo = shrink_circuit_timers(1);
 
         let ns_listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -3389,7 +3440,7 @@ mod tests {
         // verdict) plus one CONN_TMO of redial cadence is the whole budget;
         // the slack covers the dial itself.
         let budget = crate::client::transport::CircuitWatchdog::retire_bound()
-            + crate::client::transport::connection_timeout()
+            + conn_tmo
             + Duration::from_secs(10);
         let started = tokio::time::Instant::now();
         tokio::time::timeout(budget, accept_rx.recv())
@@ -3425,11 +3476,22 @@ mod tests {
     ///
     /// Measured from the peer, which is where the difference is observable: the
     /// FIN must arrive on the bound, not on the bound plus the redial cadence.
+    ///
+    /// Real time on shrunk timers, for the reason [`shrink_circuit_timers`]
+    /// gives — and here the peer's `accept` and its EOF are both real events,
+    /// so a virtual clock would have measured neither.
     #[cfg(not(feature = "rtems-exec-model"))]
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
+    #[serial_test::serial]
     async fn retiring_a_name_service_circuit_closes_it_before_the_backoff() {
         use tokio::io::AsyncReadExt;
         use tokio::net::TcpListener;
+
+        // The margin this test lives on IS the backoff, so the timeout cannot
+        // shrink to the 1 s floor its sibling uses: 3 s puts the fixed bound
+        // at 8 s and the pre-fix hold at 11 s, three seconds apart, and the
+        // slack below is spent inside that gap.
+        let conn_tmo = shrink_circuit_timers(3);
 
         let ns_listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -3465,10 +3527,10 @@ mod tests {
         let _engine_handle = tokio::spawn(engine);
 
         let bound = crate::client::transport::CircuitWatchdog::retire_bound();
-        let backoff = crate::client::transport::connection_timeout();
+        let backoff = conn_tmo;
         // Generous enough to absorb the dial and the probe round trip, and
         // still far below the `bound + backoff` the pre-fix scope produced.
-        let allowed = bound + Duration::from_secs(10);
+        let allowed = bound + Duration::from_millis(1_500);
         let held = tokio::time::timeout(bound + backoff + Duration::from_secs(30), eof_rx.recv())
             .await
             .expect("the retired circuit must close; the peer saw no FIN at all")

--- a/crates/epics-libcom-rs/src/runtime/env.rs
+++ b/crates/epics-libcom-rs/src/runtime/env.rs
@@ -371,6 +371,42 @@ mod tests {
         unsafe { std::env::set_var(p.name(), v) };
     }
 
+    /// The state every compiled-default assertion needs: nothing the generated
+    /// table knows about is set in the process environment. Restored on drop.
+    ///
+    /// Hand-picked `clear` calls cannot establish it, because the list that is
+    /// cleared and the list that is asserted on are then maintained apart:
+    /// `unset_resolves_to_the_compiled_default` cleared three parameters and
+    /// asserted on five, so a developer shell exporting
+    /// `EPICS_CA_AUTO_ADDR_LIST=NO` — which a shell that sets
+    /// `EPICS_CA_ADDR_LIST` normally does — failed it, on a table the test
+    /// never doubted. Walking `ENV_PARAM_LIST` deletes the second list:
+    /// whatever a test asserts on, the table has already covered.
+    #[must_use]
+    struct SilentEnv(Vec<(&'static str, String)>);
+
+    impl SilentEnv {
+        fn take() -> Self {
+            let saved = ENV_PARAM_LIST
+                .iter()
+                .filter_map(|p| std::env::var(p.name()).ok().map(|v| (p.name(), v)))
+                .collect();
+            for p in ENV_PARAM_LIST {
+                clear(*p);
+            }
+            Self(saved)
+        }
+    }
+
+    impl Drop for SilentEnv {
+        fn drop(&mut self) {
+            for (name, value) in &self.0 {
+                // SAFETY: see `clear`.
+                unsafe { std::env::set_var(name, value) };
+            }
+        }
+    }
+
     #[test]
     fn test_get_missing() {
         assert_eq!(get("_EPICS_RT_NONEXISTENT_VAR_12345"), None);
@@ -396,9 +432,7 @@ mod tests {
     #[test]
     #[serial(epics_env)]
     fn unset_resolves_to_the_compiled_default() {
-        clear(EPICS_CA_CONN_TMO);
-        clear(EPICS_CA_SERVER_PORT);
-        clear(EPICS_CA_ADDR_LIST);
+        let _silent = SilentEnv::take();
         assert_eq!(EPICS_CA_CONN_TMO.double(), Ok(30.0));
         assert_eq!(EPICS_CA_SERVER_PORT.long(), Some(5064));
         assert_eq!(EPICS_CA_AUTO_ADDR_LIST.bool(), Some(true));
@@ -536,8 +570,7 @@ mod tests {
     #[test]
     #[serial(epics_env)]
     fn describe_matches_env_prt_config_param() {
-        clear(EPICS_CA_ADDR_LIST);
-        clear(EPICS_CA_SERVER_PORT);
+        let _silent = SilentEnv::take();
         assert_eq!(
             EPICS_CA_ADDR_LIST.describe(),
             "EPICS_CA_ADDR_LIST is undefined"
@@ -551,7 +584,6 @@ mod tests {
             EPICS_CA_ADDR_LIST.describe(),
             "EPICS_CA_ADDR_LIST: 10.0.0.1"
         );
-        clear(EPICS_CA_ADDR_LIST);
     }
 
     #[test]

--- a/crates/epics-tools-rs/tests/procserv_e2e.rs
+++ b/crates/epics-tools-rs/tests/procserv_e2e.rs
@@ -26,6 +26,19 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::time::{Instant, sleep, timeout};
 
+/// How long to wait for something the supervisor must do: bind its console
+/// port, write a line, record a pid, reap a child, exit.
+///
+/// One constant for every such wait, because none of them is a timing
+/// assertion. The two tests that do measure time measure it with `elapsed`
+/// against a separate bound, and the `read_for` windows below collect for a
+/// fixed span on purpose; everything else here waits for an event that must
+/// arrive, and returns the moment it does. A short deadline therefore buys
+/// nothing and costs a failure whenever the machine is busy —
+/// `toggle_into_oneshot_grants_one_more_run` lost its post-kill shutdown line
+/// at 3 s during a full `--workspace` run, on a supervisor that was working.
+const MUST_ARRIVE: Duration = Duration::from_secs(15);
+
 /// Build a config wrapping `/bin/cat` on a random localhost port.
 fn cat_config(port: u16) -> ProcServConfig {
     ProcServConfig {
@@ -191,7 +204,7 @@ async fn cat_round_trip_via_tcp_console() {
     // Connect to the supervisor's TCP console.
     let mut conn = {
         // Listener is set up async; retry briefly.
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -262,10 +275,10 @@ async fn occupied_control_port_fails_fast_not_headless() {
     let cfg = cat_config(port); // same loopback port → bind conflict
     let server = ProcServ::new(cfg).expect("build");
 
-    match timeout(Duration::from_secs(2), server.run()).await {
+    match timeout(MUST_ARRIVE, server.run()).await {
         Ok(Err(_)) => {} // fail-fast: run() surfaced the bind error
         Ok(Ok(code)) => panic!("expected a bind failure, got a clean exit code {code}"),
-        Err(_) => panic!("run() did not fail-fast within 2s — came up headless?"),
+        Err(_) => panic!("run() did not fail-fast on the bind error — came up headless?"),
     }
 }
 
@@ -293,7 +306,7 @@ async fn unwritable_pid_and_log_paths_do_not_abort_startup() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -331,7 +344,7 @@ async fn kill_keystroke_signals_child() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -394,7 +407,7 @@ async fn kill_key_on_a_dead_child_restarts_it_and_still_broadcasts() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -408,7 +421,7 @@ async fn kill_key_on_a_dead_child_restarts_it_and_still_broadcasts() {
     // First Ctrl-X: kills the live child. Wait for the reaper line so the
     // supervisor has definitely cleared its child slot.
     conn.write_all(&[0x18]).await.unwrap();
-    let first = read_until(&mut conn, "Received a sigChild", Duration::from_secs(3)).await;
+    let first = read_until(&mut conn, "Received a sigChild", MUST_ARRIVE).await;
     assert!(
         first.contains("Received a sigChild"),
         "child should have been reaped after the first kill key, got: {first:?}"
@@ -417,7 +430,7 @@ async fn kill_key_on_a_dead_child_restarts_it_and_still_broadcasts() {
     // Second Ctrl-X, now with no child running. C restarts it and still
     // broadcasts the kill notice.
     conn.write_all(&[0x18]).await.unwrap();
-    let out = read_until(&mut conn, "Restarting child", Duration::from_secs(3)).await;
+    let out = read_until(&mut conn, "Restarting child", MUST_ARRIVE).await;
 
     assert!(
         out.contains("Got a kill command"),
@@ -459,7 +472,7 @@ async fn server_messages_are_written_to_the_log() {
     });
 
     // Allow the supervisor to spawn the child and flush the start banner.
-    let deadline = Instant::now() + Duration::from_secs(3);
+    let deadline = Instant::now() + MUST_ARRIVE;
     let mut contents = String::new();
     while Instant::now() < deadline {
         contents = std::fs::read_to_string(&log_path).unwrap_or_default();
@@ -500,7 +513,7 @@ async fn log_port_client_is_readonly_but_receives_output() {
 
     // Connect a control (read/write) client and a log (read-only) client.
     let connect = |port: u16| async move {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -518,7 +531,7 @@ async fn log_port_client_is_readonly_but_receives_output() {
 
     // (a) Control types; the log viewer must observe the echoed output.
     ctl.write_all(b"hello from ctl\n").await.unwrap();
-    let log_seen = read_until(&mut log, "hello from ctl", Duration::from_secs(2)).await;
+    let log_seen = read_until(&mut log, "hello from ctl", MUST_ARRIVE).await;
     assert!(
         log_seen.contains("hello from ctl"),
         "log-port client must receive output, got: {log_seen:?}"
@@ -531,7 +544,7 @@ async fn log_port_client_is_readonly_but_receives_output() {
     // supervisor (so it is never echoed to control or fed to the child).
     log.write_all(b"INJECTED_BY_LOG\n").await.unwrap();
     ctl.write_all(b"CTL_MARKER\n").await.unwrap();
-    let ctl_seen = read_until(&mut ctl, "CTL_MARKER", Duration::from_secs(2)).await;
+    let ctl_seen = read_until(&mut ctl, "CTL_MARKER", MUST_ARRIVE).await;
     assert!(
         ctl_seen.contains("CTL_MARKER"),
         "control client must see its own marker echo, got: {ctl_seen:?}"
@@ -569,7 +582,7 @@ async fn logstamp_prefixes_logger_client_stream_not_control() {
     });
 
     let connect = |port: u16| async move {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -586,24 +599,14 @@ async fn logstamp_prefixes_logger_client_stream_not_control() {
     // window, proves both clients are registered in the roster (see the
     // ordering note in `two_clients_share_same_party_line`) before ctl's
     // line is typed below.
-    let _ = read_until(
-        &mut ctl,
-        "procServ server started at:",
-        Duration::from_secs(2),
-    )
-    .await;
-    let _ = read_until(
-        &mut log,
-        "procServ server started at:",
-        Duration::from_secs(2),
-    )
-    .await;
+    let _ = read_until(&mut ctl, "procServ server started at:", MUST_ARRIVE).await;
+    let _ = read_until(&mut log, "procServ server started at:", MUST_ARRIVE).await;
 
     // Control types; `cat` echoes the line back as child output, which the
     // supervisor broadcasts. The logger sees it stamped; control raw.
     ctl.write_all(b"stamp me\n").await.unwrap();
-    let log_seen = read_until(&mut log, "stamp me", Duration::from_secs(2)).await;
-    let ctl_seen = read_until(&mut ctl, "stamp me", Duration::from_secs(2)).await;
+    let log_seen = read_until(&mut log, "stamp me", MUST_ARRIVE).await;
+    let ctl_seen = read_until(&mut ctl, "stamp me", MUST_ARRIVE).await;
 
     assert!(
         log_seen.contains("STAMP> stamp me"),
@@ -634,7 +637,7 @@ async fn timefmt_controls_banner_timestamp_format() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -644,12 +647,7 @@ async fn timefmt_controls_banner_timestamp_format() {
         }
     };
 
-    let cleaned = read_until(
-        &mut conn,
-        "server started at: TIMEFMT_MARKER",
-        Duration::from_secs(2),
-    )
-    .await;
+    let cleaned = read_until(&mut conn, "server started at: TIMEFMT_MARKER", MUST_ARRIVE).await;
     assert!(
         cleaned.contains("server started at: TIMEFMT_MARKER"),
         "banner must render the start time with the configured timefmt; got: {cleaned:?}"
@@ -681,7 +679,7 @@ async fn manual_restart_preempts_active_holdoff() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -700,7 +698,7 @@ async fn manual_restart_preempts_active_holdoff() {
     // restart 3s out; the "Received a sigChild" reaper line confirms the
     // child died and the holdoff deadline is now pending.
     conn.write_all(&[0x18]).await.unwrap();
-    let exited = read_until(&mut conn, "Received a sigChild", Duration::from_secs(3)).await;
+    let exited = read_until(&mut conn, "Received a sigChild", MUST_ARRIVE).await;
     assert!(
         exited.contains("Received a sigChild"),
         "child should exit on kill keystroke, got: {exited:?}"
@@ -711,7 +709,7 @@ async fn manual_restart_preempts_active_holdoff() {
     // `respawn_child` emits C's "@@@ Restarting child" announcement.
     let t0 = Instant::now();
     conn.write_all(&[0x12]).await.unwrap();
-    let restarted = read_until(&mut conn, "Restarting child", Duration::from_secs(2)).await;
+    let restarted = read_until(&mut conn, "Restarting child", MUST_ARRIVE).await;
     let elapsed = t0.elapsed();
     assert!(
         restarted.contains("Restarting child"),
@@ -737,7 +735,7 @@ async fn two_clients_share_same_party_line() {
 
     // Connect client A.
     let mut a = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -754,21 +752,11 @@ async fn two_clients_share_same_party_line() {
     // proof A is registered and will receive the party-line broadcast
     // below — a fixed sleep isn't: under load the banner write can
     // simply not have reached the socket yet within an arbitrary window.
-    let _ = read_until(
-        &mut a,
-        "procServ server started at:",
-        Duration::from_secs(2),
-    )
-    .await;
+    let _ = read_until(&mut a, "procServ server started at:", MUST_ARRIVE).await;
 
     // Connect client B.
     let mut b = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-    let _ = read_until(
-        &mut b,
-        "procServ server started at:",
-        Duration::from_secs(2),
-    )
-    .await;
+    let _ = read_until(&mut b, "procServ server started at:", MUST_ARRIVE).await;
 
     // A types — `cat` echoes the line back through the PTY, and the
     // supervisor broadcasts that child output to every client, so both A
@@ -825,7 +813,7 @@ async fn client_keystrokes_are_not_forwarded_to_other_clients() {
 
     // Connect A (with retry while the listener comes up) and B.
     let mut a = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -875,7 +863,7 @@ async fn ignored_chars_are_stripped_from_child_stdin() {
     });
 
     let mut c = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -887,7 +875,7 @@ async fn ignored_chars_are_stripped_from_child_stdin() {
     let _ = read_for(&mut c, Duration::from_millis(400)).await;
 
     c.write_all(b"haZllo\n").await.unwrap();
-    let seen = read_until(&mut c, "hallo", Duration::from_secs(2)).await;
+    let seen = read_until(&mut c, "hallo", MUST_ARRIVE).await;
     assert!(
         seen.contains("hallo"),
         "filtered input must reach the child as 'hallo': {seen:?}"
@@ -920,7 +908,7 @@ async fn child_exit_sigkills_orphaned_process_group() {
 
     // Wait for the grandchild PID to be recorded.
     let gpid: i32 = {
-        let deadline = Instant::now() + Duration::from_secs(3);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             if let Ok(s) = std::fs::read_to_string(&pidfile)
                 && let Some(p) = s.split_whitespace().next().and_then(|x| x.parse().ok())
@@ -975,7 +963,7 @@ async fn teardown_sigkills_a_child_that_traps_the_configurable_kill_signal() {
 
     // Wait for the child to record its PID (proves it installed the trap).
     let child_pid: i32 = {
-        let deadline = Instant::now() + Duration::from_secs(3);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             if let Ok(s) = std::fs::read_to_string(&pidfile)
                 && let Some(p) = s.split_whitespace().next().and_then(|x| x.parse().ok())
@@ -998,7 +986,7 @@ async fn teardown_sigkills_a_child_that_traps_the_configurable_kill_signal() {
     // `kill -0` still reports it alive. Poll for the real condition
     // instead of guessing how long the reaper thread takes to get
     // scheduled under load.
-    let deadline = Instant::now() + Duration::from_secs(3);
+    let deadline = Instant::now() + MUST_ARRIVE;
     loop {
         let still_alive = std::process::Command::new("/bin/sh")
             .arg("-c")
@@ -1039,14 +1027,14 @@ async fn norestart_keeps_server_alive_after_child_exit() {
     // delay — under load a blind sleep can both fire too early (flaking
     // the invariant this test targets) and needlessly slow the fast path.
     {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         while !marker.exists() {
             assert!(Instant::now() < deadline, "child never exited");
             sleep(Duration::from_millis(20)).await;
         }
     }
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -1055,12 +1043,7 @@ async fn norestart_keeps_server_alive_after_child_exit() {
             }
         }
     };
-    let banner = read_until(
-        &mut conn,
-        "procServ server started at:",
-        Duration::from_secs(2),
-    )
-    .await;
+    let banner = read_until(&mut conn, "procServ server started at:", MUST_ARRIVE).await;
     assert!(
         banner.contains("procServ server started at:"),
         "server should still serve a banner after the child exited under norestart; got: {banner:?}"
@@ -1085,7 +1068,7 @@ async fn child_exit_code_becomes_server_exit_code() {
     cfg.restart_mode = RestartMode::OneShot;
     let (server, _ports) = spawn_bound(cfg).await;
 
-    let code = timeout(Duration::from_secs(5), server.run())
+    let code = timeout(MUST_ARRIVE, server.run())
         .await
         .expect("one-shot supervisor should exit promptly")
         .expect("run ok");
@@ -1110,7 +1093,7 @@ async fn toggle_into_oneshot_grants_one_more_run() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -1119,17 +1102,17 @@ async fn toggle_into_oneshot_grants_one_more_run() {
             }
         }
     };
-    // Drain the banner + the first child's "@@@ The PID of new child".
-    let _ = read_until(&mut conn, "The PID of new child", Duration::from_secs(2)).await;
+    // Wait for the greeting, which proves this client is in the roster
+    // before the keystrokes below are typed — the same barrier the
+    // party-line tests use. Not the first child's "@@@ The PID of new
+    // child": that line is broadcast when the child spawns, which races
+    // the connect above, so a client that arrives a moment late never sees
+    // it and the wait can only ever expire.
+    let _ = read_until(&mut conn, "procServ server started at:", MUST_ARRIVE).await;
 
     // ^T → OnExit→Disabled (OFF); ^T → Disabled→OneShot (sets first_run).
     conn.write_all(&[0x14]).await.unwrap();
-    let off = read_until(
-        &mut conn,
-        "Toggled auto restart mode to OFF",
-        Duration::from_secs(2),
-    )
-    .await;
+    let off = read_until(&mut conn, "Toggled auto restart mode to OFF", MUST_ARRIVE).await;
     assert!(
         off.contains("Toggled auto restart mode to OFF"),
         "got: {off:?}"
@@ -1138,7 +1121,7 @@ async fn toggle_into_oneshot_grants_one_more_run() {
     let on = read_until(
         &mut conn,
         "Toggled auto restart mode to ONESHOT",
-        Duration::from_secs(2),
+        MUST_ARRIVE,
     )
     .await;
     assert!(
@@ -1149,7 +1132,7 @@ async fn toggle_into_oneshot_grants_one_more_run() {
     // First kill: the child exits but oneshot+first_run grants one more
     // run — a SECOND "@@@ The PID of new child" must appear (no shutdown).
     conn.write_all(&[0x18]).await.unwrap();
-    let relaunch = read_until(&mut conn, "The PID of new child", Duration::from_secs(3)).await;
+    let relaunch = read_until(&mut conn, "The PID of new child", MUST_ARRIVE).await;
     assert!(
         relaunch.contains("The PID of new child"),
         "toggle-into-oneshot must grant one more run, got: {relaunch:?}"
@@ -1158,19 +1141,14 @@ async fn toggle_into_oneshot_grants_one_more_run() {
     // Second kill: the granted run is spent (first_run cleared by the
     // relaunch's respawn_child) — this exit shuts the server down.
     conn.write_all(&[0x18]).await.unwrap();
-    let shutdown = read_until(
-        &mut conn,
-        "oneshot mode: server will exit",
-        Duration::from_secs(3),
-    )
-    .await;
+    let shutdown = read_until(&mut conn, "oneshot mode: server will exit", MUST_ARRIVE).await;
     assert!(
         shutdown.contains("oneshot mode: server will exit"),
         "spent oneshot must shut the server down, got: {shutdown:?}"
     );
 
     // run() resolves once the spent oneshot shuts the supervisor down.
-    timeout(Duration::from_secs(3), server_task)
+    timeout(MUST_ARRIVE, server_task)
         .await
         .expect("supervisor should exit after the spent oneshot")
         .expect("server task join");
@@ -1190,7 +1168,7 @@ async fn banner_precedes_telnet_negotiation() {
     });
 
     let mut conn = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match TcpStream::connect(("127.0.0.1", port)).await {
                 Ok(s) => break s,
@@ -1244,7 +1222,7 @@ async fn clean_shutdown_removes_both_the_info_and_pid_files() {
     cfg.restart_mode = RestartMode::OneShot;
 
     let (server, _ports) = spawn_bound(cfg).await;
-    timeout(Duration::from_secs(5), server.run())
+    timeout(MUST_ARRIVE, server.run())
         .await
         .expect("one-shot supervisor should exit promptly")
         .expect("run ok");
@@ -1283,7 +1261,7 @@ async fn info_file_is_published_at_startup_even_under_wait_for_manual_start() {
     // The control port is up (the manager's other discovery path), so the
     // info file must already be there — that is the whole point of writing
     // it before the main loop.
-    let deadline = Instant::now() + Duration::from_secs(2);
+    let deadline = Instant::now() + MUST_ARRIVE;
     loop {
         match TcpStream::connect(("127.0.0.1", port)).await {
             Ok(_) => break,
@@ -1293,7 +1271,7 @@ async fn info_file_is_published_at_startup_even_under_wait_for_manual_start() {
     }
 
     let body = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match std::fs::read_to_string(&info) {
                 Ok(s) if !s.is_empty() => break s,
@@ -1341,7 +1319,7 @@ async fn info_file_reports_the_kernel_assigned_port_for_a_port_zero_config() {
     });
 
     let body = {
-        let deadline = Instant::now() + Duration::from_secs(2);
+        let deadline = Instant::now() + MUST_ARRIVE;
         loop {
             match std::fs::read_to_string(&info) {
                 Ok(s) if !s.is_empty() => break s,
@@ -1365,7 +1343,7 @@ async fn info_file_reports_the_kernel_assigned_port_for_a_port_zero_config() {
 
     // The published port must be the live listener, not a guess: a client
     // that reads the info file (manage-procs) can connect to it.
-    let deadline = Instant::now() + Duration::from_secs(2);
+    let deadline = Instant::now() + MUST_ARRIVE;
     loop {
         match TcpStream::connect(("127.0.0.1", port)).await {
             Ok(_) => break,


### PR DESCRIPTION
ad-plugins-rs moves to rust-hdf5 0.5.1, whose create gate resolves a dataset path against the groups that already exist, so open_swmr builds the layout group tree before the streaming dataset that names one and no longer re-parents it with assign_dataset_to_group — the 11 SWMR tests fail without that reorder. v0.26.0..main adds no Rust public API (the rtems-boot static-IP arm is C behind compile-time defines), so the version bump is a patch.

The three test commits close what a full --workspace run turned up while verifying that: an env-table test that asserted on a parameter it never cleared, and two families of deadline that hold only on an idle machine — a paused tokio clock around a real accept, and 47 hand-sized procserv waits.