### PR TITLE
fix(asub): type the A..U cells from FTA..FTU and shape every store to them

### DIFF
--- a/crates/epics-base-rs/src/server/records/asub_record.rs
+++ b/crates/epics-base-rs/src/server/records/asub_record.rs
@@ -306,7 +306,10 @@ fn shape_channel_value(value: EpicsValue, ft: i16, no: i32) -> (EpicsValue, i32)
         // source field at offset 0).
         let scalar = match value.first_element() {
             Some(first) => first,
-            None if value.is_array() => return (channel_default(ft, no), 1),
+            // An empty array source delivers zero elements: C `dbGet` clamps
+            // `nRequest` to the source count (dbAccess.c:999-1000) and
+            // `fetch_values` records it as NEx (aSubRecord.c:287).
+            None if value.is_array() => return (channel_default(ft, no), 0),
             None => value,
         };
         let converted = scalar.convert_to(elem);
@@ -819,6 +822,16 @@ mod tests {
             .unwrap();
         assert_eq!(rec.get_field("B"), Some(EpicsValue::Double(5.5)));
         assert_eq!(rec.get_field("NEB"), Some(EpicsValue::Long(1)));
+
+        // An EMPTY array source delivers zero elements — dbGet clamps
+        // nRequest to the source count (dbAccess.c:999-1000) and NEx records
+        // it (aSubRecord.c:287) — on both cell shapes.
+        rec.put_field("B", EpicsValue::DoubleArray(vec![])).unwrap();
+        assert_eq!(rec.get_field("B"), Some(EpicsValue::Double(0.0)));
+        assert_eq!(rec.get_field("NEB"), Some(EpicsValue::Long(0)));
+        rec.put_field("A", EpicsValue::DoubleArray(vec![])).unwrap();
+        assert_eq!(rec.get_field("A"), Some(EpicsValue::LongArray(vec![])));
+        assert_eq!(rec.get_field("NEA"), Some(EpicsValue::Long(0)));
     }
 
     /// FTVx/NOVx declare the output cell the same way (C `initFields` runs

--- a/crates/epics-base-rs/src/server/records/asub_record.rs
+++ b/crates/epics-base-rs/src/server/records/asub_record.rs
@@ -166,7 +166,7 @@ impl Default for ASubRecord {
             inam: PvString::new(),
             inp: std::array::from_fn(|_| String::new()),
             a: std::array::from_fn(|_| channel_default(FTYPE_DOUBLE, 1)),
-            vala: std::array::from_fn(|_| EpicsValue::DoubleArray(Vec::new())),
+            vala: std::array::from_fn(|_| channel_default(FTYPE_DOUBLE, 1)),
             out: std::array::from_fn(|_| String::new()),
             fta: [FTYPE_DOUBLE; NUM_ARGS],
             ftva: [FTYPE_DOUBLE; NUM_ARGS],
@@ -237,7 +237,8 @@ fn channel_ftype(ft: i16) -> Ftype {
     Ftype::from_index(ft).unwrap_or(Ftype::Char)
 }
 
-/// An input cell as C `initFields` allocates it (aSubRecord.c:176-198):
+/// A channel cell as C `initFields` allocates it (aSubRecord.c:176-198,
+/// run for the A..U/FTx/NOx triple AND the VALA..VALU/FTVx/NOVx one):
 /// `callocMustSucceed(NOx, dbValueSize(FTx))`, a zero-filled FTx-typed
 /// buffer of NOx elements (`*pno == 0` is clamped to 1). The port stores
 /// the one-element case as the FTx-typed zero scalar.
@@ -277,12 +278,16 @@ fn wrap_one_element(scalar: EpicsValue, ftype: Ftype) -> EpicsValue {
     }
 }
 
-/// Shape a value entering input cell `x` — a framework link delivery or a
-/// direct put — to the channel's declared `FTx`/`NOx`. This is C
-/// `fetch_values`'s `dbGetLink(plink, (&prec->fta)[i], (&prec->a)[i], 0,
-/// &nRequest)` with `nRequest = NOx` (aSubRecord.c:278-288): the link layer
-/// converts the source element-wise into the FTx-typed buffer and clamps
-/// the delivered count to NOx. Returns the shaped value and the new NEx.
+/// Shape a value entering a channel cell — a framework link delivery, a
+/// direct put, or a subroutine's output write — to the cell's declared
+/// type/capacity. On the input side this is C `fetch_values`'s
+/// `dbGetLink(plink, (&prec->fta)[i], (&prec->a)[i], 0, &nRequest)` with
+/// `nRequest = NOx` (aSubRecord.c:278-288): the link layer converts the
+/// source element-wise into the FTx-typed buffer and clamps the delivered
+/// count to NOx. On the output side it is the buffer itself: a C
+/// subroutine writes *into* the FTVx-typed NOVx-element `vala[i]`, so no
+/// other shape can exist there. Returns the shaped value and the new
+/// NEx/NEVx.
 fn shape_channel_value(value: EpicsValue, ft: i16, no: i32) -> (EpicsValue, i32) {
     let ftype = channel_ftype(ft);
     let elem = ftype.element_type();
@@ -495,9 +500,15 @@ impl Record for ASubRecord {
                     self.out[idx] = s;
                 }
             }
-            // Output value VALA..VALU — store native; track NEVx.
+            // Output value VALA..VALU — shaped to the channel's declared
+            // FTVx/NOVx, the same rule as the input side: a C subroutine
+            // writes INTO the FTVx-typed NOVx-element buffer, so no other
+            // shape can leave `do_sub`, and the OUT push reads that buffer
+            // (`dbPutLink(&(&prec->outa)[i], (&prec->ftva)[i], ...)`,
+            // aSubRecord.c:236-238). NEVx tracks the elements written.
             "VAL" => {
-                self.neva[idx] = value.count().max(1) as i32;
+                let (value, ne) = shape_channel_value(value, self.ftva[idx], self.nova[idx]);
+                self.neva[idx] = ne;
                 self.vala[idx] = value;
             }
             "FT" | "FTV" | "NO" | "NOV" | "NE" | "NEV" => {
@@ -510,13 +521,14 @@ impl Record for ASubRecord {
                         .ok_or_else(|| CaError::TypeMismatch(name.into()))?,
                 };
                 match prefix {
-                    // FTx/NOx declare the input cell's element type and
-                    // capacity: C `initFields` clamps them (out-of-menu FTx
-                    // -> CHAR at aSubRecord.c:186-187, NOx 0 -> 1 at :189-190)
-                    // and allocates the cell as a zero-filled FTx-typed
-                    // buffer with NEx = NOx (:192-196). Both are SPC_NOMOD,
-                    // so this put is the load path — re-deriving the cell
-                    // here is that allocation.
+                    // FTx/NOx and FTVx/NOVx declare their cell's element type
+                    // and capacity: C `initFields` clamps them (out-of-menu
+                    // FTx -> CHAR at aSubRecord.c:186-187, NOx 0 -> 1 at
+                    // :189-190) and allocates the cell as a zero-filled
+                    // FTx-typed buffer with NEx = NOx (:192-196) — run for
+                    // both the input and the output triple. All four are
+                    // SPC_NOMOD, so these puts are the load path —
+                    // re-deriving the cell here is that allocation.
                     "FT" => {
                         self.fta[idx] = channel_ftype(v as i16).index();
                         self.a[idx] = channel_default(self.fta[idx], self.noa[idx]);
@@ -527,8 +539,16 @@ impl Record for ASubRecord {
                         self.a[idx] = channel_default(self.fta[idx], self.noa[idx]);
                         self.nea[idx] = self.noa[idx];
                     }
-                    "FTV" => self.ftva[idx] = v as i16,
-                    "NOV" => self.nova[idx] = v,
+                    "FTV" => {
+                        self.ftva[idx] = channel_ftype(v as i16).index();
+                        self.vala[idx] = channel_default(self.ftva[idx], self.nova[idx]);
+                        self.neva[idx] = self.nova[idx].max(1);
+                    }
+                    "NOV" => {
+                        self.nova[idx] = v.max(1);
+                        self.vala[idx] = channel_default(self.ftva[idx], self.nova[idx]);
+                        self.neva[idx] = self.nova[idx];
+                    }
                     "NE" => self.nea[idx] = v,
                     "NEV" => self.neva[idx] = v,
                     _ => unreachable!(),
@@ -699,7 +719,10 @@ mod tests {
             rec.put_field(name, EpicsValue::Double(3.0)).unwrap();
             assert_eq!(rec.get_field(name), Some(EpicsValue::Double(3.0)));
         }
-        for name in ["VALM", "VALU"] {
+        for (name, nov) in [("VALM", "NOVM"), ("VALU", "NOVU")] {
+            // C requires the output capacity declared up front, like the
+            // input side: the subroutine writes into an NOVx-element buffer.
+            rec.put_field(nov, EpicsValue::Long(2)).unwrap();
             rec.put_field(name, EpicsValue::DoubleArray(vec![1.0, 2.0]))
                 .unwrap();
             assert_eq!(
@@ -796,6 +819,41 @@ mod tests {
             .unwrap();
         assert_eq!(rec.get_field("B"), Some(EpicsValue::Double(5.5)));
         assert_eq!(rec.get_field("NEB"), Some(EpicsValue::Long(1)));
+    }
+
+    /// FTVx/NOVx declare the output cell the same way (C `initFields` runs
+    /// for the output triple too): the cell allocates typed and zeroed, and
+    /// a subroutine's write converts and clamps into it — C's subroutine
+    /// writes INTO the FTVx-typed NOVx-element buffer, so no other shape
+    /// can leave `do_sub`.
+    #[test]
+    fn ftvx_novx_declare_the_output_cell() {
+        let mut rec = ASubRecord::default();
+        rec.put_field("FTVA", EpicsValue::Short(10)).unwrap(); // DOUBLE
+        rec.put_field("NOVA", EpicsValue::Long(3)).unwrap();
+        assert_eq!(
+            rec.get_field("VALA"),
+            Some(EpicsValue::DoubleArray(vec![0.0; 3]))
+        );
+        assert_eq!(rec.get_field("NEVA"), Some(EpicsValue::Long(3)));
+
+        rec.put_field("VALA", EpicsValue::LongArray(vec![1, 2, 3, 4]))
+            .unwrap();
+        assert_eq!(
+            rec.get_field("VALA"),
+            Some(EpicsValue::DoubleArray(vec![1.0, 2.0, 3.0])),
+            "a subroutine write converts element-wise and clamps to NOVx"
+        );
+        assert_eq!(rec.get_field("NEVA"), Some(EpicsValue::Long(3)));
+
+        rec.put_field("FTVB", EpicsValue::Short(0)).unwrap(); // STRING
+        rec.put_field("VALB", EpicsValue::String("done".into()))
+            .unwrap();
+        assert_eq!(
+            rec.get_field("VALB"),
+            Some(EpicsValue::String("done".into())),
+            "a declared STRING output keeps its string"
+        );
     }
 
     /// C `fetch_values` requests the channel's FTx from `dbGetLink`

--- a/crates/epics-base-rs/src/server/records/asub_record.rs
+++ b/crates/epics-base-rs/src/server/records/asub_record.rs
@@ -1,5 +1,7 @@
 use crate::error::{CaError, CaResult};
-use crate::server::record::{FieldMetadataOverride, InputFetchPolicy, ProcessOutcome, Record};
+use crate::server::record::{
+    FieldMetadataOverride, Ftype, InputFetchPolicy, LinkReadAs, OutTarget, ProcessOutcome, Record,
+};
 use crate::types::{EpicsValue, PvString};
 
 /// Number of aSub channels. C `aSubRecord.c`: `NUM_ARGS == 21`
@@ -163,7 +165,7 @@ impl Default for ASubRecord {
             snam: PvString::new(),
             inam: PvString::new(),
             inp: std::array::from_fn(|_| String::new()),
-            a: std::array::from_fn(|_| EpicsValue::Double(0.0)),
+            a: std::array::from_fn(|_| channel_default(FTYPE_DOUBLE, 1)),
             vala: std::array::from_fn(|_| EpicsValue::DoubleArray(Vec::new())),
             out: std::array::from_fn(|_| String::new()),
             fta: [FTYPE_DOUBLE; NUM_ARGS],
@@ -226,6 +228,93 @@ fn parse_channel(name: &str) -> Option<(&'static str, usize)> {
         }
     }
     None
+}
+
+/// The `menuFtype` of an `FTx` index, with C `initFields`'s clamp: an index
+/// past the menu is treated as CHAR (`if (*pft > DBF_ENUM) *pft = DBF_CHAR;`,
+/// aSubRecord.c:186-187).
+fn channel_ftype(ft: i16) -> Ftype {
+    Ftype::from_index(ft).unwrap_or(Ftype::Char)
+}
+
+/// An input cell as C `initFields` allocates it (aSubRecord.c:176-198):
+/// `callocMustSucceed(NOx, dbValueSize(FTx))`, a zero-filled FTx-typed
+/// buffer of NOx elements (`*pno == 0` is clamped to 1). The port stores
+/// the one-element case as the FTx-typed zero scalar.
+fn channel_default(ft: i16, no: i32) -> EpicsValue {
+    let ftype = channel_ftype(ft);
+    if no > 1 {
+        ftype.zeroed(no as usize)
+    } else {
+        ftype
+            .zeroed(1)
+            .first_element()
+            .expect("zeroed(1) has element 0")
+    }
+}
+
+/// A scalar as the 1-element FTx-typed array an `NOx > 1` cell stores — C's
+/// buffer is an array whatever the source's shape; a scalar source just
+/// delivers `nRequest = 1`.
+fn wrap_one_element(scalar: EpicsValue, ftype: Ftype) -> EpicsValue {
+    match (ftype, scalar) {
+        (Ftype::String, EpicsValue::String(v)) => EpicsValue::StringArray(vec![v]),
+        (Ftype::Char, EpicsValue::Char(v)) => EpicsValue::CharArray(vec![v]),
+        (Ftype::UChar, EpicsValue::UChar(v)) => EpicsValue::UCharArray(vec![v]),
+        (Ftype::Short, EpicsValue::Short(v)) => EpicsValue::ShortArray(vec![v]),
+        (Ftype::UShort, EpicsValue::UShort(v)) => EpicsValue::UShortArray(vec![v]),
+        (Ftype::Long, EpicsValue::Long(v)) => EpicsValue::LongArray(vec![v]),
+        (Ftype::ULong, EpicsValue::ULong(v)) => EpicsValue::ULongArray(vec![v]),
+        (Ftype::Int64, EpicsValue::Int64(v)) => EpicsValue::Int64Array(vec![v]),
+        (Ftype::UInt64, EpicsValue::UInt64(v)) => EpicsValue::UInt64Array(vec![v]),
+        (Ftype::Float, EpicsValue::Float(v)) => EpicsValue::FloatArray(vec![v]),
+        (Ftype::Double, EpicsValue::Double(v)) => EpicsValue::DoubleArray(vec![v]),
+        (Ftype::Enum, EpicsValue::Enum(v)) => EpicsValue::EnumArray(vec![v]),
+        // The scalar came out of `convert_to(ftype.element_type())`, so the
+        // pair always matches; a framework-internal transient lands as the
+        // typed zero element rather than a panic.
+        (ftype, _) => ftype.zeroed(1),
+    }
+}
+
+/// Shape a value entering input cell `x` — a framework link delivery or a
+/// direct put — to the channel's declared `FTx`/`NOx`. This is C
+/// `fetch_values`'s `dbGetLink(plink, (&prec->fta)[i], (&prec->a)[i], 0,
+/// &nRequest)` with `nRequest = NOx` (aSubRecord.c:278-288): the link layer
+/// converts the source element-wise into the FTx-typed buffer and clamps
+/// the delivered count to NOx. Returns the shaped value and the new NEx.
+fn shape_channel_value(value: EpicsValue, ft: i16, no: i32) -> (EpicsValue, i32) {
+    let ftype = channel_ftype(ft);
+    let elem = ftype.element_type();
+    if no > 1 {
+        let converted = value.convert_to(elem);
+        let mut arr = if converted.is_array() {
+            converted
+        } else {
+            wrap_one_element(converted, ftype)
+        };
+        arr.truncate(no as usize);
+        let ne = arr.count() as i32;
+        (arr, ne)
+    } else {
+        // A one-element destination takes element 0 (C `dbGet` converts the
+        // source field at offset 0).
+        let scalar = match value.first_element() {
+            Some(first) => first,
+            None if value.is_array() => return (channel_default(ft, no), 1),
+            None => value,
+        };
+        let converted = scalar.convert_to(elem);
+        // `convert_to` has one array-producing scalar arm (String into a
+        // CHAR target yields the byte buffer); a one-element cell keeps
+        // element 0 of it.
+        let v = match converted.first_element() {
+            Some(first) => first,
+            None if converted.is_array() => channel_default(ft, no),
+            None => converted,
+        };
+        (v, 1)
+    }
 }
 
 /// Surface an output array channel: empty -> scalar 0.0, single
@@ -385,9 +474,14 @@ impl Record for ASubRecord {
         let (prefix, idx) =
             parse_channel(name).ok_or_else(|| CaError::FieldNotFound(name.to_string()))?;
         match prefix {
-            // Input value A..U — store native; track NEx (elements used).
+            // Input value A..U — shaped to the channel's declared FTx/NOx.
+            // C `fetch_values` lands every link value in the FTx-typed
+            // NOx-element buffer (aSubRecord.c:278-288); a direct put takes
+            // the same conversion through `dbPut` into that buffer. NEx
+            // tracks the elements actually delivered.
             "" => {
-                self.nea[idx] = value.count().max(1) as i32;
+                let (value, ne) = shape_channel_value(value, self.fta[idx], self.noa[idx]);
+                self.nea[idx] = ne;
                 self.a[idx] = value;
             }
             "INP" | "OUT" => {
@@ -416,9 +510,24 @@ impl Record for ASubRecord {
                         .ok_or_else(|| CaError::TypeMismatch(name.into()))?,
                 };
                 match prefix {
-                    "FT" => self.fta[idx] = v as i16,
+                    // FTx/NOx declare the input cell's element type and
+                    // capacity: C `initFields` clamps them (out-of-menu FTx
+                    // -> CHAR at aSubRecord.c:186-187, NOx 0 -> 1 at :189-190)
+                    // and allocates the cell as a zero-filled FTx-typed
+                    // buffer with NEx = NOx (:192-196). Both are SPC_NOMOD,
+                    // so this put is the load path — re-deriving the cell
+                    // here is that allocation.
+                    "FT" => {
+                        self.fta[idx] = channel_ftype(v as i16).index();
+                        self.a[idx] = channel_default(self.fta[idx], self.noa[idx]);
+                        self.nea[idx] = self.noa[idx].max(1);
+                    }
+                    "NO" => {
+                        self.noa[idx] = v.max(1);
+                        self.a[idx] = channel_default(self.fta[idx], self.noa[idx]);
+                        self.nea[idx] = self.noa[idx];
+                    }
                     "FTV" => self.ftva[idx] = v as i16,
-                    "NO" => self.noa[idx] = v,
                     "NOV" => self.nova[idx] = v,
                     "NE" => self.nea[idx] = v,
                     "NEV" => self.neva[idx] = v,
@@ -522,6 +631,28 @@ impl Record for ASubRecord {
         InputFetchPolicy::AbortOnFirstFailure
     }
 
+    /// C `fetch_values` asks `dbGetLink` for the channel's declared FTx
+    /// (`dbGetLink(plink, (&prec->fta)[i], ...)`, aSubRecord.c:283-284), so a
+    /// STRING channel reading a scalar source receives its DBR_STRING form —
+    /// an ENUM/MENU source delivers its state label, a numeric source its
+    /// text — which the store must not funnel through a numeric conversion.
+    /// A STRING channel with an ARRAY source keeps the native read: the
+    /// whole array reaches the FTx-typed cell, whose put boundary converts
+    /// it element-wise to strings (C's per-element `DBR_STRING` conversion
+    /// of `nRequest = NOx` elements). Every non-STRING FTx likewise reads
+    /// native — the cell is FTx-typed, so the put boundary's element-wise
+    /// coercion is C's `dbGet` conversion into the FTx buffer.
+    fn input_link_read_as(&self, link_field: &str, source: &OutTarget) -> Option<LinkReadAs> {
+        let string_channel = parse_channel(link_field)
+            .filter(|(prefix, _)| *prefix == "INP")
+            .is_some_and(|(_, idx)| channel_ftype(self.fta[idx]) == Ftype::String);
+        if string_channel && source.element_count <= 1 {
+            Some(LinkReadAs::String)
+        } else {
+            Some(LinkReadAs::Native)
+        }
+    }
+
     /// The cycle status from the framework's single `do_sub` owner. Stored
     /// verbatim; [`Self::multi_output_links`] is its only reader.
     fn set_subroutine_status(&mut self, status: i64) {
@@ -593,6 +724,9 @@ mod tests {
         assert_eq!(rec.fta[0], 0);
 
         rec.put_field("FTC", EpicsValue::Short(5)).unwrap(); // LONG
+        // C requires the capacity declared up front: NOx elements are
+        // allocated at init, and `dbGetLink` clamps `nRequest` to NOx.
+        rec.put_field("NOC", EpicsValue::Long(3)).unwrap();
         rec.put_field("C", EpicsValue::LongArray(vec![10, 20, 30]))
             .unwrap();
         assert_eq!(
@@ -601,6 +735,103 @@ mod tests {
         );
         // NEC tracks elements used.
         assert_eq!(rec.get_field("NEC"), Some(EpicsValue::Long(3)));
+    }
+
+    /// FTx/NOx declare the input cell — C `initFields` (aSubRecord.c:176-198)
+    /// allocates a zero-filled FTx-typed buffer of NOx elements, NEx = NOx,
+    /// clamping an out-of-menu FTx to CHAR (:186-187).
+    #[test]
+    fn ftx_nox_declare_the_input_cell() {
+        let mut rec = ASubRecord::default();
+        rec.put_field("FTA", EpicsValue::Short(10)).unwrap(); // DOUBLE
+        rec.put_field("NOA", EpicsValue::Long(4)).unwrap();
+        assert_eq!(
+            rec.get_field("A"),
+            Some(EpicsValue::DoubleArray(vec![0.0; 4]))
+        );
+        assert_eq!(
+            rec.get_field("NEA"),
+            Some(EpicsValue::Long(4)),
+            "C initFields: NEx starts at NOx"
+        );
+
+        rec.put_field("FTB", EpicsValue::Short(0)).unwrap(); // STRING
+        assert_eq!(rec.get_field("B"), Some(EpicsValue::String("".into())));
+
+        rec.put_field("FTC", EpicsValue::Short(99)).unwrap(); // out of menu
+        rec.put_field("NOC", EpicsValue::Long(2)).unwrap();
+        assert_eq!(
+            rec.get_field("FTC"),
+            Some(EpicsValue::Short(1)),
+            "aSubRecord.c:186-187: FTx past DBF_ENUM becomes CHAR"
+        );
+        assert_eq!(rec.get_field("C"), Some(EpicsValue::CharArray(vec![0, 0])));
+    }
+
+    /// Values entering an input cell convert into the declared buffer — C
+    /// `dbGetLink(plink, FTx, a[i], 0, &nRequest)` with `nRequest` clamped
+    /// to NOx (aSubRecord.c:278-288); `dbPut` converts the same way.
+    #[test]
+    fn input_puts_convert_and_clamp_to_the_declared_buffer() {
+        let mut rec = ASubRecord::default();
+        rec.put_field("FTA", EpicsValue::Short(5)).unwrap(); // LONG
+        rec.put_field("NOA", EpicsValue::Long(3)).unwrap();
+        // An array source converts element-wise and clamps to NOx.
+        rec.put_field("A", EpicsValue::DoubleArray(vec![1.9, 2.2, 3.7, 4.4]))
+            .unwrap();
+        assert_eq!(
+            rec.get_field("A"),
+            Some(EpicsValue::LongArray(vec![1, 2, 3]))
+        );
+        assert_eq!(rec.get_field("NEA"), Some(EpicsValue::Long(3)));
+
+        // A scalar source fills one element of an array cell (nRequest = 1).
+        rec.put_field("A", EpicsValue::Double(7.0)).unwrap();
+        assert_eq!(rec.get_field("A"), Some(EpicsValue::LongArray(vec![7])));
+        assert_eq!(rec.get_field("NEA"), Some(EpicsValue::Long(1)));
+
+        // An array into a one-element cell keeps element 0 (C's one-element
+        // destination, same rule as the store's scalar reduction).
+        rec.put_field("B", EpicsValue::DoubleArray(vec![5.5, 6.6]))
+            .unwrap();
+        assert_eq!(rec.get_field("B"), Some(EpicsValue::Double(5.5)));
+        assert_eq!(rec.get_field("NEB"), Some(EpicsValue::Long(1)));
+    }
+
+    /// C `fetch_values` requests the channel's FTx from `dbGetLink`
+    /// (aSubRecord.c:283-284): a STRING channel with a scalar source reads
+    /// DBR_STRING; an array source and every non-STRING channel read native
+    /// (the FTx-typed cell converts at its put boundary).
+    #[test]
+    fn string_channels_read_scalar_links_as_strings() {
+        let mut rec = ASubRecord::default();
+        rec.put_field("FTC", EpicsValue::Short(0)).unwrap(); // STRING
+        let scalar = OutTarget {
+            element_count: 1,
+            ..OutTarget::UNRESOLVED
+        };
+        assert_eq!(
+            rec.input_link_read_as("INPC", &scalar),
+            Some(LinkReadAs::String)
+        );
+        let array = OutTarget {
+            element_count: 8,
+            ..OutTarget::UNRESOLVED
+        };
+        assert_eq!(
+            rec.input_link_read_as("INPC", &array),
+            Some(LinkReadAs::Native)
+        );
+        assert_eq!(
+            rec.input_link_read_as("INPA", &scalar),
+            Some(LinkReadAs::Native),
+            "a DOUBLE channel reads native"
+        );
+        assert_eq!(
+            rec.input_link_read_as("SUBL", &scalar),
+            Some(LinkReadAs::Native),
+            "only INPx links carry a channel FTx"
+        );
     }
 
     /// All 21 input channels feed `multi_input_links`.

--- a/crates/epics-base-rs/tests/asub_input_links.rs
+++ b/crates/epics-base-rs/tests/asub_input_links.rs
@@ -1,0 +1,118 @@
+//! aSub input fetch honors the declared FTA..FTU / NOA..NOU.
+//!
+//! C `aSubRecord.c::fetch_values` (278-288):
+//!
+//! ```c
+//! long nRequest = (&prec->noa)[i];
+//! status = dbGetLink(plink, (&prec->fta)[i], (&prec->a)[i], 0, &nRequest);
+//! (&prec->nea)[i] = nRequest;
+//! ```
+//!
+//! — every input link is read as the channel's declared FTx, up to NOx
+//! elements, into the FTx-typed buffer `initFields` allocated. The port's
+//! cells all started as scalar `Double(0.0)` whatever FTx said, so the store
+//! judged the destination by that stale scalar: an array source was reduced
+//! to its first element, and a string source was dropped outright by the
+//! numeric funnel.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::record::{Record, SubroutineFn};
+use epics_base_rs::server::records::asub_record::ASubRecord;
+use epics_base_rs::server::records::stringout::StringoutRecord;
+use epics_base_rs::server::records::waveform::WaveformRecord;
+use epics_base_rs::types::{DbFieldType, EpicsValue};
+
+async fn process(db: &PvDatabase, rec: &str) {
+    let mut visited = HashSet::new();
+    db.process_record_with_links(rec, &mut visited, 0)
+        .await
+        .unwrap();
+}
+
+async fn field(db: &PvDatabase, rec: &str, f: &str) -> Option<EpicsValue> {
+    let inst = db.get_record(rec).unwrap();
+    let g = inst.read();
+    g.record.get_field(f)
+}
+
+/// db with a waveform source, a string source, and an aSub declaring
+/// FTA=DOUBLE/NOA=8 on INPA and FTC=STRING on INPC. The subroutine is a
+/// no-op returning 0 — the assertions are about what `fetch_values`
+/// landed in A and C.
+async fn asub_db() -> PvDatabase {
+    let db = PvDatabase::new();
+
+    let mut wf = WaveformRecord::new(8, DbFieldType::Double);
+    wf.put_field(
+        "VAL",
+        EpicsValue::DoubleArray(vec![1.0, 2.0, 3.0, 4.0, 5.0]),
+    )
+    .unwrap();
+    db.add_record("WF", Box::new(wf)).await.unwrap();
+    db.add_record("SEL", Box::new(StringoutRecord::new("rrt_connect")))
+        .await
+        .unwrap();
+
+    let mut registry: HashMap<String, Arc<SubroutineFn>> = HashMap::new();
+    registry.insert(
+        "check".into(),
+        Arc::new(Box::new(|_: &mut dyn Record| Ok(0i64)) as SubroutineFn),
+    );
+    db.install_subroutine_registry(registry).await;
+    db.add_record("NAME_HOLDER", Box::new(StringoutRecord::new("check")))
+        .await
+        .unwrap();
+
+    let mut rec = ASubRecord::default();
+    rec.put_field("SUBL", EpicsValue::String("NAME_HOLDER".into()))
+        .unwrap();
+    rec.put_field("LFLG", EpicsValue::Short(1)).unwrap(); // READ: resolve SNAM
+    rec.put_field("FTA", EpicsValue::Short(10)).unwrap(); // DOUBLE
+    rec.put_field("NOA", EpicsValue::Long(8)).unwrap();
+    rec.put_field("INPA", EpicsValue::String("WF".into()))
+        .unwrap();
+    rec.put_field("FTC", EpicsValue::Short(0)).unwrap(); // STRING
+    rec.put_field("INPC", EpicsValue::String("SEL".into()))
+        .unwrap();
+    db.add_record("ASUB", Box::new(rec)).await.unwrap();
+    db
+}
+
+/// An array source lands whole in a `NOx > 1` channel — not reduced to its
+/// first element by a scalar-shaped destination.
+#[epics_macros_rs::epics_test]
+async fn array_source_lands_whole_in_a_declared_array_channel() {
+    let db = asub_db().await;
+
+    process(&db, "ASUB").await;
+
+    assert_eq!(
+        field(&db, "ASUB", "A").await,
+        Some(EpicsValue::DoubleArray(vec![1.0, 2.0, 3.0, 4.0, 5.0])),
+        "the waveform's NORD elements must all reach A"
+    );
+    assert_eq!(
+        field(&db, "ASUB", "NEA").await,
+        Some(EpicsValue::Long(5)),
+        "NEx is the delivered element count (aSubRecord.c:287)"
+    );
+}
+
+/// A string source lands in an `FTx = STRING` channel — not dropped by the
+/// numeric store funnel.
+#[epics_macros_rs::epics_test]
+async fn string_source_lands_in_a_string_channel() {
+    let db = asub_db().await;
+
+    process(&db, "ASUB").await;
+
+    assert_eq!(
+        field(&db, "ASUB", "C").await,
+        Some(EpicsValue::String("rrt_connect".into())),
+        "a DBR_STRING read of the scalar source must reach C"
+    );
+}

--- a/crates/epics-base-rs/tests/asub_output_links.rs
+++ b/crates/epics-base-rs/tests/asub_output_links.rs
@@ -191,3 +191,47 @@ async fn r9_78_empty_snam_pushes_output_links() {
         "empty SNAM is C do_sub's `return 0`, so status 0 pushes OUTA <- VALA"
     );
 }
+
+/// A declared `FTVB=STRING` output carries its string through OUTB — the
+/// push reads the FTVx-typed cell (C `dbPutLink(&(&prec->outa)[i],
+/// (&prec->ftva)[i], ...)`, aSubRecord.c:236-238), so the sink receives a
+/// string, not a numeric collapse.
+#[epics_macros_rs::epics_test]
+async fn r9_78_string_output_pushes_through_out_link() {
+    let db = PvDatabase::new();
+    db.add_record("SINK_S", Box::new(StringoutRecord::new("")))
+        .await
+        .unwrap();
+
+    let mut registry: HashMap<String, Arc<SubroutineFn>> = HashMap::new();
+    registry.insert(
+        "swriter".into(),
+        Arc::new(Box::new(|rec: &mut dyn Record| {
+            rec.put_field("VALB", EpicsValue::String("armed".into()))?;
+            Ok(0i64)
+        }) as SubroutineFn),
+    );
+    db.install_subroutine_registry(registry).await;
+    db.add_record("NAME_HOLDER2", Box::new(StringoutRecord::new("swriter")))
+        .await
+        .unwrap();
+
+    let mut rec = ASubRecord::default();
+    rec.put_field("SUBL", EpicsValue::String("NAME_HOLDER2".into()))
+        .unwrap();
+    rec.put_field("LFLG", EpicsValue::Short(1)).unwrap(); // READ: resolve SNAM
+    rec.put_field("FTVB", EpicsValue::Short(0)).unwrap(); // STRING
+    rec.put_field("OUTB", EpicsValue::String("SINK_S".into()))
+        .unwrap();
+    db.add_record("ASUB_S", Box::new(rec)).await.unwrap();
+
+    process(&db, "ASUB_S").await;
+
+    let inst = db.get_record("SINK_S").unwrap();
+    let g = inst.read();
+    assert_eq!(
+        g.record.get_field("VAL"),
+        Some(EpicsValue::String("armed".into())),
+        "the typed VALB string must land in the stringout sink"
+    );
+}

--- a/crates/epics-base-rs/tests/database_tests.rs
+++ b/crates/epics-base-rs/tests/database_tests.rs
@@ -9538,9 +9538,11 @@ async fn asub_eflg_gates_valx_output_monitor_posting() {
     use std::sync::Mutex;
 
     let db = PvDatabase::new();
-    db.add_record("ASUB_E", Box::new(ASubRecord::default()))
-        .await
-        .unwrap();
+    let mut asub = ASubRecord::default();
+    // The output capacity must be declared, as C requires: the subroutine
+    // writes a 2-element array into VALA's NOVA-element buffer.
+    asub.put_field("NOVA", EpicsValue::Long(2)).unwrap();
+    db.add_record("ASUB_E", Box::new(asub)).await.unwrap();
 
     // Subroutine writes VALA from a shared cell so the test controls whether
     // the output changes between processes.
@@ -9568,7 +9570,7 @@ async fn asub_eflg_gates_valx_output_monitor_posting() {
     db.process_record("ASUB_E").await.unwrap();
     assert!(
         rx.try_recv().is_ok(),
-        "ON CHANGE: VALA changed from empty default -> monitor event"
+        "ON CHANGE: VALA changed from its zeroed default -> monitor event"
     );
     // Same VALA again -> no event.
     db.process_record("ASUB_E").await.unwrap();


### PR DESCRIPTION
The input cells all initialised as scalar Double(0.0) whatever FTA..FTU/NOA..NOU declared, and the link store judges its destination by the current cell value — so an array source was silently reduced to its first element and a string source was dropped by the numeric funnel. Each cell, input and output alike, is now allocated from its FTx/NOx (FTVx/NOVx) declaration as C initFields does (aSubRecord.c:176-198), every value entering A..U or VALA..VALU converts and clamps to that declaration (fetch_values :278-288; the OUT push carries the FTVx-typed buffer, :236-238), and a STRING channel reads a scalar source as DBR_STRING via input_link_read_as. One behavioural change: a subroutine writing an array to VALx without declaring NOVx now keeps element 0 only — the capacity must be declared, as C requires.