### PR TITLE
build(release): bump workspace to 0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## v0.26.2 — 2026-08-20
+
+Patch release. aSub channel cells are now allocated and filled by their
+declared FTx/NOx and FTVx/NOVx, asyn gains the busy module's devBusyAsyn
+device support plus a background-thread route for alarm pushes, and db/acf
+macro expansion runs per line so quote state cannot leak across lines.
+Additive API only (`ParamSetValue` gains a `Status` variant and busy's DTYP
+menu gains asynInt32); workspace version 0.26.1 -> 0.26.2, pins unchanged.
+
+### aSub cells take the shape FTx/NOx declares
+
+The A..U cells all initialised as scalar `Double(0.0)` whatever FTA..FTU
+declared, so a link store judged its destination by that stale scalar: an
+array source was reduced to its first element and a string source was
+dropped by the numeric funnel. Each cell now allocates from FTx/NOx as C
+`initFields` does, every value entering A..U is shaped to that declaration,
+a STRING channel reads a scalar link as DBR_STRING, and VALA..VALU take the
+same rule — a subroutine's write lands in the FTVx-typed NOVx-element
+buffer, so an array written without declaring NOVx keeps element 0 only, as
+C requires. An empty array source reports NEx 0 rather than claiming an
+element that was never delivered.
+
+### asyn: driver-clearable busy records and background alarm pushes
+
+devBusyAsyn is ported: a busy record over asynInt32 follows the driver
+parameter with no `asyn:READBACK` tag, mirroring the C device support's
+unconditional output interrupt registration, so the driver clears the busy
+when the operation completes. And `ParamSetValue::Status` gives a poll
+thread the C `setParamStatus` + `callParamCallbacks` route it lacked — a
+driver thread can now raise and clear COMM/INVALID on its readback
+parameters when the device stops responding.
+
+### Macro expansion is per line, as macLib sees it
+
+C feeds `macExpandString` one line at a time, so its quote tracking resets
+at each newline. Expanding a whole db/acf file in one call let an
+apostrophe in a comment suppress every `$(...)` below it; `parse_db` and
+`asInit` now expand per line.
+
 ## v0.26.1 — 2026-08-20
 
 Patch release. `ad-plugins-rs` moves to rust-hdf5 0.5.1, which brings that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "bitflags",
  "chrono",
@@ -994,7 +994,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "cc",
  "libc",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2241,7 +2241,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3209,7 +3209,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3829,7 +3829,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The umbrella crate pulls in what you select by feature:
 
 ```toml
 [dependencies]
-epics-rs = { version = "0.25", features = ["ad"] }
+epics-rs = { version = "0.26", features = ["ad"] }
 ```
 
 ```rust


### PR DESCRIPTION
Patch release: the aSub FTx/FTVx cell typing (#84), devBusyAsyn + ParamSetValue::Status (#82), and per-line macro expansion (#83). Additive API only — the BREAKING footer, pub-item and pub-field removal scans over v0.26.1..main are all empty, so pins stay at 0.26.1.