### PR TITLE
feat(asyn-rs): devBusyAsyn support and background-thread alarm pushes

### DIFF
--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -1653,6 +1653,15 @@ impl AsynDeviceSupport {
 
 impl DeviceSupport for AsynDeviceSupport {
     fn init(&mut self, record: &mut dyn Record) -> CaResult<()> {
+        // busy is the driver-clearable output: the busy module's devBusyAsyn
+        // registers the output interrupt callback UNCONDITIONALLY (`if
+        // (interruptCallback)` with no `asyn:READBACK` info gate,
+        // devBusyAsyn.c:245-260) — that always-on readback is the record's
+        // whole point (driver holds VAL=1, clears to 0 on completion). Forced
+        // here, not info-gated: a C db's busy records carry no info tag.
+        if record.record_type() == "busy" {
+            self.set_asyn_readback(true);
+        }
         if !self.reason_set {
             // C calls drvUser->create only when the port registered asynDrvUser
             // **and** the record named a userParam (`if (pasynInterface &&
@@ -3130,6 +3139,12 @@ pub fn register_asyn_device_menus() {
             epics_base_rs::server::record::register_device_menu(record_type, choices);
         }
     }
+    // The busy record's asyn binding comes from the busy MODULE, not asyn's own
+    // .dbd (busySupport_withASYN.dbd: `device(busy,INST_IO,asynBusyInt32,
+    // "asynInt32")`), so it is registered here rather than in the generated
+    // table above. The binding itself is the universal factory + the
+    // unconditional readback forced in `init` (devBusyAsyn.c parity).
+    epics_base_rs::server::record::register_device_menu("busy", &["asynInt32"]);
 }
 
 /// IocBuilder companion to [`register_asyn_device_support`] —
@@ -5914,6 +5929,27 @@ mod tests {
                 Some(InterfaceType::Int32),
                 ParamType::Int32
             )]
+        );
+    }
+
+    /// devBusyAsyn.c:245-260 — the busy module's device support registers the
+    /// output interrupt callback unconditionally, no `asyn:READBACK` info
+    /// gate. A Passive busy record with no info tags must therefore come out
+    /// of `init` with the readback path active (that is how the driver's
+    /// param write releases the record), and an explicit
+    /// `info(asyn:READBACK, "0")` must not defeat it (C never consults it).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn busy_record_enables_readback_unconditionally() {
+        use epics_base_rs::server::records::busy::BusyRecord;
+        let mut ads = make_adapter(ScanType::Passive);
+        let mut info = std::collections::HashMap::new();
+        info.insert("asyn:READBACK".to_string(), "0".to_string());
+        ads.apply_record_info(&info);
+        let mut rec = BusyRecord::new();
+        ads.init(&mut rec).unwrap();
+        assert!(
+            ads.io_intr_receiver().is_some(),
+            "busy must register the driver readback with no info tag"
         );
     }
 

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -1770,6 +1770,19 @@ impl PortActor {
                             mask,
                             interrupt_mask,
                         } => base.set_uint32_param(*reason, *addr, *value, *mask, *interrupt_mask),
+                        crate::request::ParamSetValue::Status {
+                            reason,
+                            addr,
+                            status,
+                            alarm_status,
+                            alarm_severity,
+                        } => base.set_param_status(
+                            *reason,
+                            *addr,
+                            *status,
+                            *alarm_status,
+                            *alarm_severity,
+                        ),
                     };
                     // A set that fails (a value the parameter cannot hold) is
                     // reported, not swallowed: C `asynPortDriver::setIntegerParam`
@@ -3867,6 +3880,75 @@ mod tests {
             *seen.lock(),
             vec![(0, 10), (1, 11), (2, 12)],
             "every address the batch wrote is flushed, request address first"
+        );
+    }
+
+    /// `ParamSetValue::Status` is the background-thread half of C's alarm
+    /// push — `lock(); setParamStatus(..); callParamCallbacks(); unlock()`.
+    /// A status-only transition marks the param changed (paramVal.cpp:71-78),
+    /// so the flush delivers the stored triplet on the `InterruptValue` while
+    /// the value stays what it was; the recovery transition back to `Success`
+    /// is delivered the same way.
+    #[test]
+    fn a_status_publish_delivers_the_alarm_without_touching_the_value() {
+        let mut base = PortDriverBase::new("status_pub", 1, PortFlags::default());
+        let val = base.create_param("VAL", ParamType::Int32).unwrap();
+        let seen = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let _sub = base.interrupts.register_sync_callback(
+            InterruptFilter {
+                reason: Some(val),
+                ..InterruptFilter::default()
+            },
+            move |iv| {
+                recorder.lock().push((
+                    iv.value.as_int32().unwrap(),
+                    iv.aux_status,
+                    iv.alarm_status,
+                    iv.alarm_severity,
+                ))
+            },
+        );
+        let tx = spawn_actor(TestDriverBase(base));
+
+        let publish = |updates| {
+            let user = AsynUser::new(0).with_timeout(Duration::from_secs(1));
+            send_and_wait(
+                &tx,
+                RequestOp::CallParamCallbacks { addr: 0, updates },
+                user,
+            )
+            .unwrap();
+        };
+        publish(vec![crate::request::ParamSetValue::new(
+            val,
+            0,
+            crate::param::ParamValue::Int32(7),
+        )]);
+        publish(vec![crate::request::ParamSetValue::status(
+            val,
+            0,
+            crate::error::AsynStatus::Disconnected,
+            0,
+            0,
+        )]);
+        publish(vec![crate::request::ParamSetValue::status(
+            val,
+            0,
+            crate::error::AsynStatus::Success,
+            0,
+            0,
+        )]);
+
+        assert_eq!(
+            *seen.lock(),
+            vec![
+                (7, crate::error::AsynStatus::Success, 0, 0),
+                (7, crate::error::AsynStatus::Disconnected, 0, 0),
+                (7, crate::error::AsynStatus::Success, 0, 0),
+            ],
+            "a status transition fires with the prior value intact, and so \
+             does the recovery back to Success"
         );
     }
 

--- a/crates/asyn-rs/src/request.rs
+++ b/crates/asyn-rs/src/request.rs
@@ -41,6 +41,21 @@ pub enum ParamSetValue {
         /// interruptMask)`); `0` for a plain value set.
         interrupt_mask: u32,
     },
+    /// C `setParamStatus` / `setParamAlarmStatus` / `setParamAlarmSeverity`
+    /// from a background thread — the alarm-push half of the C pattern
+    /// `lock(); setParamStatus(..); callParamCallbacks(); unlock()`. The
+    /// value is untouched; a status/alarm transition alone marks the param
+    /// changed so the flush delivers it (paramVal.cpp:71-104), and the
+    /// devEpics fill-in maps a non-Success `status` to the EPICS alarm
+    /// (asynDisconnected → COMM/INVALID) when `alarm_status`/`alarm_severity`
+    /// are left 0 (asynEpicsUtils.c:238-265).
+    Status {
+        reason: usize,
+        addr: i32,
+        status: AsynStatus,
+        alarm_status: u16,
+        alarm_severity: u16,
+    },
 }
 
 impl ParamSetValue {
@@ -71,11 +86,33 @@ impl ParamSetValue {
         }
     }
 
+    /// C `setParamStatus(list, index, status)` plus the alarm pair: set the
+    /// transport status and EPICS alarm without touching the value. Pass
+    /// `alarm_status`/`alarm_severity` 0 to let the record-side fill-in map
+    /// `status` itself (the C-normal path).
+    pub fn status(
+        reason: usize,
+        addr: i32,
+        status: AsynStatus,
+        alarm_status: u16,
+        alarm_severity: u16,
+    ) -> Self {
+        Self::Status {
+            reason,
+            addr,
+            status,
+            alarm_status,
+            alarm_severity,
+        }
+    }
+
     /// The address list this update lands in — the list whose changed flags a
     /// later `callParamCallbacks` has to consume for it to reach a record.
     pub fn addr(&self) -> i32 {
         match self {
-            Self::Value { addr, .. } | Self::UInt32Digital { addr, .. } => *addr,
+            Self::Value { addr, .. }
+            | Self::UInt32Digital { addr, .. }
+            | Self::Status { addr, .. } => *addr,
         }
     }
 }

--- a/crates/epics-base-rs/src/server/records/busy.rs
+++ b/crates/epics-base-rs/src/server/records/busy.rs
@@ -64,6 +64,13 @@ pub struct BusyRecord {
     // when `mlst != val`. Captured in the monitor() owner during process()
     // because the framework reads monitor_value_changed() afterwards.
     value_changed: bool,
+    /// Set by `set_device_did_compute(true)` when a device readback has
+    /// already produced both RVAL and VAL (`apply_raw_readback`). One-shot:
+    /// `process()` then skips the forward `convert_val_to_rval()` that would
+    /// recompute RVAL from VAL and discard the readback — C `processBusy`'s
+    /// callback branch sets `rval`/`val` and never re-converts
+    /// (devBusyAsyn.c:482-488). Mirrors [`bo`](super::bo).
+    skip_convert: bool,
 }
 
 impl Default for BusyRecord {
@@ -94,6 +101,7 @@ impl Default for BusyRecord {
             sims: 0,
             high_reset_pending: false,
             value_changed: false,
+            skip_convert: false,
         }
     }
 }
@@ -197,8 +205,15 @@ impl Record for BusyRecord {
 
         // Step 1: DOL reading handled by framework (OMSL=ClosedLoop)
 
-        // Step 2: VAL → RVAL conversion
-        self.convert_val_to_rval();
+        // Step 2: VAL → RVAL conversion — unless a device readback
+        // (`apply_raw_readback`) already set both RVAL and VAL, in which case
+        // skip the forward convert that would recompute RVAL from VAL and
+        // discard the readback. One-shot, mirrors bo (C `processBusy`'s
+        // callback branch returns without re-converting).
+        if !self.skip_convert {
+            self.convert_val_to_rval();
+        }
+        self.skip_convert = false;
 
         // Step 3: Save current VAL before write (for FLNK decision)
         self.oval = self.val;
@@ -267,6 +282,23 @@ impl Record for BusyRecord {
     }
 
     fn can_device_write(&self) -> bool {
+        true
+    }
+
+    fn set_device_did_compute(&mut self, did: bool) {
+        self.skip_convert = did;
+    }
+
+    /// Device readback (devBusyAsyn's always-on output callback): store the
+    /// raw and resolve VAL to 0/1, mirroring C `processBusy`'s callback branch
+    /// (devBusyAsyn.c:484-487 `pr->rval = value; pr->val = (pr->rval) ? 1 :
+    /// 0`). No MASK split — busy has only the Int32 device support
+    /// (`asynBusyInt32`), whose readback is unmasked. Returns `true` so the
+    /// store reports `computed` and the framework skips the forward convert
+    /// (via `set_device_did_compute`).
+    fn apply_raw_readback(&mut self, raw: i32) -> bool {
+        self.rval = raw as u32;
+        self.val = if self.rval != 0 { 1 } else { 0 };
         true
     }
 
@@ -578,6 +610,39 @@ mod tests {
     fn test_can_device_write() {
         let rec = BusyRecord::new();
         assert!(rec.can_device_write());
+    }
+
+    /// devBusyAsyn.c:484-487 — the driver callback stores the raw unmasked
+    /// (`pr->rval = value`) and maps VAL to 0/1; the following process() must
+    /// not recompute RVAL from VAL (the one-shot `set_device_did_compute`
+    /// gate), or a non-0/1 raw readback would be discarded.
+    #[test]
+    fn raw_readback_is_kept_through_process() {
+        let mut rec = BusyRecord::new();
+        assert!(rec.apply_raw_readback(5));
+        assert_eq!((rec.rval, rec.val), (5, 1));
+        rec.set_device_did_compute(true);
+        rec.process().unwrap();
+        assert_eq!(rec.rval, 5, "readback RVAL survives the process cycle");
+        // One-shot: the next (non-readback) process converts VAL forward again.
+        rec.process().unwrap();
+        assert_eq!(rec.rval, 1);
+    }
+
+    /// The release cycle: driver clears the param to 0, the readback maps
+    /// VAL 1 → 0, and that process fires FLNK (`val == 0 || oval == 0`) —
+    /// the completion a `caput -c`/`wait=True` client blocks on.
+    #[test]
+    fn raw_readback_zero_releases_and_fires_flnk() {
+        let mut rec = BusyRecord::new();
+        rec.put_field("VAL", EpicsValue::Enum(1)).unwrap();
+        rec.process().unwrap();
+        assert!(!rec.should_fire_forward_link(), "sustained busy: no FLNK");
+        assert!(rec.apply_raw_readback(0));
+        assert_eq!((rec.rval, rec.val), (0, 0));
+        rec.set_device_did_compute(true);
+        rec.process().unwrap();
+        assert!(rec.should_fire_forward_link());
     }
 
     #[test]


### PR DESCRIPTION
The asyn-rs halves the epics-rs-iocs ur-driver work depends on: devBusyAsyn so busy records complete from the driver (moveJ/moveL, gripper open/close), and ParamSetValue::Status so a poll thread can raise and clear COMM alarms like C's setParamStatus + callParamCallbacks. ParamSetValue gains a variant, so exhaustive matches downstream need a new arm.