### PR TITLE
build(release): bump workspace to 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## v0.27.0 — 2026-08-24
+
+Minor release. It lands the 2026-08-23 parallel C-parity round: fifteen
+agents ran interleaved review/fix rounds against the EPICS base, asyn,
+areaDetector, calc and pvxs originals, and the result is 314 one-per-finding
+fixes squashed into nine per-area commits. The public API moves with it — 18
+items removed and 24 signatures changed, measured item-by-item in
+`doc/breaking-2026-08-23.md`, which is why this is a minor and not a patch.
+`doc/c-parity-review-2026-08-23.md` records the four integration decisions
+worth auditing and the 160 root causes the round left open. Workspace version
+0.26.2 -> 0.27.0; the 18 `[workspace.dependencies]` pins and the hand-written
+`epics-pva-rs` pin in `epics-bridge-rs` move to 0.27.0 in lockstep.
+
+### One owner per state transition in the process cycle
+
+The round's largest cluster was state that several callers could move. A
+record's process cycle now leaves through `end_process_cycle` on every exit —
+early return, error, PACT — rather than each tail unwinding for itself; the
+put-notify restart is armed by the cycle a put owes rather than by the put,
+so a restart can no longer overtake the `PP` cycle that put still owed; and
+`special_after_put` is the single owner of the SNAM rebind. `PactExit`
+deliberately carries a hint bit and not a payload, which is what makes the
+async-output path safe.
+
+### Record and device support follow their C originals
+
+Link reads and alarm ladders are routed through the owners C gives them, so
+`rec_gbl_set_sevr` reports whether it raised and `rec_gbl_check_udf` takes
+the severity C passes. Every record delay field converts through
+`duration_from_secs`, the iocsh commands are transcribed from their C bodies
+rather than approximated, and `ad-core-rs` pairs every writer open with a
+close finalizer. asyn bounds every blocking wait by the caller's deadline —
+`port_handle::wait_blocking` had been ignoring its `timeout` argument.
+
+### CA and PVA wire paths
+
+Both CA receive loops grow through the one `RecvAccumulator` primitive
+instead of two hand-rolled accumulators. On the PVA side a request's
+`process` flag and DBE mask are honoured rather than defaulted, and a
+channel pinned with `server_addr` now reconnects on the circuit's flat 2 s
+timer: it had inherited the search ring's 10-bucket holdoff, which is a
+coordinate in a ring a forced-server channel does not have, so a pinned
+client slept ~10 s past a server that had already restarted.
+
+### The reference-tree suites stop reporting skips as passes
+
+Four parity suites resolved the C checkouts by reading an environment
+variable and returning early when it was unset — nextest reports that as a
+pass, so they had been green and vacuous. They now resolve through
+`epics_base_rs::reference` and fail loudly when the tree is absent, which
+means `EPICS_BASE`, `EPICS_MODULES` and `PVXS_HOME` must be exported to run
+them outside the main checkout. Un-silencing them is what exposed the PVA
+reconnect defect above. The interop job also builds its reference IOC on
+base R7.0.10: under R7.0.8 `dbAllocRecord()` reaches every field through
+`&ppvt->common`, so `-D_FORTIFY_SOURCE=3` aborts `dbLoadRecords` for any
+DBF_STRING field with an `initial` past `sizeof(dbCommon)` — `calcRecord.CALC`
+among them. Base `3d70e7064` (R7.0.9) is the floor.
+
+### Gates
+
+Every workflow's nextest invocation runs on `profile.ci`, the feature-gated
+test list is derived from the manifests instead of being hand-maintained, and
+the rustdoc gate's 47 broken and private intra-doc links are gone. The oracle
+run now fails on a dark type or a stale allowlist row rather than passing over
+it.
+
 ## v0.26.2 — 2026-08-20
 
 Patch release. aSub channel cells are now allocated and filled by their

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -995,7 +995,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "cc",
  "libc",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2243,7 +2243,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3215,7 +3215,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3835,7 +3835,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4938,7 +4938,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,30 +32,30 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.26.2"
+version = "0.27.0"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.26.1" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.26.1" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.26.1" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.26.1" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.26.1" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.26.1" }
-epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.26.1" }
-epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.26.1" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.26.1" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.26.1" }
-motor-rs = { path = "crates/motor-rs", version = "0.26.1" }
-std-rs = { path = "crates/std-rs", version = "0.26.1" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.26.1" }
-optics-rs = { path = "crates/optics-rs", version = "0.26.1" }
-mca-rs = { path = "crates/mca-rs", version = "0.26.1" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.26.1" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.26.1", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.26.1" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.27.0" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.27.0" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.27.0" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.27.0" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.27.0" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.27.0" }
+epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.27.0" }
+epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.27.0" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.27.0" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.27.0" }
+motor-rs = { path = "crates/motor-rs", version = "0.27.0" }
+std-rs = { path = "crates/std-rs", version = "0.27.0" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.27.0" }
+optics-rs = { path = "crates/optics-rs", version = "0.27.0" }
+mca-rs = { path = "crates/mca-rs", version = "0.27.0" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.27.0" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.27.0", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.27.0" }
 
 # Deployable-image profile for the embedded targets (RTEMS / VxWorks), where
 # image size is a real resource: `cargo build --profile release-embedded ...`

--- a/README.md
+++ b/README.md
@@ -274,12 +274,28 @@ Per-crate design detail lives in each crate's README and on docs.rs.
 ## Testing
 
 ```bash
-# without a C EPICS tree (what CI runs)
+# what CI runs — `--profile ci` excludes the suites that need an upstream
+# C/C++ checkout, because no cross-platform runner provisions one
+cargo nextest run --profile ci --workspace --exclude epics-oracle-rs
+
+# the dev loop: same minus the oracle, but on `profile.default`, which
+# deliberately keeps the reference-tree suites in
+export EPICS_BASE=/path/to/epics-base
+export EPICS_MODULES=/path/to/epics-modules
+export PVXS_HOME=/path/to/pvxs
 cargo nextest run --workspace --exclude epics-oracle-rs
 
-# full suite, 10,000+ tests — includes the differential oracle
+# full suite, 11,000+ tests — adds the differential oracle
 cargo nextest run --workspace
 ```
+
+The four reference-tree suites (`reference_trees`, `dbd_initial_parity`,
+`base_device_parity`, `stdsupport_device_parity`) compare the port against
+the upstream C sources. They resolve the checkout from `EPICS_BASE` /
+`EPICS_MODULES` / `PVXS_HOME`, or from a sibling directory of this
+repository, and **panic when it is absent** rather than returning early —
+nextest reports an early return as a pass, so a skip there verifies nothing
+while looking green.
 
 Coverage includes wire-format golden packets (CA + PVA), pvxs interop
 fixtures, record processing and link chains, 46 golden tests against compiled
@@ -292,10 +308,10 @@ same test bodies on the reactor-free exec backend that RTEMS uses.
 
 `epics-oracle-rs` is the differential oracle: it boots a C `softIoc` and the
 Rust IOC on the same `.db` and diffs their observable CA/PVA behavior. It
-needs a built C EPICS tree (point `EPICS_BASE_BIN` / `EPICS_ORACLE_DBD` /
-`PVXS_BIN` at it — see
-[`crates/epics-oracle-rs/README.md`](crates/epics-oracle-rs/README.md)) and
-fails loudly rather than skipping when the tree is absent, so CI excludes it.
+needs a *built* C EPICS tree, not just the sources (point `EPICS_BASE_BIN` /
+`EPICS_ORACLE_DBD` / `PVXS_BIN` at it — see
+[`crates/epics-oracle-rs/README.md`](crates/epics-oracle-rs/README.md)), and
+takes the same fail-loudly rule as the suites above, so CI excludes it too.
 **Before contributing** changes that touch record, CA, or PVA behavior, run
 the full suite *including* the oracle against a local C tree — it is the gate
 CI cannot run for you.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The umbrella crate pulls in what you select by feature:
 
 ```toml
 [dependencies]
-epics-rs = { version = "0.26", features = ["ad"] }
+epics-rs = { version = "0.27", features = ["ad"] }
 ```
 
 ```rust
@@ -74,8 +74,8 @@ through the umbrella crate — depend on them directly when needed.
 You can also depend on sub-crates directly:
 
 ```toml
-epics-base-rs = "0.25"  # just the IOC runtime
-epics-ca-rs   = "0.25"  # just Channel Access
+epics-base-rs = "0.27"  # just the IOC runtime
+epics-ca-rs   = "0.27"  # just Channel Access
 ```
 
 ## Workspace

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -205,7 +205,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # host-facing feature that pulls this dependency — `qsrv`, `pvalink`,
 # `pva-gateway`, `dual-ioc` — so host builds resolve exactly as before. Only
 # `qsrv-core`, the RTEMS selection, gets the reduced set.
-epics-pva-rs = { path = "../epics-pva-rs", version = "0.26.1", optional = true, default-features = false }
+epics-pva-rs = { path = "../epics-pva-rs", version = "0.27.0", optional = true, default-features = false }
 # `epics-ca-rs` stays inherited, but NOT because its defaults are empty — they
 # stopped being empty at `274a734b`, which introduced the `client-core`/`client`
 # split and made `default = ["client"]`. The reason is narrower and is a fact


### PR DESCRIPTION
Minor, not patch: the 2026-08-23 parity round removed 18 public items and changed 24 signatures, each measured item-by-item in `doc/breaking-2026-08-23.md`. The `-i --grep=BREAKING` footer scan again found nothing but its own summary commit, so the bump level comes from that diff, not from the log.

The 18 root `[workspace.dependencies]` pins and the hand-written `epics-pva-rs` pin in `epics-bridge-rs` move to 0.27.0 in lockstep; the `cargo update --workspace --offline` diff is 30 version lines and nothing else. `cargo publish --workspace --locked --dry-run` packages and verifies all 19 crates.
