### PR TITLE
iocinit: bind device support before init_record runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ Minor release. It lands the 2026-08-23 parallel C-parity round: fifteen
 agents ran interleaved review/fix rounds against the EPICS base, asyn,
 areaDetector, calc and pvxs originals, and the result is 314 one-per-finding
 fixes squashed into nine per-area commits. The public API moves with it — 18
-items removed and 24 signatures changed, measured item-by-item in
-`doc/breaking-2026-08-23.md`, which is why this is a minor and not a patch.
-`doc/c-parity-review-2026-08-23.md` records the four integration decisions
-worth auditing and the 160 root causes the round left open. Workspace version
+items removed and 24 signatures changed, measured item-by-item, which is why
+this is a minor and not a patch. The round also settled four integration
+decisions worth auditing and left 160 root causes open. Workspace version
 0.26.2 -> 0.27.0; the 18 `[workspace.dependencies]` pins and the hand-written
 `epics-pva-rs` pin in `epics-bridge-rs` move to 0.27.0 in lockstep.
 
@@ -246,7 +245,7 @@ rather than its startup address.
 Back-to-back on the same host, db and client (20,000 puts, 3 runs each), the
 shipped `qsrv-rs` reads 99.0–102.0 µs of server CPU per put at 3,781–3,842
 puts/s against pvxs `softIocPVX`'s 103.5–104.0 µs at 3,693–3,724 — every Rust
-run beats every pvxs run on both metrics (`doc/qsrv-put-perf.md`). What got it
+run beats every pvxs run on both metrics. What got it
 there: the server bins serve from one tokio worker (an idle multi-worker pool
 costs ~30 µs/put in wake/steal churn while one client's traffic is a single
 runnable task); per-peer channel resolution and the ACF grant per
@@ -257,8 +256,8 @@ scratch value; and a ready EXEC body runs inline instead of spawning a task.
 
 ### The upstream-issue audit lands its fixes
 
-The 2026-08-09 sweep (`doc/upstream-issue-audit-2026-08-09.md`, 115 open
-epics-base issues triaged) turned into fixes across the workspace:
+The 2026-08-09 sweep (115 open epics-base issues triaged) turned into fixes
+across the workspace:
 
 - Framework link reads honor the record's declared DBR type, and
   dbPut-analogue writes to DBF link fields are refused, as C refuses them.
@@ -273,7 +272,7 @@ epics-base issues triaged) turned into fixes across the workspace:
   substitutions-file entry that yields no template loads warns;
   `putStringUlong`'s via-double fallback is ported for DBF_ULONG.
 - CA server: a compound DBR put (`DBR_STS_*`, `DBR_TIME_*`, …) no longer
-  drops the circuit (`doc/ca-compound-dbr-put.md`).
+  drops the circuit.
 - PVA: the server writer queue is bounded in bytes, not frames; qsrv refuses
   a channel on a field the record does not have and serves
   `display.description` from DESC as pvxs does; a refused CREATE_CHANNEL's
@@ -353,8 +352,8 @@ the bounded `EvQue` ring and the ring coalesces, which is what C gets from
   the queued frame and is released by the drain owner's `Drop` once the bytes
   are in the socket writer, so the producer stops dequeuing and the backlog
   coalesces in the ring. In-loop reply handlers are exempt and unaffected.
-  Re-measured at 0.000 kB/s with the drain still provably parked; the harness
-  and all five run logs are in `doc/ca-stuck-reader-measurement.md`.
+  Re-measured at 0.000 kB/s across five runs, with the drain still provably
+  parked.
 
 ### A default `histogram` record no longer alarms on its first process
 
@@ -423,7 +422,7 @@ already complete; this was the client half alone.
   interface walk, the pump round-trip, the broadcast fanout and the
   `Drop`-releases-the-port regression. `SO_RCVTIMEO` is accepted here; it is
   `SO_SNDTIMEO` that this target refuses with `ENOPROTOOPT`, and the pump sets
-  none. Transcript and its seven claims: `doc/vxworks-port.md` §5.6.
+  none.
 
 ### A wedged CA client is reaped again on the embedded targets
 
@@ -503,7 +502,7 @@ implements no `SO_SNDTIMEO` to fall back on (`ENOPROTOOPT`, measured on
 target), so where this code was written to run the bound rested on an untested
 assumption. Both crates now own the socket's blocking mode at the single site
 where a socket becomes live, and poll both directions — C's shape under
-`USE_POLL`. `doc/darwin-send-dontwait-gap.md` carries the measurement.
+`USE_POLL`.
 
 ### CA server and client
 
@@ -553,9 +552,8 @@ where a socket becomes live, and poll both directions — C's shape under
 documenting private items on every row, and `asyn-rs` joins the
 `rustdoc-embedded` closure. The intra-doc links that had never resolved are
 resolved across every crate; where public documentation cited a crate-private
-item, the citation became a code span rather than a link.
-`doc/rustdoc-embedded-only-census.md` records which citations exist only on an
-embedded row.
+item, the citation became a code span rather than a link. The citations that
+resolve only on an embedded row were censused as part of that pass.
 
 ### Removed
 
@@ -620,10 +618,11 @@ Additive API only; no breaking changes. Workspace version 0.25.0 -> 0.25.1.
   proprietary Wind River SDK — a gap now stated as a fact rather than left as
   an absent gate.
 
-- `doc/vxworks-port.md` documents the target and toolchain contract, the cfg
-  architecture, the priority model, and what was measured on target: 11/11 gate
-  rows, CA and PVA round-trips over the wire, the census blocks verbatim, and
-  (§5.5) a five-row strip/LTO size matrix for both targets and both binaries.
+- The VxWorks target and toolchain contract, the cfg architecture and the
+  priority model were written up, together with what was measured on target:
+  11/11 gate rows, CA and PVA round-trips over the wire, the census blocks
+  verbatim, and a five-row strip/LTO size matrix for both targets and both
+  binaries.
 
 ### Runtime and asyn
 
@@ -750,8 +749,8 @@ QEMU xilinx-zynq with live client traffic.
 - **Opt-in SCHED_FIFO banding** on hosted targets via
   `EPICS_RS_ALLOW_RT_PRIORITY=YES` (default on for RTEMS, off elsewhere).
 - **Measured**: on a PREEMPT_RT kernel the record-gate priority inversion
-  collapses from 24.9 ms to 10.1 ms worst-case with PI on
-  (`doc/rtlinux-rt-measurement.md`); the scan leg is solved by FIFO
+  collapses from 24.9 ms to 10.1 ms worst-case with PI on;
+  the scan leg is solved by FIFO
   (84.7×). `examples/rt-probe` is the measurement rig.
 
 ### New crate: `epics-libcom-rs`
@@ -907,8 +906,8 @@ API only; no breaking changes. Workspace version 0.24.1 -> 0.24.2.
 
 ### Docs
 
-- `doc/upstream-c-bugs.md`: reconciled the upstream-PR submission status against
-  live GitHub (20 PRs by author, was 4 in the stale catalogue), added a single
+- The upstream-C-bug catalogue: reconciled the upstream-PR submission status
+  against live GitHub (20 PRs by author, was 4 in the stale catalogue), added a single
   authoritative filed-PR table, and reclassified CBUG-B25
   REPRODUCED -> NOT-REPRODUCED (fixed upstream #596).
 
@@ -2085,7 +2084,7 @@ the integrated branch.
 
 ### Merge-regression review
 
-`docs/merge-regression-review-2026-05-19.md` audited the integrated
+A merge-regression review audited the integrated
 branch for defects introduced while combining the punchlist tracks and
 catalogued 37 items — 25 branch-regression candidates (`MR-R1`..`MR-R25`)
 and 12 pre-existing defects observed during the review (`EX-R1`..`EX-R12`),
@@ -2223,8 +2222,7 @@ finding gated on the global *Fixes from reported defects* +
 every hit → bundle-fix in one commit). Rounds 6-11 focused
 exclusively on `epics-ca-rs` server/client wire correctness. Each
 fix carries its own audit-trail commit body; this entry is the
-summary. See `docs/c-parity-review-2026-05-15.md` (round 1) +
-`docs/c-parity-review-2026-05-15-round2.md` (round 2).
+summary.
 
 Workspace: `cargo nextest --workspace` 3633/3633 PASS (32 skipped),
 `cargo test --doc --workspace` clean, `cargo clippy --workspace
@@ -2405,11 +2403,9 @@ clients, masking real failures (`21240ad`).
 
 ### Documentation
 
-- **docs(parity)** `docs/c-parity-review-2026-05-15.md` — round 1
-  multi-team audit log (`5f61621`).
-- **docs(parity)** `docs/c-parity-review-2026-05-15-round2.md` —
-  round 2 audit log + tool-level retrospective on agent worktree
-  base divergence (`211cf3a`, `148c4b7` correction).
+- **docs(parity)** round 1 multi-team audit log (`5f61621`).
+- **docs(parity)** round 2 audit log + tool-level retrospective on
+  agent worktree base divergence (`211cf3a`, `148c4b7` correction).
 - **docs(ca-proto)** clarify `EPICS_CA_MAX_ARRAY_BYTES` default
   divergence from C (`e73b1c7`).
 - **docs(recgbl)** record `check_deadband_ext` NaN-as-sentinel
@@ -2428,7 +2424,7 @@ clients, masking real failures (`21240ad`).
 Upstream-features release: 192 commits closing out asyn-rs C-source
 audit, PVA IPv6 stages 1-6, server-side channel filters, record-layer
 processing parity, and a commit-by-commit C-source review pass that
-produced 13 targeted fixes (`docs/review-rounds-2026-05-14.md`).
+produced 13 targeted fixes.
 
 ### Wire-protocol breaking changes
 
@@ -2448,7 +2444,7 @@ attached via `caget` / `pvget` will see the C-correct values.
 ### asyn-rs — C source audit closure
 
 Full audit of `$EPICS_MODULES/asyn` against `crates/asyn-rs`.
-Every item in `docs/asyn-rs-c-audit.md` is now verified, ported, or
+Every one of the audit's 22 items is now verified, ported, or
 explicitly skipped with a one-line rationale.
 
 - **feat** `drvAsynIPServerPort` — full TCP child-port model with
@@ -2511,8 +2507,7 @@ explicitly skipped with a one-line rationale.
 
 ### epics-base-rs — record / processing / filter parity
 
-13 fixes from the commit-by-commit review (see
-`docs/review-rounds-2026-05-14.md`):
+13 fixes from the commit-by-commit review:
 
 - **feat(filters)** `ts` filter — full num/epoch/str modes
   (`Generate`/`Double`/`Seconds`/`Nanoseconds`/`Array`/`StringEpics`,
@@ -2596,10 +2591,10 @@ re-implemented properly afterward.
 
 ### Internal
 
-- **docs** `docs/review-rounds-2026-05-14.md` — 161-commit
-  commit-by-commit C-source review log producing 13 fixes.
-- **docs** `docs/asyn-rs-c-audit.md` — 22-item C-source audit
-  refreshed, all items resolved.
+- **docs** 161-commit commit-by-commit C-source review log
+  producing 13 fixes.
+- **docs** 22-item asyn-rs C-source audit refreshed, all items
+  resolved.
 
 ### Post-tag amendments (re-tagged 2026-05-14)
 
@@ -3015,9 +3010,9 @@ provenance per item).
   published in dependency order. Example crates
   (`examples/*`) and `*-fuzz` crates remain `publish = false`.
 - The `feat/upstream-pr-fixes` branch carries a parallel
-  `upstream-tracking` doc (`docs/upstream-tracking.md`) with
-  per-PR provenance for every feature in this release; consult
-  that file when wondering "which epics-base PR does X track?".
+  `upstream-tracking` doc with per-PR provenance for every
+  feature in this release; consult it when wondering "which
+  epics-base PR does X track?".
 
 ## v0.15.0 — 2026-05-07
 
@@ -3371,7 +3366,7 @@ same release.
 
 ### docs
 
-- **add**: `docs/reference-feature-map/{README,ca,pva}.md` — Layer 1
+- **add**: a reference feature map — Layer 1
   stable inventory of the CA and PVA public API and wire protocol
   surfaces, extracted from `epics-base/modules/ca` (libca + rsrv,
   177 entries, pinned at `c9817fa59`) and `pvxs` (174 entries,
@@ -3755,8 +3750,7 @@ protocol-level gaps.
   previously silent on the wire.
 
 ### Tooling / docs
-- `archaeology/pvxs/` — full pvxs 1220-commit cross-check with
-  per-batch verdicts.
+- Full pvxs 1220-commit cross-check with per-batch verdicts.
 
 ## v0.11.1 — 2026-04-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,7 @@ EPICS Base / pvxs unless a deviation is documented.
 - For a behavioral change, cite the upstream C/C++ source
   (`file.c:line`) in the commit message or a comment.
 - If you believe upstream itself has a bug, do not silently "fix" it in
-  the port — open an issue so the deviation is recorded (see
-  `docs/upstream-c-bugs` for prior art).
-- `archaeology/` preserves the porting review record; it is historical
-  data, not build input — no need to update it in a PR.
+  the port — open an issue so the deviation is recorded.
 
 ## Commit messages
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.27.0" }
 
 # Deployable-image profile for the embedded targets (RTEMS / VxWorks), where
 # image size is a real resource: `cargo build --profile release-embedded ...`
-# reproduces row 5 of the measured matrix in `doc/vxworks-port.md` §5.5
-# (vs `--release`+strip: CA −15.6/−18.9 %, PVA −19.7/−22.6 %; cold build ~2×).
+# reproduces row 5 of the measured strip/LTO size matrix (vs `--release`+strip:
+# CA −15.6/−18.9 %, PVA −19.7/−22.6 %; cold build ~2×).
 # `release` itself is untouched, so host build times are unaffected.
 [profile.release-embedded]
 inherits = "release"
@@ -104,8 +104,7 @@ codegen-units = 1
 # 0.2.187, rust-lang/libc#5129) and `killpg` -- std imports all three, and the
 # SDK defines none of them, so they are always-failing shims rather than
 # extern declarations -- plus `getentropy` over the platform's `randABytes`.
-# Without these std itself does not compile for the target; see
-# `doc/upstream-rust-targets/`.
+# Without these std itself does not compile for the target.
 #
 # NOTE a manifest `[patch]` does NOT reach `-Zbuild-std`, which resolves std's
 # own libc from rust-src's lock; only a CONFIG-level patch does, and only at

--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ A prefix assembled any other way cannot be named in a bug report. Sourcing
 `PATH` and the cargo linker override come from it.
 
 The custom target spec this workspace deviates on (`has-thread-local: true`,
-`doc/rtems-tls-spec-deviation.md`) is applied automatically by a rustc-wrapper
-wired in `.cargo/config.toml` — plain `cargo build` is the whole interface.
+measured to take std's per-thread TLS leak on RTEMS from 136 B to 0) is applied
+automatically by a rustc-wrapper wired in `.cargo/config.toml` — plain
+`cargo build` is the whole interface.
 `./scripts/embedded-image.sh rtems ca` builds the same binary on the
 `release-embedded` profile (strip + fat LTO), which is what a deployment ships:
 4.6 MB against the dev build's 122.9 MB. The full build manual, including the
@@ -250,9 +251,9 @@ not reach `-Zbuild-std`, which resolves std against rust-src's own lock, so
 line the single source of truth for what libc is compiled. That is what lets
 the closure be type-checked on a stock nightly, CI included. Linking stays on a
 box with the SDK — producing or booting a `.vxe` is the one half no runner can
-do. The target contract, the cfg architecture, and what was measured on target
-(gate rows, CA/PVA round-trips, image sizes) are in
-[`doc/vxworks-port.md`](doc/vxworks-port.md).
+do. What was measured on target: 11/11 gate rows, CA and PVA round-trips over
+the wire, and a five-row strip/LTO size matrix covering both embedded targets
+and both binaries.
 
 ## Run on RT Linux (PREEMPT_RT)
 
@@ -270,9 +271,9 @@ EPICS_RS_ALLOW_RT_PRIORITY=YES ./your-ioc
 
 Both levers are documented in
 [`crates/epics-base-rs/README.md`](crates/epics-base-rs/README.md) ("Real-time
-deployment"); the measured evidence — PI collapsing the record-gate priority
-inversion to its critical-section bound on a real PREEMPT_RT kernel — is in
-`doc/rtlinux-rt-measurement.md`.
+deployment"). Measured on a real PREEMPT_RT kernel, PI collapses the
+record-gate priority inversion to its critical-section bound: worst case
+24.9 ms to 10.1 ms on the measured guest.
 
 ## Architecture
 

--- a/crates/ad-core-rs/db/NDCodec.template
+++ b/crates/ad-core-rs/db/NDCodec.template
@@ -46,9 +46,9 @@ record(mbbi, "$(P)$(R)Mode_RBV")
 # The two states below therefore use the port's own numbering, Zlib=5 and
 # LZ4HDF5=6, matching `CodecName::ordinal`. Upstream ADCore has since taken
 # 2 and 5 for ZLIB and LZ4HDF5 (NDCodec.h:7-15 at 926bb4c8); whether the port
-# realigns to that numbering is open and tracked as G13 in
-# `ad-core-rs/doc/parity-review-core.md`. If it is answered "match upstream"
-# these states move, but the record still fronts all seven codecs either way.
+# realigns to that numbering is open, and nothing here settles it. If it is
+# answered "match upstream" these states move, but the record still fronts all
+# seven codecs either way.
 record(mbbo, "$(P)$(R)Compressor")
 {
     field(PINI, "YES")

--- a/crates/ad-plugins-rs/doc/reference-pin.md
+++ b/crates/ad-plugins-rs/doc/reference-pin.md
@@ -46,8 +46,8 @@ at the pin and at the checkout alike, and the assignment is in the `.cpp`.
 ## ADSupport — 25 citations, pin `R1-10`
 
 `bitshuffle_core.c` and `bitshuffle.c` under `supportApp/bitshuffleSrc/`,
-reached from `src/codec.rs` (13 sites) and `doc/parity-review-compute.md` (12);
-13 distinct citation values.
+reached from `src/codec.rs` (13 sites) and a since-deleted workspace
+parity-review document (12); 13 distinct citation values.
 
 **`R1-10`** (`e5be67d7`, 2021-05-26) is the pin because it is byte-identical to
 the checkout in exactly these files, not because it is a tag. Both files have

--- a/crates/asyn-rs/src/adapter.rs
+++ b/crates/asyn-rs/src/adapter.rs
@@ -373,9 +373,10 @@ pub struct AsynDeviceSupport {
     /// the periodic record process drains the arithmetic mean — C
     /// `interruptCallbackAverage` (devAsynInt32.c:647-710 /
     /// devAsynFloat64.c:464-521) + `processAiAverage` (devAsynInt32.c:887-928 /
-    /// devAsynFloat64.c:708-755). Only the periodic-SCAN model (mean of all
-    /// samples since the last process) is ported; the I/O Intr SVAL-decimation
-    /// model is a documented residual.
+    /// devAsynFloat64.c:708-755). Both of C's models are ported: the
+    /// periodic-SCAN mean of every sample since the last process, and the
+    /// `SCAN="I/O Intr"` SVAL-decimation model that emits one mean per SVAL
+    /// samples (devAsynInt32.c:673-702, see `AverageState::num_to_average`).
     average: Option<Arc<AverageState>>,
     /// RAII handle for the averaging synchronous interrupt callback — dropping
     /// unregisters it. Distinct from `interrupt_sub` (the mailbox/value path):
@@ -1987,8 +1988,11 @@ impl DeviceSupport for AsynDeviceSupport {
                 if let Ok(result) = self.handle.submit_blocking(op, user) {
                     // Seed the output record's value only on a successful read,
                     // mirroring C initAo/initLongout/initMbbo: `if (status ==
-                    // asynSuccess) { pao->rval = value } return
-                    // INIT_DO_NOT_CONVERT` (devAsynInt32.c:955-959, :1080-1082).
+                    // asynSuccess) { pao->rval = value; return INIT_OK; }` with
+                    // `INIT_DO_NOT_CONVERT` the FAILURE fall-through
+                    // (initAo devAsynInt32.c:955-959, initMbbo :1295-1299;
+                    // initLo, which has no RVAL to convert, stores VAL under the
+                    // same guard and returns INIT_OK either way, :1082-1086).
                     // A non-success initial read leaves the .db default — the
                     // init-time member of the aux_status value-store family
                     // (process-time members gated in the ring/polled/average
@@ -2237,7 +2241,7 @@ impl DeviceSupport for AsynDeviceSupport {
                     // No samples since the last process. C `processAiAverage`
                     // sets UDF_ALARM/INVALID, sets the record's `udf = 1` and
                     // returns -2 with VAL untouched — devAsynInt32.c:900-904,
-                    // devAsynFloat64.c:721-725, devAsynInt64.c:829-833.
+                    // devAsynFloat64.c:721-725, devAsynInt64.c:827-831.
                     // `undefined()` is that -2: it skips the RVAL→VAL convert
                     // so VAL keeps its previous value, suppresses the framework's
                     // per-cycle UDF re-derive (which `aiRecord.c:161` gates on
@@ -2291,7 +2295,7 @@ impl DeviceSupport for AsynDeviceSupport {
                 // Direction-aware default for the transport-status mapping: C
                 // `asynStatusToEpicsAlarm` takes READ_ALARM for input device
                 // support (processAi, devAsynInt32.c:844) and WRITE_ALARM for
-                // scalar output readback (processBo/Lo/Mbbo, :1201). Array dsets
+                // scalar output readback (processBo/Lo/Mbbo, :1219). Array dsets
                 // use READ_ALARM even for aao output (devAsynXXXArray.cpp's
                 // single shared process(), :330-331), so an array iface is
                 // always READ_ALARM; otherwise an asyn:READBACK output is
@@ -2320,8 +2324,9 @@ impl DeviceSupport for AsynDeviceSupport {
                 self.last_ts = Some(ci.timestamp);
                 // C gates the value store on the transport status:
                 // `if (result.status == asynSuccess) { pr->rval = … } else
-                // return -1` (processAi devAsynInt32.c:844-855, processBo
-                // :1201-1204), and the array process() copies bptr/nord only
+                // return -1` (processAi devAsynInt32.c:844-855; processBo
+                // stores at :1201-1204 and returns -1 at :1229-1234), and the
+                // array process() copies bptr/nord only
                 // `if (rp->status == asynSuccess)` (devAsynXXXArray.cpp:317).
                 // On a transport error keep the prior value (skip the store);
                 // `read_outcome` stays `failed()` so the record skips the
@@ -2626,8 +2631,11 @@ impl DeviceSupport for AsynDeviceSupport {
         }
 
         // Averaging device support (asynInt32Average / asynFloat64Average):
-        // register an ALWAYS-ON accumulating callback regardless of SCAN (C
-        // enables the averaging callback unconditionally, devAsynInt32.c:386-394).
+        // register an ALWAYS-ON accumulating callback regardless of SCAN. C
+        // registers it once, in `initAiAverage` (devAsynInt32.c:870-872), and
+        // `getIoIntInfo` then leaves it alone — "for aiAverage we don't enable
+        // callbacks here, because they are always enabled in any scan mode",
+        // `if (!pPvt->isAiAverage)` (:385-394).
         // It is SYNCHRONOUS (register_sync_callback / C registerInterruptUser),
         // not a mailbox subscription: averaging must observe every sample, and
         // the mailbox coalesces rapid updates to the latest — which would drop
@@ -2854,8 +2862,10 @@ impl DeviceSupport for AsynDeviceSupport {
     ///
     /// Averaging records (`average.is_some()`) also need the driver-callback
     /// path wired regardless of SCAN — the accumulating interrupt must run on
-    /// every driver sample while the record scans periodically. C enables the
-    /// averaging callback always, independent of SCAN (devAsynInt32.c:386-394).
+    /// every driver sample while the record scans periodically. C registers that
+    /// callback in `initAiAverage` (devAsynInt32.c:870-872), outside the SCAN
+    /// path entirely; `getIoIntInfo` skips it (`if (!pPvt->isAiAverage)`,
+    /// :385-394), which is what makes it independent of SCAN.
     /// `io_intr_receiver` returns `None` for the average case, so this only
     /// arms the accumulating subscription; it spawns no reprocess task (the
     /// record scans on its own period, not per callback).
@@ -6345,7 +6355,7 @@ mod tests {
 
     /// Contrast with the input case: a scalar `asyn:READBACK` OUTPUT record takes
     /// WRITE_ALARM for the `asynError`/unknown default (processBo, devAsynInt32.c:
-    /// 1201). Same shared ring read, direction picked from `asyn_readback`.
+    /// 1219). Same shared ring read, direction picked from `asyn_readback`.
     #[test]
     fn io_intr_readback_output_error_default_is_write_alarm() {
         use epics_base_rs::server::records::longin::LonginRecord;
@@ -6558,9 +6568,12 @@ mod tests {
 
     /// Init-time output readback (asyn:READBACK) seeds the record's value only on
     /// a successful read, mirroring C initAo/initLongout/initMbbo: `if (status ==
-    /// asynSuccess) { pao->rval = value } return INIT_DO_NOT_CONVERT`
-    /// (devAsynInt32.c:955-959, :1080-1082). A non-success initial read leaves the
-    /// .db default — the init-time member of the aux_status value-store family.
+    /// asynSuccess) { pao->rval = value; return INIT_OK; }`, with
+    /// `INIT_DO_NOT_CONVERT` the FAILURE fall-through (initAo
+    /// devAsynInt32.c:955-959, initMbbo :1295-1299; initLo stores VAL under the
+    /// same guard and returns INIT_OK either way, :1082-1086). A non-success
+    /// initial read leaves the .db default — the init-time member of the
+    /// aux_status value-store family.
     #[test]
     fn init_readback_transport_error_keeps_db_default() {
         use epics_base_rs::server::records::longout::LongoutRecord;
@@ -6838,7 +6851,7 @@ mod tests {
 
     /// An `asynUInt32Digital` I/O Intr `mbbiDirect` input (its only dset,
     /// `asynMbbiDirectUInt32Digital`): `processMbbiDirect` sets
-    /// `rval = value & mask` (devAsynUInt32Digital.c:1031); mbbiDirectRecord
+    /// `rval = value & mask` (devAsynUInt32Digital.c:1032); mbbiDirectRecord
     /// resolves VAL = (masked >> SHFT) and the bit fields. Before the fix the
     /// raw landed in VAL verbatim (no MASK, no SHFT, wrong bits).
     #[test]

--- a/crates/asyn-rs/src/asyn_record/device.rs
+++ b/crates/asyn-rs/src/asyn_record/device.rs
@@ -6,7 +6,7 @@
 //! Its **only** job is to hand `dbScan` the record's I/O Intr scan list, which
 //! is why a `record(asyn, ...)` without `field(DTYP, "asynRecordDevice")`
 //! cannot use `SCAN="I/O Intr"` at all: `scanAdd` finds `precord->dset == NULL`
-//! and demotes it to Passive (dbScan.c:272-276). The port reproduces both halves
+//! and demotes it to Passive (dbScan.c:269-274). The port reproduces both halves
 //! — this DSET, and the same demotion in `ioc_app::setup_io_intr`.
 //!
 //! Everything the interrupt mode actually does lives in the record's

--- a/crates/asyn-rs/src/asyn_record/mod.rs
+++ b/crates/asyn-rs/src/asyn_record/mod.rs
@@ -209,7 +209,7 @@ fn menu_choice(choices: &'static [&'static str], index: i32) -> &'static str {
 
 /// The `asynBAUD` menu index for the text the driver reported — C `getOptions`'
 /// `for (i…) if (strcmp(optbuff, baud_choices[i]) == 0) pasynRec->baud = i;`
-/// (asynRecord.c:1868-1871), which walks the very array `setOption` writes from.
+/// (asynRecord.c:1866-1870), which walks the very array `setOption` writes from.
 /// Text that matches no choice reads back as index 0, "Unknown", exactly as C's
 /// `pasynRec->baud = 0` before the loop leaves it.
 ///
@@ -711,7 +711,7 @@ struct IoPlan {
     // C `performOctetIO`'s `inlen` (asynRecord.c:1503-1511): the capacity of the
     // IFMT-selected input buffer — `sizeof(ainp)` (= AINP_SIZE) for ASCII, IMAX
     // for Hybrid/Binary, which read into BINP. It is both the default read
-    // length and the overflow threshold (`:1602-1620`); `octet_buf_size` is the
+    // length and the overflow threshold (`:1602-1621`); `octet_buf_size` is the
     // per-request read length (`min(NRRD, inlen)` or `inlen`), so an
     // NRRD-limited short read can never reach `in_len` and never reads as
     // overflow — the same reason C's check is independent of NRRD.
@@ -767,7 +767,7 @@ impl IoOutcome {
     }
 
     /// The AQR-cancel outcome, C `special()`'s `wasQueued` branch
-    /// (asynRecord.c:397-400): `reportError(… "I/O request canceled")` **and**
+    /// (asynRecord.c:397-404): `reportError(… "I/O request canceled")` **and**
     /// `recGblSetSevr(pasynRec, STATE_ALARM, MAJOR_ALARM)`, then the forced
     /// completion callback. The message and the severity are one event in C and
     /// have one owner here, so a cancel cannot land in `ERRS` with the record
@@ -827,8 +827,9 @@ fn c_read_status_word(e: &crate::error::AsynError) -> &'static str {
 
 /// Raise `(stat, sevr)` into an [`IoOutcome`] mirroring `recGblSetSevr`
 /// (recGbl.c:258-261, [`rec_gbl_set_sevr`]): a new severity replaces the pending
-/// alarm only when it is **strictly higher**, so an equal-severity later call
-/// keeps the earlier `stat`. C's `performIO` relies on this when both the
+/// alarm only when it is **strictly higher** — `if (prec->nsev < new_sevr)` in
+/// the `recGblSetSevrVMsg` the wrapper delegates to (recGbl.c:242) — so an
+/// equal-severity later call keeps the earlier `stat`. C's `performIO` relies on this when both the
 /// write and read phase of a `Write_Read` fail at MAJOR — the write's stat is
 /// the one that survives.
 fn raise_io_alarm(out: &mut IoOutcome, stat: u16, sevr: AlarmSeverity) {
@@ -853,8 +854,13 @@ fn io_user(plan: &IoPlan) -> AsynUser {
         .with_queue_timeout(QUEUE_TIMEOUT)
 }
 
-/// Build the `asynUser` for a `Flush` phase. C `asynRecord.c` issues the flush
-/// with the same reason/addr but no transfer timeout.
+/// Build the `asynUser` for a `Flush` phase. C runs the flush on the record's
+/// one queued `pasynUser`, so it carries the same TMOT as the transfers
+/// (`pasynUser->timeout = pasynRec->tmot`, asynRecord.c:818; the flush call at
+/// :1521 does not touch it). The port leaves it unset because nothing reads it:
+/// no driver `flush` consults `user.timeout`, and `InterposeFlush` overwrites
+/// it with its own configured value and restores it (C does the same,
+/// asynInterposeFlush.c:117,122,131) into a per-phase user no later phase sees.
 fn flush_user(plan: &IoPlan) -> AsynUser {
     AsynUser::new(plan.reason)
         .with_addr(plan.addr)
@@ -924,9 +930,11 @@ fn io_phases(plan: &IoPlan) -> Vec<IoPhase> {
             ],
         };
     }
-    // C's `queueRequest` is unconditional: a NoI/O cycle occupies the queue and
-    // wakes the port thread exactly like a transfer, and only the callback body
-    // is empty (asynRecord.c:342-353, :827). Modelling it as "no phases" made
+    // C's `queueRequest` does not consult TMOD: a NoI/O cycle occupies the queue
+    // and wakes the port thread exactly like a transfer, and only the callback
+    // body is empty (asynRecord.c:342-353, :827). The `stateIdle` arm's one skip
+    // is `if(pasynRecPvt->gotValue) goto done` (`:341`), the I/O Intr readback —
+    // never a transfer mode. Modelling it as "no phases" made
     // the cycle touch the port at all — so the reconnect-nudge idiom poked
     // nothing and a down port raised no alarm (R18-87).
     if plan.tmod == TransferMode::NoIo {
@@ -1028,8 +1036,8 @@ fn io_phase_op(plan: &IoPlan, phase: IoPhase) -> RequestOp {
 
 /// The `asynUser` one phase submits with. C gives every transfer the record's
 /// TMOT (`pasynUser->timeout = pasynRec->tmot`, asynRecord.c:818) — including
-/// the GPIB commands, which run under the same queued user — and only the flush
-/// carries no transfer timeout.
+/// the GPIB commands and the flush, which run under that same queued user. The
+/// port carries it on every phase but the flush; see [`flush_user`].
 fn io_phase_user(plan: &IoPlan, phase: IoPhase) -> AsynUser {
     match phase {
         IoPhase::Flush => flush_user(plan),
@@ -1661,7 +1669,7 @@ const TFIL_UNKNOWN: &str = "Unknown";
 /// `Trace*Mask` constants, so the out-of-band trace post and the
 /// `process()`-path re-import (`read_trace_state`) cannot diverge. Field DBF
 /// types match `get_field`: the mask fields are `Long`, the bit fields are
-/// `DBF_MENU` (`menu(asynTRACE)`, asynRecord.dbd:481-577) and so are posted as
+/// `DBF_MENU` (`menu(asynTRACE)`, asynRecord.dbd:481-583) and so are posted as
 /// `Enum` — a post must carry the field's native type or the monitor delivers a
 /// value the client cannot decode against the field's declared type.
 fn trace_readback_fields(rb: &TraceReadback) -> Vec<(String, EpicsValue)> {
@@ -2442,7 +2450,7 @@ impl AsynRecord {
     ///
     /// C `setOption` reports a failing `pasynOption->setOption` as
     /// `"Error setting option, %s"` with `pasynUser->errorMessage`
-    /// (asynRecord.c:1825-1828) — it never names the key, and it raises no
+    /// (asynRecord.c:1828-1831) — it never names the key, and it raises no
     /// record severity. The port invented `"set_option({key}): {e}"`, which
     /// also prefixed the Rust status debug onto the driver text.
     fn write_option(&mut self, key: &str, value: &str) {
@@ -2533,7 +2541,7 @@ impl AsynRecord {
     ///
     /// C's shape, and the whole point of it: write the field, then
     /// `db_post_events(errs, DBE_VALUE|DBE_LOG)` iff the text actually changed
-    /// (:2044-2048). ERRS is not `pp(TRUE)` (asynRecord.dbd:366-370), and the
+    /// (:2044-2048). ERRS is not `pp(TRUE)` (asynRecord.dbd:622-627), and the
     /// record's own writes are not puts, so nothing else posts it — a diagnostic
     /// written straight into the field reached the operator's screen only if some
     /// *other* field happened to be posted for an unrelated reason. Every refusal,
@@ -2622,7 +2630,7 @@ impl AsynRecord {
     ///
     /// - The port's queue gate refused it: C's `queueRequest` returned
     ///   non-success, so `special()` writes `pasynUser->errorMessage` to ERRS and
-    ///   frees the user (asynRecord.c:571-576). `asynCallbackSpecial` never runs
+    ///   frees the user (asynRecord.c:571-578). `asynCallbackSpecial` never runs
     ///   — no option or EOS is written, no connect is attempted, no readback, and
     ///   no `monitorStatus` tail.
     /// - It waited out `QUEUE_TIMEOUT`: `queueTimeoutCallbackSpecial` runs
@@ -3151,7 +3159,7 @@ impl AsynRecord {
     /// field.
     /// The one owner of a client put into an array field — C's `put_array_info`
     /// (asynRecord.c:983-993), which `dbPut` calls for every `SPC_DBADDR` field
-    /// it writes (`dbAccess.c:1366-1369`) with `nNew` = the element count that
+    /// it writes (`dbAccess.c:1365-1368`) with `nNew` = the element count that
     /// arrived:
     ///
     /// ```c
@@ -4194,7 +4202,7 @@ impl Record for AsynRecord {
                             // The gate refused the request, or it timed out in the
                             // queue: `asynCallbackSpecial` never ran, so C's
                             // `special()` reports the refusal and frees the user
-                            // (asynRecord.c:571-576) — no connect was attempted and
+                            // (asynRecord.c:571-578) — no connect was attempted and
                             // there is no callback tail to run. This is the arm the
                             // waiver rules bite on: a device-addressed CNCT put to a
                             // disconnected port is refused `asynDisconnected`
@@ -4662,7 +4670,7 @@ impl AsynRecord {
             // `TMOD = NoI/O` skips it, because C's callback never enters
             // `performIO` at all under that mode (asynRecord.c:827) — the
             // interface it would have dispatched on is never consulted. The cycle
-            // still goes on to queue: `process()` queues unconditionally
+            // still goes on to queue: `process()` queues without consulting TMOD
             // (`:342-353`), which is what makes a NoI/O process poke auto-connect
             // and raise STATE/MINOR on a port that refuses it (R18-87).
             if TransferMode::from_u16(self.tmod as u16) != TransferMode::NoIo {
@@ -5055,7 +5063,7 @@ mod tests {
     }
 
     /// R10-46: the `AQR` cancel of a still-queued request is C's `wasQueued`
-    /// branch (asynRecord.c:397-400) — "I/O request canceled" **and**
+    /// branch (asynRecord.c:397-404) — "I/O request canceled" **and**
     /// `recGblSetSevr(pasynRec, STATE_ALARM, MAJOR_ALARM)`. The message and the
     /// severity are one event, so the outcome that carries the text to the
     /// completion re-entry carries the alarm with it.
@@ -5169,7 +5177,8 @@ mod tests {
         assert_eq!((sized.omax, sized.imax), (256, 512));
     }
 
-    /// R18-87. C's `process()` queues unconditionally (asynRecord.c:342-353) and
+    /// R18-87. C's `process()` queues without consulting TMOD (asynRecord.c:342-353
+    /// — its only skip is the `gotValue` I/O Intr readback at `:341`) and
     /// only the callback body skips the transfer (`:827`). So a `TMOD = NoI/O`
     /// cycle is a real queue entry, and everything that follows from one
     /// follows here: the port-thread wake that runs auto-connect — the
@@ -5502,7 +5511,7 @@ mod tests {
             "a BAUD put on a disconnected port is asynDisconnected in C, not a driver call"
         );
         // The refusal is `queueRequest`'s return value, so C reports
-        // `pasynUserSpecial->errorMessage` (asynRecord.c:571-576) — *not* the
+        // `pasynUserSpecial->errorMessage` (asynRecord.c:571-578) — *not* the
         // "Error setting option, %s" text of a `setOption` that ran (R14-46).
         assert!(
             rec.errs.contains("not connected"),
@@ -7405,7 +7414,7 @@ mod tests {
         // reproduced by decision. The refusal is `queueRequest`'s return value,
         // so `asynCallbackSpecial` never runs: C reports
         // `pasynUserSpecial->errorMessage` and frees the user
-        // (asynRecord.c:571-576), and with no callback there is no `monitorStatus`
+        // (asynRecord.c:571-578), and with no callback there is no `monitorStatus`
         // tail — CNCT keeps the value the operator typed until the next status
         // cycle (R14-46).
         rec.cnct = 1;
@@ -7429,7 +7438,7 @@ mod tests {
         assert_eq!(
             rec.cnct, 1,
             "no callback ran, so no monitorStatus tail snapped CNCT back \
-             (asynRecord.c:571-576 vs :897)"
+             (asynRecord.c:571-578 vs :897)"
         );
 
         // The port-level route (C `connectDevice(port, -1)`) brings the line
@@ -7445,7 +7454,7 @@ mod tests {
         assert_eq!(rec.cnct, 1);
 
         // C's isConnected gate: re-putting the state the port is already in
-        // issues no driver call at all (asynRecord.c:865-882).
+        // issues no driver call at all (asynRecord.c:865-889).
         rec.cnct = 1;
         rec.special("CNCT", true).unwrap();
         assert_eq!(
@@ -7473,7 +7482,7 @@ mod tests {
     /// R14-46: a request the queue gate refuses never ran, and the record must
     /// report it as a refusal — not as a callback that did something.
     ///
-    /// C `special()` (asynRecord.c:571-576): when `queueRequest` returns non-zero
+    /// C `special()` (asynRecord.c:571-578): when `queueRequest` returns non-zero
     /// the record writes `pasynUserSpecial->errorMessage` into ERRS and frees the
     /// user. `asynCallbackSpecial` is never dispatched, so none of the work it
     /// implies happens — no `setOption`, no `setEos`, no `connect`, no
@@ -8319,8 +8328,10 @@ mod tests {
         assert_eq!(plan(TransferMode::Read, Octet), [Read]);
         assert_eq!(plan(TransferMode::Flush, Octet), [Flush]);
         // R18-87: NoI/O is one queue entry with an empty body, not zero queue
-        // entries — C `process()` queues unconditionally (asynRecord.c:342-353)
-        // and only the callback skips `performIO` (`:827`).
+        // entries — C `process()` queues without consulting TMOD
+        // (asynRecord.c:342-353; its one skip is the `gotValue` I/O Intr
+        // readback at `:341`) and the callback is what skips `performIO`
+        // (`:827`).
         assert_eq!(plan(TransferMode::NoIo, Octet), [IoPhase::NoIo]);
         assert_eq!(plan(TransferMode::NoIo, Int32), [IoPhase::NoIo]);
 
@@ -8623,7 +8634,7 @@ mod tests {
 
     /// R18-83: C's `put_array_info` (asynRecord.c:983-993) sets NOWT from the
     /// element count of the BOUT put, and NORD from the count of a BINP put —
-    /// `dbPut` calls it on every array put (`dbAccess.c:1366-1369`). Writing the
+    /// `dbPut` calls it on every array put (`dbAccess.c:1365-1368`). Writing the
     /// array *is* how the count gets set; a client does not put NOWT alongside.
     ///
     /// Without it, a `caput -a` of 120 bytes into BOUT left NOWT at its default
@@ -9308,7 +9319,7 @@ mod tests {
     ///
     /// C `reportError` (asynRecord.c:2028-2049) writes the field and then
     /// `db_post_events(errs, DBE_VALUE|DBE_LOG)` iff the text changed. ERRS is
-    /// not `pp(TRUE)` (asynRecord.dbd:366-370), so nothing else posts it: the
+    /// not `pp(TRUE)` (asynRecord.dbd:622-627), so nothing else posts it: the
     /// record's diagnostics — the queue-gate refusal, an option/EOS error, a
     /// connect error — were written into the field and never reached a CA client
     /// monitoring it. Only `resetError`'s clear posted.
@@ -9400,7 +9411,7 @@ mod tests {
             .expect("subscribe ERRS");
 
         // Boundary 1 — a refused put. C's `special()` writes the gate's own
-        // `pasynUser->errorMessage` to ERRS and frees the user (:571-576); the
+        // `pasynUser->errorMessage` to ERRS and frees the user (:571-578); the
         // operator's ERRS monitor must fire with it.
         {
             let inst = db.get_record(rec_name).unwrap();
@@ -9582,7 +9593,7 @@ mod tests {
         assert_eq!(
             pcnct_sub.recv().await,
             Some(EpicsValue::Enum(1)),
-            "monitorStatus posts PCNCT (asynRecord.c:1128)"
+            "monitorStatus posts PCNCT (asynRecord.c:1127)"
         );
     }
 
@@ -10479,7 +10490,7 @@ mod tests {
             base.init_connected(connected);
             // A port that accepts an EOS at all is one C configured with
             // `processEosIn/Out` set, so `asynOctetBase::initialize` installed
-            // `asynInterposeEos` above the driver (asynOctetBase.c:169-171).
+            // `asynInterposeEos` above the driver (asynOctetBase.c:170-172).
             // Without that layer the driver's own `setInputEos` is NULL and
             // C answers "not implemented" (R18-71).
             base.install_octet_interpose(Box::new(crate::interpose::eos::EosInterpose::default()));
@@ -10555,7 +10566,7 @@ mod tests {
             // The move has to be one the queue gate tolerates: a *disabled* or
             // *disconnected* port refuses the put at `queueRequest`, and then C
             // runs no callback and therefore no `monitorStatus` either
-            // (asynRecord.c:571-576 — that is R14-46's boundary, asserted in
+            // (asynRecord.c:571-578 — that is R14-46's boundary, asserted in
             // `a_gate_refused_request_reports_the_refusal_and_runs_no_callback`).
             // What this test is about is the *other* side of that line: a request
             // that DID run must end in the tail.

--- a/crates/asyn-rs/src/drivers/ip_port.rs
+++ b/crates/asyn-rs/src/drivers/ip_port.rs
@@ -187,7 +187,7 @@ impl IpPortConfig {
 /// (`strchr(cp, ' ')`) and `sscanf(blank+1, "%5s", protocol)` takes the first
 /// whitespace-delimited run, truncated to five characters (`char protocol[6]`);
 /// whatever follows that run is ignored. With no blank at all, `protocol[0]` is
-/// `'\0'` and C defaults to `SOCK_STREAM` (:355-357).
+/// `'\0'` and C defaults to `SOCK_STREAM` (:356-358).
 ///
 /// The token is then classified *exhaustively* — see [`protocol_from_token`].
 /// A whitelist of recognized suffixes is not enough: an unrecognized token has
@@ -602,7 +602,7 @@ pub(super) fn write_with_retry(
     cap: Option<std::time::Instant>,
 ) -> AsynResult<usize> {
     let mut offset = 0;
-    // C's `haveStartTime`/`startTime` (drvAsynIPPort.c:665, 694-708): stamped at
+    // C's `haveStartTime`/`startTime` (drvAsynIPPort.c:631, 662-674): stamped at
     // the FIRST retryable `send` and never re-armed, not even by a pass that
     // moved bytes. It is what bounds a `poll` that keeps reporting writable
     // against a `send` that keeps answering EWOULDBLOCK — a cycle the per-pass
@@ -1383,7 +1383,7 @@ impl DrvAsynIPPort {
     /// hostInfo, priority, noAutoConnect, noProcessEos)` leaves one:
     /// [`Self::new`] plus `Self::apply_ip_port_configure` (the `registerPort`
     /// autoConnect flag and, unless `noProcessEos`, the default EOS interpose —
-    /// drvAsynIPPort.c:1043-1066).
+    /// drvAsynIPPort.c:1028-1066).
     ///
     /// The single public entry for callers outside the iocsh command that need a
     /// fully-configured IP port — e.g. a `noAutoConnect` port registered for a
@@ -1483,7 +1483,7 @@ impl DrvAsynIPPort {
     }
 
     /// Everything `drvAsynIPPortConfigure` gives a port beyond constructing the
-    /// driver (drvAsynIPPort.c:1043-1066):
+    /// driver (drvAsynIPPort.c:1028-1066):
     ///
     /// ```c
     /// pasynManager->registerPort(tty->portName, ASYN_CANBLOCK, !noAutoConnect, ...);
@@ -3290,7 +3290,7 @@ mod tests {
     /// on VxWorks either: `drvAsynIPPort.c` compiles the option only under
     /// `USE_SOCKTIMEOUT`, which is `#if defined(__rtems__)` (`:71-72`), while
     /// vxWorks takes `USE_POLL` (`:74-76`) and bounds `writeIt` with
-    /// `poll(POLLOUT, writePollmsec)` (`:667-686`) instead.
+    /// `poll(POLLOUT, writePollmsec)` (`:636-652`) instead.
     ///
     /// Host proxy for a target-only failure: Linux implements the option, so
     /// the pre-fix code also returned Timeout here. What fails before the fix

--- a/crates/asyn-rs/src/drivers/ip_server_port.rs
+++ b/crates/asyn-rs/src/drivers/ip_server_port.rs
@@ -624,7 +624,7 @@ impl ClientSlot {
 }
 
 /// The accept half of the server port, detached from the driver so the listener
-/// thread can own it — C's `connectionListener` (drvAsynIPServerPort.c:290-384),
+/// thread can own it — C's `connectionListener` (drvAsynIPServerPort.c:284-386),
 /// which `drvAsynIPServerPortConfigure` starts at configure time (:711-714) and
 /// which is the *only* thing in C that accepts.
 ///
@@ -716,7 +716,7 @@ impl Acceptor {
                 // C :374-383 — the octet callbacks carry the child port name,
                 // not the payload. The listener walks the interrupt list and
                 // calls EVERY node unconditionally: there is no addr test here
-                // (unlike asynOctetBase.c:203-215, which does test addr). A
+                // (unlike asynOctetBase.c:202-210, which does test addr). A
                 // client landing in slot 3 must be announced to a listener that
                 // registered on addr 0, because "which slot" is the news.
                 self.interrupts.notify_octet(
@@ -881,9 +881,11 @@ impl DrvAsynIPServerPort {
             max,
             PortFlags {
                 // Single-device, like C: the listener registers plain
-                // `ASYN_CANBLOCK` (drvAsynIPServerPort.c:625-626) and its whole
-                // asynOctet method table is NULL (:118-122) — it is an interrupt
-                // source, not an I/O port. The per-client ports are separate
+                // `ASYN_CANBLOCK` (drvAsynIPServerPort.c:625-626) and a TCP
+                // listener's asynOctet table stays the all-NULL initializer
+                // (:118-123; C fills read/write/flush in only for SOCK_DGRAM,
+                // :652-656) — it is an interrupt source, not an I/O port.
+                // The per-client ports are separate
                 // single-device `drvAsynIPPortConfigure`d registrations
                 // (:688-694), which `make_subport` mirrors.
                 //
@@ -1822,7 +1824,7 @@ mod tests {
     use super::*;
 
     /// The listener thread is the only acceptor — C `connectionListener`
-    /// (drvAsynIPServerPort.c:290-384) — so a test observes an accept by waiting
+    /// (drvAsynIPServerPort.c:284-386) — so a test observes an accept by waiting
     /// for the slot to fill, not by driving the accept itself. Returns `idx`.
     fn wait_for_slot(srv: &DrvAsynIPServerPort, idx: usize) -> usize {
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -2465,7 +2467,7 @@ mod tests {
     ///
     /// C `connectionListener` (drvAsynIPServerPort.c:374-383) walks the octet
     /// interrupt list and calls every node with the child port's name — there
-    /// is no addr test, unlike `asynOctetBase.c:203-215`. The boundary is
+    /// is no addr test, unlike `asynOctetBase.c:202-210`. The boundary is
     /// "announcement addr == subscriber addr" (slot 0) vs "announcement addr !=
     /// subscriber addr" (slot 1): both must be delivered. An addr filter here
     /// would silently hide every client after the first.

--- a/crates/asyn-rs/src/drivers/serial_port.rs
+++ b/crates/asyn-rs/src/drivers/serial_port.rs
@@ -138,18 +138,25 @@ mod platform {
     /// `.../termios.h` in the BSP sysroot. Every line below cites the header
     /// it was read from; nothing here is inferred from another platform.
     ///
-    /// Those citations are **not re-checkable on a host without the RTEMS
-    /// toolchain**, and this machine is one: `find / -name '_termios.h'` and
-    /// `find / -type d -name 'arm-rtems*'` both come back empty of any
-    /// toolchain (the only `arm-rtems*` hits are unrelated test fixtures under
-    /// `/tmp`), as does `find / -type d -name 'rtems-libbsd'`. Install the BSP
-    /// sysroot before re-pinning any `_termios.h` / `_default_fcntl.h` line
-    /// number here; do not "verify" them against glibc's `termios.h`, whose
-    /// numbering is unrelated. The VxWorks half below has no such problem —
-    /// its sysroot *is* on this machine, under
-    /// `wrsdk-vxworks7-qemu-1.17.0/vxsdk/sysroot/{usr,krnl}/h/`, so
-    /// `sioLibCommon.h`, `sys/fcntlcom.h` and `UTILS_UNIX/termios.h` are
-    /// readable and were re-verified.
+    /// A local `find` for `_termios.h` comes back empty on a developer host,
+    /// which proves only that no toolchain is installed *there* — not that
+    /// these lines cannot be re-checked. They are re-checkable wherever
+    /// `RTEMS_BSP_PREFIX` names a BSP install, which `scripts/rtems-bsp.sh`
+    /// leaves at `rtems-bsp/<series>/arm-rtems<series>/include`. Read them
+    /// there, or copy the header out and read the copy; never edit a reference
+    /// tree, and never "verify" a line against glibc's `termios.h`, whose
+    /// numbering is unrelated.
+    ///
+    /// `sys/_termios.h` is byte-identical between series 6 and series 7, so
+    /// every `_termios.h` line cited below holds for both. That is a property
+    /// of this one header, established by reading both — not a general licence
+    /// to let one series stand in for the other.
+    ///
+    /// The VxWorks half below is readable on the developer host itself, under
+    /// `wrsdk-vxworks7-qemu-1.17.0/vxsdk/sysroot/{usr,krnl}/h/`. The RTP
+    /// (`usr/`) and kernel (`krnl/`) copies of `UTILS_UNIX/termios.h` are
+    /// byte-identical, so the `B*` ladder is the same whichever the build
+    /// reaches; `sioLibCommon.h` and `sys/fcntlcom.h` were re-verified there.
     #[cfg(target_os = "rtems")]
     mod imp {
         /// `_termios.h:226`: `typedef unsigned int speed_t;`. Its two
@@ -1056,7 +1063,7 @@ impl DrvAsynSerialPort {
         base.init_connected(false);
         base.auto_connect = true;
         // C passes `interruptProcess = 1` to `pasynOctetBase->initialize`
-        // (drvAsynSerialPort.c:1125): every successful octet read on this port fans out to
+        // (drvAsynSerialPort.c:1125-1126): every successful octet read on this port fans out to
         // its octet interrupt users, which is what drives a SCAN="I/O Intr"
         // record. See `PortDriverBase::octet_interrupt_process`.
         base.octet_interrupt_process = true;
@@ -1235,7 +1242,7 @@ impl PortDriver for DrvAsynSerialPort {
             self.saved_termios = Some(saved);
 
             // 3. Configure: push the cached termios — C `connectIt` calls
-            // `applyOptions(pasynUser, tty)` (drvAsynSerialPort.c:722), which
+            // `applyOptions(pasynUser, tty)` (drvAsynSerialPort.c:723), which
             // tcsetattr's `tty->termios` verbatim. The cache carries every
             // option set since configure, including ones set while the port
             // was down, so they take effect on this connect instead of being
@@ -1414,12 +1421,16 @@ impl PortDriver for DrvAsynSerialPort {
         self.io.flush(user)
     }
 
-    /// C `setOption` (drvAsynSerialPort.c:335-618): every supported key
-    /// mutates the **cached** termios (or `tty->baud`) unconditionally —
-    /// whether or not the port is open — and the single tail then pushes the
-    /// cache to the device when it is, restoring the previous cache if that
-    /// push fails. An option set while the port is down is therefore held and
-    /// applied at the next connect, exactly like one set while it is up.
+    /// C `setOption` (drvAsynSerialPort.c:239-619): every key that carries line
+    /// state mutates the **cached** termios (or `tty->baud`) unconditionally —
+    /// whether or not the port is open — and the single tail (:599-616) then
+    /// pushes the cache to the device when it is, restoring the previous cache
+    /// if that push fails. An option set while the port is down is therefore
+    /// held and applied at the next connect, exactly like one set while it is
+    /// up. The two keys carrying no line state are `break`, a momentary action
+    /// on the fd that returns before ever reaching the tail (:507-528), and the
+    /// `rs485_*` family, cached in `tty->rs485` (:530-592) and pushed by the
+    /// tail's own `TIOCSRS485` ioctl (:606-615).
     ///
     /// The port previously mutated the *live* termios (tcgetattr → modify →
     /// tcsetattr) and skipped the write entirely when disconnected, so
@@ -1436,7 +1447,7 @@ impl PortDriver for DrvAsynSerialPort {
         let value = value.as_str();
 
         // C keeps `baudPrev`/`termiosPrev` for the applyOptions rollback
-        // (:341-346, :599-606). `platform::termios` is Copy, so this is the same
+        // (:254-256, :599-606). `platform::termios` is Copy, so this is the same
         // snapshot-and-restore.
         let baud_prev = self.baud;
         let termios_prev = self.termios;
@@ -2766,7 +2777,7 @@ mod tests {
     ///
     /// C seeds CLOCAL into `tty->termios` (drvAsynSerialPort.c:1077), lets
     /// `setOption` clear it in the cache unconditionally (:410-419), re-pushes
-    /// the cache at every connect via `applyOptions` (:105-130, :722) and reads
+    /// the cache at every connect via `applyOptions` (:105-130, :723) and reads
     /// it back from the cache (:169-170). The port instead mutated the live
     /// termios only when connected, stored nothing, force-set CREAD|CLOCAL at
     /// every connect, and hard-coded "N" for a disconnected readback — so

--- a/crates/asyn-rs/src/drivers/serial_port_win32.rs
+++ b/crates/asyn-rs/src/drivers/serial_port_win32.rs
@@ -252,7 +252,7 @@ impl SerialIoStateWin32 {
         match timeout {
             // C leaves `SetCommTimeouts` uncalled for a negative timeout
             // (`if (pasynUser->timeout >= 0)`, drvAsynSerialPortWin32.c:577)
-            // and starts no timer (`readTimeout > 0`, :606), so its
+            // and starts no timer (`readTimeout > 0`, :607), so its
             // one-byte `ReadFile` blocks until the device answers. This
             // backend reads into the whole buffer rather than a byte at a
             // time, so the same "return on the first byte, never time out"
@@ -480,7 +480,7 @@ impl DrvAsynSerialPort {
         base.init_connected(false);
         base.auto_connect = true;
         // C passes `interruptProcess = 1` to `pasynOctetBase->initialize`
-        // (drvAsynSerialPortWin32.c:798): every successful octet read on this port fans out to
+        // (drvAsynSerialPortWin32.c:798-799): every successful octet read on this port fans out to
         // its octet interrupt users, which is what drives a SCAN="I/O Intr"
         // record. See `PortDriverBase::octet_interrupt_process`.
         base.octet_interrupt_process = true;
@@ -1268,9 +1268,9 @@ mod tests {
 
     /// C-Win32 `readIt` never closes the handle: the file's only two
     /// `closeConnection` call sites are the explicit disconnect
-    /// (`drvAsynSerialPortWin32.c:470`) and `writeIt` (`:525`), and the read
-    /// error branch at `:596-640` sets `errorMessage`, assigns `asynError` and
-    /// breaks. `writeIt` does close, so the two directions are asserted
+    /// (`drvAsynSerialPortWin32.c:470`) and `writeIt` (`:525`), and `readIt`'s
+    /// `ReadFile` error branch at `:618-625` sets `errorMessage`, assigns
+    /// `asynError` and breaks. `writeIt` does close, so the two directions are asserted
     /// together — the asymmetry is the point.
     ///
     /// The port publishes `connected` with no handle so the failure comes from

--- a/crates/asyn-rs/src/error.rs
+++ b/crates/asyn-rs/src/error.rs
@@ -126,7 +126,7 @@ pub enum AsynError {
     /// routes and mean opposite things. A refusal is `queueRequest`'s *return
     /// value* — the callback never runs, so nothing it implies happened: no
     /// bytes moved, no option was written, no readback, no `monitorStatus`
-    /// (asynRecord.c:571-576 reports `pasynUser->errorMessage` and frees the
+    /// (asynRecord.c:571-578 reports `pasynUser->errorMessage` and frees the
     /// user). A driver error arrives *inside* the callback, which did run and
     /// whose tail C still executes. Collapsing them into one variant made a
     /// refused `special()` report as a callback that ran (R14-46).

--- a/crates/asyn-rs/src/escape.rs
+++ b/crates/asyn-rs/src/escape.rs
@@ -32,7 +32,7 @@
 //!   the trace errlog branch (asynManager.c:3159) and every `asynRecord` field
 //!   (asynRecord.c:725,1629,2005) escape through — each with its own buffer size,
 //!   which the caller must state.
-//! - [`print_escaped`] — `epicsStrPrintEscaped` (epicsString.c:230-262), the
+//! - [`print_escaped`] — `epicsStrPrintEscaped` (epicsString.c:230-269), the
 //!   `FILE *` form, has no destination bound, and keeps C's `strlen(s) == 0`
 //!   first-byte-NUL early-return quirk (R17-49). This is what
 //!   `asynPortDriver::report` prints the EOS pair with
@@ -58,7 +58,7 @@ pub(crate) fn escaped_from_raw(src: &[u8], dstlen: usize) -> String {
     escape(src, dstlen.saturating_sub(1))
 }
 
-/// C `epicsStrPrintEscaped` (epicsString.c:230-262) — the `FILE *` form. C's
+/// C `epicsStrPrintEscaped` (epicsString.c:230-269) — the `FILE *` form. C's
 /// `switch` forgot the NUL case, so C prints `\x00`; the port **refuses that
 /// CBUG-D4 divergence** and renders NUL as `\0`, identically to
 /// [`escaped_from_raw`] (both reach the one [`escape`] table). It writes to a
@@ -209,7 +209,7 @@ mod tests {
     }
 
     /// R17-49. `epicsStrPrintEscaped` early-returns on `strlen(s) == 0`
-    /// (epicsString.c:236-237) even though it was handed an explicit length: a
+    /// (epicsString.c:237-238) even though it was handed an explicit length: a
     /// buffer whose first byte is NUL prints nothing at all. Against compiled
     /// libCom:
     ///

--- a/crates/asyn-rs/src/interfaces/mod.rs
+++ b/crates/asyn-rs/src/interfaces/mod.rs
@@ -252,7 +252,7 @@ impl Capability {
 ///
 /// This is the parameter-library port's interface set — the analogue of C's
 /// `asynPortDriver`, which registers every standard interface its
-/// `interfaceMask` names (asynPortDriver.cpp:4070). A transport that speaks only
+/// `interfaceMask` names (asynPortDriver.cpp:4056-4071). A transport that speaks only
 /// bytes (an IP socket, a serial line) registers far fewer and must override
 /// [`crate::port::PortDriver::capabilities`] to say so, because asynRecord reads
 /// that declaration into OCTETIV / I32IV / UI32IV / F64IV / OPTIONIV / GPIBIV and
@@ -277,7 +277,7 @@ pub fn default_capabilities() -> Vec<Capability> {
         Capability::Option,
         // A parameter-library port resolves drvInfo → reason, so it registers
         // asynDrvUser, exactly as C `asynPortDriver` does
-        // (asynPortDriver.cpp:4070 `asynDrvUserType`).
+        // (asynPortDriver.cpp:4057, `asynDrvUserMask` -> `ifaceDrvUser`).
         Capability::DrvUser,
         Capability::Flush,
         Capability::Connect,

--- a/crates/asyn-rs/src/interpose/delay.rs
+++ b/crates/asyn-rs/src/interpose/delay.rs
@@ -58,15 +58,21 @@ impl OctetInterpose for DelayInterpose {
         data: &[u8],
         next: &mut dyn OctetNext,
     ) -> AsynResult<usize> {
-        if self.delay.is_zero() {
-            return next.write(user, data);
-        }
         // C asynInterposeDelay.c:41-50 writeIt: write one char, then
         // epicsThreadSleep(delay) — AFTER every char, including the last
         // and including a single-char write. On a write error it breaks
         // before sleeping and publishes what it managed to send
         // (`*nbytesTransfered = transfered`, :52), so the count rides out on
         // the error instead of being dropped by `?`.
+        //
+        // The chunking is unconditional in C: `writeIt` has no zero-delay
+        // arm, and `epicsThreadSleep(0)` is a `nanosleep({0,0})` that yields
+        // (osdThread.c:922-933), not an early return. So a port configured
+        // `asynInterposeDelay(port, addr, 0)` still writes one byte per call
+        // to the layer below. Short-circuiting the whole loop on a zero
+        // delay collapsed that into a single N-byte write — a different call
+        // pattern below (one TCP segment where C sends N) and a different
+        // partial count on a failing write.
         let mut total = 0;
         for byte in data.iter() {
             match next.write(user, std::slice::from_ref(byte)) {
@@ -134,8 +140,14 @@ mod tests {
         assert_eq!(base.written[2], b"c");
     }
 
+    /// A zero delay does not turn the layer off. C's `writeIt` (:41-50) has no
+    /// zero-delay arm — it chunks whatever `pvt->delay` holds, and
+    /// `epicsThreadSleep(0)` yields rather than returning early
+    /// (`osdThread.c:922-933`) — so `asynInterposeDelay(port, addr, 0)` still
+    /// hands the layer below one byte per call. Collapsing it to a single
+    /// N-byte write changed what the device sees.
     #[test]
-    fn test_delay_zero_passthrough() {
+    fn zero_delay_still_writes_one_char_at_a_time() {
         let mut stack = OctetInterposeStack::new(false);
         stack.install(-1, Box::new(DelayInterpose::new(Duration::ZERO)));
 
@@ -144,8 +156,11 @@ mod tests {
 
         let n = stack.dispatch_write(&mut user, b"abc", &mut base).unwrap();
         assert_eq!(n, 3);
-        // Zero delay: single write
-        assert_eq!(base.written.len(), 1);
+        assert_eq!(
+            base.written,
+            vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()],
+            "C chunks on any delay, zero included"
+        );
     }
 
     #[test]

--- a/crates/asyn-rs/src/interpose/eos.rs
+++ b/crates/asyn-rs/src/interpose/eos.rs
@@ -11,7 +11,9 @@ use crate::error::AsynResult;
 use crate::port::eos_device_key;
 use crate::user::AsynUser;
 
-use super::{EomReason, OctetInterpose, OctetNext, OctetReadResult, PartialOctetRead};
+use super::{
+    EomReason, EosSet, MAX_EOS_LEN, OctetInterpose, OctetNext, OctetReadResult, PartialOctetRead,
+};
 
 /// Fixed internal buffer size matching C asyn's INPUT_SIZE.
 const INPUT_BUFFER_SIZE: usize = 2048;
@@ -93,7 +95,7 @@ pub struct EosInterpose {
     /// C `eosPvt::processEosIn` (asynInterposeEos.c:42, set from the
     /// `asynInterposeEosConfig` argument at :128). When false the layer is not
     /// in the input path at all: `readIt` delegates straight to the driver
-    /// (:191-193) and the terminator setters are the driver's (:260, :293).
+    /// (:191-193) and the terminator accessors are the driver's (:293, :318).
     process_in: bool,
     /// C `eosPvt::processEosOut` (:50, :134) — same, for the write path (:161).
     process_out: bool,
@@ -375,28 +377,39 @@ impl OctetInterpose for EosInterpose {
         next.flush(user)
     }
 
-    fn set_input_eos(&mut self, addr: i32, eos: &[u8]) -> bool {
+    fn set_input_eos(&mut self, addr: i32, eos: &[u8]) -> EosSet {
         // C :293-295 — with `processEosIn == 0` the terminator belongs to the
         // driver, not to this layer, and the call is *delegated downwards*;
         // taking it here would make `read` (which delegates) and the stored
-        // terminator disagree.
+        // terminator disagree. C tests the flag before the length, so a
+        // delegated call is never refused here for its length either.
         if !self.process_in {
-            return false;
+            return EosSet::NotTaken;
+        }
+        if eos.len() > MAX_EOS_LEN {
+            return EosSet::IllegalLength;
         }
         let dev = self.device(addr);
         dev.config.input_eos = eos.to_vec();
         // Reset the resync state machine — a mid-stream terminator change
         // must not carry a partial match from the old terminator.
         dev.eos_in_match = 0;
-        true
+        EosSet::Stored
     }
 
-    fn set_output_eos(&mut self, addr: i32, eos: &[u8]) -> bool {
-        if !self.process_out {
-            return false;
+    fn set_output_eos(&mut self, addr: i32, eos: &[u8]) -> EosSet {
+        // C `setOutputEos` (asynInterposeEos.c:344-363) carries no
+        // `processEosOut` test at all: it validates the length, stores
+        // `eosOut`/`eosOutLen` and answers asynSuccess whatever the flag,
+        // and `getOutputEos` (:365-390) reads it back the same way. The flag
+        // gates `writeIt` alone (:161-163), so with `processOut = 0` the
+        // terminator is held and simply never appended — a set-then-read-back
+        // from a startup script succeeds, which is what refusing it broke.
+        if eos.len() > MAX_EOS_LEN {
+            return EosSet::IllegalLength;
         }
         self.device(addr).config.output_eos = eos.to_vec();
-        true
+        EosSet::Stored
     }
 
     /// C `eosInExceptionHandler` (asynInterposeEos.c:142-151): on
@@ -459,6 +472,53 @@ mod tests {
         fn flush(&mut self, _user: &mut AsynUser) -> AsynResult<()> {
             Ok(())
         }
+    }
+
+    /// C `setOutputEos` (asynInterposeEos.c:344-363) carries no
+    /// `processEosOut` test: it validates the length, stores
+    /// `eosOut`/`eosOutLen` and answers asynSuccess whatever the flag, which
+    /// gates `writeIt` alone (:161-163). So `processOut = 0` means "held but
+    /// never appended", never "refused" — a startup script's set-then-read-back
+    /// succeeds. And the length switch refuses before assigning, so a refusal
+    /// leaves the stored terminator standing.
+    #[test]
+    fn output_eos_stores_whatever_process_out_says() {
+        let mut eos = EosInterpose::with_processing(EosConfig::default(), true, false);
+        assert_eq!(eos.set_output_eos(0, b"\r\n"), EosSet::Stored);
+        assert_eq!(eos.get_output_eos(0), b"\r\n");
+
+        assert_eq!(eos.set_output_eos(0, b"\r\n\0"), EosSet::IllegalLength);
+        assert_eq!(
+            eos.get_output_eos(0),
+            b"\r\n",
+            "a refused length must store nothing"
+        );
+
+        // The flag still gates the write: the stored terminator is not
+        // appended (C `writeIt` :161-163).
+        let mut base = MockOctetBase::new(b"");
+        let mut user = AsynUser::default();
+        eos.write(&mut user, b"CMD", &mut base).unwrap();
+        assert_eq!(base.written, b"CMD".to_vec());
+
+        // With the flag on, the same stored terminator is appended.
+        let mut on = EosInterpose::with_processing(EosConfig::default(), true, true);
+        assert_eq!(on.set_output_eos(0, b"\r\n"), EosSet::Stored);
+        let mut base = MockOctetBase::new(b"");
+        on.write(&mut user, b"CMD", &mut base).unwrap();
+        assert_eq!(base.written, b"CMD\r\n".to_vec());
+    }
+
+    /// The input half is *not* the same shape: C's `setInputEos` tests
+    /// `processEosIn` first and delegates downwards when it is 0 (:293-295),
+    /// as `getInputEos` (:318-320) and `readIt` (:191-193) do.
+    #[test]
+    fn input_eos_delegates_when_process_in_is_off() {
+        let mut eos = EosInterpose::with_processing(EosConfig::default(), false, true);
+        assert_eq!(eos.set_input_eos(0, b"\n"), EosSet::NotTaken);
+        // Refused for the flag, not for the length — C never reaches the
+        // switch on that path.
+        assert_eq!(eos.set_input_eos(0, b"abc"), EosSet::NotTaken);
     }
 
     #[test]

--- a/crates/asyn-rs/src/interpose/mod.rs
+++ b/crates/asyn-rs/src/interpose/mod.rs
@@ -78,6 +78,42 @@ pub trait OctetNext: Send + Sync {
     fn flush(&mut self, user: &mut AsynUser) -> AsynResult<()>;
 }
 
+/// The longest terminator C's EOS interpose can hold: `eosIn[2]` / `eosOut[2]`
+/// (asynInterposeEos.c:51-54), which is what its `switch (eoslen)` enforces.
+pub const MAX_EOS_LEN: usize = 2;
+
+/// What one terminator write did as it travelled the interpose chain — the
+/// three answers C's `setInputEos`/`setOutputEos` can give, which a `bool`
+/// could not carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EosSet {
+    /// No layer stored it, so the call falls through to the driver's own
+    /// method — C's `setInputEosFail`/`setOutputEosFail` on a port that has
+    /// none (asynOctetBase.c:115-118, :401-415).
+    NotTaken,
+    /// A layer validated the length and stored the terminator.
+    Stored,
+    /// A layer owns the terminator but C refuses this length: the `switch
+    /// (eoslen)` in `setInputEos`/`setOutputEos` answers `"<port> illegal
+    /// eoslen <n>"` *before* assigning anything (asynInterposeEos.c:299-310,
+    /// :352-362), so no layer state moved.
+    IllegalLength,
+}
+
+impl EosSet {
+    /// Fold one layer's answer into the chain's. A refusal outranks a store,
+    /// and a store outranks the fall-through — the chain reports the strongest
+    /// thing that happened to the value, and the strongest is the one C would
+    /// have returned from the first layer that owns the terminator.
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::IllegalLength, _) | (_, Self::IllegalLength) => Self::IllegalLength,
+            (Self::Stored, _) | (_, Self::Stored) => Self::Stored,
+            _ => Self::NotTaken,
+        }
+    }
+}
+
 /// Interpose layer for octet (byte-stream) I/O.
 ///
 /// Each layer receives the `next` handle to delegate to the layer below.
@@ -116,23 +152,22 @@ pub trait OctetInterpose: Send + Sync {
     /// (asynInterposeEos.c:288); this is the Rust equivalent so a runtime IEOS
     /// change reaches the installed EOS interpose on the right device.
     ///
-    /// Returns whether **this layer** took the terminator. C's interpose does
-    /// not answer with a flag — it either stores the value and returns
-    /// `asynSuccess`, or delegates *downwards* to the next `setInputEos`
-    /// (:293-295) and ultimately to the driver's, which `initOverride` has
-    /// replaced with `setInputEosFail` when the driver has none
-    /// (asynOctetBase.c:115, :401-403). The bool is that delegation made
-    /// explicit, so [`crate::port::PortDriver::set_input_eos`]'s default can
-    /// be the Fail stub without having to guess whether a layer above it
-    /// answered first.
-    fn set_input_eos(&mut self, _addr: i32, _eos: &[u8]) -> bool {
-        false
+    /// Returns what **this layer** did with the terminator. C's interpose does
+    /// not answer with a flag — it either validates the length and stores the
+    /// value, or delegates *downwards* to the next `setInputEos` (:293-295)
+    /// and ultimately to the driver's, which `initOverride` has replaced with
+    /// `setInputEosFail` when the driver has none (asynOctetBase.c:115,
+    /// :401-403). [`EosSet`] is that fall-through made explicit, so
+    /// [`crate::port::PortDriver::set_input_eos`]'s default can be the Fail
+    /// stub without having to guess whether a layer above it answered first.
+    fn set_input_eos(&mut self, _addr: i32, _eos: &[u8]) -> EosSet {
+        EosSet::NotTaken
     }
 
     /// Notify the layer of an output end-of-string change (see
     /// [`Self::set_input_eos`]). Default: not taken.
-    fn set_output_eos(&mut self, _addr: i32, _eos: &[u8]) -> bool {
-        false
+    fn set_output_eos(&mut self, _addr: i32, _eos: &[u8]) -> EosSet {
+        EosSet::NotTaken
     }
 
     /// Drop every piece of state scoped to the *current* link, because the
@@ -228,8 +263,9 @@ impl OctetInterposeStack {
     }
 
     /// Total number of interpose layers on the port, across every device's chain
-    /// — what `asynReport` counts (asynManager.c:993-1005 walks each `dpCommon`'s
-    /// list).
+    /// — what `reportPrintInterfaceList` (asynManager.c:993-1005) prints, once
+    /// for the port's own `dpCommon` (:1077) and again for each device's
+    /// (:1105), under the `asynReport` iocsh command.
     pub fn len(&self) -> usize {
         self.chains.values().map(Vec::len).sum()
     }
@@ -250,27 +286,28 @@ impl OctetInterposeStack {
     /// default). C routes `setInputEos` through the `asynOctet` interface
     /// `findInterface` returned for that `asynUser`, so it reaches exactly the
     /// layers that will serve the device's reads.
-    /// Returns whether any layer took it — C's chain either terminates in a
-    /// layer that stores the value or falls through to the driver's method.
-    pub fn set_input_eos(&mut self, addr: i32, eos: &[u8]) -> bool {
-        let mut taken = false;
+    /// Returns what the chain did with it — C's chain either terminates in a
+    /// layer that stores the value, refuses the length, or falls through to
+    /// the driver's method.
+    pub fn set_input_eos(&mut self, addr: i32, eos: &[u8]) -> EosSet {
+        let mut answer = EosSet::NotTaken;
         if let Some(chain) = self.chain_mut(addr) {
             for layer in chain {
-                taken |= layer.set_input_eos(addr, eos);
+                answer = answer.merge(layer.set_input_eos(addr, eos));
             }
         }
-        taken
+        answer
     }
 
     /// Forward an output EOS change (see [`Self::set_input_eos`]).
-    pub fn set_output_eos(&mut self, addr: i32, eos: &[u8]) -> bool {
-        let mut taken = false;
+    pub fn set_output_eos(&mut self, addr: i32, eos: &[u8]) -> EosSet {
+        let mut answer = EosSet::NotTaken;
         if let Some(chain) = self.chain_mut(addr) {
             for layer in chain {
-                taken |= layer.set_output_eos(addr, eos);
+                answer = answer.merge(layer.set_output_eos(addr, eos));
             }
         }
-        taken
+        answer
     }
 
     /// Tell every layer, on every device's chain, that the port's connection

--- a/crates/asyn-rs/src/interrupt.rs
+++ b/crates/asyn-rs/src/interrupt.rs
@@ -81,7 +81,7 @@ impl InterruptFilter {
     ///
     /// C's octet interrupt list is not keyed by `reason` **at all**:
     /// `asynOctetBase::callInterruptUsers` tests `if (addr == pinterrupt->addr)`
-    /// and consults `reason` nowhere (asynOctetBase.c:203-215). The only thing
+    /// and consults `reason` nowhere (asynOctetBase.c:202-210). The only thing
     /// that varies between C's two octet fan-outs is whether the addr test runs
     /// — see [`OctetFanOut`]. So this gate is the addr rule plus the
     /// per-interface routing every path shares; the `reason` and
@@ -133,7 +133,7 @@ impl InterruptFilter {
 /// C has exactly two octet fan-out rules, and they are different on purpose:
 ///
 /// - [`ByAddr`](Self::ByAddr) — `asynOctetBase::callInterruptUsers`
-///   (asynOctetBase.c:203-215): deliver to every registered octet user whose
+///   (asynOctetBase.c:202-210): deliver to every registered octet user whose
 ///   `addr` equals the read's. This is the rule for a device read.
 /// - [`EveryUser`](Self::EveryUser) — `drvAsynIPServerPort`'s listener thread
 ///   (drvAsynIPServerPort.c:374-383 for a new connection, :312-320 for a UDP
@@ -1063,7 +1063,7 @@ mod tests {
     }
 
     /// The two octet fan-out rules, at their boundaries. C's octet interrupt
-    /// list is keyed by `addr` alone (asynOctetBase.c:203-215) — `reason` is
+    /// list is keyed by `addr` alone (asynOctetBase.c:202-210) — `reason` is
     /// never consulted — and the IP-server listener applies no key at all
     /// (drvAsynIPServerPort.c:374-383).
     ///

--- a/crates/asyn-rs/src/iocsh.rs
+++ b/crates/asyn-rs/src/iocsh.rs
@@ -1,10 +1,13 @@
 //! Asyn iocsh shell-command registration.
 //!
-//! C parity: `asynShellCommands.c:581-906` registers six shell commands
-//! (`asynReport`, `asynSetOption`, `asynSetTraceMask`, `asynSetTraceIOMask`,
-//! `asynSetTraceInfoMask`, `asynSetTraceFile`) plus the
-//! `asynSetTraceIOTruncateSize` setter. This module exposes the same
-//! surface via [`register_asyn_commands`], which takes an
+//! C parity: `asynRegister` (asynShellCommands.c:1347-1379) registers 27
+//! shell commands — the report/option/trace setters (`asynReport`,
+//! `asynSetOption`, `asynShowOption`, the five `asynSetTrace*`), the ten
+//! octet I/O and EOS commands, `asynEnable`/`asynAutoConnect`/
+//! `asynWaitConnect`/`asynSetAutoConnectTimeout`, the timestamp-source pair
+//! and the timer/queue-lock/shutdown setters. This
+//! module exposes the same surface via [`register_asyn_commands`], which
+//! takes an
 //! `IocApplication` (the public registration carrier on the
 //! `epics-base-rs` side) along with the `PortManager` whose
 //! `TraceManager` is the back-end for the trace mutators.
@@ -183,13 +186,13 @@ const SHOW_EOS_BUF_SIZE: usize = 4 * 10 + 2;
 
 /// The I/O deadline every asyn *shell* command puts on the `asynUser` it
 /// builds: C sets `pasynUser->timeout = 2` in `asynSetOption`
-/// (asynShellCommands.c:119), `asynSetEos` (:239) and `asynShowEos` (:288),
+/// (asynShellCommands.c:119), `asynSetEos` (:238) and `asynShowEos` (:289),
 /// rather than leaving the default. One constant so the shell commands cannot
 /// drift apart again.
 const SHELL_IO_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// The `asynUser` C's `asynSetEos` / `asynShowEos` build
-/// (asynShellCommands.c:239-241, :288-290).
+/// (asynShellCommands.c:238-240, :289-291).
 ///
 /// Three fields matter and all come from C: the device the command names —
 /// `findInterface(portName, addr, ...)` `connectDevice`s the user to it
@@ -631,12 +634,12 @@ pub fn build_asyn_commands(mgr: Arc<PortManager>) -> Vec<CommandDef> {
 
     // asynInterposeDelay portName addr delay(sec) --------------------------
     //
-    // C `asynInterposeDelay.c:221-234` registers this 3-arg command; nothing
+    // C `asynInterposeDelay.c:215-237` registers this 3-arg command; nothing
     // else installs the layer (no driver configure command pushes it), so
     // without the registrar a startup script cannot reach a device that needs
     // an inter-character write delay at all. C prints
     // "%s interposeInterface asynOctetType failed." and returns -1 when the
-    // interposeInterface call fails (:186-190).
+    // interposeInterface call fails (:189-192).
     //
     // As with `asynInterposeEcho`, the `addr` names the device the layer lands on
     // (:187,200) — `asynInterposeDelay("gpib",4,0.01)` slows device 4 and leaves
@@ -1698,7 +1701,7 @@ pub fn drv_asyn_prologix_port_configure_command(services: PortServices) -> Comma
 /// already taken. Both have already printed the diagnostic and torn down
 /// whatever was half-built, so the caller has nothing to clean up and only has
 /// to stop — C's `drvAsynIPPortConfigure: Can't register myself.` / `ttyCleanup`
-/// / `return -1` (drvAsynIPPort.c:1062-1069).
+/// / `return -1` (drvAsynIPPort.c:1033-1035).
 ///
 /// `Some` hands back the runtime handle for the callers that need it (the
 /// server port binds its listening socket through it). Callers that do not may
@@ -2438,18 +2441,21 @@ mod tests {
         handle
             .set_input_eos_blocking(shell_eos_user(0), b"\n")
             .unwrap();
-        // processOut = 0: C's interpose does NOT take the output terminator —
-        // it delegates down to `poctet->setOutputEos` (asynInterposeEos.c:341-344),
-        // and this driver has none, so `setOutputEosFail` answers
-        // "<port> setOutputEos not implemented" (asynOctetBase.c:117, :409-411).
-        // The write below therefore appends nothing for two reasons at once,
-        // and the refusal is the one C reports.
-        let refused = handle
+        // processOut = 0 gates C's `writeIt` alone (asynInterposeEos.c:161-163):
+        // `setOutputEos` (:344-363) and `getOutputEos` (:365-390) carry no
+        // `processEosOut` test at all, so the terminator is stored, answered
+        // asynSuccess and read back — it is simply never appended. A startup
+        // script that sets OEOS and reads it back therefore succeeds, which is
+        // what refusing it broke.
+        handle
             .set_output_eos_blocking(shell_eos_user(0), b"\n")
-            .expect_err("processOut=0 delegates to a driver with no setOutputEos");
-        assert!(
-            refused.to_string().contains("setOutputEos not implemented"),
-            "got {refused}"
+            .expect("processOut=0 still stores the output terminator");
+        assert_eq!(
+            handle
+                .get_output_eos_blocking(shell_eos_user(0))
+                .expect("readback"),
+            b"\n".to_vec(),
+            "C's getOutputEos reads eosOut back whatever processEosOut says"
         );
 
         // processIn = 1: the read stops at the terminator and strips it.
@@ -2646,8 +2652,8 @@ mod tests {
 
     /// The EOS shell commands hand their `asynUser` C's 2 s I/O deadline.
     ///
-    /// C `asynSetEos` sets `pasynUser->timeout = 2` (asynShellCommands.c:239)
-    /// before queueing the `setEos` callback, and `asynShowEos` (:288) and
+    /// C `asynSetEos` sets `pasynUser->timeout = 2` (asynShellCommands.c:238)
+    /// before queueing the `setEos` callback, and `asynShowEos` (:289) and
     /// `asynSetOption` (:119) do the same — the shell never leaves this field at
     /// the default. Rust's EOS handler built its user with the 1 s default while
     /// its `asynSetOption` sibling already set 2 s; [`SHELL_IO_TIMEOUT`] is now
@@ -2658,7 +2664,7 @@ mod tests {
         assert_eq!(
             user.timeout,
             Some(Duration::from_secs(2)),
-            "C asynSetEos sets pasynUser->timeout = 2 (asynShellCommands.c:239)"
+            "C asynSetEos sets pasynUser->timeout = 2 (asynShellCommands.c:238)"
         );
         // The other half C sets on the same user, kept under the same test so a
         // future edit cannot drop the waiver while preserving the timeout.
@@ -3043,7 +3049,7 @@ mod tests {
     }
 
     /// R8-58: C registers `asynInterposeDelay` with iocsh
-    /// (`asynInterposeDelay.c:221-234`); like the echo layer nothing else
+    /// (`asynInterposeDelay.c:215-237`); like the echo layer nothing else
     /// installs it, so without the registrar the ported `DelayInterpose` is
     /// unreachable from a startup script. Drive the command against a
     /// registered port and prove the port's octet write goes from one 3-byte

--- a/crates/asyn-rs/src/lib.rs
+++ b/crates/asyn-rs/src/lib.rs
@@ -18,8 +18,28 @@
 //! | `epics-base` | `R7.0.10` |
 //! | `modbus` | `R3-4-10-gb1009d0` |
 //! | `motor` | `R7-4-5-g78b474cd` |
+//! | `motor/modules/motorSmarAct` | `843a49d880bcfb0e9a41d4386ae27d2fff12d132` |
+//! | `motor/modules/motorNewport` | `e6416024432ae0384da6e376438f658278a8d036` |
 //! | `ADCore` | `R3-14-111-g6c53844e` |
 //! | `busy` | `R1-7-4-6-g2dfe92d` |
+//!
+//! **A submodule needs its own row; it does not inherit the parent's.**
+//! `motorSmarAct` and `motorNewport` are gitlinks under `motor`, so
+//! `R7-4-5-g78b474cd` says nothing about which revision of
+//! `smarActMCSMotorDriver.cpp` a citation resolves at — the vendor drivers
+//! move on their own release cadence between two `motor` tags. Read a
+//! submodule's pin from the parent's gitlink
+//! (`git ls-tree <motor pin> modules/<name>`), never from the submodule
+//! checkout's `HEAD`, which is free to run ahead exactly as the top-level
+//! trees do. A tree cited here with no row of its own is unanchored, whether
+//! or not something above it in the filesystem has one.
+//!
+//! Those two rows carry a bare SHA where every other row carries a `git
+//! describe` string, because for a gitlink the describe string is not an
+//! anchor: `git submodule status` renders the superproject's view
+//! (`R2-1-19-g843a49d`, `R1-2-1-54-ge641602`) while the submodule's own
+//! `git describe` answers `R2-1-2` and `R1-3`. Neither string resolves
+//! inside the tree the citation is read against, so the SHA is the pin.
 //!
 //! **Resolve by symbol at the pin; the line is a hint.** Find the named
 //! function, struct, macro or field first, and treat the line number as a hint

--- a/crates/asyn-rs/src/manager.rs
+++ b/crates/asyn-rs/src/manager.rs
@@ -451,7 +451,7 @@ mod tests {
         drv.base.create_param("VAL", ParamType::Int32).unwrap();
         // A port that accepts an EOS is one C configured with `processEosIn/
         // Out`, so `asynOctetBase::initialize` installed `asynInterposeEos`
-        // above the driver (asynOctetBase.c:169-171). A driver with no EOS
+        // above the driver (asynOctetBase.c:170-172). A driver with no EOS
         // methods and no such layer answers "not implemented" (R18-71).
         drv.base
             .install_octet_interpose(Box::new(crate::interpose::eos::EosInterpose::default()));

--- a/crates/asyn-rs/src/param.rs
+++ b/crates/asyn-rs/src/param.rs
@@ -507,7 +507,7 @@ impl ParamList {
     /// Strict variant — returns [`AsynError::ParamUndefined`] when the
     /// entry has never been set. C parity:
     /// `paramVal::getDouble` (`paramVal.cpp:259-266`) +
-    /// `paramList::getDouble` (`asynPortDriver.cpp:383-401`).
+    /// `paramList::getDouble` (`asynPortDriver.cpp:383-403`).
     pub fn get_float64_strict(&self, index: usize, addr: i32) -> AsynResult<f64> {
         let entry = self.get_entry(index, addr)?;
         let value = entry.value.as_float64()?;
@@ -1204,7 +1204,7 @@ impl ParamList {
     /// C has one `paramList` per address and reports the one it was handed; here
     /// one list holds every address, so the address is the argument. It takes no
     /// detail level because C's does not use it: `paramVal::report` prints the
-    /// same line whatever `details` says (paramVal.cpp:296-330), and the only
+    /// same line whatever `details` says (paramVal.cpp:296-372), and the only
     /// thing the level decides is *how many* lists are printed — which is
     /// [`crate::port::PortDriverBase::report_params`]'s decision, and stays there.
     pub fn report(&self, out: &mut dyn std::fmt::Write, addr: i32) {

--- a/crates/asyn-rs/src/port.rs
+++ b/crates/asyn-rs/src/port.rs
@@ -92,7 +92,7 @@ use crate::error::{AsynError, AsynResult, AsynStatus};
 use crate::exception::{AsynException, ExceptionEvent, ExceptionManager};
 use crate::interfaces::InterfaceType;
 use crate::interpose::{
-    EomReason, OctetInterpose, OctetInterposeStack, OctetNext, OctetReadResult,
+    EomReason, EosSet, OctetInterpose, OctetInterposeStack, OctetNext, OctetReadResult,
 };
 use crate::interrupt::{InterruptManager, InterruptValue, OctetFanOut};
 use crate::param::{EnumEntry, InterruptReason, ParamList, ParamType, ParamValue};
@@ -254,8 +254,8 @@ pub struct PortDriverBase {
     /// `pasynOctetBase->initialize` (asynOctetBase.c:161-169). When set, every
     /// successful octet read fans the data out to the port's octet interrupt
     /// users (`readIt` → `callInterruptUsers`, :224-238). The stream drivers set
-    /// it — drvAsynIPPort.c:1055, drvAsynSerialPort.c:1125,
-    /// drvAsynSerialPortWin32.c:798, drvAsynFTDIPort.cpp:616 — and it is what
+    /// it — drvAsynIPPort.c:1055, drvAsynSerialPort.c:1125-1126,
+    /// drvAsynSerialPortWin32.c:798-799, drvAsynFTDIPort.cpp:616 — and it is what
     /// makes a `stringin`/`waveform` with `SCAN="I/O Intr"` on such a port
     /// process at all. Parameter-cache ports (echoDriver, USBTMC, GPIB,
     /// IP-server) pass 0 and are unaffected.
@@ -445,8 +445,10 @@ impl PortDriverBase {
         self.announcer.count()
     }
 
-    /// How many callbacks are registered on this port's exception list — C
-    /// `asynReport`'s `exceptionUsers` count (asynManager.c:1068-1070).
+    /// How many callbacks are registered on this port's exception list — the
+    /// `exceptionUsers` count `reportPrintPort` prints (asynManager.c:1068-1072).
+    /// `asynReport` itself is the iocsh command (asynShellCommands.c:587); it
+    /// reaches this through `asynManager`'s own `report` (:1136).
     pub fn exception_callback_count(&self) -> usize {
         self.announcer
             .sink
@@ -728,11 +730,16 @@ impl PortDriverBase {
     /// (the port is not yet registered, so no listeners exist).
     pub fn set_auto_connect(&mut self, yes: bool) {
         self.auto_connect = yes;
-        // asyn PR #217 (asynManager.c:2322-2324): flipping auto-connect ON
-        // while the port is down starts the connect timer, so the flip
-        // alone brings the port up. Pre-fix, the only autonomous attempt
-        // was the one exception-wake pass — one try, then silence until
-        // traffic or a disconnect edge armed the timer.
+        // A DEVIATION from the pinned C, adopting asyn PR #217
+        // (`87918f5e06b7`, "Queue connect timer on autoconnect enable"):
+        // flipping auto-connect ON while the port is down starts the connect
+        // timer, so the flip alone brings the port up. That PR is UNMERGED —
+        // it is on no upstream branch, so `autoConnectAsyn` at the pin
+        // (asynManager.c:2310-2324) sets `autoConnect` and announces, and
+        // nothing else; its `:2322-2324` are `exceptionOccurred` and the
+        // return. Stock asyn's only autonomous attempt is the one
+        // exception-wake pass — one try, then silence until traffic or a
+        // disconnect edge arms the timer (:2181-2182).
         if yes && !self.connected.get() {
             self.connect_retry_at = Some(Instant::now() + CONNECT_RETRY_INITIAL);
         }
@@ -749,9 +756,9 @@ impl PortDriverBase {
             dev.auto_connect = yes;
             !dev.connected
         };
-        // Same PR #217 arm as `set_auto_connect`: C keys the check on the
-        // dpCommon `findDpCommon` resolved — the DEVICE's — while the
-        // timer it starts is the port's (asynManager.c:2322-2324).
+        // Same PR #217 deviation as `set_auto_connect`, and the PR keys its
+        // check on the dpCommon `findDpCommon` resolved — the DEVICE's —
+        // while the timer it starts is the port's.
         if yes && device_down {
             self.connect_retry_at = Some(Instant::now() + CONNECT_RETRY_INITIAL);
         }
@@ -784,7 +791,7 @@ impl PortDriverBase {
     /// [`Self::check_enabled`]: C's `if(!pport->dpc.enabled) return asynDisabled`
     /// (:1541-1546) sits *above* `checkPortConnect` and is reached by every
     /// request, and its port thread refuses to run anything at all on a disabled
-    /// port (`portThread`, :802-805).
+    /// port (`portThread`, :806-809).
     ///
     /// The `ConnectCheck` can only come from [`AsynUser::connect_check`], so the
     /// waiver is available exactly to the requests C gives it to.
@@ -794,7 +801,7 @@ impl PortDriverBase {
     /// runs and nothing it implies happened. A caller must be able to tell that
     /// from a driver error raised *inside* a callback that did run — the record
     /// writes the refusal to ERRS and stops, where a driver error still gets the
-    /// callback's readback and `monitorStatus` tail (asynRecord.c:571-576 vs
+    /// callback's readback and `monitorStatus` tail (asynRecord.c:571-578 vs
     /// :788-900). This is the only place that stamps it.
     pub fn check_queue(&self, addr: i32, connect: ConnectCheck) -> AsynResult<()> {
         self.check_queue_inner(addr, connect)
@@ -1209,11 +1216,11 @@ impl PortDriverBase {
     /// parameter block of the driver's report.
     ///
     /// `details` is the level `report` was called with, **unshifted**: C hands
-    /// `reportParams` the same number it got (:3692), and the level decides one
+    /// `reportParams` the same number it got (:3693), and the level decides one
     /// thing only — how many address lists are printed (`details >= 2` → all
     /// `maxAddr` of them, else list 0 alone, :1804). The values are *not* a
     /// deeper level: `paramVal::report` prints name, type, value and status for
-    /// every parameter at every level (paramVal.cpp:296-330).
+    /// every parameter at every level (paramVal.cpp:296-372).
     ///
     /// Passing `level - 1` here put the whole block one level late — `asynReport
     /// 1` printed a bare count where C prints every parameter with its value, and
@@ -1364,8 +1371,8 @@ impl PortDriverBase {
     /// simultaneously), that collapse delivers a wrong-typed value to all but one
     /// of them. C's `drvModbusAsyn::readPoller` instead decodes the one register
     /// block **separately per interface** and invokes each interface's own
-    /// interrupt list (`int32`/`uInt32Digital`/`float64`,
-    /// drvModbusAsyn.cpp:1706/1736/1808). This is the analogue: the driver
+    /// interrupt list — `interruptStart` on `uInt32Digital`/`int32`/`float64`
+    /// at drvModbusAsyn.cpp:1674/1716/1788. This is the analogue: the driver
     /// decodes per interface and fires each value tagged with its `iface`, so the
     /// interrupt filter routes it only to records on that interface
     /// ([`InterruptFilter::iface`](crate::interrupt::InterruptFilter::iface)). `uint32_changed_mask` is the changed-bit
@@ -1375,7 +1382,7 @@ impl PortDriverBase {
     ///
     /// `aux_status` is the device I/O status this fire carries (C
     /// `pInterrupt->pasynUser->auxStatus`, set on every callback the poller
-    /// emits — `drvModbusAsyn.cpp:1697/1738/1774/1810/1880/1915`). A driver whose
+    /// emits — `drvModbusAsyn.cpp:1699/1738/1774/1810/1845/1880/1916`). A driver whose
     /// last acquisition failed still fires its interrupt lists, with the failing
     /// status, so I/O-Intr records go to READ/INVALID instead of freezing on the
     /// last good value; pass [`AsynStatus::Success`] on a clean acquisition.
@@ -1547,6 +1554,15 @@ fn eos_not_implemented(port: &str, method: &str) -> AsynError {
     }
 }
 
+/// C's `switch (eoslen)` refusal, verbatim: `"%s illegal eoslen %d"` with the
+/// port name and the length (asynInterposeEos.c:301-302, :354-355).
+fn illegal_eoslen(port: &str, eoslen: usize) -> AsynError {
+    AsynError::Status {
+        status: AsynStatus::Error,
+        message: format!("{port} illegal eoslen {eoslen}"),
+    }
+}
+
 pub trait PortDriver: Send + Sync + 'static {
     fn base(&self) -> &PortDriverBase;
     fn base_mut(&mut self) -> &mut PortDriverBase;
@@ -1668,7 +1684,7 @@ pub trait PortDriver: Send + Sync + 'static {
                     crate::escape::print_escaped(output)
                 );
             }
-            // C hands its own level straight to `reportParams` (:3692).
+            // C hands its own level straight to `reportParams` (:3693).
             base.report_params(out, level);
         }
         // There is no options block: `asynPortDriver::report` never prints one
@@ -2034,25 +2050,26 @@ pub trait PortDriver: Send + Sync + 'static {
     // ## EOS connect-wait policy (C asyn issue #103)
     //
     // C asyn `asynOctetSyncIO::setInputEos` / `setOutputEos`
-    // (`asynOctetSyncIO.c:300-321`, 346-367) call `lockPort` ahead of
-    // the actual `setInputEos` — `lockPort` waits up to the user's
-    // timeout for the port to be connected, by `epicsEventWait`-ing
-    // on the connect event published from `connectIt`. On IOC init
-    // and exit this serialises EOS configuration against the connect
-    // task, but it also means a `setInputEos` issued before the port
-    // has ever connected blocks the calling thread (issue #103
-    // captured the symptom: IOC startup pauses for the full asyn
-    // timeout when the device is off-line).
+    // (`asynOctetSyncIO.c:300-321`, `:346-367`) bracket the driver call in
+    // `lockPort`/`unlockPort`. `lockPort` is a plain mutex take —
+    // `defunct` check, then `synchronousLock` (asynManager.c:1789-1798) —
+    // and waits for no connection, so an EOS set blocks only behind
+    // whoever else holds the port. The connect wait lives elsewhere:
+    // `registerPort` calls `waitConnect(pport->pconnectUser,
+    // pasynBase->autoConnectTimeout)` on an autoConnect port
+    // (asynManager.c:2135), and `waitConnect` `epicsEventWaitWithTimeout`s
+    // on a connect event signalled from an exception handler (:3292-3336).
+    // That is what issue #103 sees: IOC startup pausing for the whole
+    // autoConnect timeout when the device is off-line.
     //
     // The Rust path here is purely in-memory: `set_input_eos` and
     // `set_output_eos` write the bytes into `PortDriverBase` and the
     // EOS interpose stack reads from those fields at next read/write
-    // time. No connect-wait, no lock contention with the connect
-    // task — so issue #103's symptom cannot reproduce. If a future
-    // refactor introduces a connect-gated EOS path (e.g. a driver
-    // that owns the EOS state inside its connect()-allocated
-    // resource), authors MUST keep the wait optional / bounded so
-    // the connect-wait failure mode doesn't return.
+    // time. No port lock, no connect-wait — so neither stall can reach an
+    // EOS call here. If a future refactor introduces a connect-gated EOS
+    // path (e.g. a driver that owns the EOS state inside its
+    // connect()-allocated resource), authors MUST keep the wait optional /
+    // bounded so the connect-wait failure mode doesn't return.
 
     // Every hook takes the `asynUser`, because in C every one of them does
     // (`asynOctet::setInputEos(void *ppvt, asynUser *pasynUser, ...)`,
@@ -2081,18 +2098,15 @@ pub trait PortDriver: Send + Sync + 'static {
         let addr = user.addr;
         let port = self.base().port_name.clone();
         let base = self.base_mut();
-        if !base.interpose_octet.set_input_eos(addr, eos) {
-            return Err(eos_not_implemented(&port, "setInputEos"));
-        }
         // The length rule belongs to the layer that stores the terminator
-        // (asynInterposeEos.c:299-303), so it is applied only once a layer
-        // has taken it — a port with no EOS support answers "not implemented"
-        // for every length, exactly as its Fail stub does.
-        if eos.len() > 2 {
-            return Err(AsynError::Status {
-                status: AsynStatus::Error,
-                message: format!("{port} illegal eoslen {}", eos.len()),
-            });
+        // (asynInterposeEos.c:299-303), so a port with no EOS support answers
+        // "not implemented" for every length, exactly as its Fail stub does,
+        // and a layer that owns the terminator refuses an illegal one without
+        // storing it.
+        match base.interpose_octet.set_input_eos(addr, eos) {
+            EosSet::NotTaken => return Err(eos_not_implemented(&port, "setInputEos")),
+            EosSet::IllegalLength => return Err(illegal_eoslen(&port, eos.len())),
+            EosSet::Stored => {}
         }
         base.eos_entry(addr).input = eos.to_vec();
         Ok(())
@@ -2111,14 +2125,10 @@ pub trait PortDriver: Send + Sync + 'static {
         let addr = user.addr;
         let port = self.base().port_name.clone();
         let base = self.base_mut();
-        if !base.interpose_octet.set_output_eos(addr, eos) {
-            return Err(eos_not_implemented(&port, "setOutputEos"));
-        }
-        if eos.len() > 2 {
-            return Err(AsynError::Status {
-                status: AsynStatus::Error,
-                message: format!("{port} illegal eoslen {}", eos.len()),
-            });
+        match base.interpose_octet.set_output_eos(addr, eos) {
+            EosSet::NotTaken => return Err(eos_not_implemented(&port, "setOutputEos")),
+            EosSet::IllegalLength => return Err(illegal_eoslen(&port, eos.len())),
+            EosSet::Stored => {}
         }
         base.eos_entry(addr).output = eos.to_vec();
         Ok(())
@@ -2269,7 +2279,7 @@ impl OctetNext for DriverOctetLink<'_> {
         if self.driver.base().octet_interrupt_process {
             let raw = &buf[..nbytes_transferred];
             // C's rule for a device read: `addr` decides, `reason` is never
-            // consulted (asynOctetBase.c:203-215). `reason` still rides on the
+            // consulted (asynOctetBase.c:202-210). `reason` still rides on the
             // value — C leaves `pasynUser->reason` on the callback's user — but
             // it selects nobody.
             self.driver.base().interrupts.notify_octet(
@@ -3137,7 +3147,7 @@ mod tests {
         let mut drv = TestDriver::new();
         // A single-device port takes its EOS from `asynInterposeEos`, which C
         // installs above the driver when the port is configured with
-        // `processEosIn/Out` (asynOctetBase.c:169-171); without it the
+        // `processEosIn/Out` (asynOctetBase.c:170-172); without it the
         // driver's own NULL method answers "not implemented" (R18-71).
         drv.base
             .install_octet_interpose(Box::new(crate::interpose::eos::EosInterpose::default()));
@@ -3153,9 +3163,12 @@ mod tests {
     /// `"<port> <method> not implemented"`. A `noProcessEos` port therefore
     /// *refuses* a terminator; it does not accept one and then never
     /// terminate. The two boundaries are the whole rule: no layer at all, and
-    /// a layer that takes only one direction (C installs `asynInterposeEos`
-    /// per flag, :169-171, and the interpose delegates the other direction
-    /// down, asynInterposeEos.c:293-295, :341-344).
+    /// a layer that takes only one direction (`asynInterposeEosConfig` stores
+    /// both flags, asynInterposeEos.c:128-138). C delegates only the *input*
+    /// direction down when `processEosIn == 0` — setInputEos :293-295,
+    /// getInputEos :318-320; its output pair (:344-363, :365-390) has no
+    /// `processEosOut` test and stores unconditionally, that flag gating
+    /// `writeIt` alone (:161-163).
     #[test]
     fn a_port_with_no_eos_layer_refuses_a_terminator() {
         use crate::interpose::eos::{EosConfig, EosInterpose};
@@ -3185,8 +3198,10 @@ mod tests {
         assert!(bare.get_input_eos(&AsynUser::default()).is_empty());
         assert!(bare.get_output_eos(&AsynUser::default()).is_empty());
 
-        // Boundary 2: the layer takes input only. IEOS lands, OEOS is refused
-        // by the same Fail-stub message, because nothing below took it.
+        // Boundary 2: the layer takes input only — and OEOS still lands.
+        // C's `setOutputEos` (:344-363) has no `processEosOut` test; the flag
+        // gates `writeIt` alone (:161-163), so the terminator is stored, read
+        // back, and simply never appended.
         let mut half = TestDriver::new();
         half.base_mut()
             .install_octet_interpose(Box::new(EosInterpose::with_processing(
@@ -3196,14 +3211,34 @@ mod tests {
             )));
         half.set_input_eos(&AsynUser::default(), b"\n").unwrap();
         assert_eq!(half.get_input_eos(&AsynUser::default()), b"\n");
+        half.set_output_eos(&AsynUser::default(), b"\r\n")
+            .expect("processOut = 0 still stores OEOS");
+        assert_eq!(half.get_output_eos(&AsynUser::default()), b"\r\n");
+
+        // Boundary 3: a length the storing layer refuses. C's `switch
+        // (eoslen)` answers `"<port> illegal eoslen <n>"` *before* assigning
+        // (:299-310, :352-362), so the terminator already stored still stands.
         let err = half
-            .set_output_eos(&AsynUser::default(), b"\r\n")
-            .expect_err("processOut = 0 must refuse OEOS");
+            .set_output_eos(&AsynUser::default(), b"\r\n\0")
+            .expect_err("eoslen 3 is past eosOut[2]");
+        assert!(err.to_string().contains("test illegal eoslen 3"), "{err}");
+        assert_eq!(half.get_output_eos(&AsynUser::default()), b"\r\n");
+        let err = half
+            .set_input_eos(&AsynUser::default(), b"abc")
+            .expect_err("eoslen 3 is past eosIn[2]");
+        assert!(err.to_string().contains("test illegal eoslen 3"), "{err}");
+        assert_eq!(half.get_input_eos(&AsynUser::default()), b"\n");
+
+        // Boundary 4: no layer at all refuses every length with the Fail
+        // stub's words, not the length rule's — the rule belongs to the layer
+        // that stores, and there is none.
+        let err = bare
+            .set_output_eos(&AsynUser::default(), b"\r\n\0")
+            .expect_err("a noProcessEos port refuses whatever the length");
         assert!(
             err.to_string().contains("setOutputEos not implemented"),
             "{err}"
         );
-        assert!(half.get_output_eos(&AsynUser::default()).is_empty());
     }
 
     /// R6-46 owner path: `set_connected` is the single transition owner, so
@@ -3990,7 +4025,7 @@ mod tests {
     /// unchanged (asynPortDriver.cpp:3693); `reportParams` prints list 0 at any
     /// level and all `maxAddr` lists at `details >= 2` (:1804); and
     /// `paramVal::report` prints name, type, value and status for every parameter
-    /// at every level (paramVal.cpp:296-330). Passing `level - 1` made
+    /// at every level (paramVal.cpp:296-372). Passing `level - 1` made
     /// `asynReport 1` print a bare count, and values appear only at 3.
     ///
     /// One case per threshold boundary: details 0 (no block), 1 (list 0, with
@@ -4090,7 +4125,7 @@ mod tests {
     ///
     /// C prints the EOS pair with `epicsStrPrintEscaped` (asynPortDriver.cpp:3687,
     /// 3690), whose table is `\a \b \f \n \r \t \v \\ \' \"`, the byte itself
-    /// when `isprint`, and `\xNN` otherwise (epicsString.c:230-262). The report's
+    /// when `isprint`, and `\xNN` otherwise (epicsString.c:230-269). The report's
     /// own two-case table wrote a binary terminator raw into stdout.
     #[test]
     fn report_escapes_the_eos_with_the_c_table() {

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -112,7 +112,7 @@ impl ActorMessage {
         // C derives the queue band from the KIND of request, never from a
         // field a caller has to remember to set: `asynRecord` picks
         // `asynQueuePriorityConnect` from `pmsg->callbackType ==
-        // callbackConnect` (asynRecord.c:562-566), and `asynCommonSyncIO`'s
+        // callbackConnect` (asynRecord.c:561-565), and `asynCommonSyncIO`'s
         // connect/disconnect pass the constant literally
         // (asynCommonSyncIO.c:142, :154). `CDispatch::ConnectQueue` is that
         // kind, and it already fixes the connected waiver
@@ -217,7 +217,7 @@ enum CDispatch {
     /// no queue for the block holder to divert it into. These are `pasynManager`'s
     /// own entry points, which take `asynManagerLock`, act and return: `enable`
     /// (asynManager.c:2222-2249), `autoConnectAsyn` (:2310-2324),
-    /// `isConnected`/`isEnabled`/`isAutoConnect` (:2326-2354),
+    /// `isConnected`/`isEnabled`/`isAutoConnect` (:2326-2368),
     /// `blockProcessCallback` (:1692-1723), `shutdownPort`, `interposeInterface`.
     ///
     /// The gate must not run on them: a port disabled with `asynEnable(port,0)`
@@ -291,7 +291,7 @@ impl BlockHolders {
     }
 
     /// C's eligibility test, verbatim: **both** holders must be NULL or this
-    /// user (asynManager.c:889-892). One holder alone is never enough to admit
+    /// user (asynManager.c:887-890). One holder alone is never enough to admit
     /// a request, and never enough to refuse one.
     fn admits(&self, token: Option<u64>, dp: DpKey) -> bool {
         let free = |h: Option<&(u64, u32)>| match h {
@@ -646,7 +646,7 @@ impl PortActor {
     /// What it does *not* run on is a pass C's thread would never have taken. C
     /// waits on `notifyPortThread` and only the five signal sites listed on
     /// [`Self::woken`] reach it; `isConnected` (:2326-2337), `isEnabled` (:2340),
-    /// `isAutoConnect` (:2348) and `report` (:1136) are plain reads under
+    /// `isAutoConnect` (:2356) and `report` (:1136) are plain reads under
     /// `asynManagerLock` and signal nothing. Here every one of them is a message,
     /// and a message wakes the actor — so the wake latch, not the message, is
     /// what gates this tail (R16-46). Without it a status poller dials the
@@ -663,7 +663,7 @@ impl PortActor {
         self.auto_connect_port();
     }
 
-    /// C `epicsEventMustWait(pport->notifyPortThread)` (asynManager.c:805) —
+    /// C `epicsEventMustWait(pport->notifyPortThread)` (asynManager.c:804) —
     /// consume the wake and say whether there was one. The two halves are the
     /// latch the actor sets at C's signal sites ([`Self::woken`]) and the port's
     /// announced-exception count, which catches the announcements C signals for
@@ -741,7 +741,7 @@ impl PortActor {
     /// The gate every connect attempt the actor makes *on its own initiative*
     /// passes — the retry timer and both auto-connect levels. It is the same
     /// gate a request passes, asked on behalf of the connect user C builds for
-    /// the port (`pport->pconnectUser`, asynManager.c:3231): `addr == -1` at
+    /// the port (`pport->pconnectUser`, asynManager.c:3226-3231): `addr == -1` at
     /// Connect priority, so `checkPortConnect` is `FALSE` (:1536-1538) and only
     /// the unconditional enabled/defunct half binds (:1541-1546).
     ///
@@ -987,15 +987,15 @@ impl PortActor {
             // `report` (asynManager.c:1136-1171) spawns a `reportPort` thread and
             // calls `pasynCommon->report(drvPvt, fp, details)` directly (:1121-1123).
             // No queue, no gate: a disabled port reports `enabled:No`, a
-            // disconnected one `connected:No` (:1112-1115). The diagnostic you
+            // disconnected one `connected:No` (:1057-1060). The diagnostic you
             // reach for *because* the port is down must not be the one the down
             // port refuses (W10-D6). The one state C will not report on is a
             // destroyed port, handled in the dispatch arm (:1038-1042).
             | RequestOp::Report { .. } => CDispatch::Direct,
 
             // C reaches `asynCommon->connect`/`disconnect` only from a callback
-            // queued at Connect priority (asynRecord's CNCT/PCNCT put,
-            // asynRecord.c:503-505,562-571) or from the port thread itself.
+            // queued at Connect priority (asynRecord's CNCT put,
+            // asynRecord.c:537-538,561-571) or from the port thread itself.
             RequestOp::Connect
             | RequestOp::Disconnect
             | RequestOp::ConnectAddr
@@ -1485,9 +1485,9 @@ impl PortActor {
                 // owns the bracket atomically under its serial dispatch.
                 //
                 // The bracket runs only when there IS a saved terminator, as
-                // C's `if (saveEosLen)` guard does (:1535, :1540) — a driver
+                // C's `if (saveEosLen)` guard does (:1534, :1539) — a driver
                 // with no EOS methods answers `asynError` to both accessors
-                // (asynOctetBase.c:401-411) and C explicitly tolerates that
+                // (asynOctetBase.c:401-415) and C explicitly tolerates that
                 // (:1531 "getOutputEos can return an error if the driver does
                 // not implement it"). Clearing unconditionally turned every
                 // binary transfer on such a port into that refusal.
@@ -1509,7 +1509,7 @@ impl PortActor {
                 // restore it on every exit path so a configured IEOS does not
                 // stop the read early or strip bytes belonging to the binary
                 // payload. Guarded by `saveEosLen` exactly as C guards it
-                // (:1571, :1576) — see `OctetWriteBinary` above.
+                // (:1570, :1575) — see `OctetWriteBinary` above.
                 let saved = self.driver.get_input_eos(user);
                 let bracket = !saved.is_empty();
                 if bracket {
@@ -1981,7 +1981,7 @@ impl PortActor {
                 // Flush every address list this batch wrote, not just the
                 // request's. C has no bundled set-then-flush: a driver calls
                 // `setXxxParam` per list and then `callParamCallbacks(addr)`
-                // once for each list it touched (asynPortDriver.cpp:820). This
+                // once for each list it touched (asynPortDriver.cpp:1785-1794). This
                 // carrier bundles the two, so it owes a flush for every list it
                 // just wrote — `call_param_callbacks` consumes the changed flags
                 // of one list only, so flushing the request address alone stores
@@ -2158,7 +2158,7 @@ fn combine_read_alarm(status: AsynStatus, alarm_status: u16, alarm_severity: u16
 /// `epics` feature, which is why `--no-default-features` never compiled.
 ///
 /// The values are the `menuAlarmStat.dbd` / `menuAlarmSevr.dbd` ordinals, fixed
-/// by `libcom/src/misc/alarm.h:62-85` and part of the EPICS record ABI.
+/// by `libcom/src/misc/alarm.h:39-45,62-85` and part of the EPICS record ABI.
 /// `tests::asyn_alarm_codes_match_epics_base` holds them to
 /// `epics_base_rs`'s under the `epics` feature, so a drift on either side is a
 /// test failure rather than a silently wrong ALARM/SEVR field.
@@ -2679,7 +2679,7 @@ mod tests {
     /// asynManager.c:811-855), and every C caller of connect/disconnect
     /// queues there — `asynCommonSyncIO` passes the constant
     /// (asynCommonSyncIO.c:142, :154), `asynRecord` derives it from the
-    /// callback type (asynRecord.c:562-566). Here the band comes from
+    /// callback type (asynRecord.c:561-565). Here the band comes from
     /// [`PortActor::c_dispatch`] for the same reason, so a `CNCT` put built
     /// on a `#[default]` Medium user still overtakes a sustained High stream
     /// instead of starving behind it.
@@ -3839,7 +3839,7 @@ mod tests {
         };
 
         // Boundary 1 — disabled: the wake finds the queue gate refusing, so no
-        // attempt reaches the hardware (C `portThread` :802-805; R14-50).
+        // attempt reaches the hardware (C `portThread` :806-809; R14-50).
         let (tx, calls) = spawn(true, false, true);
         send_and_wait(
             &tx,
@@ -3893,7 +3893,7 @@ mod tests {
     ///
     /// C's `portThread` runs a pass only when `notifyPortThread` is signalled, and
     /// `isConnected` (asynManager.c:2326-2337), `isEnabled` (:2340),
-    /// `isAutoConnect` (:2348) and `report` (:1136) signal nothing — they take
+    /// `isAutoConnect` (:2356) and `report` (:1136) signal nothing — they take
     /// `asynManagerLock`, read a flag and return. Here every one of them is a
     /// message that wakes the actor, so before the wake latch each of them ended
     /// in `autoConnectDevice(pport,0)`: a status poller pulled a dead port's
@@ -4143,7 +4143,7 @@ mod tests {
 
     /// `callParamCallbacks(addr)` consumes the changed flags of **one** address
     /// list (`ParamList::take_changed`), and C drivers call it once per list
-    /// they wrote (asynPortDriver.cpp:820). This carrier bundles the sets and
+    /// they wrote (asynPortDriver.cpp:1785-1794). This carrier bundles the sets and
     /// the flush, so it owes a flush for every list the batch wrote: flushing
     /// only the request address stored the other lists' values and fired no
     /// interrupt for them, so a multi-device driver publishing six joint angles
@@ -4325,8 +4325,10 @@ mod tests {
     /// C's `asynReport` header prints `multiDevice:` straight off
     /// `pport->attributes & ASYN_MULTIDEVICE` (asynManager.c:1043-1047), and the
     /// IP server listener is registered with plain `ASYN_CANBLOCK`
-    /// (drvAsynIPServerPort.c:625-626) — its asynOctet table is all NULL
-    /// (:118-122), so it is an interrupt source, not an addressable port. The
+    /// (drvAsynIPServerPort.c:625-626) — a TCP listener's asynOctet table stays
+    /// the all-NULL initializer (:118-123; C fills read/write/flush in only for
+    /// SOCK_DGRAM, :652-656), so it is an interrupt source, not an addressable
+    /// port. The
     /// per-client ports are separate single-device registrations (:688-694).
     #[test]
     fn the_ip_server_listener_reports_multidevice_no_like_c() {
@@ -4458,7 +4460,7 @@ mod tests {
     /// W10-D6: C's `report` (asynManager.c:1136-1171) spawns a `reportPort` thread
     /// and calls `pasynCommon->report(drvPvt, fp, details)` directly (:1121-1123).
     /// It never queues, so no gate runs: a disabled port reports `enabled:No` and
-    /// a disconnected one `connected:No` (:1112-1115). Queue-gating it made
+    /// a disconnected one `connected:No` (:1057-1060). Queue-gating it made
     /// `asynReport` on a down port print a refusal instead of the diagnostic the
     /// operator opened it for.
     ///
@@ -4624,10 +4626,10 @@ mod tests {
             !out.contains("EOS["),
             "a port with no octet interface has no EOS to report: {out}"
         );
-        // C `reportParams(fp, details)` with the level unshifted (:3692): at
+        // C `reportParams(fp, details)` with the level unshifted (:3693): at
         // details 1 the whole parameter block is already there — list 0, the
         // count, and every parameter with its value (:1804-1807,
-        // paramVal.cpp:296-330).
+        // paramVal.cpp:296-372).
         assert!(
             out.contains("Parameter list 0\nNumber of parameters is: 1\n")
                 && out.contains("Parameter 0 type=asynInt32, name=VAL, value is undefined\n"),

--- a/crates/asyn-rs/src/port_handle.rs
+++ b/crates/asyn-rs/src/port_handle.rs
@@ -452,7 +452,8 @@ impl PortHandle {
     /// *user's* `timeoutUser`, so the deadline is only worth waking for where the
     /// caller has something to do at it — asynRecord's `pact` process request,
     /// which reports "process queueRequest timeout" and forces the record's
-    /// completion 10 s after queueing, whatever the port is doing (:919-927).
+    /// completion 10 s after queueing, whatever the port is doing
+    /// (asynRecord.c:919-927).
     ///
     /// Whether the deadline is honoured is not this timer's call: it hands the
     /// question to [`CancelToken::time_out_if_queued`], C's `if(!isQueued)`

--- a/crates/asyn-rs/src/request.rs
+++ b/crates/asyn-rs/src/request.rs
@@ -179,8 +179,8 @@ pub enum RequestOp {
     /// pending UCMD/ACMD: it resets ERRS, sets the user's timeout, and calls
     /// nothing.
     ///
-    /// The point is the queue entry itself. `process()` queues unconditionally
-    /// (`:342-353`), so a NoI/O cycle still wakes the port thread — which is how
+    /// The point is the queue entry itself. `process()` queues without consulting
+    /// TMOD (`:342-353`), so a NoI/O cycle still wakes the port thread — as
     /// the reconnect-nudge idiom pokes auto-connect — and still meets the queue
     /// gate, so a disconnected port answers it with the refusal the record turns
     /// into ERRS and STATE/MINOR.
@@ -377,7 +377,7 @@ pub enum RequestOp {
     /// Install the delay interpose on top of the port's octet stack. C parity:
     /// `asynInterposeDelay(portName, addr, delay)`
     /// (`asynInterposeDelay.c:176-215`), registered with iocsh at
-    /// `asynInterposeDelay.c:221-234`. Same actor-ownership reason as
+    /// `asynInterposeDelay.c:215-237`. Same actor-ownership reason as
     /// [`RequestOp::PushEchoInterpose`].
     PushDelayInterpose {
         delay: std::time::Duration,

--- a/crates/asyn-rs/src/runtime/axis.rs
+++ b/crates/asyn-rs/src/runtime/axis.rs
@@ -353,12 +353,15 @@ impl AxisRuntime {
     async fn poll_motor(&mut self) {
         let user = AsynUser::new(0);
         // A failed poll must still publish a status. C drivers signal the
-        // failure by setting `motorStatusProblem_` + `motorStatusCommsError_`
-        // and calling `callParamCallbacks()` anyway before returning the error
-        // (smarActMCSMotorDriver.cpp:503-507, XPSAxis.cpp:756); the caller
-        // discards the returned status (asynMotorController.cpp:219-221 forced,
-        // :658 background), so the failure reaches the record only as MSTA
-        // bit 12 (COMM_ERR) → COMM/INVALID alarm (motorRecord.cc:3392-3398).
+        // failure by setting `motorStatusCommsError_` and calling
+        // `callParamCallbacks()` anyway before returning the error, from the
+        // error label the failed read jumped to (XPSAxis.cpp:755-757's `done:`;
+        // smarActMCSMotorDriver.cpp:503-507's `bail:`, which sets
+        // `motorStatusProblem_` as well); the caller
+        // discards the returned status on the background poll
+        // (asynMotorController.cpp:658) — the forced update at :219-222 does keep
+        // it in `writeInt32`'s `status` — so the failure reaches the record as
+        // MSTA bit 12 (COMM_ERR) → COMM/INVALID alarm (motorRecord.cc:3392-3398).
         // Every field the failed poll never wrote keeps its previous value,
         // which is what carrying `latest_status` forward reproduces.
         let status = match self.motor.poll(&user) {
@@ -522,9 +525,10 @@ mod tests {
     /// R6-50: a poll that fails must still publish a status carrying
     /// COMM_ERR, not just log an event — otherwise MSTA never raises bit 12,
     /// the record never processes, and the axis silently freezes on its last
-    /// good readback. C drivers set `motorStatusProblem_` +
-    /// `motorStatusCommsError_` and call `callParamCallbacks()` before
-    /// returning the error (smarActMCSMotorDriver.cpp:503-507, XPSAxis.cpp:756).
+    /// good readback. C drivers set `motorStatusCommsError_` and call
+    /// `callParamCallbacks()` before returning the error
+    /// (XPSAxis.cpp:755-757, smarActMCSMotorDriver.cpp:503-507 — the latter
+    /// sets `motorStatusProblem_` too, XPS sets only the comms bit).
     #[tokio::test]
     async fn failed_poll_publishes_comms_error_status() {
         use std::sync::Arc;

--- a/crates/asyn-rs/src/runtime/port.rs
+++ b/crates/asyn-rs/src/runtime/port.rs
@@ -161,9 +161,11 @@ fn stop_port_actor(
 ///
 /// Arming first is the whole point: a connect that lands between "am I
 /// connected?" and "start waiting" would be missed by any caller that checked
-/// the flag first. So [`Self::arm`] registers the callback, the caller may then
-/// short-circuit on an already-connected port (C :3308-3311), and
-/// [`Self::wait`] blocks for the rest. Both waiters in the crate — port
+/// the flag first. C has that race — it reads `pport->dpc.connected` at
+/// :3308-3311 and only arms afterwards, at :3316 — so here [`Self::arm`]
+/// registers the callback first, the caller may then short-circuit on an
+/// already-connected port, and [`Self::wait`] blocks for the rest. That
+/// ordering is a deliberate deviation. Both waiters in the crate — port
 /// registration and the iocsh `asynWaitConnect` — go through it, so neither can
 /// grow its own race.
 pub struct ConnectWaiter {
@@ -232,9 +234,9 @@ pub fn create_port_runtime<D: PortDriver>(
 /// survives anywhere in the process.
 ///
 /// C parity: `registerPort` → `registerDriver` creates the port thread at
-/// `asynManager.c:2081`, and on failure (:2082-2092) prints, unwinds every
+/// `asynManager.c:2079-2080`, and on failure (:2081-2091) prints, unwinds every
 /// resource it had built for the port, and returns `asynError` **before**
-/// `ellAdd(&pasynBase->asynPortList, ...)` (:2095) — the port never enters the
+/// `ellAdd(&pasynBase->asynPortList, ...)` (:2094) — the port never enters the
 /// list. The unwind is this function's `Err` return: the `PortActor` (which
 /// owns the driver) is dropped along with the closure `Builder::spawn`
 /// rejected, and the one resource that is *not* local — the connect-exception
@@ -242,7 +244,7 @@ pub fn create_port_runtime<D: PortDriver>(
 /// by [`ConnectWaiter`]'s `Drop`.
 ///
 /// A caller that can report the failure returns it, as
-/// `drvAsynIPPortConfigure` does (`drvAsynIPPort.c:1062-1069`: print,
+/// `drvAsynIPPortConfigure` does (`drvAsynIPPort.c:1033-1035`: print,
 /// `ttyCleanup`, `return -1`) — the iocsh command fails and the IOC boots on
 /// without that port. A caller with no error channel — one shaped like a C++
 /// constructor, returning the built port by value — uses
@@ -310,7 +312,7 @@ pub fn create_port_runtime_boxed(
     let event_tx_clone = event_tx.clone();
     let name_clone = port_name.clone();
 
-    // C's `waitConnect` (asynManager.c:2135, :3294-3337): registration waits on
+    // C's `waitConnect` (asynManager.c:2135, :3292-3337): registration waits on
     // the port's *connect exception* for at most `autoConnectTimeout`, so the
     // line of st.cmd after `drvAsynIPPortConfigure` already sees a live port.
     // The waiter is armed before the actor thread exists, so the connect it
@@ -367,11 +369,13 @@ pub fn create_port_runtime_boxed(
     };
 
     // C `registerPort` ends by arming the port's own process-exit callback —
-    // `epicsAtExit(destroyPortDriver, (void *)pport->portName)`
-    // (asynManager.c:2097) — so a port is wired into shutdown by the same call
-    // that brings it up, and no port creator has to remember to do it. This is
-    // that line: every port in this process, however it was made, is stopped by
-    // the IOC's shutdown owner (`epics_libcom_rs::runtime::exit`).
+    // `epicsAtExit(destroyPortDriver, (void *)pport->portName)` — but only for
+    // an `ASYN_DESTRUCTIBLE` port (asynManager.c:2096-2098); every other port
+    // in C simply survives to process exit with no teardown at all. This line
+    // arms it for EVERY port, a deliberate widening: the actor owns the driver,
+    // so the teardown a driver owes its device rides its `Drop` (below), and a
+    // port creator that forgot a capability bit would otherwise leak an MQTT
+    // session or leave a serial line open.
     //
     // Stopping the actor is the whole mechanism. The actor owns the driver
     // exclusively, so its thread ending drops the driver, and the driver's
@@ -379,7 +383,7 @@ pub fn create_port_runtime_boxed(
     // serial `disconnect`. Drivers therefore need to know nothing about
     // shutdown, which is C's arrangement too: `shutdownPort` fires
     // `asynExceptionShutdown` and leaves the destruction to the driver
-    // (asynManager.c:2300-2304).
+    // (asynManager.c:2301-2305).
     //
     // The callback holds the two channel ends, not the runtime handle: holding
     // a `PortHandle` would keep the port reachable, and so alive, for the life

--- a/crates/asyn-rs/src/trace.rs
+++ b/crates/asyn-rs/src/trace.rs
@@ -1637,7 +1637,7 @@ mod tests {
 
     /// R17-49 on the trace line. The ESCAPE block runs (C gates it on
     /// `nBytes > 0`, asynManager.c:3153) but `epicsStrPrintEscaped` writes
-    /// nothing for a payload whose first byte is NUL (epicsString.c:236-237),
+    /// nothing for a payload whose first byte is NUL (epicsString.c:237-238),
     /// so a `FILE *` sink gets an *empty* data line — the block's newline and
     /// no bytes. The errlog sink escapes it as `\0…` instead.
     #[test]

--- a/crates/asyn-rs/tests/interpose_is_manager_level.rs
+++ b/crates/asyn-rs/tests/interpose_is_manager_level.rs
@@ -124,7 +124,7 @@ fn an_installed_eos_interpose_serves_a_driver_that_never_dispatches_it() {
 }
 
 /// The write side of the same chain: `asynInterposeDelay`, pushed from iocsh
-/// after configure (asynInterposeDelay.c:187,221-234), writes one character at a
+/// after configure (asynInterposeDelay.c:187,215-237), writes one character at a
 /// time on *any* port. The driver below sees three one-byte writes; before the
 /// fix the layer was never entered and it saw one three-byte write.
 #[test]

--- a/crates/asyn-rs/tests/ioc_exit_stops_every_port_actor.rs
+++ b/crates/asyn-rs/tests/ioc_exit_stops_every_port_actor.rs
@@ -9,9 +9,10 @@
 //!
 //! The owner is `epics_libcom_rs::runtime::exit` (C `epicsExit.c`), which
 //! `IocApplication::run` calls on every way out. Ports enrol themselves in it at
-//! creation, exactly where C's `registerPort` does
-//! (`epicsAtExit(destroyPortDriver, …)`, asynManager.c:2097), so a driver still
-//! knows nothing about shutdown.
+//! creation, where C's `registerPort` enrols an `ASYN_DESTRUCTIBLE` one
+//! (`epicsAtExit(destroyPortDriver, …)`, asynManager.c:2096-2098) — here every
+//! port enrols, whatever it declared, so a driver still knows nothing about
+//! shutdown.
 //!
 //! Three ports here, torn down by one call: one driver that records its own
 //! `Drop`, and two shipped drivers that are not the one that reported this —

--- a/crates/asyn-rs/tests/iocsh_port_is_traceable.rs
+++ b/crates/asyn-rs/tests/iocsh_port_is_traceable.rs
@@ -2,7 +2,8 @@
 //! — must come up with a trace configuration and an exception list.
 //!
 //! In C those are properties of the port itself: `registerPort` calls
-//! `tracePvtInit(&pport->dpc.trace)` (asynManager.c:503) and initialises
+//! `dpCommonInit` (asynManager.c:2066), which runs
+//! `tracePvtInit(&pdpCommon->trace)` (:528) and initialises
 //! `dpc.exceptionUserList`, which `announceExceptionOccurred` walks
 //! (asynManager.c:611-637). There is no way to register a port without them.
 //!

--- a/crates/asyn-rs/tests/octet_read_fans_out_interrupts.rs
+++ b/crates/asyn-rs/tests/octet_read_fans_out_interrupts.rs
@@ -4,7 +4,7 @@
 //! `callInterruptUsers(pasynUser, pasynPvt, data, nbytesTransfered, eomReason)`
 //! after every successful read, when the port enabled `interruptProcess` — which
 //! both stream drivers do (`pasynOctetBase->initialize(..., 1)`,
-//! drvAsynIPPort.c:1055 and drvAsynSerialPort.c:1125). It is what makes a
+//! drvAsynIPPort.c:1055 and drvAsynSerialPort.c:1125-1126). It is what makes a
 //! `stringin`/`waveform` with `SCAN="I/O Intr"` on a serial or IP port process:
 //! the driver read is the interrupt.
 //!

--- a/crates/asyn-rs/tests/port_connects_at_registration.rs
+++ b/crates/asyn-rs/tests/port_connects_at_registration.rs
@@ -78,7 +78,7 @@ fn an_auto_connect_port_is_up_the_moment_it_is_created() {
 
 /// The `noAutoConnect` port is the negative control: C's `waitConnect` is gated
 /// on `pport->dpc.autoConnect` (asynManager.c:2135) and its timer callback on
-/// the same flag (:3257), so registration must leave this port down and must not
+/// the same flag (:3258), so registration must leave this port down and must not
 /// stall waiting for a connect that is never queued.
 #[test]
 fn a_no_auto_connect_port_stays_down_at_registration() {

--- a/crates/asyn-rs/tests/spc_nomod_fields_refuse_every_runtime_write.rs
+++ b/crates/asyn-rs/tests/spc_nomod_fields_refuse_every_runtime_write.rs
@@ -7,7 +7,7 @@
 //! write to any of them in ONE place: `dbPut` runs `dbPutSpecial(paddr, 0)`,
 //! whose first act is `if ((special == SPC_NOMOD) && (pass == 0)) return
 //! S_db_noMod` (dbAccess.c:122-127). Every runtime entry lands there —
-//! `dbPutField` calls `dbPut` (dbAccess.c:1265), so a CA put, `dbpf`, an OUT
+//! `dbPutField` calls `dbPut` (dbAccess.c:1262), so a CA put, `dbpf`, an OUT
 //! link and an autosave `reboot_restore` are all refused by the same test.
 //!
 //! The port's gate is `field_io::check_no_mod`, and its `dbPutField`-analogue

--- a/crates/asyn-rs/tests/time_series_busy_post_mask.rs
+++ b/crates/asyn-rs/tests/time_series_busy_post_mask.rs
@@ -12,8 +12,8 @@
 //! The third argument is a LITERAL `DBE_VALUE | DBE_LOG`. It is not
 //! `monitor_mask`, so it never carries `recGblResetAlarms`'s alarm-transition
 //! bit — and `waveformRecord.c` posts BUSY nowhere at all (its only four
-//! `db_post_events` are NORD at `:148` and `:213`, HASH at `:319`, VAL at
-//! `:324`), so this is the whole of C's BUSY posting.
+//! `db_post_events` are NORD at `waveformRecord.c:148` and `:213`, HASH at
+//! `:319`, VAL at `:324`), so this is the whole of C's BUSY posting.
 //!
 //! The port reaches BUSY through the generic change-detecting subscriber walk,
 //! whose default aux mask is `alarm_bits | DBE_VALUE | DBE_LOG`
@@ -251,9 +251,10 @@ async fn the_first_arm_of_a_one_element_series_posts_nord_with_the_literal_mask(
 ///
 /// `devAsynXXXTimeSeries.h:179` is a bare `pwf->rarm = 0;` — no
 /// `db_post_events` follows it, and `waveformRecord.c`'s four post sites
-/// (NORD `:148`/`:213`, HASH `:319`, VAL `:324`) do not name RARM either. So
+/// (NORD `waveformRecord.c:148`/`:213`, HASH `:319`, VAL `:324`) do not name
+/// RARM either. So
 /// the whole of C's RARM posting is `dbPut`'s own field tail
-/// (`dbAccess.c:1408-1418`), which fires on the client's write and carries
+/// (`dbAccess.c:1406-1413`), which fires on the client's write and carries
 /// `DBE_VALUE | DBE_LOG`: a `camonitor TS:MASK.RARM` shows 1 when the caput
 /// lands and never returns to 0.
 ///

--- a/crates/epics-base-rs/Cargo.toml
+++ b/crates/epics-base-rs/Cargo.toml
@@ -16,9 +16,8 @@ hostname = "0.4"
 chrono = "0.4"
 parking_lot = "0.12"
 # Lock-free snapshot cells for the read-mostly database indices and the ACF
-# config cell — see `doc/rtems-priority-locks-design.md` §3/§5 step 3. Readers
-# take an `Arc` snapshot with no lock, so a low-priority reader can never hold
-# a high-priority scan thread off an index.
+# config cell. Readers take an `Arc` snapshot with no lock, so a low-priority
+# reader can never hold a high-priority scan thread off an index.
 arc-swap = "1"
 tracing = "0.1"
 epics-macros-rs = { workspace = true }

--- a/crates/epics-base-rs/README.md
+++ b/crates/epics-base-rs/README.md
@@ -127,11 +127,11 @@ for a blocking-front-end deployment (dedicated OS threads, no tokio reactor) —
 `crates/epics-libcom-rs/build.rs` states the intended Linux PREEMPT_RT use, and
 why the switch is an environment variable rather than a cargo feature.
 
-Measured on a PREEMPT_RT kernel in `doc/rtlinux-rt-measurement.md`: with PI on,
-the record-gate priority inversion the mutex was built to kill collapses to the
-critical-section bound (worst case 24.9 ms → 10.1 ms on the measured guest;
-absolute numbers are VM-relative, the ratios are the defensible part). The scan
-latency decomposition lives in `doc/rtlinux-scan-tail-decomposition.md`.
+Measured on a PREEMPT_RT kernel: with PI on, the record-gate priority inversion
+the mutex was built to kill collapses to the critical-section bound (worst case
+24.9 ms → 10.1 ms on the measured guest; absolute numbers are VM-relative, the
+ratios are the defensible part). The scan leg is not what PI solves — SCHED_FIFO
+banding is, at 84.7× on the same guest.
 
 ```
 epics-base-rs/src/

--- a/crates/epics-base-rs/src/error.rs
+++ b/crates/epics-base-rs/src/error.rs
@@ -69,10 +69,15 @@ pub enum CaError {
     #[error("link error: {0}")]
     LinkError(String),
 
-    #[error("DB parse error at line {line}, column {column}: {message}")]
+    /// A `.db`/`.dbd` parse abort, carried as C `yyerror` prints it
+    /// (`dbYacc.y:370-383`): the line, the sentence, and `yytext` — the token
+    /// the lexer had matched when the parser rejected it, which is what C
+    /// quotes in its ` at or before '%s'` clause. An empty `token` is a
+    /// failure raised where no token was matched, and prints no such clause.
+    #[error("DB parse error at line {line}: {message}")]
     DbParseError {
         line: usize,
-        column: usize,
+        token: String,
         message: String,
     },
 

--- a/crates/epics-base-rs/src/lib.rs
+++ b/crates/epics-base-rs/src/lib.rs
@@ -17,6 +17,9 @@
 //! | `ca-gateway` | `R2-1-3-0-54-g0666f21` |
 //! | `optics` | `R2-14-15-g3def19d` |
 //! | `mca` | `687d563` (tree carries no tags) |
+//! | `autosave` | `R6-0-20-g186f467` |
+//! | `iocStats` | `4.0.1` |
+//! | `opcua` | `75c4f1c` (tree carries no tags) |
 //!
 //! **Resolve by symbol at the pin; the line is a hint.** Find the named
 //! function, struct, macro or field first, and treat the line number as a hint

--- a/crates/epics-base-rs/src/server/autosave/error.rs
+++ b/crates/epics-base-rs/src/server/autosave/error.rs
@@ -31,6 +31,16 @@ pub enum AutosaveError {
         source: String,
         line: usize,
     },
+    /// A `$(`/`${` whose closing delimiter never arrived. Distinct from
+    /// the two above because macLib names no macro for it — it copies
+    /// the reference and the whole rest of the line through verbatim
+    /// (`macCore.c:862-875`) — so what a `.req` author is shown is the
+    /// text that was passed through, not a key to go and define.
+    UnterminatedMacro {
+        reference: String,
+        source: String,
+        line: usize,
+    },
     CorruptSaveFile {
         path: String,
         message: String,
@@ -64,6 +74,16 @@ impl fmt::Display for AutosaveError {
             }
             Self::RecursiveMacro { key, source, line } => {
                 write!(f, "recursive macro '{key}' in {source} at line {line}")
+            }
+            Self::UnterminatedMacro {
+                reference,
+                source,
+                line,
+            } => {
+                write!(
+                    f,
+                    "unterminated macro reference '{reference}' in {source} at line {line}"
+                )
             }
             Self::CorruptSaveFile { path, message } => {
                 write!(f, "corrupt save file '{path}': {message}")

--- a/crates/epics-base-rs/src/server/autosave/macros.rs
+++ b/crates/epics-base-rs/src/server/autosave/macros.rs
@@ -58,11 +58,13 @@ impl MacroContext {
     /// Autosave-specific options: `env_fallback` (C `macEnvExpand`) and
     /// `dollar_escape` (`$$` → literal `$`, a `.req` convenience).
     ///
-    /// Either fault the engine can record is a hard error here — an
-    /// undefined macro with no default, and a macro that resolves into
-    /// itself — because both leave a placeholder where the `.req` wanted
-    /// a PV name, and a `.req` line built from a placeholder names a PV
-    /// that does not exist. Which one it was is read from
+    /// Every fault the engine can record is a hard error here — an
+    /// undefined macro with no default, a macro that resolves into
+    /// itself, and a reference whose closing delimiter never arrived —
+    /// because all three leave text where the `.req` wanted a PV name,
+    /// and a `.req` line built from a placeholder (or from a raw
+    /// passed-through `$(`) names a PV that does not exist. Which one it
+    /// was is read from
     /// [`MacroExpansion::fault`], never from one of its lists, so a new
     /// fault arm cannot be silently accepted here.
     ///
@@ -90,6 +92,11 @@ impl MacroContext {
             },
             MacroFault::Recursive(key) => AutosaveError::RecursiveMacro {
                 key: key.to_string(),
+                source: source.to_string(),
+                line,
+            },
+            MacroFault::Unterminated(reference) => AutosaveError::UnterminatedMacro {
+                reference: reference.to_string(),
                 source: source.to_string(),
                 line,
             },

--- a/crates/epics-base-rs/src/server/builtin_devices/mod.rs
+++ b/crates/epics-base-rs/src/server/builtin_devices/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod dbstate;
 pub mod getenv;
+pub mod soft_callback;
 pub mod stdio;
 pub mod timestamp;
 

--- a/crates/epics-base-rs/src/server/builtin_devices/soft_callback.rs
+++ b/crates/epics-base-rs/src/server/builtin_devices/soft_callback.rs
@@ -1,0 +1,106 @@
+//! `"Async Soft Channel"`'s `add_record` — the INP check C makes before an
+//! asynchronous soft input record is ever processed.
+//!
+//! ```c
+//! static long add_record(dbCommon *pcommon)
+//! {
+//!     aiRecord *prec = (aiRecord *)pcommon;
+//!     DBLINK *plink = &prec->inp;
+//!     ...
+//!     if (dbLinkIsDefined(plink) && dbLinkIsConstant(plink))
+//!         return 0;
+//!
+//!     if (plink->type != PV_LINK) {
+//!         long status = S_db_badField;
+//!
+//!         recGblRecordError(status, prec,
+//!             "devAiSoftCallback (add_record) Illegal INP field");
+//!         return status;
+//!     }
+//! ```
+//! (`devAiSoftCallback.c:76-93`, and the same shape in the six input twins.)
+//!
+//! Two facts decide what this port owes.
+//!
+//! The first early return is DEAD at IOC init. `dbLinkIsDefined` is
+//! `plink->lset != 0` (`dbLink.c:215-218`), and `iocInit.c::doResolveLinks`
+//! calls `add_record` BEFORE `dbInitLink` for that same link
+//! (`iocInit.c:546-559`), so `lset` is still NULL and the guard cannot fire.
+//! It exists for the other caller, `dbPutFieldLink` (`dbAccess.c:1196`) — a
+//! DTYP changed at runtime, on a link that is already initialised. So at
+//! startup the ONLY test is `plink->type != PV_LINK`, which is why a
+//! `field(INP, {const:9})` earns the error and a `field(INP, "someRecord")`
+//! does not.
+//!
+//! Only the seven INPUT flavours have an `add_record` at all. `devAoSoft-
+//! Callback.c` and the nine other output files declare a plain dset with no
+//! `dsxt`, so an output `"Async Soft Channel"` record is never checked —
+//! matching `softIoc` R7.0.10 on `asyncSoftTest.db`, which emits exactly seven
+//! of these lines and nothing for `ao1`/`bo1`/`lso1`/`so1`.
+
+use crate::server::record::{ParsedLink, RecordInstance, parse_link_v2};
+
+/// The `dev<T>SoftCallback` dset whose name goes in the message, for the seven
+/// input record types C ships one for.
+///
+/// The name is not derivable from the record type — C abbreviates `int64in` to
+/// `I64in`, `longin` to `Li` and `stringin` to `Si` — so it is a table, and the
+/// table is also the gate: a record type absent from it has no `add_record` in
+/// C and must not be checked.
+fn callback_dset(record_type: &str) -> Option<&'static str> {
+    Some(match record_type {
+        "ai" => "devAiSoftCallback",
+        "bi" => "devBiSoftCallback",
+        "int64in" => "devI64inSoftCallback",
+        "longin" => "devLiSoftCallback",
+        "mbbi" => "devMbbiSoftCallback",
+        "mbbiDirect" => "devMbbiDirectSoftCallback",
+        "stringin" => "devSiSoftCallback",
+        _ => return None,
+    })
+}
+
+/// C `plink->type == PV_LINK` for a link the `.db` parser has produced and
+/// `dbInitLink` has not yet touched.
+///
+/// A PV link is the only thing `dbParseLink` turns into `PV_LINK`; this port
+/// resolves the CA/CP/PP modifiers at parse time and so splits that one C type
+/// across two variants, but both are the same `PV_LINK` here. Everything
+/// else — a constant, an empty field, a JSON link (`{const:9}` included), a
+/// `#C0 S0` hardware address — is one of C's other link types.
+fn is_pv_link(inp: &str) -> bool {
+    matches!(parse_link_v2(inp), ParsedLink::Db(_) | ParsedLink::Ca(_))
+}
+
+/// C `dev<T>SoftCallback::add_record`, for one record, at the point
+/// `iocInit.c::doResolveLinks` calls it.
+///
+/// Reports and returns; `doResolveLinks` discards the status
+/// (`iocInit.c:551-554`), so the record is built either way and the operator's
+/// only warning that its INP can never be read is this line.
+pub(crate) fn add_record(instance: &RecordInstance, name: &str) {
+    // The dset gate: `add_record` is `devXxxSoftCallback`'s dsxt entry, so it
+    // exists only for a record whose DTYP selected that dset. This predicate
+    // is the hook's own, not its caller's — the init owner calls the hook for
+    // every record at C's `doResolveLinks` point and each hook answers for
+    // itself, the way C's `pdsxt` is either present on the dset or not.
+    if crate::server::device_support::classify_soft(&instance.common.dtyp)
+        != Some(crate::server::device_support::SoftDtyp::Async)
+    {
+        return;
+    }
+    let Some(dset) = callback_dset(instance.record.record_type()) else {
+        return;
+    };
+    if is_pv_link(&instance.common.inp) {
+        return;
+    }
+    // `S_db_badField` is `(511 << 16) | 15`, and `dbAccessErrSymTbl` IS linked,
+    // so `errSymLookup` finds it and prints the phrase rather than the numeric
+    // fallback the `M_devSup` statuses take.
+    crate::server::recgbl::rec_gbl_record_error(
+        "Illegal field value",
+        name,
+        &format!("{dset} (add_record) Illegal INP field"),
+    );
+}

--- a/crates/epics-base-rs/src/server/database/field_io.rs
+++ b/crates/epics-base-rs/src/server/database/field_io.rs
@@ -89,6 +89,46 @@ fn check_no_mod(instance: &crate::server::record::RecordInstance, field: &str) -
     Ok(())
 }
 
+/// [`check_no_mod`] as `dbPut` runs it — the refusal that also SPEAKS.
+///
+/// C's SPC_NOMOD arm is not a bare `return`: it reports before it returns.
+///
+/// ```c
+/// /* dbAccess.c:122-127, dbPutSpecial(paddr, 0) */
+/// if ((special == SPC_NOMOD) && (pass == 0)) {
+///     status = S_db_noMod;
+///     recGblDbaddrError(status, paddr, "dbPut");
+///     return status;
+/// }
+/// ```
+///
+/// `errSymLookup(S_db_noMod)` is `"Attempt to modify noMod field"`
+/// (`dbAccessDefs.h:179`), so the console line is exactly
+/// `recGblDbaddrError: dbPut Attempt to modify noMod field PV: REC.FIELD` —
+/// measured on softIoc @`R7.0.10` for `dbpf T:SUB.INAM` and `dbpf T:SEL.VAL`,
+/// where stdout still shows the unchanged read-back and the refusal is
+/// announced only here. A port that returns the status and says nothing loses
+/// the whole report, because `dbpf` itself prints no diagnostic of its own.
+///
+/// INVARIANT: every `dbPut`-layer SPC_NOMOD refusal MUST write this line, and
+/// no other layer may. The gate above stays silent so
+/// [`PvDatabase::check_external_put_preconditions`] — pvxs `doPreProcessing`,
+/// which refuses ABOVE `dbPut` and never reaches `dbPutSpecial` — cannot emit
+/// a line C does not write, nor double it on the routes that go on to put.
+fn check_no_mod_in_db_put(
+    instance: &crate::server::record::RecordInstance,
+    field: &str,
+) -> CaResult<()> {
+    check_no_mod(instance, field).inspect_err(|_| {
+        crate::server::recgbl::rec_gbl_dbaddr_error(
+            "Attempt to modify noMod field",
+            &instance.name,
+            field,
+            "dbPut",
+        );
+    })
+}
+
 /// C `dbPut`'s link-field refusal (`field_type > DBF_DEVICE` →
 /// `S_db_badDbrtype`, `dbAccess.c:1340-1347`): only `dbPutField` may change a
 /// DBF_INLINK/OUTLINK/FWDLINK field — it routes them through `dbPutFieldLink`
@@ -338,7 +378,23 @@ fn snam_special_after_put(
         // created. Clearing there too would make `RecordInstance::subroutine`
         // mean either "nothing bound" or "a parked record's retained routine"
         // depending on the record type.
-        if !instance.record.parks_pact() {
+        if instance.record.parks_pact() {
+            // The other half of that same C branch, and the reason a client
+            // can see for the park: `epicsPrintf("%s.SNAM is empty\n",
+            // prec->name)` (`subRecord.c:183`), which is `errlogPrintf`
+            // (`errlog.h:90`) — the errlog, not stderr. It fires on EVERY put
+            // that leaves SNAM empty, including empty -> empty, because pass 0
+            // released the park before the store and this pass re-takes it.
+            //
+            // `parks_pact()` gates the line for the same reason it gates the
+            // retained binding above: in C the print and `pact = TRUE` are one
+            // block, and the only other record whose `special()` reaches an
+            // empty subroutine name is aSub, which is silent AND park-free
+            // (`aSubRecord.c:560-561`). A record that answers `parks_pact()`
+            // therefore owes this line; `enter_pact()` in `special_after_put`
+            // takes the park itself, on the same predicate, straight after.
+            crate::runtime::log::errlog_printf(&format!("{}.SNAM is empty\n", instance.name));
+        } else {
             instance.subroutine = None;
         }
         return Ok(());
@@ -806,6 +862,50 @@ impl NotifyRequest {
     }
 }
 
+/// The teardown owner for a blocking external client PUT — the PVA/QSRV
+/// counterpart of C `rsrvFreePutNotify` (`camessage.c:1630-1638`), the CA
+/// server's own client-teardown call into `dbNotifyCancel`.
+///
+/// # Invariant (CONTRACT)
+///
+/// A blocking external PUT whose awaiting future is dropped before the
+/// completion arrives MUST release the record's put-notify slot before it
+/// goes. Leaving that to the next put's arrival-time sweep is not enough: a
+/// client already parked on `notify_restart_list` is not an arrival, so it
+/// waits behind a completion that can never come.
+///
+/// pvxs has no separate hook to mirror because a blocking put IS the
+/// operation's future there: the native PVA server spawns the PUT EXEC body
+/// and stores its abort handle on the op (`server_native::tcp`,
+/// `finish_exec_data_task`), so DESTROY_CHANNEL and connection teardown alike
+/// drop `ChannelState::ops`, abort the task and drop this future mid-await.
+/// The source's `notify_channel_close` is deliberately NOT the owner: an
+/// abort only *marks* the task, and the future is dropped whenever the
+/// executor next reaches it, so a sweep run from the close callback can find
+/// the receiver still alive and release nothing.
+///
+/// The receiver is owned HERE and closed by hand because `Drop::drop` runs
+/// BEFORE a struct's own fields drop — asking the database first would find
+/// `Sender::is_closed()` still false and sweep nothing.
+struct ClientAwaitingNotify<'a> {
+    db: &'a PvDatabase,
+    record: &'a str,
+    rx: crate::runtime::sync::oneshot::Receiver<()>,
+    /// Set once the await returns, which disarms the release: the completion
+    /// path owns the slot from that point.
+    answered: bool,
+}
+
+impl Drop for ClientAwaitingNotify<'_> {
+    fn drop(&mut self) {
+        if self.answered {
+            return;
+        }
+        self.rx.close();
+        self.db.cancel_unanswerable_notify(self.record);
+    }
+}
+
 /// The one claim on a record's put-notify slot for the whole gate-held CA put
 /// body, and the single finalizer every exit path out of it passes through.
 ///
@@ -1247,7 +1347,7 @@ impl PvDatabase {
                 // stops a record's OUT link from truncating a waveform's NELM.
                 // The refusal is returned to the caller; `write_out_link_value`
                 // (C `dbPutLink`) turns it into the writer's LINK/INVALID alarm.
-                check_no_mod(&instance, &field)?;
+                check_no_mod_in_db_put(&instance, &field)?;
 
                 // C `dbPut` refuses a link-field target the same way, before
                 // conversion (`dbAccess.c:1340`) — see `check_not_link_field`.
@@ -1594,7 +1694,7 @@ impl PvDatabase {
 
                 // Same `dbPut` gate as `put_pv` — this is the third `dbPut` body
                 // (value + monitor post), and C has ONE.
-                check_no_mod(&instance, &field)?;
+                check_no_mod_in_db_put(&instance, &field)?;
                 check_not_link_field(&instance, &field)?;
 
                 let request = dbput_request(&*instance.record, &field, value)?;
@@ -1907,7 +2007,7 @@ impl PvDatabase {
                     let completion = self
                         .put_record_field_from_ca(record_name, field, value)
                         .await?;
-                    Self::await_completion(completion).await;
+                    self.await_completion(record_name, completion).await;
                     Ok(())
                 } else {
                     self.put_record_field_from_ca_no_notify(record_name, field, value)
@@ -1924,7 +2024,7 @@ impl PvDatabase {
                     // bare `process_record_with_links` returns as soon as
                     // the record goes PACT.
                     let completion = self.process_record_with_notify(record_name).await?;
-                    Self::await_completion(completion).await;
+                    self.await_completion(record_name, completion).await;
                     Ok(())
                 } else {
                     // `doPostProcessing(forceProcessing == True)`
@@ -1938,10 +2038,28 @@ impl PvDatabase {
         }
     }
 
-    async fn await_completion(completion: crate::server::record::ProcessCompletion) {
-        if let crate::server::record::ProcessCompletion::Async(rx) = completion {
-            let _ = rx.await;
-        }
+    /// Await a blocking external PUT's completion under
+    /// [`ClientAwaitingNotify`], so a client that goes away mid-put hands the
+    /// record back instead of wedging every put queued behind it.
+    async fn await_completion(
+        &self,
+        record_name: &str,
+        completion: crate::server::record::ProcessCompletion,
+    ) {
+        let crate::server::record::ProcessCompletion::Async(rx) = completion else {
+            return;
+        };
+        let mut pending = ClientAwaitingNotify {
+            db: self,
+            record: record_name,
+            rx,
+            answered: false,
+        };
+        // Either outcome ends the wait. `Err` means the sender was dropped
+        // without sending, and only the completion path does that — it takes
+        // the sender out of the set first, so the sweep would no-op anyway.
+        let _ = (&mut pending.rx).await;
+        pending.answered = true;
     }
 
     /// C `dbPut`'s alarm-acknowledge interception (`dbAccess.c:1331-1335`) —
@@ -2214,6 +2332,7 @@ impl PvDatabase {
         let rec_arc = self
             .get_record(record_name)
             .ok_or_else(|| CaError::ChannelNotFound(record_name.to_string()))?;
+        self.cancel_unanswerable_notify(record_name);
         let notify = {
             let mut guard = rec_arc.write();
             if arrival.defers(&guard) {
@@ -2233,6 +2352,60 @@ impl PvDatabase {
         let mut visited = HashSet::new();
         self.process_record_with_links_already_locked(record_name, &mut visited, 0)?;
         Ok(Some(notify))
+    }
+
+    /// C `dbNotifyCancel` (`dbNotify.c:385-430`) as `rsrvFreePutNotify` reaches
+    /// it (`camessage.c:1630-1638`): a put-notify whose client is gone leaves
+    /// EVERY record it owns, and each record's restart-list head takes it
+    /// (`restartCheck`).
+    ///
+    /// # Invariant (CONTRACT)
+    ///
+    /// A wait-set that can never answer MUST NOT leave any record's put-notify
+    /// slot occupied. **This is the single owner of that release.** Without it
+    /// a record type that legitimately withholds its `ca_put_callback` (`busy`
+    /// at VAL=1, `mca` mid-acquisition) is wedged by the first client that
+    /// gives up: the slot stays taken forever and every later put queues behind
+    /// it unwritten.
+    ///
+    /// The sweep is over the set's own membership
+    /// ([`NotifyWaitSet::joined_records`]), not over the entry record, because
+    /// C's is (`dbNotify.c:428-430` empties the whole wait list, and only then
+    /// does `:433` deal with the entry). An entry-only release left the same
+    /// wedge one hop down the chain, on the record most likely to be holding a
+    /// set it will never leave: an FLNK target that is itself a `busy` at
+    /// VAL=1 declines its own `recGblFwdLink` by contract, so its membership
+    /// outlives the client that started the chain.
+    ///
+    /// Takes no lock of its own on entry, and holds only one record's write
+    /// lock at a time, so it can be called from a client-teardown `Drop` and
+    /// cannot deadlock against a chain that locks records in the other order.
+    ///
+    /// [`NotifyWaitSet::joined_records`]: crate::server::record::NotifyWaitSet
+    pub fn cancel_unanswerable_notify(&self, record_name: &str) {
+        let Some(rec) = self.get_record(record_name) else {
+            return;
+        };
+        let Some(dead) = rec.read().unanswerable_notify() else {
+            return;
+        };
+        // C `dbNotifyCancel`: the whole wait list, then the entry. `joined`
+        // already carries the entry, so one pass covers both arms.
+        for name in dead.joined_records() {
+            let Some(member) = self.get_record(&name) else {
+                continue;
+            };
+            let exit = {
+                let mut guard = member.write();
+                if !guard.release_notify(&dead) {
+                    continue;
+                }
+                guard.pact_exit_without_release()
+            };
+            // `apply_pact_exit` takes no record lock, by construction — the
+            // drain it spawns takes the record's write gate itself.
+            self.apply_pact_exit(&name, &member, exit);
+        }
     }
 
     /// Claim `record_name`'s put-notify slot for this put, in the SAME
@@ -2333,8 +2506,9 @@ impl PvDatabase {
 
             // SPC_NOMOD / read-only fields: rejected inside C's `dbPut`, i.e.
             // after the DISP gate above and before the PROC-driven process
-            // below. One gate owner for every route ([`check_no_mod`]).
-            check_no_mod(&instance, &field)?;
+            // below. One gate owner for every route
+            // ([`check_no_mod_in_db_put`]).
+            check_no_mod_in_db_put(&instance, &field)?;
         }
 
         // C `processNotifyCommon` (dbNotify.c:225-232) tests PACT ABOVE the
@@ -2392,6 +2566,7 @@ impl PvDatabase {
         )> = None;
         if want_notify {
             let is_restart = notify_request.is_restart();
+            self.cancel_unanswerable_notify(record_name);
             let mut guard = rec.write();
             // A restart is already the record's owner, so only PACT can stop it
             // (C skips dbNotify.c:213 for it and falls straight to :225).
@@ -3134,7 +3309,7 @@ impl PvDatabase {
                 )? {
                     value = text;
                 }
-                check_no_mod(&instance, &field)?;
+                check_no_mod_in_db_put(&instance, &field)?;
                 // C `dbPutSpecial(paddr, 0)` — the pre-store pass, which
                 // `dbPut` runs on every entry path including the `dbPutField`
                 // this body models (autosave's `reboot_restore`). A non-zero

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -645,6 +645,23 @@ struct PvDatabaseInner {
     /// tests and a second `iocInit` may call again, and `OnceLock` would
     /// silently drop the second registry instead of replacing it.
     subroutine_registry: ArcSwap<HashMap<String, Arc<crate::server::record::SubroutineFn>>>,
+    /// C's process-global device support table, seen through
+    /// `dbDTYPtoDevSup`: the lookup `doInitRecord0` makes to fill
+    /// `precord->dset` BEFORE it calls `prset->init_record(precord, 0)`
+    /// (`iocInit.c:530-536`).
+    ///
+    /// It lives on the DATABASE, not on the builder that collected the
+    /// factories, because the creation sink is the only place that can bind a
+    /// dset at C's position — ahead of the record's own init passes. While the
+    /// two builders each held their own copy, the bind could only happen after
+    /// the whole database had been built, so every record type's `init_record`
+    /// ran with `dset == NULL` invisible to it and executed the tail C's
+    /// `if (!pdset) return S_dev_noDSET` skips.
+    ///
+    /// `None` until a builder installs one — a database assembled by hand
+    /// (unit tests, `PvDatabase::new`) registers no device support at all,
+    /// which is C's empty `devList` and gives the same answer.
+    device_support_resolver: ArcSwapOption<crate::server::ioc_app::DeviceSupportResolver>,
     /// Breakpoint tables by name (C `bptList`), shared by every db-load path so
     /// `ai`/`ao` records with `LINR >= 3` resolve their linearisation table. An
     /// `Arc` snapshot is installed on each record at creation; the master grows
@@ -1059,6 +1076,7 @@ impl PvDatabase {
                     seeded_record_attributes(),
                 ),
                 subroutine_registry: ArcSwap::from_pointee(HashMap::new()),
+                device_support_resolver: ArcSwapOption::empty(),
                 breaktable_registry: SnapshotCell::new(
                     crate::server::cvt_bpt::BreakTableRegistry::new(),
                 ),
@@ -1199,6 +1217,33 @@ impl PvDatabase {
         registry: HashMap<String, Arc<crate::server::record::SubroutineFn>>,
     ) {
         self.inner.subroutine_registry.store(Arc::new(registry));
+    }
+
+    /// Install the process-wide device support table — C's registrars filling
+    /// `devList` before `iocInit`. Every record created after this line binds
+    /// its dset from it at creation, which is C's `doInitRecord0` order; a
+    /// record created BEFORE it keeps no device support, exactly as a C record
+    /// loaded before its `device()` lines would.
+    pub fn install_device_support_resolver(
+        &self,
+        resolver: crate::server::ioc_app::DeviceSupportResolver,
+    ) {
+        self.inner
+            .device_support_resolver
+            .store(Some(Arc::new(resolver)));
+    }
+
+    /// How many records hold device support — the `iocInit: N records, M with
+    /// device support` count. Derived from the records themselves rather than
+    /// tallied by a wiring pass, because there is no longer a wiring pass:
+    /// the bind happens at each record's creation.
+    pub(crate) async fn records_with_device_support(&self) -> usize {
+        let names = self.all_record_names().await;
+        names
+            .iter()
+            .filter_map(|name| self.get_record(name))
+            .filter(|rec| rec.read().device.is_some())
+            .count()
     }
 
     /// Look up a registered subroutine by name. The processing path uses this
@@ -2636,6 +2681,23 @@ impl PvDatabase {
                 .insert(name.to_string(), empty_links);
         }
 
+        // C `doInitRecord0` (`iocInit.c:530-536`) binds the dset and only then
+        // calls `init_record(pass 0)`. Both lines are here, in that order,
+        // because every `<rec>Record.c init_record` opens by testing the dset
+        // — `ao`'s `prec->init = TRUE`, `sub`'s MLST/ALST/LALM seed and `ai`'s
+        // are all BELOW that test, and running the passes first is what made
+        // them reachable for a record C refuses.
+        crate::server::ioc_app::attach_device_support(
+            &mut instance,
+            name,
+            self.inner.device_support_resolver.load().as_deref(),
+        );
+        // C `registryFunctionFind` reads a process-global registry from inside
+        // `init_record` pass 1, so the record is handed the registry rather
+        // than resolved against it from out here: the lookup's failure is an
+        // early return that the init tail must not run past, and only the init
+        // owner can honour that.
+        instance.arm_init_subroutines(self.inner.subroutine_registry.load_full());
         instance.run_init_passes(name);
 
         // The init-seed owner: every CONSTANT link the record declares
@@ -2723,7 +2785,7 @@ impl PvDatabase {
         if let Some(kind) = kind {
             return Err(CaError::DbParseError {
                 line: 0,
-                column: 0,
+                token: String::new(),
                 message: format!("name '{name}' is already registered as a {kind}"),
             });
         }

--- a/crates/epics-base-rs/src/server/database/processing.rs
+++ b/crates/epics-base-rs/src/server/database/processing.rs
@@ -436,12 +436,43 @@ impl AsyncDbHandle {
     }
 }
 
-/// C `dbNotifyCompletion`: this record finished its contribution to the
-/// put-notify (sync completion, async completion, or SDIS-disable bail).
-/// Take its wait-set membership and leave — the completion oneshot fires on
-/// the `leave` that empties the set. Idempotent: a record not in any
-/// put-notify is a no-op.
+/// C `dbNotifyCompletion` (`dbNotify.c:445`) reached the way a process cycle
+/// reaches it — through `recGblFwdLink` (`recGbl.c:295`), record support's only
+/// route to it. Take this record's wait-set membership and leave; the
+/// completion oneshot fires on the `leave` that empties the set.
+///
+/// # Invariant (CONTRACT)
+///
+/// A cycle completes an outstanding put-notify IF AND ONLY IF it runs
+/// `recGblFwdLink`. Two things stop it, and **both are read here** so no cycle
+/// tail can consult one and forget the other:
+///
+/// - [`Record::is_put_complete`](crate::server::record::Record::is_put_complete)
+///   — device support took the write async
+///   (`if (!pact && prec->pact) return(0)`), so this pass never reaches the
+///   tail.
+/// - [`Record::should_fire_forward_link`](crate::server::record::Record::should_fire_forward_link)
+///   — the tail was reached and the record type declined it.
+///   `dbNotifyCompletion` sits INSIDE the skipped call, so a suppressed
+///   forward link withholds the `ca_put_callback` too.
+///   `busy` is the clearest case: `busyRecord.c:271` runs the tail only for
+///   `val == 0 || oval == 0`, which is why `caput -c` on a busy record that
+///   stays at 1 is meant to hang until something writes "Done".
+///
+/// Reading them together HERE, rather than at each cycle tail, is what keeps a
+/// record type's C gate to one override: a type states its gate in
+/// `should_fire_forward_link` and gets the notify behaviour for free.
+///
+/// The SDIS-disable bail is C's OTHER `dbNotifyCompletion` caller
+/// (`dbAccess.c:623`), outside `recGblFwdLink` and so deliberately ungated —
+/// it open-codes the take/leave in `process_record_with_links_inner` and does
+/// not come through here.
+///
+/// Idempotent: a record in no put-notify is a no-op.
 fn complete_put_notify(inst: &mut RecordInstance) {
+    if !inst.record.is_put_complete() || !inst.record.should_fire_forward_link() {
+        return;
+    }
     if let Some(ws) = inst.notify.take() {
         ws.leave();
     }
@@ -2318,6 +2349,73 @@ impl PvDatabase {
                 // landing on a disabled record stalls until socket
                 // disconnect. `leave` fires the completion oneshot when
                 // this empties the wait-set.
+                if let Some(ws) = notify {
+                    ws.leave();
+                }
+                return Ok(());
+            }
+        }
+
+        // 0.4. The dset gate — the FIRST statement of every C `process()`
+        // that needs device support:
+        //
+        // ```c
+        // if( (pdset==NULL) || (pdset->read_ai==NULL) ) {
+        //     prec->pact=TRUE;
+        //     recGblRecordError(S_dev_missingSup, prec, "read_ai");
+        //     return(S_dev_missingSup);
+        // }
+        // ```
+        // (`aiRecord.c:143-147`, and the same four lines in 19 more
+        // `<rec>Record.c` files.) It sits here, after `dbProcess`'s PACT test
+        // and the SDIS disable bail and before anything of the body, because
+        // that is where C's is: `dbProcess` reaches `prset->process` only past
+        // those two, and `process` refuses on its first line.
+        //
+        // This is not a message. The PACT it takes is never released — the
+        // only release is a cycle tail this record never reaches — so the
+        // record is inert from its first process attempt onward, exactly as it
+        // is in C, and every later attempt is turned away by the PACT guard
+        // above without a second report. Reporting without taking PACT would
+        // have printed C's line over a record that then went on processing:
+        // measured against `softIoc` R7.0.10 on `asyn`'s `testErrors` IOC, C
+        // leaves `testErrors:AoInt32` at `PACT 1`, `STAT UDF`, `TIME
+        // <undefined>` where this port left it `PACT 0`, `STAT NO_ALARM` and
+        // stamped.
+        //
+        // The gate is `dev_sup_process_refusal`, which is `None` for every
+        // record type whose C `process()` has no dset test — `calc`, `sub`,
+        // `fanout`, and `calcout`, which refuses only at init.
+        {
+            let refusal = {
+                let instance = rec.read();
+                if crate::server::device_support::is_soft_dtyp(&instance.common.dtyp)
+                    || instance.device.is_some()
+                {
+                    None
+                } else {
+                    crate::server::recgbl::dev_sup_process_refusal(instance.record.record_type())
+                }
+            };
+            if let Some(message) = refusal {
+                let notify = {
+                    let mut instance = rec.write();
+                    instance.enter_pact();
+                    // C returns from `process()` without reaching
+                    // `recGblFwdLink`, so its `dbNotifyCompletion` never fires
+                    // and a put-notify parked on such a record waits for a
+                    // cycle that will never come. Releasing the wait-set is
+                    // the same thing the SDIS bail above does, and for the
+                    // same reason: a CA WRITE_NOTIFY caller must not be held
+                    // to a socket timeout by a record that has already decided
+                    // not to run.
+                    instance.notify.take()
+                };
+                crate::server::recgbl::rec_gbl_record_error(
+                    &crate::server::recgbl::DevSupStatus::MissingSup.text(),
+                    name,
+                    message,
+                );
                 if let Some(ws) = notify {
                     ws.leave();
                 }
@@ -4799,14 +4897,12 @@ impl PvDatabase {
             }
             // The record `leave`s the wait-set only here, after its full
             // OUT/FLNK/process-action tail has run — so every PP target it drove
-            // has already joined (`enter`ed). Gated on `is_put_complete`: a
-            // record reporting more work (e.g. motor mid-move via
-            // `is_put_complete()==false`) keeps its membership and leaves on the
-            // later cycle that completes the put. The completion oneshot fires on
-            // the `leave` that empties the set.
-            if guard.record.is_put_complete() {
-                complete_put_notify(&mut guard);
-            }
+            // has already joined (`enter`ed). Whether this cycle may leave at
+            // all is `complete_put_notify`'s decision, not this site's: a record
+            // reporting more work (motor mid-move) or declining its forward link
+            // (busy at VAL=1) keeps its membership and leaves on the later cycle
+            // that reaches C's `recGblFwdLink`.
+            complete_put_notify(&mut guard);
         }
         self.apply_pact_exit(name, rec, exit);
     }
@@ -6688,6 +6784,17 @@ impl PvDatabase {
 /// The body of the init-seed owner, over a locked record — shared by
 /// [`PvDatabase::rec_gbl_init_constant_links`] and `PvDatabase::add_record`.
 pub(crate) fn seed_constant_links(instance: &mut RecordInstance) {
+    // The SECOND seat of C's `init_record` body, and so it takes the same
+    // opening test: every step below sits BELOW `if (!pdset) { … return
+    // S_dev_noDSET; }` in the C source it ports — the soft dset's constant
+    // load, the record's own `recGblInitConstantLink` table (`aoRecord.c:112`),
+    // and the tail plus tracker seed at `aoRecord.c:156-161`. A record whose
+    // dset is NULL reaches none of them, which is why softIoc reads `MLST: 0`
+    // on an `ai` whose DTYP nobody registered where the port read its VAL.
+    if !instance.init_record_reaches_body() {
+        return;
+    }
+
     // 0. The long-string load, C `dbLoadLinkLS` — a lset entry of its own, NOT
     //    `recGblInitConstantLink`, and the only one that can write a
     //    long-string VAL: `lso` runs it on DOL (lsoRecord.c:82), `lsi`'s soft

--- a/crates/epics-base-rs/src/server/db_convert_json.rs
+++ b/crates/epics-base-rs/src/server/db_convert_json.rs
@@ -1090,7 +1090,13 @@ impl Token {
         match self {
             Token::Text(s) => s.clone(),
             Token::Int(i) => truncate(&EpicsValue::Int64(*i).convert_to(DbFieldType::String)),
-            Token::Double(d) => truncate(&EpicsValue::Double(*d).convert_to(DbFieldType::String)),
+            // `dbcj_double` hands the converter a NULL `paddr`
+            // (`dbConvertJSON.c:58`), so `cvt_d_st` finds no rset and renders
+            // at its own seeded precision of 6 — not Rust's `Display`, which
+            // gave `1` where C gives `1.000000`.
+            Token::Double(d) => truncate(&EpicsValue::String(
+                crate::types::codec::cvt_double_to_string(*d, 6).into(),
+            )),
         }
     }
 
@@ -1234,6 +1240,31 @@ mod tests {
         assert_eq!(
             db_put_convert_json("[1,\"b\"]", DbFieldType::String, 2).unwrap(),
             EpicsValue::StringArray(vec!["1".into(), "b".into()])
+        );
+    }
+
+    /// A REAL token into a `DBF_STRING` target renders at precision 6, not at
+    /// the record's PREC and not through Rust's `Display`: `dbcj_double`
+    /// passes `conv(&num, parser->pdest, NULL)` (`dbConvertJSON.c:58`), and
+    /// with a NULL `paddr` `cvt_d_st` finds no rset and keeps its own seed
+    /// (`dbFastLinkConv.c:1339-1344`).
+    ///
+    /// softIoc @`R7.0.10`, `T:WS` a `STRING` waveform with `NELM=4` and
+    /// `PREC=3`:
+    ///
+    /// ```text
+    /// dbpf T:WS "[1.0, 2.5, 1.23456789]"
+    /// dbgf T:WS -> DBF_STRING[3]: "1.000000"  "2.500000"  "1.234568"
+    /// ```
+    #[test]
+    fn a_real_token_into_a_string_target_renders_at_precision_six() {
+        assert_eq!(
+            db_put_convert_json("[1.0, 2.5, 1.23456789]", DbFieldType::String, 4).unwrap(),
+            EpicsValue::StringArray(vec![
+                "1.000000".into(),
+                "2.500000".into(),
+                "1.234568".into()
+            ])
         );
     }
 

--- a/crates/epics-base-rs/src/server/db_loader/include.rs
+++ b/crates/epics-base-rs/src/server/db_loader/include.rs
@@ -6,8 +6,7 @@ use crate::error::{CaError, CaResult};
 
 use crate::runtime::log::ERL_ERROR;
 
-use super::substitute_macros;
-use super::{DbFaults, DbRecordDef};
+use super::{DbFaults, DbRecordDef, MacroDefs};
 
 /// Configuration for file-based DB loading with include support.
 pub struct DbLoadConfig {
@@ -29,7 +28,7 @@ impl Default for DbLoadConfig {
 /// and dropped — see [`super::parse_db`].
 pub fn parse_db_file(
     path: &Path,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     config: &DbLoadConfig,
 ) -> CaResult<Vec<DbRecordDef>> {
     let parsed = parse_db_file_with_breaktables(path, macros, config)?;
@@ -44,7 +43,7 @@ pub fn parse_db_file(
 /// into the database registry and resolves file-scope aliases against it.
 pub fn parse_db_file_with_breaktables(
     path: &Path,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     config: &DbLoadConfig,
 ) -> CaResult<super::ParsedDb> {
     // The include layer and the record parser both report through the
@@ -58,7 +57,7 @@ pub fn parse_db_file_with_breaktables(
 /// operator wrote it rather than by the path this process resolved.
 pub fn parse_db_opened_with_breaktables(
     opened: &DbOpenedFile,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     config: &DbLoadConfig,
 ) -> CaResult<super::ParsedDb> {
     // The include layer and the record parser both report through the
@@ -107,13 +106,28 @@ pub struct DbExpandedText {
 /// offset into a string that exists only inside this process.
 pub fn expand_includes_mapped(
     opened: &DbOpenedFile,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     config: &DbLoadConfig,
     faults: &mut DbFaults,
 ) -> CaResult<DbExpandedText> {
+    // ONE table for the whole read, includes and all. C `dbReadCOM`
+    // creates a single `MAC_HANDLE`, installs the caller's macros into it
+    // and reads `dbQuietMacroWarnings` into it once at open
+    // (`dbLexRoutines.c:256-300`), and `dbIncludeNew` pushes the included
+    // file onto `inputFileList` without touching the handle
+    // (`:443-461`) — so every line of every file in the tree is expanded
+    // through the same table. msi does the same with one `macCreateHandle`
+    // for the whole run (`msi.cpp:111`).
+    let mut table = super::MacroTable::new(
+        macros,
+        super::MacroExpandOptions {
+            suppress_warnings: super::db_quiet_macro_warnings(),
+            ..super::MacroExpandOptions::default()
+        },
+    );
     let mut stack = Vec::new();
     let mut out = Lines::default();
-    expand_includes_inner(opened, macros, config, &mut stack, faults, &mut out)?;
+    expand_includes_inner(opened, &mut table, config, &mut stack, faults, &mut out)?;
     Ok(DbExpandedText {
         text: out.text,
         source: super::DbSource::new(out.lines, out.frames),
@@ -150,7 +164,7 @@ impl Lines {
 /// Expand `include "..."` directives recursively.
 pub fn expand_includes(
     path: &Path,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     config: &DbLoadConfig,
     faults: &mut DbFaults,
 ) -> CaResult<String> {
@@ -174,7 +188,7 @@ struct OpenFile {
 
 fn expand_includes_inner(
     opened: &DbOpenedFile,
-    macros: &HashMap<String, String>,
+    table: &mut super::MacroTable,
     config: &DbLoadConfig,
     stack: &mut Vec<OpenFile>,
     faults: &mut DbFaults,
@@ -190,7 +204,7 @@ fn expand_includes_inner(
         let chain: Vec<&str> = stack.iter().map(|f| f.named.as_str()).collect();
         return Err(CaError::DbParseError {
             line: 0,
-            column: 0,
+            token: String::new(),
             message: format!("circular include: {} -> {named}", chain.join(" -> ")),
         });
     }
@@ -199,7 +213,7 @@ fn expand_includes_inner(
     if stack.len() >= config.max_include_depth {
         return Err(CaError::DbParseError {
             line: 0,
-            column: 0,
+            token: String::new(),
             message: format!(
                 "include depth limit ({}) exceeded at '{named}'",
                 config.max_include_depth,
@@ -209,7 +223,7 @@ fn expand_includes_inner(
 
     let content = std::fs::read_to_string(&identity).map_err(|e| CaError::DbParseError {
         line: 0,
-        column: 0,
+        token: String::new(),
         message: format!("cannot read '{named}': {e}"),
     })?;
 
@@ -218,9 +232,12 @@ fn expand_includes_inner(
         named: named.clone(),
     });
 
-    // Local macro overrides from `substitute` directives.
-    // These override the caller-provided macros for subsequent includes.
-    let mut local_macros = macros.clone();
+    // No per-file copy of the macros: a `substitute` inside an included
+    // file writes the shared table and its definition outlives the
+    // include, because msi shares one handle across `include` and pushes
+    // no scope for it (`msi.cpp:305-358`). Measured — a file defining
+    // `X=inner` under an outer `X=outer` leaves `after:[inner]` behind
+    // it, where this port used to restore `outer`.
 
     // Include search path. Starts from the caller-supplied config and
     // is mutated by `path`/`addpath` directives encountered in the
@@ -251,28 +268,47 @@ fn expand_includes_inner(
         let line_num = i as u32 + 1;
         let line = raw.strip_suffix('\n').unwrap_or(raw);
         if let Some(subst_str) = parse_substitute_directive(line) {
-            // Apply substitute overrides to local macros. Quote- and
-            // escape-aware splitting matches C `macParseDefns`
-            // (macUtil.c): a `,` or `=` inside `'...'`/`"..."` or after
-            // a `\` does not act as a separator.
-            for (k, v) in parse_macro_defns(&subst_str) {
-                let expanded_v = substitute_macros(&v, &local_macros);
-                local_macros.insert(k, expanded_v);
+            // msi is the reference for this one: C's `.db` grammar has no
+            // `substitute` directive at all. `makeSubstitutions` matches
+            // its two commands on the RAW line and sets `expand = 0`, so
+            // a command line is never itself expanded (`msi.cpp:305-358`),
+            // and `addMacroReplacements` hands the text between the outer
+            // quotes to `macParseDefns` and straight on to
+            // `macInstallMacros` (`:256-275`) — so what is installed is
+            // the RAW value. This port expanded it first, which froze a
+            // reference C leaves live.
+            for (name, value) in parse_macro_defns(&subst_str) {
+                match value {
+                    Some(rawval) => table.define(&name, rawval),
+                    // C `macPutValue( handle, name, NULL )`: a definition
+                    // with no `=` deletes, uncovering an outer one.
+                    None => table.undefine(&name),
+                }
             }
             emit(out, line_num, String::from("\n"));
-        } else if let Some(dirs) = parse_path_directive(line, "path") {
+            continue;
+        }
+        // Every other line goes through the file's one table exactly
+        // once, BEFORE anything looks at what it says. C `db_yyinput`
+        // (`dbLexRoutines.c:375-391`) expands each `fgets` line and hands
+        // the result to the lexer, so `include`, `path` and `addpath` are
+        // grammar productions reading already-expanded text and carry the
+        // same two per-line diagnostics as any other line. This port used
+        // to match them on the raw line and expand only the argument,
+        // which left an `include "$(NOPE)b.db"` line without the
+        // `WARNING: … has undefined macros` C prints for it.
+        let expanded = super::db_expand_line_in(table, raw, Some(&file_name), line_num);
+        let line = expanded.strip_suffix('\n').unwrap_or(&expanded);
+        if let Some(dirs) = parse_path_directive(line, "path") {
             // `path "a:b:c"` — replace the search path. C separates
             // entries with the OS path separator.
-            let expanded = substitute_macros(&dirs, &local_macros);
-            local_paths = db_path(&expanded);
+            local_paths = db_path(&dirs);
             emit(out, line_num, String::from("\n"));
         } else if let Some(dirs) = parse_path_directive(line, "addpath") {
             // `addpath "a:b"` — append to the search path.
-            let expanded = substitute_macros(&dirs, &local_macros);
-            local_paths.extend(db_add_path(&expanded));
+            local_paths.extend(db_add_path(&dirs));
             emit(out, line_num, String::from("\n"));
-        } else if let Some(filename) = parse_include_directive(line) {
-            let expanded_filename = substitute_macros(&filename, &local_macros);
+        } else if let Some(expanded_filename) = parse_include_directive(line) {
             // C `dbIncludeNew` (`dbLexRoutines.c:450-456`) prints this
             // exact line and calls `yyerror(NULL)`, NOT `yyerrorAbort`:
             // the include is skipped, everything already read stays, and
@@ -291,15 +327,9 @@ fn expand_includes_inner(
                 ));
                 continue;
             };
-            expand_includes_inner(&included, &local_macros, config, stack, faults, out)?;
+            expand_includes_inner(&included, table, config, stack, faults, out)?;
         } else {
-            // C `db_yyinput`: the macros in force at this line, and the
-            // two diagnostics macLib and the loader raise for it.
-            emit(
-                out,
-                line_num,
-                super::db_expand_line(raw, &local_macros, Some(&file_name), line_num),
-            );
+            emit(out, line_num, expanded);
         }
     }
 
@@ -337,30 +367,45 @@ pub(crate) fn parse_include_directive(line: &str) -> Option<String> {
 
 /// Parse a `substitute` directive line.
 ///
-/// EPICS DB files use `substitute "NAME=VALUE"` to override macros for subsequent
-/// `include` directives. Returns the quoted content if the line is a substitute directive.
+/// msi is the reference: C's `.db` grammar has no `substitute` at all.
+/// `makeSubstitutions` (`msi.cpp:305-358`) scans for the closing quote
+/// with `\"` skipped as a pair, and gives the text between the quotes to
+/// `macParseDefns` WITHOUT unescaping it — so a value written
+/// `A=\"1\"` reaches macLib as the six characters `\"1\"` and comes out
+/// of the level-1 pass as `"1"`. Reading the closing quote as the first
+/// `"` instead truncated the value at the escape.
+///
+/// After that quote msi allows only blanks before the end of the line;
+/// anything else and the line is not a command at all, and is expanded as
+/// ordinary text.
 pub(crate) fn parse_substitute_directive(line: &str) -> Option<String> {
     let trimmed = line.trim();
     if trimmed.starts_with('#') {
         return None;
     }
-    if !trimmed.starts_with("substitute") {
-        return None;
-    }
-    let rest = &trimmed["substitute".len()..];
-    if rest.is_empty() {
-        return None;
-    }
-    // SAFETY: `rest` is non-empty (checked by `is_empty()` above)
-    let first = rest.chars().next().unwrap();
+    let rest = trimmed.strip_prefix("substitute")?;
+    let first = rest.chars().next()?;
     if !first.is_whitespace() && first != '"' {
         return None;
     }
-    // Extract quoted content
     let quote_start = rest.find('"')?;
     let after_quote = &rest[quote_start + 1..];
-    let quote_end = after_quote.find('"')?;
-    Some(after_quote[..quote_end].to_string())
+    let mut end = 0;
+    let bytes = after_quote.as_bytes();
+    while end < bytes.len() && bytes[end] != b'"' {
+        end += if bytes[end] == b'\\' && end + 1 < bytes.len() && bytes[end + 1] == b'"' {
+            2
+        } else {
+            1
+        };
+    }
+    if end >= bytes.len() {
+        return None;
+    }
+    if !after_quote[end + 1..].chars().all(|c| c == ' ') {
+        return None;
+    }
+    Some(after_quote[..end].to_string())
 }
 
 /// Parse a `path "..."` / `addpath "..."` directive line. `keyword`
@@ -480,92 +525,167 @@ pub fn loaded_path() -> Option<Vec<PathBuf>> {
         .clone()
 }
 
-/// Parse a `name=value,name2=value2,...` macro-definition string into
-/// `(name, value)` pairs, quote- and escape-aware.
+/// Parse a `name=value,name2=value2,...` macro-definition string into the
+/// `macPutValue` calls C would make for it, in order.
 ///
-/// Mirrors C `macParseDefns` (`macUtil.c`): a `,` or `=` is only a
-/// separator when it is outside `'...'`/`"..."` and not immediately
-/// preceded by a backslash. Whitespace around names/values is
-/// trimmed; surrounding quotes are NOT stripped (macLib keeps them so
-/// the value can carry literal separators). Definitions with no `=`
-/// are dropped.
-pub(crate) fn parse_macro_defns(defns: &str) -> Vec<(String, String)> {
-    let chars: Vec<char> = defns.chars().collect();
-    let mut pairs: Vec<(String, String)> = Vec::new();
-    let mut name = String::new();
-    let mut value = String::new();
-    let mut quote: Option<char> = None;
-    // false = collecting name, true = collecting value
-    let mut in_value = false;
-    let mut has_eq = false;
-    let mut i = 0;
+/// C `macParseDefns` (`macUtil.c:31-247`). A `,` or `=` is a separator
+/// only outside `'...'`/`"..."` and not escaped by a backslash, and
+/// whitespace around a name or a value is trimmed. Three of its rules
+/// this port did not have, each measured through `msi`:
+///
+///   * quotes and escapes are removed from NAMES and left in VALUES
+///     ("unlike values, they will not be re-parsed", `:199-227`), because
+///     a value is re-read by `trans` at level 1 and a name never is. So
+///     `'A'=1` defines `A`, while `A="1"` defines `A` as `"1"` and it is
+///     the level-1 pass that strips those quotes. Measured with
+///     `msi -M B=preset` on `substitute "'A'=1,B"`: `A=[1]`.
+///   * a name with no `=` after it is a DELETION. `macParseDefns` leaves
+///     the value pointer NULL (`del[i]`, `:105-110`) and
+///     `macInstallMacros` passes it to `macPutValue` (`:275`), whose NULL
+///     arm deletes the entry — so an OUTER definition of the same name is
+///     uncovered. Same measurement: `B=[$(B)]`, undefined, not `preset`.
+///     This port dropped such a definition and left `B` standing.
+///   * an EMPTY name is a name. `=1` installs a macro called `""` and
+///     `$()` resolves it; measured with `msi` on `substitute "=1,B=2"`:
+///     `empty:[1]`.
+///
+/// `None` is C's NULL value: delete the name rather than define it.
+pub(crate) fn parse_macro_defns(defns: &str) -> Vec<(String, Option<String>)> {
+    /// C `macParseDefns`'s four states (`macUtil.c:57`), kept because the
+    /// fall-through between them is what decides where a `,` with no `=`
+    /// before it leaves the parse.
+    enum St {
+        PreName,
+        InName,
+        PreValue,
+        InValue,
+    }
 
-    let flush = |name: &mut String,
-                 value: &mut String,
-                 has_eq: &mut bool,
-                 pairs: &mut Vec<(String, String)>| {
-        let k = name.trim();
-        if *has_eq && !k.is_empty() {
-            pairs.push((k.to_string(), value.trim().to_string()));
+    let chars: Vec<char> = defns.chars().collect();
+    // C's `end[num]--` loop: trailing whitespace comes off the RAW field,
+    // before any quote is removed from it.
+    let trimmed = |from: usize, to: usize| -> String {
+        let mut end = to;
+        while end > from && chars[end - 1].is_whitespace() {
+            end -= 1;
         }
-        name.clear();
-        value.clear();
-        *has_eq = false;
+        chars[from..end].iter().collect()
     };
+
+    let mut pairs: Vec<(String, Option<String>)> = Vec::new();
+    let mut name = String::new();
+    let mut del = false;
+    let mut start = 0;
+    let mut state = St::PreName;
+    let mut quote: Option<char> = None;
+    let mut i = 0;
 
     while i < chars.len() {
         let c = chars[i];
-        // Escape: backslash + next char are a literal 2-char unit.
-        if c == '\\' && i + 1 < chars.len() {
-            if in_value {
-                value.push(c);
-                value.push(chars[i + 1]);
-            } else {
-                name.push(c);
-                name.push(chars[i + 1]);
-            }
-            i += 2;
-            continue;
-        }
-        // Quote state.
+        // C updates `quote` BEFORE the state switch, so the OPENING quote
+        // character is inside the quote and the CLOSING one is outside it.
         if let Some(q) = quote {
             if c == q {
                 quote = None;
             }
-            if in_value {
-                value.push(c);
-            } else {
-                name.push(c);
-            }
-            i += 1;
-            continue;
         } else if c == '\'' || c == '"' {
             quote = Some(c);
-            if in_value {
-                value.push(c);
-            } else {
-                name.push(c);
+        }
+        let quoted = quote.is_some();
+        let escape = c == '\\' && i + 1 < chars.len();
+
+        loop {
+            match state {
+                St::PreName => {
+                    if !quoted && !escape && (c.is_whitespace() || c == ',') {
+                        break;
+                    }
+                    start = i;
+                    state = St::InName;
+                }
+                St::InName => {
+                    if quoted || escape || (c != '=' && c != ',') {
+                        break;
+                    }
+                    name = trimmed(start, i);
+                    del = c == ',';
+                    state = St::PreValue;
+                    if c != ',' {
+                        break;
+                    }
+                }
+                St::PreValue => {
+                    if !quoted && !escape && c.is_whitespace() {
+                        break;
+                    }
+                    start = i;
+                    state = St::InValue;
+                }
+                St::InValue => {
+                    if quoted || escape || c != ',' {
+                        break;
+                    }
+                    let value = trimmed(start, i);
+                    pairs.push((dequote(&name), (!del).then_some(value)));
+                    del = false;
+                    state = St::PreName;
+                    break;
+                }
             }
+        }
+        i += if escape { 2 } else { 1 };
+    }
+
+    // C's "tidy up from state at end of string" (`macUtil.c:135-155`),
+    // whose own fall-through is why a trailing name with no `=` still
+    // produces a pair, and a trailing `,` produces none.
+    match state {
+        St::PreName => {}
+        St::InName => pairs.push((dequote(&trimmed(start, chars.len())), None)),
+        St::PreValue => pairs.push((dequote(&name), Some(String::new()))),
+        St::InValue => {
+            let value = trimmed(start, chars.len());
+            pairs.push((dequote(&name), (!del).then_some(value)));
+        }
+    }
+    pairs
+}
+
+/// C `macParseDefns`'s in-place name cleanup (`macUtil.c:199-227`):
+/// quotes are dropped and a backslash is dropped in favour of the
+/// character after it.
+///
+/// The two interact the way C's loop does and not the way a reader
+/// expects: the escape branch runs after the quote branch has already
+/// declined the character, so `\"` yields a LITERAL `"` in the name
+/// rather than opening a quoted region. That is why `substitute
+/// "\"A\"=1"` defines a macro whose name is `"A"`, quotes included, and
+/// `$(A)` stays undefined.
+fn dequote(name: &str) -> String {
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::with_capacity(name.len());
+    let mut quote: Option<char> = None;
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if let Some(q) = quote {
+            if c == q {
+                quote = None;
+                i += 1;
+                continue;
+            }
+        } else if c == '\'' || c == '"' {
+            quote = Some(c);
             i += 1;
             continue;
         }
-        // Unquoted separators.
-        match c {
-            '=' if !in_value => {
-                in_value = true;
-                has_eq = true;
-            }
-            ',' => {
-                flush(&mut name, &mut value, &mut has_eq, &mut pairs);
-                in_value = false;
-            }
-            _ if in_value => value.push(c),
-            _ => name.push(c),
+        if c == '\\' && i + 1 < chars.len() {
+            i += 1;
         }
+        out.push(chars[i]);
         i += 1;
     }
-    flush(&mut name, &mut value, &mut has_eq, &mut pairs);
-    pairs
+    out
 }
 
 /// C `dbOpenFile` (`dbLexRoutines.c:166-193`) — the single rule every
@@ -677,11 +797,21 @@ pub fn db_expand_file_name(filename: &str) -> Option<String> {
 mod macro_defns_tests {
     use super::*;
 
+    /// `(name, Some(value))` written compactly.
+    fn def(name: &str, value: &str) -> (String, Option<String>) {
+        (name.to_string(), Some(value.to_string()))
+    }
+
+    /// `(name, None)` — C's NULL value, which deletes.
+    fn del(name: &str) -> (String, Option<String>) {
+        (name.to_string(), None)
+    }
+
     #[test]
     fn simple_pairs() {
         assert_eq!(
             parse_macro_defns("A=1,B=2"),
-            vec![("A".into(), "1".into()), ("B".into(), "2".into())]
+            vec![def("A", "1"), def("B", "2")]
         );
     }
 
@@ -689,16 +819,17 @@ mod macro_defns_tests {
     fn whitespace_trimmed() {
         assert_eq!(
             parse_macro_defns(" A = 1 , B = 2 "),
-            vec![("A".into(), "1".into()), ("B".into(), "2".into())]
+            vec![def("A", "1"), def("B", "2")]
         );
     }
 
-    /// a comma inside a quoted value does NOT split the pair.
+    /// a comma inside a quoted value does NOT split the pair, and the
+    /// quotes stay on the value — `trans` at level 1 is what removes them.
     #[test]
     fn quoted_comma_not_split() {
         assert_eq!(
             parse_macro_defns(r#"MSG="a,b",N=1"#),
-            vec![("MSG".into(), r#""a,b""#.into()), ("N".into(), "1".into())]
+            vec![def("MSG", r#""a,b""#), def("N", "1")]
         );
     }
 
@@ -707,27 +838,64 @@ mod macro_defns_tests {
     fn quoted_equals_not_split() {
         assert_eq!(
             parse_macro_defns(r#"EXPR="x=y""#),
-            vec![("EXPR".into(), r#""x=y""#.into())]
+            vec![def("EXPR", r#""x=y""#)]
         );
     }
 
-    /// An unquoted comma still splits (C parity for `MSG=a,b`).
+    /// An unquoted comma still splits, and what follows it has no `=`, so
+    /// it is a DELETION of `b` rather than nothing at all.
     #[test]
-    fn unquoted_comma_splits() {
+    fn unquoted_comma_splits_and_the_tail_deletes() {
         assert_eq!(
             parse_macro_defns("MSG=a,b"),
-            // `b` has no `=` so it is dropped (not a definition).
-            vec![("MSG".into(), "a".into())]
+            vec![def("MSG", "a"), del("b")]
         );
     }
 
-    /// An escaped separator is literal, not a split point.
+    /// An escaped separator is literal, not a split point, and the
+    /// backslash stays in the VALUE for the level-1 pass to consume.
     #[test]
     fn escaped_separator_is_literal() {
+        assert_eq!(parse_macro_defns(r"K=a\,b"), vec![def("K", r"a\,b")]);
+    }
+
+    /// Quotes come OFF a name — measured with `msi -M B=preset` on
+    /// `substitute "'A'=1,B"`, which prints `A=[1] B=[$(B)]`.
+    #[test]
+    fn quotes_are_removed_from_a_name_and_a_bare_name_deletes() {
+        assert_eq!(parse_macro_defns("'A'=1,B"), vec![def("A", "1"), del("B")]);
+    }
+
+    /// An ESCAPED quote in a name is a literal quote character, because
+    /// C's cleanup loop reaches the escape branch only after the quote
+    /// branch has declined the character. `msi` on `substitute
+    /// "\"A\"=1"` leaves `$(A)` undefined for exactly this reason.
+    #[test]
+    fn an_escaped_quote_stays_in_the_name() {
+        assert_eq!(parse_macro_defns(r#"\"A\"=1"#), vec![def(r#""A""#, "1")]);
+    }
+
+    /// An empty name is a name: `msi` on `substitute "=1,B=2"` prints
+    /// `empty:[1]` for `$()`.
+    #[test]
+    fn an_empty_name_is_still_a_definition() {
         assert_eq!(
-            parse_macro_defns(r"K=a\,b"),
-            vec![("K".into(), r"a\,b".into())]
+            parse_macro_defns("=1,B=2"),
+            vec![def("", "1"), def("B", "2")]
         );
+    }
+
+    /// A trailing comma closes the previous pair and opens nothing.
+    #[test]
+    fn a_trailing_comma_adds_nothing() {
+        assert_eq!(parse_macro_defns("A=1,"), vec![def("A", "1")]);
+    }
+
+    /// A name with `=` and nothing after it defines the empty value, which
+    /// is not the same as deleting.
+    #[test]
+    fn an_empty_value_is_not_a_deletion() {
+        assert_eq!(parse_macro_defns("A="), vec![def("A", "")]);
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/db_loader/mod.rs
+++ b/crates/epics-base-rs/src/server/db_loader/mod.rs
@@ -17,8 +17,10 @@ pub use include::{
     parse_db_file_with_breaktables, parse_db_opened_with_breaktables, set_loaded_path,
 };
 pub use source::{DbIncludeFrame, DbSource};
-pub(crate) use substitution::resolve_template;
-pub use substitution::{TemplateLoad, parse_substitutions, substitution_rows};
+pub use substitution::{
+    RowMacro, SubstitutionEvent, SubstitutionFault, Substitutions, TemplateLoad,
+    db_template_max_vars, parse_substitutions, set_db_template_max_vars,
+};
 
 /// Factory function that creates a record instance.
 pub type RecordFactory = Box<dyn Fn() -> Box<dyn Record> + Send + Sync>;
@@ -795,6 +797,22 @@ pub struct DbRecordDef {
     /// Mirrors `info` directives in EPICS db files; common tags include
     /// `asyn:READBACK` (asyn upstream PRs #60 / #208), `Q:form`, etc.
     pub info_tags: Vec<(String, String)>,
+    /// 1-based line of the flattened, macro-expanded text the record HEAD
+    /// ended on — the index [`DbSource::at`] takes, and C's
+    /// `pinputFileNow->line_num` when `dbRecordHead` reduces.
+    ///
+    /// The head and not the body, because that is where C decides the record
+    /// exists: `dbCreateRecord` runs from the `record_head` action
+    /// (`dbYacc.y:227-235`), so an unknown record type is refused with the
+    /// closing `)` still the last token the lexer matched — ` at or before
+    /// ')' … line 1` on `softIoc` @`R7.0.10`, not the line of the `}` far
+    /// below. It travels ON the record for the reason [`DbFieldDef::line`]
+    /// gives: the install loop reorders and drops entries, and a parallel
+    /// vector would hand the survivors somebody else's line.
+    ///
+    /// `0` is "no source behind this record" — one built programmatically,
+    /// where C has no line either.
+    pub line: u32,
 }
 
 /// One `field(NAME,"value")` element, with where it was read from.
@@ -839,11 +857,18 @@ impl DbFieldDef {
 ///
 /// The check runs **after** macro substitution, mirroring base where
 /// `dbRecordHead` is invoked from the lexer with the substituted name.
-pub(crate) fn validate_record_name(name: &str, line: usize, col: usize) -> CaResult<()> {
+///
+/// The third argument is no longer read. C locates both refusals at the `)`
+/// the `record_head`/`alias` production had just reduced — measured on
+/// `softIoc` @`R7.0.10`, `record(ai, "")` and `record(ai, "a b")` both print
+/// ` at or before ')'` — so the locator is a constant, not something a caller
+/// can know better. Dropping the parameter needs the iocsh caller that still
+/// passes one, which is another panel's file.
+pub(crate) fn validate_record_name(name: &str, line: usize, _col: usize) -> CaResult<()> {
     if name.is_empty() {
         return Err(CaError::DbParseError {
             line,
-            column: col,
+            token: String::from(")"),
             message: "record/alias name can't be empty".into(),
         });
     }
@@ -864,7 +889,7 @@ pub(crate) fn validate_record_name(name: &str, line: usize, col: usize) -> CaRes
         if matches!(c, ' ' | '\t' | '"' | '\'' | '.' | '$') {
             return Err(CaError::DbParseError {
                 line,
-                column: col,
+                token: String::from(")"),
                 message: format!("bad character '{c}' in record/alias name \"{name}\""),
             });
         }
@@ -948,22 +973,6 @@ impl DbDiagnostic {
     }
 }
 
-/// What the FIRST diagnostic of a text quotes to say WHERE in the line
-/// it is — C's ` at or before '%s'` (`dbYacc.y:378`).
-#[derive(Debug)]
-enum Locator {
-    /// C's `yytext`: the token the lexer had last matched. The port's
-    /// recoverable diagnostics know it because they are raised from a
-    /// grammar position C reduces with a known token — a field's
-    /// closing `)`, say.
-    Token(String),
-    /// The column the parser had reached. C has no counterpart because
-    /// its lexer always holds a `yytext`; this port's recursive-descent
-    /// parser keeps no such seat, and naming the column it DOES hold is
-    /// true where quoting a token it never recorded would be a guess.
-    Column(usize),
-}
-
 #[derive(Debug, Default)]
 pub struct DbFaults {
     messages: Vec<String>,
@@ -971,8 +980,15 @@ pub struct DbFaults {
     /// `my_buffer` (`dbYacc.y:374-381`) — for the whole flattened text.
     source: Option<source::DbSource>,
     /// Where in [`Self::source`] a diagnostic is currently about, i.e.
-    /// where C's `pinputFileNow` would be parked, together with the
-    /// locator that names the spot inside the line.
+    /// where C's `pinputFileNow` would be parked, together with C's
+    /// `yytext` — the token that names the spot inside the line.
+    ///
+    /// A token and not a column: C's ` at or before '%s'` quotes the text
+    /// the lexer had matched, and every abort this port raises knows that
+    /// text, because a recursive-descent parser rejects AT a token it has
+    /// just read or is looking at. Carrying a column instead was this
+    /// port's own invention and read ` at or before column 1` where C
+    /// reads ` at or before '}'`.
     ///
     /// ONE field, not a line beside a token, because the two must agree:
     /// a line from one diagnostic wearing another's token is a position
@@ -983,7 +999,7 @@ pub struct DbFaults {
     /// for the operator than no line number, so the position is CLEARED
     /// at the end of the parse rather than left to decay. See
     /// [`Self::seek`].
-    park: Option<(u32, Locator)>,
+    park: Option<(u32, String)>,
     /// C's `yyFailed` (`dbYacc.y:377-380`): ` at or before` and the
     /// include stack are printed for the FIRST diagnostic of a text
     /// only, and every one after it gets the line echo alone.
@@ -1002,7 +1018,7 @@ impl DbFaults {
     /// raised from here names that line. `yytext` is the token just
     /// consumed, which is what C quotes in ` at or before '%s'`.
     pub fn seek(&mut self, line: u32, yytext: &str) {
-        self.park = Some((line, Locator::Token(yytext.to_owned())));
+        self.park = Some((line, yytext.to_owned()));
     }
 
     /// Leave the lexer's seat. Every later diagnostic prints without
@@ -1038,7 +1054,7 @@ impl DbFaults {
         let message = match err {
             CaError::DbParseError {
                 line,
-                column,
+                token,
                 message,
             } => {
                 // `line: 0` is the include layer saying this failure has
@@ -1046,11 +1062,11 @@ impl DbFaults {
                 // that could not be read. The message stands alone then,
                 // which is also what C's `yyerror` degrades to when
                 // `dbIncludePrint` has no frame to walk.
-                self.park = (*line > 0).then_some((*line as u32, Locator::Column(*column)));
+                self.park = (*line > 0).then(|| (*line as u32, token.clone()));
                 // The `message` field, NOT the error's `Display`: that
-                // spells the position a second time, in this port's own
-                // words (`DB parse error at line 3, column 6: …`), and
-                // the position is what the two lines below say properly.
+                // spells the line a second time, in this port's own
+                // words (`DB parse error at line 3: …`), and the position
+                // is what the two lines below say properly.
                 message.clone()
             }
             _ => {
@@ -1125,12 +1141,9 @@ impl DbFaults {
     /// after the message slot — or `None` when this port cannot say
     /// where it was.
     fn position_context(&mut self) -> Option<String> {
-        let (line, locator) = self.park.as_ref()?;
+        let (line, token) = self.park.as_ref()?;
         let line = *line;
-        let clause = match locator {
-            Locator::Token(token) => format!(" at or before '{token}'"),
-            Locator::Column(column) => format!(" at or before column {column}"),
-        };
+        let clause = format!(" at or before '{token}'");
         let (frames, text) = self.source.as_ref()?.at(line)?;
         let mut out = String::new();
         if !self.yy_failed {
@@ -1353,7 +1366,7 @@ pub fn unknown_alias_message(alias: &str, target: &str) -> String {
 /// and dropped. C keeps the records it already read too — callers that
 /// own a database ([`crate::server::ioc_builder`], `dbLoadRecords`)
 /// take [`ParsedDb::unresolved_aliases`] instead and resolve them.
-pub fn parse_db(input: &str, macros: &HashMap<String, String>) -> CaResult<Vec<DbRecordDef>> {
+pub fn parse_db(input: &str, macros: impl Into<MacroDefs>) -> CaResult<Vec<DbRecordDef>> {
     let parsed = parse_db_with_breaktables(input, macros)?.load_status(DB_STRING_SOURCE)?;
     for (target, alias) in &parsed.unresolved_aliases {
         eprintln!("{}", unknown_alias_message(alias, target));
@@ -1399,32 +1412,46 @@ pub fn set_db_quiet_macro_warnings(quiet: bool) {
 /// straight to `dbLoadRecords`, where the two raw values walk into each
 /// other on the first expansion. Measured against `softIoc R7.0.10`:
 /// three lines C wrote that this used to swallow, now
-/// [`MacroExpansion::recursive`] and the notice in [`refer`].
+/// [`MacroFault::Recursive`] and the notice in [`refer`].
 ///
 /// The earlier reading that no such input existed came from testing
 /// through the iocsh command line, where the shell's own expansion
 /// consumes `$(…)` before `dbLoadRecords` is called — `A=$(B),B=$(A)`
 /// there is two UNDEFINED references, not a cycle.
 ///
-/// The unterminated arm (`macCore.c:865-875`) is a separate line C
-/// prints, `macLib: unterminated macro reference in …`, and this
-/// expander still has none: `refer` returns `None` and the caller copies
-/// the `$` through. UNFIXED, and untested against C either way.
+/// The unterminated arm (`macCore.c:862-875`) is a separate `macLib:`
+/// line C prints for a `$(`/`${` whose closing delimiter never matched,
+/// and it raises this same warning under it — measured on `softIoc
+/// R7.0.10`, two lines per bad line, and `var dbQuietMacroWarnings 1`
+/// drops the `macLib:` one and keeps this one, exactly as for the other
+/// two arms. [`MacroFault::Unterminated`] and the notice in [`refer`].
 ///
 /// `filename` is `None` for text that never came from a file — C has no
 /// such path (`dbReadDatabase` always names one), so the per-file warning
 /// is simply not raised rather than invented with a placeholder name.
 pub(crate) fn db_read_lines(
     text: &str,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     filename: Option<&str>,
 ) -> (String, DbSource) {
+    // One table for the file, because C holds one `MAC_HANDLE` for the
+    // whole `.db` (`dbReadCOM`, `dbLexRoutines.c:256-300`) and reads
+    // `dbQuietMacroWarnings` into it once, at open. So a macro whose own
+    // value is faulty is expanded — and complained about — once here,
+    // not once per line that mentions it.
+    let mut table = MacroTable::new(
+        macros,
+        MacroExpandOptions {
+            suppress_warnings: db_quiet_macro_warnings(),
+            ..MacroExpandOptions::default()
+        },
+    );
     let mut out = String::with_capacity(text.len());
     let mut lines = Vec::new();
     let mut frames = Vec::new();
     for (i, raw) in text.split_inclusive('\n').enumerate() {
         let line_num = i as u32 + 1;
-        let expanded = db_expand_line(raw, macros, filename, line_num);
+        let expanded = db_expand_line_in(&mut table, raw, filename, line_num);
         out.push_str(&expanded);
         lines.push(expanded);
         frames.push(std::sync::Arc::from(vec![DbIncludeFrame {
@@ -1444,17 +1471,19 @@ pub(crate) fn db_read_lines(
 /// it, because macLib quotes the string it was given: C's console shows
 /// the closing `)` of `(expanding string …)` on the NEXT line for that
 /// reason, and a caller that trimmed first would print a different shape.
-pub(crate) fn db_expand_line(
+///
+/// The table is always the caller's, and there is no variant that builds
+/// one per line: C has exactly one `MAC_HANDLE` for a whole `dbReadCOM`
+/// (`dbLexRoutines.c:256-300`) and msi one for a whole run
+/// (`msi.cpp:111`), so a per-line table can only ever announce a faulty
+/// definition once per line where C announces it once per file.
+pub(crate) fn db_expand_line_in(
+    table: &mut MacroTable,
     raw: &str,
-    macros: &HashMap<String, String>,
     filename: Option<&str>,
     line_num: u32,
 ) -> String {
-    let opts = MacroExpandOptions {
-        suppress_warnings: db_quiet_macro_warnings(),
-        ..MacroExpandOptions::default()
-    };
-    let expansion = expand_macros(raw, macros, opts);
+    let expansion = table.expand(raw);
     // C `entry->error`, not "an undefined name": `macExpandString`
     // returns the same negative length for a recursive reference, and
     // this warning is what tells the operator the line went out wrong.
@@ -1482,10 +1511,7 @@ pub(crate) fn db_expand_line(
 }
 
 /// Like [`parse_db`] but returns the whole [`ParsedDb`].
-pub fn parse_db_with_breaktables(
-    input: &str,
-    macros: &HashMap<String, String>,
-) -> CaResult<ParsedDb> {
+pub fn parse_db_with_breaktables(input: &str, macros: impl Into<MacroDefs>) -> CaResult<ParsedDb> {
     // Per LINE, not per file: C's loader expands each `fgets` line
     // separately (`dbLexRoutines.c:375-391`), so quote state cannot leak
     // across lines — see [`db_read_lines`].
@@ -1619,9 +1645,9 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             expect_char(&chars, &mut pos, &mut col, ',', line)?;
             skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
             let alias_name = read_token_string(&chars, &mut pos, &mut line, &mut col)?;
-            validate_record_name(&alias_name, line, col)?;
             skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
             expect_char(&chars, &mut pos, &mut col, ')', line)?;
+            validate_record_name(&alias_name, line, col)?;
             global_aliases.push((target, alias_name));
             continue;
         }
@@ -1651,7 +1677,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                 if pos >= chars.len() {
                     return Err(CaError::DbParseError {
                         line,
-                        column: col,
+                        token: String::new(),
                         message: "unexpected end of file in breaktable body".into(),
                     });
                 }
@@ -1665,7 +1691,6 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                     col += 1;
                     continue;
                 }
-                let start = col;
                 let mut tok = String::new();
                 while pos < chars.len() && is_number_char(chars[pos]) {
                     tok.push(chars[pos]);
@@ -1675,7 +1700,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                 if tok.is_empty() {
                     return Err(CaError::DbParseError {
                         line,
-                        column: col,
+                        token: yytext_at(&chars, pos),
                         message: format!(
                             "breaktable {bt_name}: expected a number, got '{}'",
                             chars[pos]
@@ -1684,7 +1709,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                 }
                 let num: f64 = tok.parse().map_err(|_| CaError::DbParseError {
                     line,
-                    column: start,
+                    token: tok.clone(),
                     message: format!("breaktable {bt_name}: non-numeric value '{tok}'"),
                 })?;
                 nums.push(num);
@@ -1694,7 +1719,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             if nums.len() % 2 != 0 {
                 return Err(CaError::DbParseError {
                     line,
-                    column: col,
+                    token: String::from("}"),
                     message: format!("breaktable {bt_name}: Raw value missing"),
                 });
             }
@@ -1702,7 +1727,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             let table = crate::server::cvt_bpt::BrkTable::build(bt_name, &pairs).map_err(|e| {
                 CaError::DbParseError {
                     line,
-                    column: col,
+                    token: String::from("}"),
                     message: e,
                 }
             })?;
@@ -1724,7 +1749,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             continue;
         }
         if word == "device" {
-            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 4, 4, "device")?;
+            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 4, 4)?;
             dbd.devices.push(DbdDevice {
                 record_type: a[0].clone(),
                 link_type: a[1].clone(),
@@ -1734,12 +1759,12 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             continue;
         }
         if word == "driver" {
-            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 1, "driver")?;
+            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 1)?;
             dbd.drivers.push(a[0].clone());
             continue;
         }
         if word == "link" {
-            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 2, 2, "link")?;
+            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 2, 2)?;
             dbd.link_types.push(DbdLinkType {
                 key: a[0].clone(),
                 lset: a[1].clone(),
@@ -1747,19 +1772,19 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             continue;
         }
         if word == "registrar" {
-            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 1, "registrar")?;
+            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 1)?;
             dbd.registrars.push(a[0].clone());
             continue;
         }
         if word == "function" {
-            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 1, "function")?;
+            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 1)?;
             dbd.functions.push(a[0].clone());
             continue;
         }
         if word == "variable" {
             // C `dbYacc.y:192-202`: the one-argument form is
             // `dbVariable($3, "int")`.
-            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 2, "variable")?;
+            let a = parse_arg_list(&chars, &mut pos, &mut line, &mut col, 1, 2)?;
             dbd.variables.push(DbdVariable {
                 name: a[0].clone(),
                 dtype: a.get(1).cloned().unwrap_or_else(|| "int".to_string()),
@@ -1770,8 +1795,8 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
         if word != "record" && word != "grecord" {
             return Err(CaError::DbParseError {
                 line,
-                column: col,
-                message: format!("expected 'record', got '{word}'"),
+                token: word.clone(),
+                message: SYNTAX_ERROR.into(),
             });
         }
 
@@ -1786,10 +1811,20 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
 
         skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
         let name = read_token_string(&chars, &mut pos, &mut line, &mut col)?;
-        validate_record_name(&name, line, col)?;
 
         skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
         expect_char(&chars, &mut pos, &mut col, ')', line)?;
+        // Where C's lexer is parked when `dbRecordHead` reduces, which is the
+        // line every refusal of the head itself is reported on.
+        let head_line = line as u32;
+        // C runs `dbRecordNameValidate` from the `record_head` ACTION, which
+        // bison reduces only after the `)` (`dbYacc.y:227-235`), so a third
+        // argument is a grammar rejection at the comma and never reaches the
+        // name check: `record(ai, "", extra)` prints ` at or before ','` on
+        // `softIoc` @`R7.0.10`, while `record(ai, "")` prints the empty-name
+        // refusal located at `)`. Validating before the paren gave both of
+        // them the name refusal.
+        validate_record_name(&name, line, col)?;
 
         skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
         let mut fields = Vec::new();
@@ -1809,7 +1844,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                 if pos >= chars.len() {
                     return Err(CaError::DbParseError {
                         line,
-                        column: col,
+                        token: String::new(),
                         message: "unexpected end of file in record body".into(),
                     });
                 }
@@ -1831,8 +1866,8 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                 if kw != "field" && kw != "info" && kw != "alias" {
                     return Err(CaError::DbParseError {
                         line,
-                        column: col,
-                        message: format!("expected 'field', got '{kw}'"),
+                        token: kw.clone(),
+                        message: SYNTAX_ERROR.into(),
                     });
                 }
 
@@ -1842,9 +1877,9 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
                     expect_char(&chars, &mut pos, &mut col, '(', line)?;
                     skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
                     let alias_name = read_token_string(&chars, &mut pos, &mut line, &mut col)?;
-                    validate_record_name(&alias_name, line, col)?;
                     skip_whitespace_and_comments(&chars, &mut pos, &mut line, &mut col);
                     expect_char(&chars, &mut pos, &mut col, ')', line)?;
+                    validate_record_name(&alias_name, line, col)?;
                     aliases.push(alias_name);
                     continue;
                 }
@@ -1958,6 +1993,7 @@ fn parse_db_items(expanded: &str, faults: &mut DbFaults) -> CaResult<DbItems> {
             fields,
             aliases,
             info_tags,
+            line: head_line,
         });
     }
 
@@ -2015,9 +2051,10 @@ pub struct MacroExpandOptions {
 /// Outcome of [`expand_macros`]: the expanded text, plus the fault that
 /// made it wrong if one did.
 ///
-/// Two faults reach here — a name with no definition and a name that
-/// resolves into itself — and they are C's single `entry->error`
-/// (`macCore.c:216-224`) split by cause. Both lists are therefore
+/// Three faults reach here — a name with no definition, a name that
+/// resolves into itself, and a reference whose closing delimiter never
+/// matched its opener — and they are C's single `entry->error`
+/// (`macCore.c:216-224`) split by cause. All three lists are therefore
 /// private, and the only way to read them is [`Self::fault`], or
 /// [`Self::errored`] for the same answer as a bool. A consumer able to
 /// reach one list directly hard-fails on the fault it named and returns
@@ -2027,6 +2064,21 @@ pub struct MacroExpandOptions {
 #[derive(Clone, Debug, Default)]
 pub struct MacroExpansion {
     pub text: String,
+    faults: MacroFaults,
+}
+
+/// C `MAC_ENTRY.error`, kept as the names that set it rather than a
+/// bool, and kept as ONE value because C keeps one: `refer` translates a
+/// reference name and a used default through the caller's own `entry`
+/// so their faults land here, and translates scoped definitions through
+/// a separate `MAC_ENTRY subs` whose `error` is never merged back
+/// (`macCore.c:820-826`). That second rule is why this is a struct and
+/// not three loose fields on [`ExpandCtx`] — [`ExpandCtx::detached`]
+/// swaps the whole set out for the scoped region in one move, so no
+/// future arm can leak into the caller by being added to only two of
+/// three lists.
+#[derive(Clone, Debug, Default)]
+struct MacroFaults {
     /// Every macro referenced with neither a definition (nor an env
     /// value, when `env_fallback`) nor a default. The text still carries
     /// C's `$(name,undefined)` placeholder for each
@@ -2039,11 +2091,19 @@ pub struct MacroExpansion {
     /// different placeholders, and a caller that hard-fails on an
     /// undefined name must not be told a recursive one was undefined.
     recursive: Vec<String>,
+    /// Every `$(`/`${` whose closing delimiter never arrived — C
+    /// `refer`'s first error arm (`macCore.c:862-875`). Each entry is
+    /// the raw text C copied through verbatim, from the `$` to the end
+    /// of the string, because that arm writes no placeholder and names
+    /// no macro: the reference never became a name to look up.
+    unterminated: Vec<String>,
 }
 
-/// Which fault an expansion hit, and the first macro name that hit it.
-/// One variant per placeholder C writes, so a caller cannot report a
-/// recursion as an undefined name.
+/// Which fault an expansion hit, and the first text that hit it — the
+/// macro name for the two arms that parsed one, the copied-through
+/// source for the arm that did not. One variant per way C sets
+/// `entry->error`, so a caller cannot report a recursion as an undefined
+/// name, nor either of them as a reference that was never closed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MacroFault<'a> {
     /// No definition, no env value, no default — C's
@@ -2052,26 +2112,36 @@ pub enum MacroFault<'a> {
     /// Resolving the name re-entered itself — C's `refentry->visited`
     /// guard (`macCore.c:895-904`).
     Recursive(&'a str),
+    /// The closing delimiter never matched the opener, so C copied the
+    /// reference and everything after it through verbatim
+    /// (`macCore.c:862-875`). The payload is that copied text — this arm
+    /// carries no macro NAME because the reference never produced one.
+    Unterminated(&'a str),
 }
 
 impl MacroExpansion {
     /// The single owner of "did this expansion come out wrong, and
-    /// why". Both arms are read here so that no caller can read only
-    /// one.
+    /// why". Every arm is read here so that no caller can read only
+    /// some of them.
     ///
-    /// A macro is never in both lists: `recursive` is recorded only
-    /// where the name resolved to a table entry, `undefined` only where
-    /// it resolved to nothing. So the order below decides nothing but
-    /// which of two independent faults a string carrying both reports
-    /// first.
+    /// A macro is never in more than one list: `recursive` is recorded
+    /// only where the name resolved to a table entry, `undefined` only
+    /// where it resolved to nothing, `unterminated` only where no name
+    /// was ever parsed. So the order below decides nothing but which of
+    /// several independent faults a string carrying more than one
+    /// reports first.
     #[must_use]
     pub fn fault(&self) -> Option<MacroFault<'_>> {
-        if let Some(name) = self.undefined.first() {
+        if let Some(name) = self.faults.undefined.first() {
             return Some(MacroFault::Undefined(name.as_str()));
         }
-        self.recursive
+        if let Some(name) = self.faults.recursive.first() {
+            return Some(MacroFault::Recursive(name.as_str()));
+        }
+        self.faults
+            .unterminated
             .first()
-            .map(|name| MacroFault::Recursive(name.as_str()))
+            .map(|raw| MacroFault::Unterminated(raw.as_str()))
     }
 
     /// C `MAC_ENTRY.error`: whether the expansion came out wrong, by any
@@ -2086,30 +2156,607 @@ impl MacroExpansion {
     }
 }
 
-/// Engine state threaded through [`trans`] / [`refer`] / [`parse_scoped`]:
-/// the base macro map, the resolution options, and the running list of
-/// undefined-macro names.
-struct ExpandCtx<'a> {
-    macros: &'a HashMap<String, String>,
+/// C `entry->type`: the word every `macLib:` notice prints in front of
+/// the entry name, and the reason those notices are not all about
+/// `string`. C carries six (`macCore.c:208`, `:283`, `:418`, `:595`,
+/// `:811`, `:826`); the `"default value"` seat is the one this port has
+/// no use for, because it slices a default out instead of running C's
+/// discarding first pass over it.
+const KIND_STRING: &str = "string";
+const KIND_MACRO: &str = "macro";
+const KIND_ENVIRONMENT: &str = "environment variable";
+const KIND_SCOPE_MARKER: &str = "scope marker";
+const KIND_SCOPED_MACRO: &str = "scoped macro";
+
+/// One `MAC_ENTRY.error`, carrying the text that raised it.
+///
+/// C keeps a bare `int error` and merges it with `entry->error =
+/// entry->error || refentry->error` (`macCore.c:885`), which is all its
+/// callers need: every one of them only compares `macExpandString`'s
+/// returned length against zero. This port's callers ask WHICH fault
+/// ([`MacroExpansion::fault`]), so the cause travels with the flag and a
+/// fault merged out of a cached value still names the macro that broke.
+#[derive(Clone, Debug)]
+enum TableFault {
+    Undefined(String),
+    Recursive(String),
+    Unterminated(String),
+}
+
+impl MacroFaults {
+    /// The only way a fault gets in, so an arm added to [`MacroFault`]
+    /// cannot be routed to the wrong list or to no list at all.
+    fn raise(&mut self, fault: TableFault) {
+        match fault {
+            TableFault::Undefined(name) => self.undefined.push(name),
+            TableFault::Recursive(name) => self.recursive.push(name),
+            TableFault::Unterminated(text) => self.unterminated.push(text),
+        }
+    }
+
+    /// C `entry->error = entry->error || refentry->error`
+    /// (`macCore.c:885`): a reference that resolves to a cached value
+    /// inherits that value's fault.
+    ///
+    /// C inherits one bit and so cannot say what the macro's fault was;
+    /// this inherits the causes, which costs nothing — only
+    /// [`MacroExpansion::fault`] reads them, and it reads the first.
+    fn merge(&mut self, other: &MacroFaults) {
+        self.undefined.extend_from_slice(&other.undefined);
+        self.recursive.extend_from_slice(&other.recursive);
+        self.unterminated.extend_from_slice(&other.unterminated);
+    }
+
+    /// Re-seat every recursion in this set onto `name`.
+    ///
+    /// A recursion is a property of the macro that could not be
+    /// resolved, not of the inner reference the resolution had to refuse
+    /// to find that out — C's own notice says so in as many words,
+    /// `macro A is recursive (expanding macro B)` (`macCore.c:895-901`).
+    /// So a fault merged out of `A`'s cached value reports `A`, which is
+    /// the name the caller wrote. The other two arms are properties of
+    /// something INSIDE the value — a name that resolves to nothing, a
+    /// bracket that never closes — and keep their own text.
+    fn rename_recursive(&mut self, name: &str) {
+        for entry in &mut self.recursive {
+            name.clone_into(entry);
+        }
+    }
+}
+
+/// C `MAC_ENTRY` (`macLib.h:34-45`): one macro, holding both the
+/// definition as given and the expansion cached from it.
+///
+/// The cache is the point of the type. C expands every raw value into
+/// `entry->value` in one pass over the whole table and then resolves a
+/// reference by COPYING that value (`refer`, `macCore.c:882-886`), so a
+/// macro whose own value is faulty raises its notice once, under its own
+/// name, before any caller's string is looked at — and every later
+/// reference to it reports the cached fault instead of deriving a fresh
+/// one from a different seat.
+#[derive(Clone, Debug)]
+struct MacEntry {
+    /// C `entry->name`. The scope markers carry the literal `<scope>`.
+    name: String,
+    /// C `entry->type` — one of the `KIND_*` constants above.
+    kind: &'static str,
+    /// C `entry->rawval`: the definition exactly as given.
+    rawval: String,
+    /// C `entry->value`: the definition with its own references
+    /// resolved. `None` until [`expand_table`] fills it, and set back to
+    /// `None` by any redefinition of this entry.
+    value: Option<String>,
+    /// C `entry->error`, as the causes that raised it — see
+    /// [`TableFault`]. Reset at the top of every [`expand_table`] pass,
+    /// exactly where C resets the bool (`macCore.c:670`).
+    faults: MacroFaults,
+    /// C `entry->visited`: raised around a translation of THIS entry's
+    /// raw value, so a reference that comes back round to it is refused
+    /// rather than followed (`macCore.c:888-893`).
+    visited: bool,
+    /// C `entry->special`: a `<scope>` marker rather than a macro
+    /// (`macPushScope`, `macCore.c:416-419`).
+    special: bool,
+    /// C `entry->level`: the scope depth this entry was defined at,
+    /// which decides whether a redefinition overwrites it or shadows it.
+    level: usize,
+}
+
+/// The `macPutValue` calls a caller wants made, in the order it wants
+/// them made in.
+///
+/// C builds its table one `macPutValue` at a time — `macInstallMacros`
+/// walks the `pairs` array `macParseDefns` produced, in file order
+/// (`macUtil.c:250-275`) — and `expand` then walks the table in that
+/// same order (`macCore.c:655`), so the sequence a `.db` load's macLib
+/// notices come out in is the sequence the definitions were written in.
+/// A [`HashMap`] cannot carry that, and sorting its keys by name only
+/// looked right because the shapes measured so far happened to be in
+/// alphabetical order already.
+///
+/// So the order is carried here instead, and the conversion from a
+/// [`HashMap`] is the one place the loss is named: those definitions
+/// arrive in no order at all, and sorting them by name at least makes
+/// the notices reproducible from run to run.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MacroDefs {
+    /// Name/value pairs in definition order, at most one entry per name.
+    defs: Vec<(String, String)>,
+}
+
+impl MacroDefs {
+    /// An empty set of definitions.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// C `macPutValue` (`macCore.c:262-289`): a redefinition replaces the
+    /// value and keeps the entry where it is, because `rawval` writes
+    /// through the entry `lookup` found rather than appending a second
+    /// one.
+    pub fn put(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        let name = name.into();
+        match self.defs.iter_mut().find(|(n, _)| *n == name) {
+            Some(slot) => slot.1 = value.into(),
+            None => self.defs.push((name, value.into())),
+        }
+    }
+
+    /// The definitions in order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.defs.iter().map(|(n, v)| (n.as_str(), v.as_str()))
+    }
+
+    /// How many names are defined.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.defs.len()
+    }
+
+    /// Whether nothing is defined.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.defs.is_empty()
+    }
+}
+
+impl FromIterator<(String, String)> for MacroDefs {
+    /// Definition order, last definition of a name winning — C's, since
+    /// every one of these is a `macPutValue`.
+    fn from_iter<I: IntoIterator<Item = (String, String)>>(iter: I) -> Self {
+        let mut defs = Self::new();
+        for (name, value) in iter {
+            defs.put(name, value);
+        }
+        defs
+    }
+}
+
+impl From<Vec<(String, String)>> for MacroDefs {
+    fn from(pairs: Vec<(String, String)>) -> Self {
+        pairs.into_iter().collect()
+    }
+}
+
+impl From<&MacroDefs> for MacroDefs {
+    fn from(defs: &MacroDefs) -> Self {
+        defs.clone()
+    }
+}
+
+impl From<&HashMap<String, String>> for MacroDefs {
+    /// The lossy direction, and the only one: a hash map has no
+    /// definition order to carry, so the names are sorted to make the
+    /// notice order at least the same on every run. A caller that knows
+    /// the order the operator wrote should build a [`MacroDefs`]
+    /// directly.
+    fn from(macros: &HashMap<String, String>) -> Self {
+        let mut names: Vec<&String> = macros.keys().collect();
+        names.sort_unstable();
+        names
+            .into_iter()
+            .map(|name| (name.clone(), macros[name].clone()))
+            .collect()
+    }
+}
+
+/// C `MAC_HANDLE` (`macLib.h:47-57`): the macro table, the scope depth,
+/// and the one bit that says whether the cached values can be trusted.
+///
+/// This is the unit C creates once per FILE and expands once per line
+/// (`dbReadCOM` holds `macHandle` across the whole `.db`,
+/// `dbLexRoutines.c:256-300`), which is what makes a macro's own fault a
+/// once-per-file notice rather than a once-per-line one. Callers that
+/// have a single string and no file keep using [`expand_macros`], which
+/// is this type for the length of one call.
+///
+/// Entries are in the order they were defined in, which is C's
+/// `macPutValue` call order and the order the expansion pass walks them
+/// in (C `expand`, `macCore.c:655`) — so it is the order the notices a
+/// faulty definition raises come out in.
+/// That order is a property of [`MacroDefs`], not of this type: a table
+/// built from one is in the caller's order by construction, and a table
+/// built from a [`HashMap`] is in the only order a hash map can offer.
+pub struct MacroTable {
+    /// C `handle->list`. Ordered and searched from the tail.
+    ///
+    /// While an expansion is running it is only appended to or truncated
+    /// at the tail — see [`MacroTable::pop_scope`] — which is what lets
+    /// `refer` hold an index across a nested translation.
+    /// [`MacroTable::undefine`] is the one mutation that removes from the
+    /// middle, and it is reachable only from the file reader, between
+    /// lines, where no such index exists.
+    entries: Vec<MacEntry>,
+    /// C `handle->level`: how many scopes are open.
+    level: usize,
+    /// C `handle->dirty`: some raw value has changed since the last
+    /// [`expand_table`], so no cached value may be used. Raised by every
+    /// definition and every scope pop, lowered only by a completed
+    /// expansion pass.
+    dirty: bool,
+    /// C's handle flags, plus this port's `$$` convenience.
     opts: MacroExpandOptions,
-    undefined: Vec<String>,
-    recursive: Vec<String>,
-    /// C's `MAC_ENTRY.name` for this expansion, which every `macLib:`
-    /// warning quotes. `macExpandString` fills in the source string
-    /// itself and the type `"string"` (`macCore.c:208-209`), and `trans`
-    /// hands the SAME entry down every recursion (`:849`, `:889`,
-    /// `:909`), so a warning raised while expanding a macro's value
-    /// still names the line the caller passed in.
-    expanding: &'a str,
+}
+
+impl MacroTable {
+    /// C `macCreateHandle` + one `macPutValue` per pair
+    /// (`macCore.c:64-118`). The table starts dirty: nothing is expanded
+    /// until something asks for an expansion.
+    ///
+    /// The definitions arrive in [`MacroDefs`] order and are installed in
+    /// it, so the notice order of the first expansion pass is the
+    /// caller's own definition order and does not have to be arranged
+    /// for afterwards.
+    #[must_use]
+    pub fn new(defs: impl Into<MacroDefs>, opts: MacroExpandOptions) -> Self {
+        let entries = defs
+            .into()
+            .defs
+            .into_iter()
+            .map(|(name, rawval)| MacEntry {
+                name,
+                kind: KIND_MACRO,
+                rawval,
+                value: None,
+                faults: MacroFaults::default(),
+                visited: false,
+                special: false,
+                level: 0,
+            })
+            .collect();
+        Self {
+            entries,
+            level: 0,
+            dirty: true,
+            opts,
+        }
+    }
+
+    /// C `macExpandString` (`macCore.c:175-227`): bring the cached
+    /// values up to date, then translate `src` under a stack entry typed
+    /// `"string"` whose name is `src` itself.
+    ///
+    /// Both halves matter to what comes out. The table pass is what
+    /// decides the text of a reference into a cycle and the seat of
+    /// every notice a macro's own value raises; the string pass is the
+    /// only place the caller's own text is ever looked at.
+    #[must_use]
+    pub fn expand(&mut self, src: &str) -> MacroExpansion {
+        let suppressed = self.opts.suppress_warnings;
+        let mut ctx = ExpandCtx {
+            table: self,
+            seat: Seat {
+                kind: KIND_STRING,
+                name: src.to_string(),
+                faults: MacroFaults::default(),
+            },
+            suppressed,
+        };
+        expand_table(&mut ctx);
+        let chars: Vec<char> = src.chars().collect();
+        let mut out = String::with_capacity(src.len());
+        trans(&chars, 0, &mut ctx, &mut out);
+        MacroExpansion {
+            text: out,
+            faults: ctx.seat.faults,
+        }
+    }
+
+    /// C `macPutValue( handle, name, value )` (`macCore.c:262-289`) with
+    /// a non-NULL value: install `rawval` for `name` at the current scope
+    /// level.
+    ///
+    /// The value is stored RAW. C never expands a definition as it is
+    /// installed — `macInstallMacros` hands `macPutValue` exactly the
+    /// bytes `macParseDefns` cut out (`macUtil.c:250-275`) — so a
+    /// definition that mentions another macro stays live and follows
+    /// whatever that macro is when it is finally read.
+    pub fn define(&mut self, name: &str, rawval: String) {
+        self.put(name, KIND_MACRO, rawval);
+    }
+
+    /// C `macPutValue( handle, name, NULL )` (`macCore.c:274-280`): the
+    /// name is deleted rather than defined, which is what a definition
+    /// with no `=` in it means (`macParseDefns`'s `del[i]`,
+    /// `macUtil.c:105-110`).
+    ///
+    /// Deleting is not the same as defining nothing: an OUTER definition
+    /// of the same name is uncovered by it, and a reference that finds
+    /// nothing at all is undefined rather than empty.
+    pub fn undefine(&mut self, name: &str) {
+        let Some(idx) = self.lookup(name) else {
+            return;
+        };
+        self.entries.remove(idx);
+        self.dirty = true;
+    }
+
+    /// C `lookup( handle, name, FALSE )` (`macCore.c:571-585`): search
+    /// backwards "so scoping works" — the newest definition of a name
+    /// wins — and never match a scope marker.
+    fn lookup(&self, name: &str) -> Option<usize> {
+        self.entries
+            .iter()
+            .rposition(|e| !e.special && e.name == name)
+    }
+
+    /// [`Self::lookup`] with the rest of C's `lookup`: on a miss under
+    /// `FLAG_USE_ENVIRONMENT`, the environment is read and the value is
+    /// INSTALLED as an entry typed `"environment variable"`
+    /// (`macCore.c:586-598`).
+    ///
+    /// Installing it is not an optimisation, it is why an environment
+    /// hit dirties the table: the entry arrives with no cached value, so
+    /// every reference after it in the same string resolves from raw
+    /// values until the next expansion pass.
+    fn lookup_or_env(&mut self, name: &str) -> Option<usize> {
+        if let Some(i) = self.lookup(name) {
+            return Some(i);
+        }
+        if !self.opts.env_fallback || name.is_empty() {
+            return None;
+        }
+        let value = crate::runtime::env::get(name)?;
+        Some(self.put(name, KIND_ENVIRONMENT, value))
+    }
+
+    /// C `macPutValue` (`macCore.c:262-289`) and the `rawval` it ends in
+    /// (`:610-619`).
+    ///
+    /// A definition at or below the current scope level overwrites in
+    /// place; one that came from an OUTER scope is shadowed by a new
+    /// entry instead, so popping the scope brings the outer value back.
+    /// Either way the whole table goes dirty, because any other entry
+    /// may reference this one and no cached value can be trusted until
+    /// they are all rebuilt.
+    fn put(&mut self, name: &str, kind: &'static str, rawval: String) -> usize {
+        let idx = match self.lookup(name) {
+            Some(i) if self.entries[i].level >= self.level => i,
+            _ => {
+                self.entries.push(MacEntry {
+                    name: name.to_string(),
+                    kind,
+                    rawval: String::new(),
+                    value: None,
+                    faults: MacroFaults::default(),
+                    visited: false,
+                    special: false,
+                    level: self.level,
+                });
+                self.entries.len() - 1
+            }
+        };
+        let entry = &mut self.entries[idx];
+        entry.kind = kind;
+        entry.rawval = rawval;
+        entry.value = None;
+        entry.faults = MacroFaults::default();
+        self.dirty = true;
+        idx
+    }
+
+    /// C `macPushScope` (`macCore.c:400-424`): a marker entry at the
+    /// tail, which everything defined from here on sits after.
+    fn push_scope(&mut self) {
+        self.level += 1;
+        self.entries.push(MacEntry {
+            name: String::from("<scope>"),
+            kind: KIND_SCOPE_MARKER,
+            rawval: String::new(),
+            value: None,
+            faults: MacroFaults::default(),
+            visited: false,
+            special: true,
+            level: self.level,
+        });
+    }
+
+    /// C `macPopScope` (`macCore.c:434-475`): delete the most recent
+    /// `<scope>` marker and every entry defined since it.
+    ///
+    /// Those entries are exactly the tail — nothing is ever inserted
+    /// before an existing entry — so the deletion is a truncation, and
+    /// an index held by an enclosing [`refer`] frame into anything below
+    /// the marker survives it. C's `delete` dirties the table for the
+    /// same reason a redefinition does: a surviving entry may have
+    /// referenced what just went away.
+    fn pop_scope(&mut self) {
+        let at = self
+            .entries
+            .iter()
+            .rposition(|e| e.special)
+            .expect("refer pushes the scope marker before it can pop one");
+        self.entries.truncate(at);
+        self.level -= 1;
+        self.dirty = true;
+    }
+}
+
+/// The `MAC_ENTRY` a translation runs under: the two words every
+/// `macLib:` notice prints, and the `error` field the faults land in.
+///
+/// C swaps it four ways and the swaps are the whole of why one notice
+/// says `string` and the next says `macro`. `macExpandString` seats a
+/// stack entry typed `"string"` whose name is the caller's whole source
+/// string (`macCore.c:206-209`); [`expand_table`] seats the table entry
+/// being expanded (`:668`); and `refer` seats a throwaway `dflt` around
+/// the default's discarding pass (`:805-816`) and a throwaway `subs`
+/// around the scoped definitions (`:820-826`), neither of which merges
+/// its error back. Everything else — a resolved value translated raw, a
+/// used default — keeps the caller's seat, which is why a fault found
+/// three macros deep still names the entry the chain started from.
+struct Seat {
+    kind: &'static str,
+    name: String,
+    faults: MacroFaults,
+}
+
+/// Engine state threaded through [`trans`] / [`refer`] / [`parse_scoped`]:
+/// the table being resolved against, the [`Seat`] the current
+/// translation runs under, and the suppression bit the guards below
+/// raise and lower.
+///
+/// The scope stack and the recursion stack that used to be here are both
+/// gone into the table, where C keeps them: a scoped definition is an
+/// entry between a `<scope>` marker and the tail, and "currently being
+/// expanded" is [`MacEntry::visited`].
+struct ExpandCtx<'a> {
+    table: &'a mut MacroTable,
+    seat: Seat,
+    /// C `handle->flags & FLAG_SUPPRESS_WARNINGS`, which `refer` raises
+    /// and lowers around regions rather than setting once
+    /// (`macCore.c:795-800`, `:805-816`, `:822-859`). Seeded from
+    /// [`MacroExpandOptions::suppress_warnings`] and read wherever a
+    /// `macLib:` notice is about to be written, so a caller's knob and a
+    /// region's own quiet are the same bit.
+    suppressed: bool,
+}
+
+impl ExpandCtx<'_> {
+    /// C's `flags = handle->flags; handle->flags |=
+    /// FLAG_SUPPRESS_WARNINGS; …; handle->flags = flags` around the
+    /// translation of a reference NAME (`macCore.c:795-800`). The
+    /// notices go quiet, but the seat is unchanged, so a fault inside the
+    /// name still fails the surrounding expansion. Measured on `softIoc
+    /// R7.0.10`: `$($(NAMEREF))` writes ONE line and it names the
+    /// suppressed placeholder, `macro $(NAMEREF) is undefined`.
+    fn suppressing<R>(&mut self, body: impl FnOnce(&mut Self) -> R) -> R {
+        let saved = std::mem::replace(&mut self.suppressed, true);
+        let out = body(self);
+        self.suppressed = saved;
+        out
+    }
+
+    /// Run `body` under a different [`Seat`] and hand back the faults it
+    /// raised, for the caller to merge or to drop. Every seat change in
+    /// C is this shape, so this is the only way the seat moves.
+    fn seated<R>(&mut self, seat: Seat, body: impl FnOnce(&mut Self) -> R) -> (R, MacroFaults) {
+        let saved = std::mem::replace(&mut self.seat, seat);
+        let out = body(self);
+        let raised = std::mem::replace(&mut self.seat, saved).faults;
+        (out, raised)
+    }
+
+    /// C's `MAC_ENTRY subs` for the scoped-definition region
+    /// (`macCore.c:820-826`): a fresh seat whose `error` is never merged
+    /// back, under a raised suppression flag. So a fault inside
+    /// `,K=$(UNDEF)` neither warns nor fails the expansion around it —
+    /// measured on `softIoc R7.0.10`, `$(P,K=$(UNDEF))` with `P` defined
+    /// is silent and loads as `pval`.
+    ///
+    /// `name` is C's `subs.name`, which it re-seats between the two
+    /// halves of a definition: the reference's own name while the
+    /// definition's NAME is translated, the definition's name while its
+    /// VALUE is (`:840`, `:847`).
+    fn detached<R>(&mut self, name: String, body: impl FnOnce(&mut Self) -> R) -> R {
+        let seat = Seat {
+            kind: KIND_SCOPED_MACRO,
+            name,
+            faults: MacroFaults::default(),
+        };
+        let (out, _discarded) = self.suppressing(|ctx| ctx.seated(seat, body));
+        out
+    }
+}
+
+/// C `expand` (`macCore.c:645-679`): translate every raw value into its
+/// cached value, each under its OWN entry, then mark the table clean.
+///
+/// This is not a pass over "the macros the string mentions" — C expands
+/// the whole table on the first use after any change, and that is what
+/// makes a resolved reference a COPY (`refer`, `:882-886`) rather than a
+/// re-translation. Both halves of the difference are observable.
+/// Measured on `softIoc R7.0.10` with `A=$(B)`, `B=$(A)` delivered
+/// through `dbLoadTemplate` and a `.db` line reading `$(A)`: C writes
+/// `macro A is recursive (expanding macro B)` and then `macro B is
+/// recursive (expanding macro A)` — both seated on the table entry, not
+/// on the string — and loads `$(B,recursive)`, which is `A`'s cached
+/// value and not anything the string pass could have produced.
+///
+/// The table stays dirty for the duration, so a reference met while
+/// expanding takes `refer`'s raw branch and [`MacEntry::visited`] is the
+/// only thing between a cycle and an unbounded recursion — exactly as in
+/// C, where `handle->dirty` is cleared only after the loop.
+fn expand_table(ctx: &mut ExpandCtx) {
+    if !ctx.table.dirty {
+        return;
+    }
+    let mut i = 0;
+    // Not a `for` over a snapshot: resolving one entry can APPEND
+    // another (an environment value materialises as an entry), and C's
+    // list walk reaches those too.
+    while i < ctx.table.entries.len() {
+        // A `<scope>` marker has no raw value at all — `create` leaves it
+        // NULL (`macCore.c:556`) and C would fault here. It never does,
+        // because every scope `refer` opens is closed inside the same
+        // reference, and the public `macPushScope` callers expand between
+        // scopes rather than inside one.
+        if ctx.table.entries[i].special {
+            i += 1;
+            continue;
+        }
+        let raw: Vec<char> = ctx.table.entries[i].rawval.chars().collect();
+        let seat = Seat {
+            kind: ctx.table.entries[i].kind,
+            name: ctx.table.entries[i].name.clone(),
+            faults: MacroFaults::default(),
+        };
+        let mut value = String::new();
+        // C starts at level 1 "so quotes and escapes will be removed
+        // from expanded value" (`macCore.c:672-673`) — a cached value is
+        // never the user's own text.
+        let (_, raised) = ctx.seated(seat, |ctx| trans(&raw, 1, ctx, &mut value));
+        let entry = &mut ctx.table.entries[i];
+        entry.value = Some(value);
+        entry.faults = raised;
+        i += 1;
+    }
+    ctx.table.dirty = false;
 }
 
 /// Expand `$(...)` / `${...}` macro references, mirroring the C `macLib`
-/// engine (`modules/libcom/src/macLib/macCore.c` `trans` / `refer`).
-/// This is the single macLib implementation for the crate; the `.db`
-/// parser, `dbLoadGroup`, and autosave all route through it (with
+/// engine (`modules/libcom/src/macLib/macCore.c` `expand` / `trans` /
+/// `refer`). This is the single macLib implementation for the crate; the
+/// `.db` parser, `dbLoadGroup`, and autosave all route through it (with
 /// per-caller [`MacroExpandOptions`]) rather than re-implementing it.
+///
+/// One call is one [`MacroTable`], which is C's handle for the length of
+/// one string. Callers that expand many strings against one set of
+/// macros — a file's worth of lines — should build the table once and
+/// call [`MacroTable::expand`] per line instead, because a macro whose
+/// own value is faulty raises its notice once per TABLE, not once per
+/// string.
+///
 /// Implemented behaviors:
 ///
+///   - every raw value is expanded into a cached value before the
+///     caller's string is looked at, and a reference to a macro COPIES
+///     that cached value with its error merged rather than translating
+///     the raw value again (C `expand`, `macCore.c:645-679`; `refer`,
+///     `:882-886`). A definition, a scope pop or an environment hit
+///     invalidates the cache, and until the next pass references
+///     resolve from raw values.
 ///   - `\<char>` blocks macro detection; both bytes reach the output in
 ///     the caller's own string, and the backslash is dropped from
 ///     anything that arrived through a macro (`trans:701-703,739-744`;
@@ -2120,56 +2767,45 @@ struct ExpandCtx<'a> {
 ///     (`refer` runs `trans` on the name — `$($(WHICH))`).
 ///   - the name terminates at `=`, `,` or the closing bracket
 ///     (`macEnd = "=,)"`); `,name=val` introduces scoped macro
-///     definitions visible only inside that reference's expansion.
-///   - a resolved macro value is re-scanned for further `$(...)`
-///     (chained expansion); a self-/mutually-referential macro stops
-///     at the `visiting` guard (C per-entry `visited`).
+///     definitions visible only inside that reference's expansion, and
+///     visible to the definitions AFTER them in the same list
+///     (`macPushScope` precedes the loop, `macCore.c:827-850`).
+///   - a self- or mutually-referential macro is refused at C's
+///     per-entry `visited` guard (`macCore.c:888-904`), leaving
+///     `$(name,recursive)` and [`MacroFault::Recursive`].
 ///   - an undefined macro with no default emits the placeholder
 ///     `$(name,undefined)` (`refer:errval = ",undefined)"`) and comes
 ///     back as [`MacroFault::Undefined`].
+///   - a reference whose closing delimiter never matched its opener is
+///     copied through verbatim together with everything after it, and
+///     nothing in that tail is expanded a second time
+///     (`refer`, `macCore.c:862-875`) — [`MacroFault::Unterminated`].
 ///   - with [`MacroExpandOptions::env_fallback`], an otherwise-unset
 ///     name resolves from the process environment before the default
 ///     (C `macCreateHandle(&h, environ)`).
+#[must_use]
 pub fn expand_macros(
     input: &str,
-    macros: &HashMap<String, String>,
+    macros: impl Into<MacroDefs>,
     opts: MacroExpandOptions,
 ) -> MacroExpansion {
-    let chars: Vec<char> = input.chars().collect();
-    let mut out = String::with_capacity(input.len());
-    let mut ctx = ExpandCtx {
-        macros,
-        opts,
-        undefined: Vec::new(),
-        recursive: Vec::new(),
-        expanding: input,
-    };
-    trans(
-        &chars,
-        0,
-        &mut ctx,
-        &mut Vec::new(),
-        &mut Vec::new(),
-        &mut out,
-    );
-    MacroExpansion {
-        text: out,
-        undefined: ctx.undefined,
-        recursive: ctx.recursive,
-    }
+    MacroTable::new(macros, opts).expand(input)
 }
 
 /// Expand `$(...)` / `${...}` macro references with the default
-/// macLib options (no env fallback, no `$$` escape, undefined →
-/// placeholder). Thin wrapper over [`expand_macros`]; `pub` so
-/// `dbLoadGroup` and other consumers reuse the one engine instead of
-/// re-implementing macLib.
-pub fn substitute_macros(input: &str, macros: &HashMap<String, String>) -> String {
+/// macLib options (no env fallback, no `$` escape, undefined →
+/// placeholder). Thin wrapper over [`expand_macros`], for the callers
+/// those defaults are right for: the `include` / `path` / `substitute`
+/// directives of the `.db` reader, and `.acf` text through
+/// [`substitute_macros_per_line`]. `dbLoadGroup` and autosave reuse the
+/// same engine but not this wrapper — both need options of their own,
+/// and both call [`expand_macros`] directly.
+pub fn substitute_macros(input: &str, macros: impl Into<MacroDefs>) -> String {
     expand_macros(input, macros, MacroExpandOptions::default()).text
 }
 
-/// [`substitute_macros`], one line at a time — how C's file readers feed
-/// macLib.
+/// [`substitute_macros`], one line at a time against ONE table — how C's
+/// file readers feed macLib.
 ///
 /// `dbLoadRecords` hands `macExpandString` a single `fgets` line
 /// (`dbLexRoutines.c:375-391`), and `asInitFile` does the same
@@ -2180,35 +2816,29 @@ pub fn substitute_macros(input: &str, macros: &HashMap<String, String>) -> Strin
 /// and silently disabled every `$(...)` on the lines after it, until the
 /// parser failed on an unexpanded record name. Within a line the quote
 /// rules are unchanged — `'$(X)'` still suppresses.
-pub fn substitute_macros_per_line(input: &str, macros: &HashMap<String, String>) -> String {
+///
+/// The table is the file's, not the line's, because C's is: `asInitFile`
+/// creates one handle and reads every line through it, so a macro whose
+/// own value is faulty is expanded — and complained about — once.
+pub fn substitute_macros_per_line(input: &str, macros: impl Into<MacroDefs>) -> String {
+    let mut table = MacroTable::new(macros, MacroExpandOptions::default());
     input
         .split_inclusive('\n')
-        .map(|line| substitute_macros(line, macros))
+        .map(|line| table.expand(line).text)
         .collect()
 }
 
 /// Translate `chars` into `out`, expanding macro references.
 ///
-/// `scopes` is the stack of scoped-macro frames pushed by enclosing
-/// `$(name,key=val)` references; lookup walks it innermost-first then
-/// falls back to `ctx.macros` (and, when enabled, the environment).
-/// `visiting` is the stack of macro names currently being expanded — it
-/// guards against a self-referential macro (`A=$(A)`) recursing forever,
-/// mirroring C `macCore.c`'s per-entry `visited` flag.
-fn trans(
-    chars: &[char],
-    level: usize,
-    ctx: &mut ExpandCtx,
-    scopes: &mut Vec<HashMap<String, String>>,
-    visiting: &mut Vec<String>,
-    out: &mut String,
-) {
+/// `level` is C's: 0 is the string the caller handed
+/// [`MacroTable::expand`], and every recursion — a macro's value, a
+/// reference name, a default, a scoped definition, a cached value being
+/// built — runs one deeper, which is what decides whether quotes and
+/// backslashes are syntax or text. Scopes and the recursion guard live
+/// in [`ExpandCtx::table`].
+fn trans(chars: &[char], level: usize, ctx: &mut ExpandCtx, out: &mut String) {
     // C `macCore.c:701-703`: "discard quotes and escapes if level is > 0
-    // (i.e. if these aren't the user's quotes and escapes)". Level 0 is
-    // the string the caller handed `macExpandString`; every recursion out
-    // of `refer` — a macro's value, a reference name, a default, a scoped
-    // definition — runs at `level + 1`, so a quote or a backslash that
-    // arrived through a macro is syntax and never reaches the output.
+    // (i.e. if these aren't the user's quotes and escapes)".
     let discard = level > 0;
     let mut quote: Option<char> = None;
     let mut i = 0;
@@ -2233,7 +2863,7 @@ fn trans(
         }
 
         // `$$` → literal `$` (opt-in; autosave `.req` convenience).
-        if ctx.opts.dollar_escape && c == '$' && i + 1 < chars.len() && chars[i + 1] == '$' {
+        if ctx.table.opts.dollar_escape && c == '$' && i + 1 < chars.len() && chars[i + 1] == '$' {
             out.push('$');
             i += 2;
             continue;
@@ -2255,10 +2885,8 @@ fn trans(
         let mac_ref =
             c == '$' && i + 1 < chars.len() && (chars[i + 1] == '(' || chars[i + 1] == '{');
         if mac_ref && quote != Some('\'') {
-            if let Some(next) = refer(chars, i, level, ctx, scopes, visiting, out) {
-                i = next;
-                continue;
-            }
+            i = refer(chars, i, level, ctx, out);
+            continue;
         }
 
         out.push(c);
@@ -2266,18 +2894,19 @@ fn trans(
     }
 }
 
-/// Expand one macro reference starting at `chars[start]` (`$`). On
-/// success returns the index just past the closing bracket; returns
-/// `None` if the reference is unterminated (caller copies `$` raw).
+/// Expand one macro reference starting at `chars[start]` (`$`). Returns
+/// the index just past the closing bracket, or — when the closing
+/// delimiter never matched the opener — the index past the whole
+/// remaining scan, which this then copies out verbatim (C
+/// `macCore.c:862-875`). `None` is never returned: every `$(`/`${` the
+/// caller hands over is consumed here, terminated or not.
 fn refer(
     chars: &[char],
     start: usize,
     level: usize,
     ctx: &mut ExpandCtx,
-    scopes: &mut Vec<HashMap<String, String>>,
-    visiting: &mut Vec<String>,
     out: &mut String,
-) -> Option<usize> {
+) -> usize {
     let close = if chars[start + 1] == '(' { ')' } else { '}' };
     // Find the matching close bracket, honoring nested `$(`/`${`.
     let body_start = start + 2;
@@ -2298,7 +2927,55 @@ fn refer(
         j += 1;
     }
     if depth != 0 {
-        return None; // unterminated — caller emits '$' literally
+        // C `refer`'s first error arm (`macCore.c:862-875`): the closing
+        // delimiter never matched the opener, so this is not a
+        // reference. C rewinds the output pointer to where the reference
+        // began (`v = *value`) and copies the raw text from the `$`
+        // through the last character `trans` scanned — the whole rest of
+        // the string, because the failed name translation ran to the end
+        // of it — then sets `entry->error` and says so.
+        //
+        // Copying the tail HERE, rather than handing the caller a `$` to
+        // re-scan, is what makes the text match: a re-scan re-enters
+        // `trans` just past the `$` and expands whatever `$(…)` follows,
+        // where C never looks at the tail again. Measured on `softIoc
+        // R7.0.10` with `Q=ZZZ`, C writes `x$(A $(Q) y` for the line
+        // `"x$(A $(Q) y"` — the inner `$(Q)` was consumed as part of the
+        // unterminated reference's NAME and is not expanded a second
+        // time. This port used to write `x$(A ZZZ y`.
+        //
+        // The arm is reached from a pre-scan for the matching bracket,
+        // before any scoped definition in the body has been parsed,
+        // where C discovers the mismatch only after parsing them and
+        // pushing a scope it then pops. Neither the text nor this notice
+        // can see the difference; the one thing that can is that C
+        // leaves the table dirty afterwards and this does not, so C may
+        // re-expand — and re-announce — a faulty macro value that this
+        // announces once.
+        let verbatim: String = chars[start..].iter().collect();
+        ctx.seat
+            .faults
+            .raise(TableFault::Unterminated(verbatim.clone()));
+        if !ctx.suppressed {
+            // C's third `macLib:` notice, alongside `undefined` and
+            // `recursive` below and painted by the same `ANSI_MAGENTA`
+            // (`errlog.h:301`) that `errlog` strips off a non-terminal
+            // console. It quotes `entry->type entry->name`, which is
+            // whatever seat this translation runs under: the caller's
+            // whole string when the `$(` is in the string, the macro's
+            // own name when it is in a macro's value.
+            let unterminated = if crate::runtime::log::errlog_console_paints() {
+                "\x1b[35;1munterminated\x1b[0m"
+            } else {
+                "unterminated"
+            };
+            crate::runtime::log::errlog_printf(&format!(
+                "macLib: {unterminated} macro reference in {} {}\n",
+                ctx.seat.kind, ctx.seat.name
+            ));
+        }
+        out.push_str(&verbatim);
+        return chars.len();
     }
     let body = &chars[body_start..j];
     let after = j + 1;
@@ -2312,87 +2989,79 @@ fn refer(
         None => (body, &body[body.len()..]),
     };
 
-    // the name itself may contain macro references — expand it.
+    // The name itself may contain macro references — expand it, quietly.
+    // C raises `FLAG_SUPPRESS_WARNINGS` for exactly this translation and
+    // lowers it again (`macCore.c:795-800`), so the placeholder an
+    // unresolved inner reference leaves in the name is the SHORT `$(X)`
+    // form and no notice is written for it. The fault still lands,
+    // because C hands the name translation the caller's own seat.
     let mut name = String::new();
-    trans(name_chars, level + 1, ctx, scopes, visiting, &mut name);
+    ctx.suppressing(|ctx| trans(name_chars, level + 1, ctx, &mut name));
 
     // Default value (`=...`) and scoped definitions (`,k=v`).
     let mut default: Option<&[char]> = None;
-    let mut scoped: Vec<(String, String)> = Vec::new();
+    let mut scoped: Option<&[char]> = None;
     if let Some(first) = rest.first() {
         if *first == '=' {
             // Default runs until the first top-level `,` or end.
             let dflt = &rest[1..];
-            let dsplit = top_level_comma(dflt);
-            match dsplit {
+            match top_level_comma(dflt) {
                 Some(k) => {
                     default = Some(&dflt[..k]);
-                    parse_scoped(&dflt[k..], level, ctx, scopes, visiting, &mut scoped);
+                    scoped = Some(&dflt[k..]);
                 }
                 None => default = Some(dflt),
             }
         } else if *first == ',' {
-            parse_scoped(rest, level, ctx, scopes, visiting, &mut scoped);
+            scoped = Some(rest);
         }
     }
 
-    // Push the scoped frame (visible only inside this expansion).
-    let mut frame: HashMap<String, String> = HashMap::new();
-    for (k, v) in scoped {
-        frame.insert(k, v);
+    // C pushes the scope only when a `,` list follows, and pops it at
+    // the single exit (`macCore.c:822-830`, `:932-935`). The condition
+    // is not a saving: a push and its pop each dirty the table, so an
+    // unconditional pair would make every reference in a string throw
+    // away the cached values the reference before it was resolved from.
+    //
+    // The frame goes on BEFORE the definitions are read, because C's
+    // `macPushScope` does and each `macPutValue` lands in it as the loop
+    // reaches it (`:850`). So definition N's value is translated with
+    // definitions 1..N-1 visible, and only those: measured on `softIoc
+    // R7.0.10` with an outer `A=outer`, `$(B,A=1,B=$(A))` is `1` while
+    // the reverse `$(B,B=$(A),A=1)` is `outer`.
+    let pop = scoped.is_some();
+    if let Some(defs) = scoped {
+        ctx.table.push_scope();
+        parse_scoped(defs, level, ctx, &name);
     }
-    scopes.push(frame);
 
-    // Look up: innermost scope first, then base macros, then (when
-    // enabled) the process environment — C `macCreateHandle(&h, environ)`
-    // installs env entries as macros, so env resolution sits at the same
-    // level as a defined macro, before any default.
-    let resolved = scopes
-        .iter()
-        .rev()
-        .find_map(|s| s.get(&name).cloned())
-        .or_else(|| ctx.macros.get(&name).cloned())
-        .or_else(|| {
-            if ctx.opts.env_fallback {
-                crate::runtime::env::get(&name)
-            } else {
-                None
-            }
-        });
-
-    match resolved {
-        Some(val) => {
-            if visiting.contains(&name) {
+    match ctx.table.lookup_or_env(&name) {
+        Some(idx) => {
+            if ctx.table.entries[idx].visited {
                 // C `refer` finding `refentry->visited` already set
                 // (`macCore.c:895-904`): the reference is refused, NOT
                 // resolved. The port used to emit the value verbatim,
                 // which broke the cycle but left the operator with a
-                // silently half-expanded `.db` — measured against
-                // `softIoc` on `A="$(B)", B="$(A)"` through a
-                // `.substitutions`, C wrote three lines here and this
-                // wrote none.
+                // silently half-expanded `.db`.
                 //
-                // `visiting.last()` is C's `entry` — the macro whose raw
-                // value is being translated when the cycle closes — and
-                // `name` is its `refentry`, which is why C's own output
-                // for that pair reads `macro A is recursive (expanding
-                // macro B)`.
-                //
-                // C detects this once per macro TABLE entry, in the
-                // `expand()` pass it runs when the table is dirty
-                // (`macCore.c:646-679`); this expander resolves lazily
-                // and so reports once per reference. Same cycle, same
-                // sentence, and the count follows the engine.
-                ctx.recursive.push(name.clone());
-                if !ctx.opts.suppress_warnings {
+                // The seat is the entry whose raw value was being
+                // translated when the cycle closed, and `name` is the
+                // reference that closed it — C's `entry` and
+                // `refentry`, in that order. Reached from
+                // [`expand_table`] the seat is a table entry, so the
+                // notice reads `macro A is recursive (expanding macro
+                // B)`, which is what `softIoc R7.0.10` writes.
+                let refkind = ctx.table.entries[idx].kind;
+                ctx.seat.faults.raise(TableFault::Recursive(name.clone()));
+                if !ctx.suppressed {
                     let recursive = if crate::runtime::log::errlog_console_paints() {
                         "\x1b[35;1mrecursive\x1b[0m"
                     } else {
                         "recursive"
                     };
-                    let entry = visiting.last().map_or("", String::as_str);
                     crate::runtime::log::errlog_printf(&format!(
-                        "macLib: macro {entry} is {recursive} (expanding macro {name})\n"
+                        "macLib: {} {} is {recursive} (expanding {refkind} {name})\n",
+                        ctx.seat.kind, ctx.seat.name
                     ));
                 }
                 out.push('$');
@@ -2400,17 +3069,34 @@ fn refer(
                 out.push_str(&name);
                 // Same knob, same two texts as the undefined arm
                 // (`macCore.c:920-928`).
-                if ctx.opts.suppress_warnings {
+                if ctx.suppressed {
                     out.push(')');
                 } else {
                     out.push_str(",recursive)");
                 }
+            } else if ctx.table.dirty {
+                // No cached value can be trusted, so translate the raw
+                // one under the CALLER's seat — C passes `entry`, not
+                // `refentry` (`macCore.c:890`) — with the entry's
+                // `visited` guard raised around it.
+                let raw: Vec<char> = ctx.table.entries[idx].rawval.chars().collect();
+                ctx.table.entries[idx].visited = true;
+                trans(&raw, level + 1, ctx, out);
+                ctx.table.entries[idx].visited = false;
             } else {
-                // re-scan the resolved value for further refs.
-                visiting.push(name.clone());
-                let val_chars: Vec<char> = val.chars().collect();
-                trans(&val_chars, level + 1, ctx, scopes, visiting, out);
-                visiting.pop();
+                // C `cpy2val( refentry->value, … )` plus `entry->error =
+                // entry->error || refentry->error` (`macCore.c:882-886`).
+                // The value is COPIED, not re-scanned: whatever the
+                // table pass made of it — including the placeholder a
+                // cycle left in it — is what the string gets, and the
+                // fault that produced it comes across without being
+                // raised a second time.
+                let entry = &ctx.table.entries[idx];
+                let value = entry.value.clone().unwrap_or_default();
+                let mut faults = entry.faults.clone();
+                faults.rename_recursive(&name);
+                out.push_str(&value);
+                ctx.seat.faults.merge(&faults);
             }
         }
         None => match default {
@@ -2418,30 +3104,26 @@ fn refer(
                 // C `refer` translates the default at `level + 1`
                 // (`macCore.c:909`), so every quote in it is discarded —
                 // not just a surrounding pair.
-                trans(def_chars, level + 1, ctx, scopes, visiting, out);
+                trans(def_chars, level + 1, ctx, out);
             }
             None => {
-                // L-4: undefined macro placeholder. Record the name so
-                // a hard-fail caller reaches it through
-                // `MacroExpansion::fault`, instead of accepting the
-                // placeholder as text.
-                ctx.undefined.push(name.clone());
-                if !ctx.opts.suppress_warnings {
-                    // C `refer` (`macCore.c:913-917`), through
-                    // `errlogPrintf` and not `fprintf` — which is why the
-                    // magenta on `undefined` follows the console while the
-                    // `ERROR`/`WARNING` words of the `.db` loader do not:
-                    // errlog strips escapes when its console is not a
-                    // terminal (`errlog.c:672-681`) and a direct `fprintf`
-                    // never enters that pump.
+                // C `refer` (`macCore.c:913-917`), through `errlogPrintf`
+                // and not `fprintf` — which is why the magenta on
+                // `undefined` follows the console while the
+                // `ERROR`/`WARNING` words of the `.db` loader do not:
+                // errlog strips escapes when its console is not a
+                // terminal (`errlog.c:672-681`) and a direct `fprintf`
+                // never enters that pump.
+                ctx.seat.faults.raise(TableFault::Undefined(name.clone()));
+                if !ctx.suppressed {
                     let undefined = if crate::runtime::log::errlog_console_paints() {
                         "\x1b[35;1mundefined\x1b[0m"
                     } else {
                         "undefined"
                     };
                     crate::runtime::log::errlog_printf(&format!(
-                        "macLib: macro {name} is {undefined} (expanding string {})\n",
-                        ctx.expanding
+                        "macLib: macro {name} is {undefined} (expanding {} {})\n",
+                        ctx.seat.kind, ctx.seat.name
                     ));
                 }
                 out.push('$');
@@ -2451,7 +3133,7 @@ fn refer(
                 // `,undefined)` tail otherwise (`macCore.c:920-928`), so
                 // the knob changes the loader's own view of the value and
                 // not just what the operator reads.
-                if ctx.opts.suppress_warnings {
+                if ctx.suppressed {
                     out.push(')');
                 } else {
                     out.push_str(",undefined)");
@@ -2460,20 +3142,29 @@ fn refer(
         },
     }
 
-    scopes.pop();
-    Some(after)
+    if pop {
+        ctx.table.pop_scope();
+    }
+    after
 }
 
-/// Parse a `,key=val,key2=val2,...` scoped-definition tail. A bare
-/// `,key` with no `=` defines nothing (C silently skips it).
-fn parse_scoped(
-    rest: &[char],
-    level: usize,
-    ctx: &mut ExpandCtx,
-    scopes: &mut Vec<HashMap<String, String>>,
-    visiting: &mut Vec<String>,
-    out: &mut Vec<(String, String)>,
-) {
+/// Parse a `,key=val,key2=val2,...` scoped-definition tail into the
+/// scope [`refer`] has already pushed. A bare `,key` with no `=`
+/// defines nothing (C silently skips it).
+///
+/// Each definition lands in the table as the loop reaches it, so a later
+/// one can reference an earlier one and not the other way round — C
+/// `macPutValue` inside the `while (*r == ',')` loop (`macCore.c:850`).
+/// Every definition also dirties the table, which is C's explicit
+/// `handle->dirty = TRUE` on the next line and the reason the rest of
+/// the enclosing string resolves from raw values.
+///
+/// Both halves of a definition are translated through
+/// [`ExpandCtx::detached`], C's `MAC_ENTRY subs` (`macCore.c:820-826`):
+/// a fault in a scoped name or value is neither warned about nor merged
+/// into the enclosing expansion. `refname` is the seat name C uses for
+/// the first half and the definition's own name the seat for the second.
+fn parse_scoped(rest: &[char], level: usize, ctx: &mut ExpandCtx, refname: &str) {
     let mut k = 0;
     while k < rest.len() {
         if rest[k] != ',' {
@@ -2482,24 +3173,29 @@ fn parse_scoped(
         k += 1; // step over ','
         // Scoped name: up to next top-level `=` or `,`.
         let seg = &rest[k..];
-        let term = top_level_terminator(seg);
-        let (name_part, tail) = match term {
+        let (name_part, tail) = match top_level_terminator(seg) {
             Some(t) => (&seg[..t], &seg[t..]),
             None => (seg, &seg[seg.len()..]),
         };
         let mut sname = String::new();
-        trans(name_part, level + 1, ctx, scopes, visiting, &mut sname);
+        ctx.detached(refname.to_string(), |ctx| {
+            trans(name_part, level + 1, ctx, &mut sname);
+        });
         k += name_part.len();
         if let Some('=') = tail.first() {
             let valseg = &tail[1..];
-            let vterm = top_level_comma(valseg);
-            let (val_part, _) = match vterm {
+            let (val_part, _) = match top_level_comma(valseg) {
                 Some(t) => (&valseg[..t], &valseg[t..]),
                 None => (valseg, &valseg[valseg.len()..]),
             };
             let mut sval = String::new();
-            trans(val_part, level + 1, ctx, scopes, visiting, &mut sval);
-            out.push((sname, sval));
+            ctx.detached(sname.clone(), |ctx| {
+                trans(val_part, level + 1, ctx, &mut sval);
+            });
+            // C `macPutValue`, which types the new entry `"macro"` even
+            // here (`macCore.c:283`) — `"scoped macro"` is the seat the
+            // definition was translated under, not the entry's own type.
+            ctx.table.put(&sname, KIND_MACRO, sval);
             k += 1 + val_part.len();
         }
         // else: bare `,name` — no value, defines nothing.
@@ -2552,6 +3248,12 @@ fn top_level_comma(body: &[char]) -> Option<usize> {
 
 /// Read `( a , b , ... )` and return the strings. `min`/`max` bound the
 /// count the way C's grammar does by having one production per arity.
+///
+/// The bound is checked WHERE C's grammar checks it, not after the list is
+/// built: an argument too many is rejected at the comma that would open it —
+/// `record(ai, "", extra)` prints ` at or before ','` on `softIoc` @`R7.0.10`,
+/// with the parser never reaching the `)` — and an argument too few at the `)`
+/// that ended the list, which is where `alias("C8")` reports.
 fn parse_arg_list(
     chars: &[char],
     pos: &mut usize,
@@ -2559,7 +3261,6 @@ fn parse_arg_list(
     col: &mut usize,
     min: usize,
     max: usize,
-    what: &str,
 ) -> CaResult<Vec<String>> {
     skip_whitespace_and_comments(chars, pos, line, col);
     let open_line = *line;
@@ -2571,6 +3272,13 @@ fn parse_arg_list(
         skip_whitespace_and_comments(chars, pos, line, col);
         match chars.get(*pos) {
             Some(',') => {
+                if args.len() >= max {
+                    return Err(CaError::DbParseError {
+                        line: *line,
+                        token: String::from(","),
+                        message: SYNTAX_ERROR.into(),
+                    });
+                }
                 *pos += 1;
                 *col += 1;
             }
@@ -2579,16 +3287,11 @@ fn parse_arg_list(
     }
     skip_whitespace_and_comments(chars, pos, line, col);
     expect_char(chars, pos, col, ')', *line)?;
-    if args.len() < min || args.len() > max {
-        let want = if min == max {
-            format!("{min}")
-        } else {
-            format!("{min} or {max}")
-        };
+    if args.len() < min {
         return Err(CaError::DbParseError {
             line: open_line,
-            column: *col,
-            message: format!("{what} takes {want} arguments, got {}", args.len()),
+            token: String::from(")"),
+            message: SYNTAX_ERROR.into(),
         });
     }
     Ok(args)
@@ -2602,7 +3305,7 @@ fn parse_menu(
     line: &mut usize,
     col: &mut usize,
 ) -> CaResult<DbdMenu> {
-    let name = parse_arg_list(chars, pos, line, col, 1, 1, "menu")?.remove(0);
+    let name = parse_arg_list(chars, pos, line, col, 1, 1)?.remove(0);
     skip_whitespace_and_comments(chars, pos, line, col);
     expect_char(chars, pos, col, '{', *line)?;
     let mut choices = Vec::new();
@@ -2612,7 +3315,7 @@ fn parse_menu(
             None => {
                 return Err(CaError::DbParseError {
                     line: *line,
-                    column: *col,
+                    token: String::new(),
                     message: format!("unexpected end of file in menu({name})"),
                 });
             }
@@ -2626,7 +3329,7 @@ fn parse_menu(
         let kw = read_word(chars, pos, col);
         match kw.as_str() {
             "choice" => {
-                let mut a = parse_arg_list(chars, pos, line, col, 2, 2, "choice")?;
+                let mut a = parse_arg_list(chars, pos, line, col, 2, 2)?;
                 let value = a.remove(1);
                 choices.push((a.remove(0), value));
             }
@@ -2637,8 +3340,8 @@ fn parse_menu(
             _ => {
                 return Err(CaError::DbParseError {
                     line: *line,
-                    column: *col,
-                    message: format!("expected 'choice' in menu({name}), got '{kw}'"),
+                    token: kw.clone(),
+                    message: SYNTAX_ERROR.into(),
                 });
             }
         }
@@ -2653,7 +3356,7 @@ fn parse_menu(
         let values: Vec<String> = choices.iter().map(|(_, value)| value.clone()).collect();
         crate::server::record::menu_scan::install(&values).map_err(|e| CaError::DbParseError {
             line: *line,
-            column: *col,
+            token: String::from("}"),
             message: format!("menu({name}): {e}"),
         })?;
     }
@@ -2670,7 +3373,7 @@ fn parse_recordtype(
     line: &mut usize,
     col: &mut usize,
 ) -> CaResult<DbdRecordType> {
-    let name = parse_arg_list(chars, pos, line, col, 1, 1, "recordtype")?.remove(0);
+    let name = parse_arg_list(chars, pos, line, col, 1, 1)?.remove(0);
     skip_whitespace_and_comments(chars, pos, line, col);
     expect_char(chars, pos, col, '{', *line)?;
     let mut fields = Vec::new();
@@ -2681,7 +3384,7 @@ fn parse_recordtype(
             None => {
                 return Err(CaError::DbParseError {
                     line: *line,
-                    column: *col,
+                    token: String::new(),
                     message: format!("unexpected end of file in recordtype({name})"),
                 });
             }
@@ -2720,8 +3423,8 @@ fn parse_recordtype(
             _ => {
                 return Err(CaError::DbParseError {
                     line: *line,
-                    column: *col,
-                    message: format!("expected 'field' in recordtype({name}), got '{kw}'"),
+                    token: kw.clone(),
+                    message: SYNTAX_ERROR.into(),
                 });
             }
         }
@@ -2741,7 +3444,7 @@ fn parse_recordtype_field(
     col: &mut usize,
     rtype: &str,
 ) -> CaResult<DbdField> {
-    let mut head = parse_arg_list(chars, pos, line, col, 2, 2, "field")?;
+    let mut head = parse_arg_list(chars, pos, line, col, 2, 2)?;
     let dbf_type = head.remove(1);
     let name = head.remove(0);
     skip_whitespace_and_comments(chars, pos, line, col);
@@ -2753,7 +3456,7 @@ fn parse_recordtype_field(
             None => {
                 return Err(CaError::DbParseError {
                     line: *line,
-                    column: *col,
+                    token: String::new(),
                     message: format!("unexpected end of file in {rtype}.{name}"),
                 });
             }
@@ -2772,11 +3475,11 @@ fn parse_recordtype_field(
         if key.is_empty() {
             return Err(CaError::DbParseError {
                 line: *line,
-                column: *col,
-                message: format!("expected a field item in {rtype}.{name}"),
+                token: yytext_at(chars, *pos),
+                message: SYNTAX_ERROR.into(),
             });
         }
-        let value = parse_arg_list(chars, pos, line, col, 1, 1, &key)?.remove(0);
+        let value = parse_arg_list(chars, pos, line, col, 1, 1)?.remove(0);
         items.push((key, value));
     }
     Ok(DbdField {
@@ -2833,8 +3536,8 @@ fn read_quoted_string(
     if *pos >= chars.len() || chars[*pos] != '"' {
         return Err(CaError::DbParseError {
             line: *line,
-            column: *col,
-            message: "expected '\"'".into(),
+            token: yytext_at(chars, *pos),
+            message: SYNTAX_ERROR.into(),
         });
     }
     *pos += 1;
@@ -2877,7 +3580,7 @@ fn read_quoted_string(
             // string, closing quote missing")`), not a literal char.
             return Err(CaError::DbParseError {
                 line: *line,
-                column: *col,
+                token: String::from("\""),
                 message: "Newline in string, closing quote missing".into(),
             });
         } else {
@@ -2890,7 +3593,7 @@ fn read_quoted_string(
     if *pos >= chars.len() {
         return Err(CaError::DbParseError {
             line: *line,
-            column: *col,
+            token: String::new(),
             message: "unterminated string".into(),
         });
     }
@@ -2931,17 +3634,21 @@ fn read_json_string(
         _ => {
             return Err(CaError::DbParseError {
                 line: *line,
-                column: *col,
-                message: "expected a quoted value".into(),
+                token: yytext_at(chars, *pos),
+                message: SYNTAX_ERROR.into(),
             });
         }
     };
+    // Where C's `yytext` for this token begins. Every abort below is raised
+    // from inside the one `jsonstr` rule (`dbLex.l:32`), so they all quote the
+    // same run of text and the locator is decided once.
+    let quote_start = *pos;
     *pos += 1;
     *col += 1;
 
-    let err = |line: usize, col: usize, message: &str| CaError::DbParseError {
+    let err = |line: usize, message: &str| CaError::DbParseError {
         line,
-        column: col,
+        token: yytext_at(chars, quote_start),
         message: message.into(),
     };
 
@@ -2950,7 +3657,7 @@ fn read_json_string(
     let mut escaped = String::new();
     loop {
         let Some(&c) = chars.get(*pos) else {
-            return Err(err(*line, *col, "unterminated string"));
+            return Err(err(*line, "unterminated string"));
         };
         if c == quote {
             *pos += 1;
@@ -2961,11 +3668,11 @@ fn read_json_string(
             // dbLex.l:131-133 — the JSON string rule cannot match a newline
             // (`normalchar` excludes every control character), and the
             // catch-all reports the missing quote.
-            return Err(err(*line, *col, "Newline in string, closing quote missing"));
+            return Err(err(*line, "Newline in string, closing quote missing"));
         }
         if c == '\\' {
             let Some(&esc) = chars.get(*pos + 1) else {
-                return Err(err(*line, *col, "unterminated string"));
+                return Err(err(*line, "unterminated string"));
             };
             // `escapedchar` is `{backslash}[^ux1-9]`; `x` and `u` introduce the
             // fixed-width `latinchar`/`unicodechar` forms, and `\1`..`\9` are
@@ -2981,7 +3688,6 @@ fn read_json_string(
                 'x' | 'u' | '1'..='9' => {
                     return Err(err(
                         *line,
-                        *col,
                         "invalid escape sequence (\\x needs 2 hex digits, \
                          \\u needs 4, and \\1..\\9 are not escapes)",
                     ));
@@ -3005,7 +3711,6 @@ fn read_json_string(
         if (c as u32) < 0x20 {
             return Err(err(
                 *line,
-                *col,
                 "a control character must be escaped inside a quoted value",
             ));
         }
@@ -3075,7 +3780,7 @@ fn read_json_value(
 
     Err(CaError::DbParseError {
         line: start_line,
-        column: *col,
+        token: String::new(),
         message: format!("unterminated JSON value (missing '{close}')"),
     })
 }
@@ -3124,11 +3829,10 @@ fn read_token_string(
         }
     }
     if s.is_empty() {
-        let got = chars.get(*pos).map_or("EOF".to_string(), |c| c.to_string());
         return Err(CaError::DbParseError {
             line: *line,
-            column: *col,
-            message: format!("expected a name (bareword or quoted string), got '{got}'"),
+            token: yytext_at(chars, *pos),
+            message: SYNTAX_ERROR.into(),
         });
     }
     Ok(s)
@@ -3198,14 +3902,70 @@ fn read_field_value(
     if *pos < chars.len() && chars[*pos] != ')' && chars[*pos] != ',' {
         return Err(CaError::DbParseError {
             line: *line,
-            column: *col,
-            message: format!(
-                "illegal character '{}' in unquoted value (expected a quoted string or bareword)",
-                chars[*pos]
-            ),
+            token: yytext_at(chars, *pos),
+            message: SYNTAX_ERROR.into(),
         });
     }
     Ok(PvString::from(s))
+}
+
+/// The sentence bison itself writes for EVERY grammar rejection
+/// (`yyerror("syntax error")`): `dbYacc.y` declares no `%error-verbose` and no
+/// per-production message, so `record(ai)`, `field(DESC "x")` and a stray `}`
+/// all print the same three words on `softIoc` @`R7.0.10`. The token is what
+/// tells them apart, and it is the ` at or before` clause's job.
+///
+/// This port used to name the expectation instead — `expected ')', got '}'` —
+/// which reads better and is not what an operator comparing against C sees.
+const SYNTAX_ERROR: &str = "syntax error";
+
+/// C's `yytext` at `pos`: the token the `.db` lexer would have matched there,
+/// which is what `yyerror` quotes (`dbYacc.y:378`).
+///
+/// The lexer's own token shapes, so the quoting matches C's. A quoted string
+/// is returned WITH its quotes — `field(DESC "x")` prints ` at or before '"x"'`
+/// on `softIoc` @`R7.0.10`, not the one character the port used to name — a
+/// bareword is the whole `{bareword}` run (`dbLex.l:20`), and anything else is
+/// the single character. End of input matched no token at all and answers with
+/// the empty string.
+fn yytext_at(chars: &[char], pos: usize) -> String {
+    let Some(&c) = chars.get(pos) else {
+        return String::new();
+    };
+    if c == '"' || c == '\'' {
+        // `{doublequote}({dqschar}|{escape})*{doublequote}` (`dbLex.l:88-92`):
+        // the escape is two characters and neither of them closes the string.
+        let mut out = String::from(c);
+        let mut i = pos + 1;
+        while let Some(&d) = chars.get(i) {
+            out.push(d);
+            i += 1;
+            if d == '\\' {
+                if let Some(&e) = chars.get(i) {
+                    out.push(e);
+                    i += 1;
+                }
+                continue;
+            }
+            if d == c || d == '\n' {
+                break;
+            }
+        }
+        return out;
+    }
+    if is_bareword_char(c) {
+        return chars[pos..]
+            .iter()
+            .take_while(|&&d| is_bareword_char(d))
+            .collect();
+    }
+    c.to_string()
+}
+
+/// `bareword [a-zA-Z0-9_\-+:.\[\]<>;]` (`dbLex.l:20`).
+fn is_bareword_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(c, '_' | '-' | '+' | ':' | '.' | '[' | ']' | '<' | '>' | ';')
 }
 
 fn expect_char(
@@ -3216,15 +3976,10 @@ fn expect_char(
     line: usize,
 ) -> CaResult<()> {
     if *pos >= chars.len() || chars[*pos] != expected {
-        let got = if *pos < chars.len() {
-            chars[*pos].to_string()
-        } else {
-            "EOF".to_string()
-        };
         return Err(CaError::DbParseError {
             line,
-            column: *col,
-            message: format!("expected '{expected}', got '{got}'"),
+            token: yytext_at(chars, *pos),
+            message: SYNTAX_ERROR.into(),
         });
     }
     *pos += 1;
@@ -3424,7 +4179,7 @@ fn unregistered_record_type(record_type: &str) -> CaError {
     };
     CaError::DbParseError {
         line: 0,
-        column: 0,
+        token: String::new(),
         message,
     }
 }
@@ -5379,7 +6134,7 @@ record(ai, "REC") {
         let r = expand_macros("$(A)$(B=def)$(C)", &macros, MacroExpandOptions::default());
         assert_eq!(r.text, "$(A,undefined)def$(C,undefined)");
         // B had a default → not undefined; A and C are, in scan order.
-        assert_eq!(r.undefined, vec!["A".to_string(), "C".to_string()]);
+        assert_eq!(r.faults.undefined, vec!["A".to_string(), "C".to_string()]);
     }
 
     /// C `macCore.c:701-703` — "discard quotes and escapes if level
@@ -5447,7 +6202,7 @@ record(ai, "REC") {
         assert_eq!(substitute_macros("$$100", &macros), "$$100");
         let r = expand_macros("$$100", &macros, MacroExpandOptions::default());
         assert_eq!(r.text, "$$100");
-        assert!(r.undefined.is_empty());
+        assert!(r.faults.undefined.is_empty());
     }
 
     // `env_fallback` resolves an otherwise-unset name from the process
@@ -5471,7 +6226,7 @@ record(ai, "REC") {
             },
         );
         assert_eq!(on.text, "FROM_ENV");
-        assert!(on.undefined.is_empty());
+        assert!(on.faults.undefined.is_empty());
         unsafe { std::env::remove_var(var) };
     }
 
@@ -5567,21 +6322,32 @@ record(ai, "REC") {
     #[test]
     fn substitute_macros_self_reference_terminates() {
         // Re-expansion must not recurse forever on `A=$(A)`.
-        // The recursion guard emits the value once without re-scan.
+        // The guard REFUSES the reference rather than resolving it once:
+        // the text is C's `$(A,recursive)` placeholder and a `macLib:
+        // macro A is recursive` notice goes out with it
+        // (`macCore.c:895-904`).
         let mut macros = HashMap::new();
         macros.insert("A".to_string(), "$(A)".to_string());
-        // Must terminate; the exact text is the cycle-broken value.
-        let out = substitute_macros("$(A)", &macros);
-        assert!(out.contains("A"), "self-ref expansion produced: {out}");
+        assert_eq!(substitute_macros("$(A)", &macros), "$(A,recursive)");
     }
 
     #[test]
     fn substitute_macros_mutual_reference_terminates() {
-        // A=$(B), B=$(A) — mutual cycle must also terminate.
+        // A=$(B), B=$(A) — a mutual cycle must also terminate, and what
+        // it leaves behind is the OTHER member of the pair.
+        //
+        // `$(A)` copies A's cached value, and the table pass built that
+        // value by following `$(B)` and refusing the `$(A)` inside it,
+        // so the placeholder names B. Measured on `softIoc R7.0.10`
+        // through `dbLoadTemplate` with this exact pair: C loads
+        // `$(B,recursive)`. A lazy expander answers `$(A,recursive)`
+        // here — the reference it happened to refuse first — which is a
+        // wrong loaded VALUE and not a wording difference, and is why
+        // the engine keeps a table at all.
         let mut macros = HashMap::new();
         macros.insert("A".to_string(), "$(B)".to_string());
         macros.insert("B".to_string(), "$(A)".to_string());
-        let _ = substitute_macros("$(A)", &macros); // must not hang
+        assert_eq!(substitute_macros("$(A)", &macros), "$(B,recursive)");
     }
 
     /// The real `menuScan` body at `R7.0.10`

--- a/crates/epics-base-rs/src/server/db_loader/substitution.rs
+++ b/crates/epics-base-rs/src/server/db_loader/substitution.rs
@@ -29,10 +29,7 @@
 //!   - the deprecated `WORD { ... }` row prefix is accepted (C warns
 //!     and ignores the extraneous word).
 
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-
-use crate::error::{CaError, CaResult};
+use std::sync::atomic::{AtomicI32, Ordering};
 
 /// Token from the substitutions-file lexer (`dbLoadTemplate_lex.l`).
 #[derive(Debug, Clone, PartialEq)]
@@ -40,13 +37,114 @@ enum Tok {
     Pattern,
     File,
     Global,
-    /// Quoted or unquoted value. The lexer collapses both `WORD` and
-    /// `QUOTE` into a string; `QUOTE` strips the surrounding quotes.
-    Str(String),
+    /// A `WORD` or a `QUOTE`, with the quote character that delimited it.
+    /// C keeps the two apart to the end: `variable_definition` and
+    /// `pattern_value` have one rule per token kind and put the quotes
+    /// back around a `QUOTE` when they build `sub_collect`
+    /// (`dbLoadTemplate.y:220-255`, `:301-323`).
+    Str {
+        text: String,
+        quote: Option<char>,
+    },
     Equals,
     Comma,
     OBrace,
     CBrace,
+}
+
+/// The token text C would have in `yytext` when it reports a fault on
+/// this token — bison's `yyerror` prints it verbatim
+/// (`dbLoadTemplate.y:336`).
+fn tok_text(tok: &Tok) -> String {
+    match tok {
+        Tok::Pattern => "pattern".into(),
+        Tok::File => "file".into(),
+        Tok::Global => "global".into(),
+        // `yytext` is what flex matched, so a quoted token still wears
+        // the quotes it was written with.
+        Tok::Str {
+            text,
+            quote: Some(q),
+        } => format!("{q}{text}{q}"),
+        Tok::Str { text, quote: None } => text.clone(),
+        Tok::Equals => "=".into(),
+        Tok::Comma => ",".into(),
+        Tok::OBrace => "{".into(),
+        Tok::CBrace => "}".into(),
+    }
+}
+
+/// One `yyerror` call. C prints exactly two lines for each
+/// (`dbLoadTemplate.y:330-338`):
+///
+/// ```text
+/// Substitution file error: <message>
+/// line <line>: '<yytext>'
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubstitutionFault {
+    pub line: usize,
+    /// `None` is C's `yyerror(NULL)`, which prints `Substitution file
+    /// error.` and no message of its own (`dbLoadTemplate.y:334-335`).
+    pub message: Option<String>,
+    /// C's `yytext` at the moment of the report.
+    pub yytext: String,
+}
+
+impl SubstitutionFault {
+    /// C `msiLoadRecords` (`dbLoadTemplate.y:49-57`): the row's
+    /// `dbLoadRecords` returned non-zero, so `yyerror` reports and the
+    /// action `YYABORT`s.
+    ///
+    /// `yytext` is `}` for every row, because all four row rules end in
+    /// `C_BRACE` and bison reduces them without reading a lookahead — the
+    /// lexer is still parked on the brace that closed the row. That is
+    /// also why the line is the closing brace's and not the `file` line's
+    /// or the next token's.
+    pub fn row_failed(load: &TemplateLoad) -> Self {
+        Self {
+            line: load.line,
+            message: Some("Error while reading included file".into()),
+            yytext: tok_text(&Tok::CBrace),
+        }
+    }
+
+    /// C's catch-all lexer rule, `dbLoadTemplate_lex.l:47-56`:
+    /// `sprintf(message, "invalid character '%c'", yytext[0])`.
+    fn invalid_character(line: usize, c: char) -> Self {
+        Self {
+            line,
+            message: Some(format!("invalid character '{c}'")),
+            yytext: c.to_string(),
+        }
+    }
+}
+
+/// One thing the substitutions file asks for, in the order C does it.
+/// C interleaves the two: the lexer reports a stray character the moment
+/// it reaches it, which is before the rows that follow it and after the
+/// rows that precede it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubstitutionEvent {
+    /// A `dbLoadRecords` call — one substitution row.
+    Load(TemplateLoad),
+    /// A fault C reported and carried on from.
+    Fault(SubstitutionFault),
+    /// A notice C writes straight to stderr rather than through
+    /// `yyerror`, so it has no `line <N>: '<yytext>'` frame under it.
+    /// The text is C's, newlines included.
+    Notice(String),
+}
+
+/// A parsed substitutions file: what C would do, in C's order.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Substitutions {
+    pub events: Vec<SubstitutionEvent>,
+    /// The fault that ended the parse, if any. `Some` is C's non-zero
+    /// `yyparse` (`dbLoadTemplate.y:417` returns it as the command's
+    /// status); the events before it still happened, because C loads
+    /// each row from the grammar action as it is reduced.
+    pub stopped: Option<SubstitutionFault>,
 }
 
 /// Tokenize a substitutions file.
@@ -57,9 +155,17 @@ enum Tok {
 ///   - quoted `"..."` / `'...'` with `\.` escapes; quotes stripped
 ///   - `=` `,` `{` `}` punctuation
 ///   - `#`-to-EOL comments, whitespace skipped
-fn lex(input: &str) -> CaResult<Vec<(Tok, usize)>> {
+///
+/// Cannot fail. C's only lexer error is the catch-all `.` rule
+/// (`dbLoadTemplate_lex.l:47-56`), which calls `yyerror`, returns NO token
+/// and lets flex resume at the next character — so a stray byte costs one
+/// character, not the file. Every fault this raises is one C recovered from.
+fn lex(input: &str) -> Lexed {
     let chars: Vec<char> = input.chars().collect();
     let mut out: Vec<(Tok, usize)> = Vec::new();
+    // Each fault remembers how many tokens the lexer had produced when
+    // it hit it, which is what puts it back in C's order among the rows.
+    let mut faults: Vec<(usize, SubstitutionFault)> = Vec::new();
     let mut i = 0;
     let mut line = 1usize;
 
@@ -101,54 +207,32 @@ fn lex(input: &str) -> CaResult<Vec<(Tok, usize)>> {
                 i += 1;
             }
             '"' | '\'' => {
-                // Quoted string: `\.` escapes; surrounding quotes are
-                // stripped. A newline before the closing quote is a
-                // lexer error (`dstringchar`/`sstringchar` exclude
-                // `\n`).
-                let quote = c;
-                i += 1;
-                let mut s = String::new();
-                loop {
-                    if i >= chars.len() {
-                        return Err(CaError::DbParseError {
+                // C's QUOTE rule is ONE flex pattern that has to reach a
+                // closing quote on the same line: `dstringchar`/`sstringchar`
+                // are `[^"\n\\]`/`[^'\n\\]` and `{escape}` is
+                // `{backslash}.`, where flex's `.` never matches a newline.
+                // When the pattern cannot match, flex falls through to the
+                // `.` rule, which consumes the quote CHARACTER alone. So an
+                // unterminated string is not a distinct error in C — it is
+                // `invalid character '"'` and the rest of the line lexes as
+                // ordinary tokens. Measured on softIoc: `{ N="A1 }` reports
+                // the quote and still loads the row as `N=A1`.
+                match scan_quoted(&chars, i) {
+                    Some((text, next)) => {
+                        out.push((
+                            Tok::Str {
+                                text,
+                                quote: Some(c),
+                            },
                             line,
-                            column: 0,
-                            message: "unterminated string in substitutions file".into(),
-                        });
+                        ));
+                        i = next;
                     }
-                    let ch = chars[i];
-                    if ch == quote {
+                    None => {
+                        faults.push((out.len(), SubstitutionFault::invalid_character(line, c)));
                         i += 1;
-                        break;
                     }
-                    if ch == '\n' {
-                        return Err(CaError::DbParseError {
-                            line,
-                            column: 0,
-                            message: "newline in string in substitutions file".into(),
-                        });
-                    }
-                    if ch == '\\' && i + 1 < chars.len() && chars[i + 1] != '\n' {
-                        // Keep escape bytes raw — they are forwarded
-                        // into the macro substitution string verbatim,
-                        // matching C `dbmfStrdup(yytext+1)`.
-                        //
-                        // The `!= '\n'` guard is required: C `{escape}`
-                        // is `{backslash}.` and flex `.` never matches a
-                        // newline (`dstringchar`/`sstringchar` are
-                        // `[^"\n\\]`), so a backslash immediately before a
-                        // newline is NOT an escape. Skipping this branch
-                        // lets the newline reach the `\n` check above,
-                        // which is the lexer error C produces.
-                        s.push('\\');
-                        s.push(chars[i + 1]);
-                        i += 2;
-                        continue;
-                    }
-                    s.push(ch);
-                    i += 1;
                 }
-                out.push((Tok::Str(s), line));
             }
             _ if is_bareword(c) => {
                 let mut s = String::new();
@@ -160,20 +244,76 @@ fn lex(input: &str) -> CaResult<Vec<(Tok, usize)>> {
                     "pattern" => Tok::Pattern,
                     "file" => Tok::File,
                     "global" => Tok::Global,
-                    _ => Tok::Str(s),
+                    _ => Tok::Str {
+                        text: s,
+                        quote: None,
+                    },
                 };
                 out.push((tok, line));
             }
             other => {
-                return Err(CaError::DbParseError {
-                    line,
-                    column: 0,
-                    message: format!("invalid character '{other}' in substitutions file"),
-                });
+                // C `dbLoadTemplate_lex.l:47-56`. One character named, one
+                // character dropped, lexing resumes: `{ N=A%1 }` yields the
+                // tokens `N`, `=`, `A`, `1` exactly as C's does.
+                faults.push((out.len(), SubstitutionFault::invalid_character(line, other)));
+                i += 1;
             }
         }
     }
-    Ok(out)
+    Lexed {
+        toks: out,
+        faults,
+        final_line: line,
+    }
+}
+
+/// What one pass of the lexer produced.
+struct Lexed {
+    toks: Vec<(Tok, usize)>,
+    /// Recovered faults, each tagged with the number of tokens the lexer
+    /// had produced when it hit the offending character.
+    faults: Vec<(usize, SubstitutionFault)>,
+    /// `line_num` at end of input — the line C reports a fault at when
+    /// there is no token left to name.
+    final_line: usize,
+}
+
+/// C's `{doublequote}({dstringchar}|{escape})*{doublequote}` as flex applies
+/// it: the whole token or nothing. `at` indexes the opening quote; the result
+/// is the token text with the quotes stripped — C `dbmfStrdup(yytext+1)` then
+/// truncating the last byte (`dbLoadTemplate_lex.l:26-31`) — and the index
+/// just past the closing quote.
+///
+/// Escape bytes stay raw: they are forwarded into the macro substitution
+/// string verbatim, which is what C's `dbmfStrdup` of `yytext` does.
+fn scan_quoted(chars: &[char], at: usize) -> Option<(String, usize)> {
+    let quote = chars[at];
+    let mut text = String::new();
+    let mut i = at + 1;
+    loop {
+        let ch = *chars.get(i)?;
+        if ch == quote {
+            return Some((text, i + 1));
+        }
+        if ch == '\n' {
+            return None;
+        }
+        if ch == '\\' {
+            // `{escape}` is a backslash and ONE character, and flex's `.`
+            // does not match a newline, so a backslash at end of line is not
+            // an escape and the pattern cannot match from here.
+            let next = *chars.get(i + 1)?;
+            if next == '\n' {
+                return None;
+            }
+            text.push('\\');
+            text.push(next);
+            i += 2;
+            continue;
+        }
+        text.push(ch);
+        i += 1;
+    }
 }
 
 /// A single resolved template load: a template filename plus the macro
@@ -181,26 +321,89 @@ fn lex(input: &str) -> CaResult<Vec<(Tok, usize)>> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TemplateLoad {
     pub file: String,
-    pub macros: Vec<(String, String)>,
+    pub macros: Vec<RowMacro>,
+    /// The line of the row's closing brace — `line_num` where C reports a
+    /// failure of this row. See [`SubstitutionFault::row_failed`].
+    pub line: usize,
+}
+
+/// One `name=value` of a substitution row, as C keeps it: the value's
+/// text, plus whether it arrived as a `QUOTE` rather than a `WORD`.
+/// C decides the echo on the token kind alone — `pattern { A } { "1" }`
+/// echoes `A="1"` and `pattern { A } { 1 }` echoes `A=1`, though both
+/// substitute the same `1`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RowMacro {
+    pub name: String,
+    pub value: String,
+    pub quoted: bool,
+}
+
+/// C `int dbTemplateMaxVars = 100;` (`dbLoadTemplate.y:45`), the size of
+/// the `vars` array a `pattern` line fills. `dbCore.dbd:29` declares it
+/// `variable(dbTemplateMaxVars,int)`, so a startup script raises it with
+/// `var dbTemplateMaxVars 200` and the next `dbLoadTemplate` sees the new
+/// value — C reads the global at the point of use, and so does this.
+///
+/// The `sub_collect` buffer C sizes from the same number —
+/// `dbTemplateMaxVars * MAX_VAR_FACTOR` (`dbLoadTemplate.y:377`) — is NOT
+/// modelled, because C never checks it: every `strcat` into `sub_locals`
+/// (`:220-255`, `:301-323`) writes unguarded, so overrunning it is a
+/// buffer overflow with no diagnostic to match. The substitution string is
+/// a `String` here and has no ceiling — a closed question rather than an
+/// open deviation: there is no C text to match, a `String` cannot overflow,
+/// and no input can make the two disagree on anything observable.
+static DB_TEMPLATE_MAX_VARS: AtomicI32 = AtomicI32::new(100);
+
+/// Read the ceiling — the accessor half of the `var dbTemplateMaxVars`
+/// knob ([`crate::server::iocsh::vars`]).
+pub fn db_template_max_vars() -> i32 {
+    DB_TEMPLATE_MAX_VARS.load(Ordering::Relaxed)
+}
+
+/// See [`db_template_max_vars`]. C's `varHandler` writes the global
+/// through its raw pointer and validates nothing; `dbLoadTemplate` is
+/// where a value below 1 is refused (`dbLoadTemplate.y:355-360`).
+pub fn set_db_template_max_vars(value: i32) {
+    DB_TEMPLATE_MAX_VARS.store(value, Ordering::Relaxed);
+}
+
+/// A `WORD`/`QUOTE` in value position, before it is paired with a name.
+struct RowValue {
+    text: String,
+    quoted: bool,
 }
 
 /// Recursive-descent parser over the token stream.
 struct Parser {
     toks: Vec<(Tok, usize)>,
     pos: usize,
+    /// `line_num` at end of input, for a fault with no token to name.
+    final_line: usize,
     /// Accumulated `global {}` definitions (C `sub_locals` base).
-    globals: Vec<(String, String)>,
-    /// Resolved template loads, in file order.
-    loads: Vec<TemplateLoad>,
+    globals: Vec<RowMacro>,
+    /// Loads and notices in the order C produces them, each tagged with
+    /// the token position it was produced at so the lexer's faults can be
+    /// merged back into C's order.
+    events: Vec<(usize, SubstitutionEvent)>,
+    /// How many of `events` are loads — the `file` entry's row count.
+    load_count: usize,
 }
 
+/// A parse that stopped: C's `yyparse` returning non-zero. Every row
+/// reduced before it still ran its `msiLoadRecords` action, so the
+/// loads collected so far are kept.
+type ParseResult<T> = Result<T, SubstitutionFault>;
+
 impl Parser {
-    fn new(toks: Vec<(Tok, usize)>) -> Self {
+    fn new(toks: Vec<(Tok, usize)>, final_line: usize) -> Self {
         Self {
             toks,
             pos: 0,
+            final_line,
             globals: Vec::new(),
-            loads: Vec::new(),
+            events: Vec::new(),
+            load_count: 0,
         }
     }
 
@@ -211,16 +414,49 @@ impl Parser {
     fn line(&self) -> usize {
         self.toks
             .get(self.pos)
-            .or_else(|| self.toks.last())
             .map(|(_, l)| *l)
-            .unwrap_or(0)
+            .unwrap_or(self.final_line)
     }
 
-    fn err(&self, msg: impl Into<String>) -> CaError {
-        CaError::DbParseError {
+    /// Report at the lookahead token, the way bison does: the token that
+    /// could not be shifted is still the current one, so it supplies both
+    /// `line_num` and `yytext`.
+    ///
+    /// The sentence is bison's constant, and takes no parameter so that no
+    /// grammar site can invent one: C's grammar sets no `parse.error
+    /// verbose`, so every way a `.substitutions` file can fail the grammar
+    /// reaches `yyerror` with the one string `syntax error`
+    /// (`dbLoadTemplate.y:330-338`). Measured over ten failing files on
+    /// `bin/linux-x86_64/softIoc` (R7.0.10-146-g8f5015b663d764ad75df), C
+    /// emits no other sentence, and the `line <N>: '<yytext>'` frame under
+    /// it already names the offending token — so an expectation set here
+    /// would only cost a site script the sentence it greps for.
+    fn syntax_error(&self) -> SubstitutionFault {
+        SubstitutionFault {
             line: self.line(),
-            column: 0,
-            message: msg.into(),
+            message: Some("syntax error".into()),
+            // At end of input C prints whatever `yytext` still points at,
+            // which is a freed lex buffer. Measured over eleven files that
+            // end mid-grammar, three runs each: the sentence and the line
+            // number came out identical every time, and the `yytext` under
+            // them was empty in six, the last matched token in one, and
+            // uninitialised heap in four — different bytes on every run of
+            // the same file. C's second line is therefore not a value to
+            // reproduce; its first line is, and is the one a script
+            // matches. The empty string is the stand-in for the rest.
+            yytext: self.peek().map(tok_text).unwrap_or_default(),
+        }
+    }
+
+    /// C `yyerror(NULL)`: the position frame with no message above it.
+    fn err_unnamed(&self) -> SubstitutionFault {
+        SubstitutionFault {
+            line: self.line(),
+            message: None,
+            // Empty at end of input for the reason
+            // [`Parser::syntax_error`] gives: C's `yytext` is a freed
+            // buffer there.
+            yytext: self.peek().map(tok_text).unwrap_or_default(),
         }
     }
 
@@ -232,38 +468,65 @@ impl Parser {
         t
     }
 
-    fn expect(&mut self, want: &Tok) -> CaResult<()> {
-        match self.next() {
-            Some(ref got) if got == want => Ok(()),
-            Some(got) => Err(self.err(format!("expected {want:?}, got {got:?}"))),
-            None => Err(self.err(format!("expected {want:?}, got end of file"))),
+    fn expect(&mut self, want: &Tok) -> ParseResult<()> {
+        match self.peek() {
+            Some(got) if got == want => {
+                self.pos += 1;
+                Ok(())
+            }
+            _ => Err(self.syntax_error()),
         }
     }
 
-    fn expect_str(&mut self) -> CaResult<String> {
-        match self.next() {
-            Some(Tok::Str(s)) => Ok(s),
-            Some(got) => Err(self.err(format!("expected a name/value, got {got:?}"))),
-            None => Err(self.err("expected a name/value, got end of file")),
+    /// A `WORD` or `QUOTE`, where C's grammar takes either —
+    /// `template_filename: DBFILE WORD | DBFILE QUOTE`
+    /// (`dbLoadTemplate.y:117-137`).
+    fn expect_str(&mut self) -> ParseResult<String> {
+        Ok(self.expect_value()?.text)
+    }
+
+    /// A `WORD` where C's grammar takes ONLY a `WORD`: a `pattern_name`
+    /// (`dbLoadTemplate.y:154`), the name half of a `variable_definition`
+    /// (`:301`, `:312`), and the extraneous word of a deprecated row
+    /// (`:197`, `:279`). Quoting one of those is a syntax error on a real
+    /// IOC, so accepting it here would only move the failure to the site.
+    fn expect_word(&mut self) -> ParseResult<String> {
+        if let Some(Tok::Str { quote: Some(_), .. }) = self.peek() {
+            return Err(self.syntax_error());
+        }
+        self.expect_str()
+    }
+
+    /// A `WORD` or `QUOTE` used as a substitution VALUE, where C's two
+    /// grammar rules differ: the quotes go back on for the echo.
+    fn expect_value(&mut self) -> ParseResult<RowValue> {
+        match self.peek() {
+            Some(Tok::Str { text, quote }) => {
+                let value = RowValue {
+                    text: text.clone(),
+                    quoted: quote.is_some(),
+                };
+                self.pos += 1;
+                Ok(value)
+            }
+            _ => Err(self.syntax_error()),
         }
     }
 
     /// `substitution_file: (global_definitions | template_substitutions)*`
-    fn parse(&mut self) -> CaResult<Vec<TemplateLoad>> {
+    fn parse(&mut self) -> ParseResult<()> {
         while let Some(tok) = self.peek() {
             match tok {
                 Tok::Global => self.parse_global()?,
                 Tok::File => self.parse_file()?,
-                other => {
-                    return Err(self.err(format!("expected 'global' or 'file', got {other:?}")));
-                }
+                _ => return Err(self.syntax_error()),
             }
         }
-        Ok(std::mem::take(&mut self.loads))
+        Ok(())
     }
 
     /// `global { var=val, ... }` — accumulates into `self.globals`.
-    fn parse_global(&mut self) -> CaResult<()> {
+    fn parse_global(&mut self) -> ParseResult<()> {
         self.expect(&Tok::Global)?;
         self.expect(&Tok::OBrace)?;
         let defs = self.parse_variable_definitions()?;
@@ -275,11 +538,11 @@ impl Parser {
     }
 
     /// `file WORD|QUOTE { ... }`
-    fn parse_file(&mut self) -> CaResult<()> {
+    fn parse_file(&mut self) -> ParseResult<()> {
         let entry_line = self.line();
         self.expect(&Tok::File)?;
         let filename = self.expect_str()?;
-        let loads_before = self.loads.len();
+        let loads_before = self.load_count;
         self.expect(&Tok::OBrace)?;
         // `file "x" {}` — empty body, no loads.
         if self.peek() == Some(&Tok::CBrace) {
@@ -297,7 +560,7 @@ impl Parser {
         // yields no rows (empty `{}`, row-less pattern, globals-only) —
         // epics-base#666. Upstream is undecided between expand-once and
         // a doc fix, so the semantics stay; only the silence goes.
-        if self.loads.len() == loads_before {
+        if self.load_count == loads_before {
             tracing::warn!(
                 file = %filename,
                 line = entry_line,
@@ -308,7 +571,7 @@ impl Parser {
     }
 
     /// `pattern { names } { row } { row } ...`
-    fn parse_pattern_block(&mut self, filename: &str) -> CaResult<()> {
+    fn parse_pattern_block(&mut self, filename: &str) -> ParseResult<()> {
         self.expect(&Tok::Pattern)?;
         self.expect(&Tok::OBrace)?;
         let mut names: Vec<String> = Vec::new();
@@ -317,11 +580,26 @@ impl Parser {
                 Some(Tok::Comma) => {
                     self.next();
                 }
-                Some(Tok::Str(_)) => names.push(self.expect_str()?),
-                Some(other) => {
-                    return Err(self.err(format!("expected pattern name, got {other:?}")));
+                Some(Tok::Str { .. }) => {
+                    // C `pattern_name` (`dbLoadTemplate.y:154-171`): a name
+                    // past the ceiling is reported and DROPPED — the guard
+                    // leaves `var_count` alone and `yyerror(NULL)` does not
+                    // abort, so each further name reports again and the row
+                    // binds only the names that fit.
+                    let ceiling = db_template_max_vars();
+                    if names.len() as i32 >= ceiling {
+                        let fault = self.err_unnamed();
+                        self.notice(format!(
+                            "More than dbTemplateMaxVars = {ceiling} macro variables used"
+                        ));
+                        self.events
+                            .push((self.pos, SubstitutionEvent::Fault(fault)));
+                        self.next();
+                        continue;
+                    }
+                    names.push(self.expect_word()?)
                 }
-                None => return Err(self.err("unterminated pattern name list")),
+                _ => return Err(self.syntax_error()),
             }
         }
         self.expect(&Tok::CBrace)?;
@@ -332,17 +610,22 @@ impl Parser {
                 Tok::Global => self.parse_global()?,
                 Tok::OBrace => {
                     let row = self.parse_pattern_row()?;
-                    self.emit_load(filename, self.pattern_macros(&names, &row));
+                    let macros = self.pattern_macros(&names, &row);
+                    self.emit_load(filename, macros);
                 }
-                // Deprecated `WORD { row }` form — C warns and skips
-                // the extraneous leading word.
-                Tok::Str(_) => {
-                    let _extraneous = self.expect_str()?;
+                // Deprecated `WORD { row }` form — C warns, drops the
+                // extraneous leading word and loads the row anyway.
+                Tok::Str { .. } => {
+                    let extraneous = self.expect_word()?;
                     let row = self.parse_pattern_row()?;
-                    self.emit_load(filename, self.pattern_macros(&names, &row));
+                    // C reports the surplus values from inside the row and
+                    // the deprecation from the row's action, in that order.
+                    let macros = self.pattern_macros(&names, &row);
+                    self.deprecated_row_notice(&extraneous);
+                    self.emit_load(filename, macros);
                 }
                 Tok::CBrace => break,
-                other => return Err(self.err(format!("expected substitution row, got {other:?}"))),
+                _ => return Err(self.syntax_error()),
             }
         }
         Ok(())
@@ -351,22 +634,19 @@ impl Parser {
     /// `{ "v1", "v2", ... }` — a positional value row. Each value
     /// carries the line it was read from, because a surplus one is
     /// reported by line number.
-    fn parse_pattern_row(&mut self) -> CaResult<Vec<(String, usize)>> {
+    fn parse_pattern_row(&mut self) -> ParseResult<Vec<(RowValue, usize)>> {
         self.expect(&Tok::OBrace)?;
-        let mut values: Vec<(String, usize)> = Vec::new();
+        let mut values: Vec<(RowValue, usize)> = Vec::new();
         while self.peek() != Some(&Tok::CBrace) {
             match self.peek() {
                 Some(Tok::Comma) => {
                     self.next();
                 }
-                Some(Tok::Str(_)) => {
+                Some(Tok::Str { .. }) => {
                     let line = self.line();
-                    values.push((self.expect_str()?, line));
+                    values.push((self.expect_value()?, line));
                 }
-                Some(other) => {
-                    return Err(self.err(format!("expected substitution value, got {other:?}")));
-                }
-                None => return Err(self.err("unterminated substitution row")),
+                _ => return Err(self.syntax_error()),
             }
         }
         self.expect(&Tok::CBrace)?;
@@ -379,19 +659,30 @@ impl Parser {
     /// reports the same surplus as "Warning, too many values given".
     /// Neither aborts the load, and a short row leaving the remaining
     /// names unbound is silent in C, so only the surplus is reported.
-    fn pattern_macros(&self, names: &[String], row: &[(String, usize)]) -> Vec<(String, String)> {
+    fn pattern_macros(&mut self, names: &[String], row: &[(RowValue, usize)]) -> Vec<RowMacro> {
+        // C reports the surplus from `pattern_value` as the value is
+        // reduced (`dbLoadTemplate.y:233`, `:250`), so `line_num` is that
+        // value's own line and not the row's closing brace: measured, a
+        // row whose third value sits on line 3 and whose brace closes on
+        // line 4 reports line 3.
         for (_, line) in row.iter().skip(names.len()) {
-            tracing::warn!("dbLoadTemplate: Too many values given, line {line}.");
+            self.notice(format!(
+                "dbLoadTemplate: Too many values given, line {line}."
+            ));
         }
         names
             .iter()
             .zip(row.iter())
-            .map(|(n, (v, _))| (n.clone(), v.clone()))
+            .map(|(name, (value, _))| RowMacro {
+                name: name.clone(),
+                value: value.text.clone(),
+                quoted: value.quoted,
+            })
             .collect()
     }
 
     /// `file "x" { { var=val,... } { ... } ... }` — named rows.
-    fn parse_variable_substitutions(&mut self, filename: &str) -> CaResult<()> {
+    fn parse_variable_substitutions(&mut self, filename: &str) -> ParseResult<()> {
         while let Some(tok) = self.peek() {
             match tok {
                 Tok::Global => self.parse_global()?,
@@ -402,15 +693,16 @@ impl Parser {
                     self.emit_load(filename, defs);
                 }
                 // Deprecated `WORD { var=val }` form.
-                Tok::Str(_) => {
-                    let _extraneous = self.expect_str()?;
+                Tok::Str { .. } => {
+                    let extraneous = self.expect_word()?;
                     self.expect(&Tok::OBrace)?;
                     let defs = self.parse_variable_definitions()?;
                     self.expect(&Tok::CBrace)?;
+                    self.deprecated_row_notice(&extraneous);
                     self.emit_load(filename, defs);
                 }
                 Tok::CBrace => break,
-                other => return Err(self.err(format!("expected substitution row, got {other:?}"))),
+                _ => return Err(self.syntax_error()),
             }
         }
         Ok(())
@@ -418,103 +710,151 @@ impl Parser {
 
     /// `var=val, var2=val2, ...` — zero or more `WORD = WORD|QUOTE`
     /// pairs separated/terminated by optional commas.
-    fn parse_variable_definitions(&mut self) -> CaResult<Vec<(String, String)>> {
-        let mut defs: Vec<(String, String)> = Vec::new();
+    fn parse_variable_definitions(&mut self) -> ParseResult<Vec<RowMacro>> {
+        let mut defs: Vec<RowMacro> = Vec::new();
         while self.peek() != Some(&Tok::CBrace) {
             match self.peek() {
                 Some(Tok::Comma) => {
                     self.next();
                 }
-                Some(Tok::Str(_)) => {
-                    let name = self.expect_str()?;
+                Some(Tok::Str { .. }) => {
+                    let name = self.expect_word()?;
                     self.expect(&Tok::Equals)?;
-                    let value = self.expect_str()?;
-                    defs.push((name, value));
+                    let value = self.expect_value()?;
+                    defs.push(RowMacro {
+                        name,
+                        value: value.text,
+                        quoted: value.quoted,
+                    });
                 }
-                Some(other) => {
-                    return Err(self.err(format!("expected 'name=value', got {other:?}")));
-                }
-                None => return Err(self.err("unterminated definition block")),
+                _ => return Err(self.syntax_error()),
             }
         }
         Ok(defs)
     }
 
-    /// Record one resolved template load: `globals + row` macros.
-    fn emit_load(&mut self, filename: &str, row: Vec<(String, String)>) {
+    /// Record one resolved template load: `globals + row` macros. The
+    /// token position is where C's grammar action fires — right after the
+    /// row's closing brace, with no lookahead read yet.
+    fn emit_load(&mut self, filename: &str, row: Vec<RowMacro>) {
         let mut macros = self.globals.clone();
         macros.extend(row);
-        self.loads.push(TemplateLoad {
-            file: filename.to_string(),
-            macros,
-        });
+        self.load_count += 1;
+        self.events.push((
+            self.pos,
+            SubstitutionEvent::Load(TemplateLoad {
+                file: filename.to_string(),
+                macros,
+                line: self.last_line(),
+            }),
+        ));
+    }
+
+    /// One of C's plain `fprintf(stderr, ...)` notices, in stream order.
+    fn notice(&mut self, text: String) {
+        self.events
+            .push((self.pos, SubstitutionEvent::Notice(text)));
+    }
+
+    /// The line of the token just consumed — where C's lexer stands while
+    /// a row's grammar action runs, the row having ended in `C_BRACE`.
+    fn last_line(&self) -> usize {
+        self.toks[self.pos - 1].1
+    }
+
+    /// C's deprecated `WORD { … }` row (`dbLoadTemplate.y:199-203`,
+    /// `:281-285`), which it accepts and reports. The line is `line_num`
+    /// at the row's action, so — despite what the sentence says about the
+    /// string — it is the row's closing brace and not the word's own line:
+    /// measured, a word on line 3 before a row that closes on line 4 is
+    /// reported as line 4.
+    fn deprecated_row_notice(&mut self, word: &str) {
+        let line = self.last_line();
+        self.notice(format!(
+            "dbLoadTemplate: Substitution file uses deprecated syntax.\n    \
+             the string '{word}' on line {line} that comes just before the\n    \
+             '{{' character is extraneous and should be removed."
+        ));
     }
 }
 
-/// Parse a `.substitutions` file body into the list of template loads
-/// it describes. Does not touch the filesystem — see
-/// `load_substitution_file` for the loading entry point.
-pub fn parse_substitutions(input: &str) -> CaResult<Vec<TemplateLoad>> {
-    let toks = lex(input)?;
-    Parser::new(toks).parse()
-}
-
-/// Resolve a `.substitutions` file into the ordered list of
-/// `dbLoadRecords` calls it describes — one row per substitution, each
-/// carrying the merged macro set (caller macros, then the row's own
-/// globals + values overriding them).
+/// Parse a `.substitutions` file body into the sequence of loads and
+/// faults C would produce from it, in C's order. Does not touch the
+/// filesystem — the caller owns the database and runs each load.
 ///
-/// Nothing here touches the filesystem beyond reading the
-/// `.substitutions` text, and nothing batches: C `dbLoadTemplate` runs
-/// `msiLoadRecords` from the `pattern_definition` action
-/// (`dbLoadTemplate.y:186`), so every row's records are already in
-/// `pdbbase` before the next row is read and a later failure loses only
-/// the remainder. The caller — the only party that owns a database — is
-/// therefore the one that must resolve, parse and install row by row.
-pub fn substitution_rows(
-    path: &Path,
-    macros: &HashMap<String, String>,
-) -> CaResult<Vec<(String, HashMap<String, String>)>> {
-    let content = std::fs::read_to_string(path).map_err(|e| CaError::DbParseError {
-        line: 0,
-        column: 0,
-        message: format!("cannot read substitutions file '{}': {}", path.display(), e),
-    })?;
-    Ok(parse_substitutions(&content)?
-        .into_iter()
-        .map(|load| {
-            // macLib last-definition-wins: the caller's macros go in
-            // first so a row entry of the same name overrides them.
-            let mut merged = macros.clone();
-            merged.extend(load.macros);
-            (load.file, merged)
-        })
-        .collect())
-}
+/// Never fails as a whole: C's lexer recovers from a stray character
+/// (`dbLoadTemplate_lex.l:47-56`) and its parser has already run the
+/// grammar action — the `dbLoadRecords` — of every row it reduced before
+/// stopping, so a broken file still loads the rows it got through.
+pub fn parse_substitutions(input: &str) -> Substitutions {
+    let Lexed {
+        toks,
+        faults,
+        final_line,
+    } = lex(input);
+    let mut parser = Parser::new(toks, final_line);
+    let stopped = parser.parse().err();
 
-/// Resolve a template filename through C `dbOpenFile`, which owns the
-/// `macEnvExpand` pass `dbReadCOM` (`dbLexRoutines.c:276`) runs on
-/// every name `dbLoadRecords` is handed — and a `.substitutions`
-/// `file` name is handed straight to `dbLoadRecords`
-/// (`dbLoadTemplate.y:51`) without any earlier expansion, so the
-/// environment is the only thing that can resolve it.
-pub(crate) fn resolve_template(
-    filename: &str,
-    include_paths: &[PathBuf],
-) -> CaResult<super::include::DbOpenedFile> {
-    super::include::db_open_file_located(filename, include_paths).ok_or_else(|| {
-        CaError::DbParseError {
-            line: 0,
-            column: 0,
-            message: format!("template file not found: '{filename}'"),
+    // C reads no further than the token it failed on, so a stray
+    // character past that point is never reached and never reported.
+    let last_read = parser.pos;
+    let mut faults = faults
+        .into_iter()
+        .filter(|(at, _)| *at <= last_read)
+        .peekable();
+
+    let mut events = Vec::new();
+    for (at, event) in std::mem::take(&mut parser.events) {
+        while faults.peek().is_some_and(|(fault_at, _)| *fault_at < at) {
+            events.push(SubstitutionEvent::Fault(faults.next().unwrap().1));
         }
-    })
+        events.push(event);
+    }
+    events.extend(faults.map(|(_, fault)| SubstitutionEvent::Fault(fault)));
+
+    Substitutions { events, stopped }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::path::Path;
+
     use super::super::include::{DbLoadConfig, parse_db_opened_with_breaktables};
     use super::*;
+
+    /// A row's macros as plain `name=value`, for the tests that do not
+    /// care which of them arrived quoted.
+    fn pairs(macros: &[RowMacro]) -> Vec<(String, String)> {
+        macros
+            .iter()
+            .map(|m| (m.name.clone(), m.value.clone()))
+            .collect()
+    }
+
+    /// The rows of a parse, faults and all.
+    fn loads_of_events(subs: &Substitutions) -> Vec<&TemplateLoad> {
+        subs.events
+            .iter()
+            .filter_map(|ev| match ev {
+                SubstitutionEvent::Load(load) => Some(load),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The rows of a file that parses cleanly.
+    fn loads_of(src: &str) -> Vec<TemplateLoad> {
+        let subs = parse_substitutions(src);
+        assert_eq!(subs.stopped, None, "unexpected parse fault");
+        subs.events
+            .into_iter()
+            .map(|ev| match ev {
+                SubstitutionEvent::Load(load) => load,
+                other => panic!("unexpected {other:?}"),
+            })
+            .collect()
+    }
 
     /// Drive a `.substitutions` file the way `dbLoadTemplate` does:
     /// resolve, parse and collect one row at a time. The command
@@ -525,11 +865,17 @@ mod tests {
         macros: &HashMap<String, String>,
         config: &DbLoadConfig,
     ) -> Vec<super::super::DbRecordDef> {
-        substitution_rows(subs, macros)
-            .unwrap()
+        let text = std::fs::read_to_string(subs).unwrap();
+        loads_of(&text)
             .into_iter()
-            .flat_map(|(file, merged)| {
-                let template = resolve_template(&file, &config.include_paths).unwrap();
+            .flat_map(|load| {
+                // macLib last-definition-wins: the caller's macros go in
+                // first so a row entry of the same name overrides them.
+                let mut merged = macros.clone();
+                merged.extend(pairs(&load.macros));
+                let template =
+                    super::super::include::db_open_file_located(&load.file, &config.include_paths)
+                        .unwrap();
                 parse_db_opened_with_breaktables(&template, &merged, config)
                     .unwrap()
                     .records
@@ -546,15 +892,15 @@ file "rec.db" {
         { "IOC:", "2" }
 }
 "#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 2);
         assert_eq!(loads[0].file, "rec.db");
         assert_eq!(
-            loads[0].macros,
+            pairs(&loads[0].macros),
             vec![("P".into(), "IOC:".into()), ("N".into(), "1".into())]
         );
         assert_eq!(
-            loads[1].macros,
+            pairs(&loads[1].macros),
             vec![("P".into(), "IOC:".into()), ("N".into(), "2".into())]
         );
     }
@@ -563,10 +909,10 @@ file "rec.db" {
     fn parse_pattern_with_comma_separated_names() {
         // pattern names may be comma-separated or whitespace-separated.
         let src = r#"file "x.db" { pattern {A,B,C} {"1","2","3"} }"#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 1);
         assert_eq!(
-            loads[0].macros,
+            pairs(&loads[0].macros),
             vec![
                 ("A".into(), "1".into()),
                 ("B".into(), "2".into()),
@@ -583,14 +929,14 @@ file "rec.db" {
     { A=3, B=4 }
 }
 "#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 2);
         assert_eq!(
-            loads[0].macros,
+            pairs(&loads[0].macros),
             vec![("A".into(), "1".into()), ("B".into(), "2".into())]
         );
         assert_eq!(
-            loads[1].macros,
+            pairs(&loads[1].macros),
             vec![("A".into(), "3".into()), ("B".into(), "4".into())]
         );
     }
@@ -605,15 +951,15 @@ file "rec.db" {
         { "2" }
 }
 "#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 2);
         // Globals prepended to every row.
         assert_eq!(
-            loads[0].macros,
+            pairs(&loads[0].macros),
             vec![("G".into(), "gval".into()), ("N".into(), "1".into())]
         );
         assert_eq!(
-            loads[1].macros,
+            pairs(&loads[1].macros),
             vec![("G".into(), "gval".into()), ("N".into(), "2".into())]
         );
     }
@@ -621,21 +967,21 @@ file "rec.db" {
     #[test]
     fn parse_quoted_filename() {
         let src = r#"file "path/to/rec.db" { { A=1 } }"#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads[0].file, "path/to/rec.db");
     }
 
     #[test]
     fn parse_bare_filename() {
         let src = r#"file rec.db { { A=1 } }"#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads[0].file, "rec.db");
     }
 
     #[test]
     fn parse_empty_file_body() {
         let src = r#"file "rec.db" { }"#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert!(loads.is_empty());
     }
 
@@ -669,7 +1015,7 @@ file "rec.db" {
             .with_max_level(tracing::Level::WARN)
             .finish();
         let _guard = tracing::subscriber::set_default(subscriber);
-        parse_substitutions(src).unwrap();
+        parse_substitutions(src);
         String::from_utf8_lossy(&buf.0.lock().unwrap()).into_owned()
     }
 
@@ -696,6 +1042,16 @@ file "rec.db" {
         );
     }
 
+    fn notices_of(subs: &Substitutions) -> Vec<&str> {
+        subs.events
+            .iter()
+            .filter_map(|ev| match ev {
+                SubstitutionEvent::Notice(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// C `pattern_value` reports every value past the last pattern name
     /// (`dbLoadTemplate.y:233`, `:250`; `msi.cpp:933`) and drops it. The
     /// port dropped it silently, so a `.substitutions` row that had
@@ -705,7 +1061,10 @@ file "rec.db" {
     /// unmatched name unbound without a diagnostic.
     #[test]
     fn a_value_past_the_last_pattern_name_is_reported() {
-        let out = captured("file \"rec.db\" {\n  pattern { A, B }\n  { \"1\", \"2\", \"3\" }\n}");
+        let subs = parse_substitutions(
+            "file \"rec.db\" {\n  pattern { A, B }\n  { \"1\", \"2\", \"3\" }\n}",
+        );
+        let out = notices_of(&subs).join("\n");
         assert!(
             out.contains("Too many values given, line 3."),
             "the surplus value must be reported with its line, got: {out:?}"
@@ -716,12 +1075,9 @@ file "rec.db" {
             "one report per surplus value, got: {out:?}"
         );
 
-        let loads = parse_substitutions(
-            "file \"rec.db\" {\n  pattern { A, B }\n  { \"1\", \"2\", \"3\" }\n}",
-        )
-        .unwrap();
+        let loads = loads_of_events(&subs);
         assert_eq!(
-            loads[0].macros,
+            pairs(&loads[0].macros),
             vec![
                 ("A".to_string(), "1".to_string()),
                 ("B".to_string(), "2".to_string())
@@ -729,9 +1085,9 @@ file "rec.db" {
             "the surplus value is dropped, the rest still bind"
         );
 
-        assert_eq!(
-            captured("file \"rec.db\" {\n  pattern { A, B }\n  { \"1\" }\n}"),
-            "",
+        let short = parse_substitutions("file \"rec.db\" {\n  pattern { A, B }\n  { \"1\" }\n}");
+        assert!(
+            notices_of(&short).is_empty(),
             "a short row leaves B unbound without a diagnostic, as in C"
         );
     }
@@ -741,7 +1097,7 @@ file "rec.db" {
         // `pattern {N} {}` — empty row is a valid load with no row
         // macros (C `pattern_definition: O_BRACE C_BRACE`).
         let src = r#"file "rec.db" { pattern {N} {} }"#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 1);
         assert!(loads[0].macros.is_empty());
     }
@@ -755,7 +1111,7 @@ file "rec.db" {   # trailing comment
         { "1" }   # row comment
 }
 "#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 1);
     }
 
@@ -764,9 +1120,18 @@ file "rec.db" {   # trailing comment
         // The deprecated `WORD { ... }` row form is accepted (C warns
         // then ignores the extraneous word).
         let src = r#"file "rec.db" { pattern {N} extra {"1"} }"#;
-        let loads = parse_substitutions(src).unwrap();
+        let subs = parse_substitutions(src);
+        let loads = loads_of_events(&subs);
         assert_eq!(loads.len(), 1);
-        assert_eq!(loads[0].macros, vec![("N".into(), "1".into())]);
+        assert_eq!(pairs(&loads[0].macros), vec![("N".into(), "1".into())]);
+        assert_eq!(
+            notices_of(&subs),
+            vec![
+                "dbLoadTemplate: Substitution file uses deprecated syntax.\n    \
+                 the string 'extra' on line 1 that comes just before the\n    \
+                 '{' character is extraneous and should be removed."
+            ]
+        );
     }
 
     #[test]
@@ -775,37 +1140,85 @@ file "rec.db" {   # trailing comment
 file "a.db" { { X=1 } }
 file "b.db" { { Y=2 } }
 "#;
-        let loads = parse_substitutions(src).unwrap();
+        let loads = loads_of(src);
         assert_eq!(loads.len(), 2);
         assert_eq!(loads[0].file, "a.db");
         assert_eq!(loads[1].file, "b.db");
     }
 
-    #[test]
-    fn parse_rejects_unterminated_string() {
-        let src = "file \"rec.db\" { { A=\"oops\nB=1 } }";
-        assert!(parse_substitutions(src).is_err());
+    fn faults_of(subs: &Substitutions) -> Vec<&SubstitutionFault> {
+        subs.events
+            .iter()
+            .filter_map(|ev| match ev {
+                SubstitutionEvent::Fault(f) => Some(f),
+                _ => None,
+            })
+            .collect()
     }
 
+    /// An unterminated string is not a distinct error in C: the QUOTE
+    /// pattern cannot match, so the quote falls to the `.` rule and the
+    /// rest of the line lexes as barewords. Measured on softIoc, this
+    /// file reports one bad character and still loads `N=oops`.
     #[test]
-    fn parse_rejects_backslash_before_newline_in_string() {
-        // C `{escape}` is `{backslash}.` and flex `.` never matches a
-        // newline (`dstringchar` is `[^"\n\\]`), so a backslash
-        // immediately before a newline is NOT an escape — the string
-        // cannot continue across the line and the lexer errors. The
-        // backslash must not "swallow" the newline.
-        let src = "file \"rec.db\" { { A=\"oops\\\nB\" } }";
-        assert!(parse_substitutions(src).is_err());
+    fn an_unterminated_string_degrades_to_one_bad_character() {
+        let src = "file \"rec.db\" { { N=\"oops\nB=1 } }";
+        let subs = parse_substitutions(src);
+        assert_eq!(subs.stopped, None);
+        assert_eq!(
+            faults_of(&subs),
+            vec![&SubstitutionFault {
+                line: 1,
+                message: Some("invalid character '\"'".into()),
+                yytext: "\"".into(),
+            }]
+        );
+        let loads = loads_of_events(&subs);
+        assert_eq!(loads.len(), 1);
+        // Both definitions survive: with the quote gone, `oops` and
+        // `B=1` are ordinary tokens and the row reads `{ N=oops B=1 }`.
+        assert_eq!(
+            pairs(&loads[0].macros),
+            vec![("N".into(), "oops".into()), ("B".into(), "1".into())]
+        );
+    }
+
+    /// C `{escape}` is `{backslash}.` and flex `.` never matches a
+    /// newline (`dstringchar` is `[^"\n\\]`), so a backslash immediately
+    /// before a newline is NOT an escape — the string cannot continue
+    /// across the line. Both quotes therefore fall to the `.` rule, and
+    /// the `B` left without a value ends the parse. Measured on softIoc.
+    #[test]
+    fn a_backslash_before_a_newline_does_not_continue_the_string() {
+        let src = "file \"rec.db\" { { N=\"oops\\\nB\" } }";
+        let subs = parse_substitutions(src);
+        assert_eq!(
+            faults_of(&subs)
+                .iter()
+                .map(|f| (f.line, f.message.clone().unwrap_or_default()))
+                .collect::<Vec<_>>(),
+            vec![
+                (1, "invalid character '\"'".to_string()),
+                (2, "invalid character '\"'".to_string()),
+            ]
+        );
+        assert!(loads_of_events(&subs).is_empty());
+        let stopped = subs
+            .stopped
+            .as_ref()
+            .expect("the dangling name must stop the parse");
+        assert_eq!((stopped.line, stopped.yytext.as_str()), (2, "}"));
     }
 
     #[test]
     fn parse_rejects_missing_keyword() {
         let src = r#"{ A=1 }"#;
-        assert!(parse_substitutions(src).is_err());
+        let stopped = parse_substitutions(src).stopped.expect("must stop");
+        assert_eq!((stopped.line, stopped.yytext.as_str()), (1, "{"));
     }
 
     #[test]
-    fn substitution_rows_drives_template_loads() {
+    fn template_loads_drive_one_dbloadrecords_per_row() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
 
@@ -842,7 +1255,7 @@ file "b.db" { { Y=2 } }
     /// `dbLoadRecords`, whose `dbOpenFile` never looks at the
     /// substitutions file's own directory.
     #[test]
-    fn substitution_rows_takes_templates_from_the_path_list() {
+    fn template_loads_take_templates_from_the_path_list() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let path_dir = tempfile::tempdir().unwrap();
@@ -871,7 +1284,7 @@ file "b.db" { { Y=2 } }
     /// loads exactly when `TOP` is an environment variable.
     #[test]
     #[serial_test::serial(epics_env)]
-    fn substitution_rows_env_expands_the_template_name() {
+    fn template_loads_env_expand_the_template_name() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
         let tpl_dir = tempfile::tempdir().unwrap();
@@ -895,7 +1308,7 @@ file "b.db" { { Y=2 } }
     }
 
     #[test]
-    fn substitution_rows_caller_macros_overridden_by_row() {
+    fn template_loads_let_the_row_override_caller_macros() {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
 

--- a/crates/epics-base-rs/src/server/device_support.rs
+++ b/crates/epics-base-rs/src/server/device_support.rs
@@ -607,10 +607,39 @@ pub trait DeviceSupport: Send + Sync + 'static {
 /// The device is attached (`instance.device = Some(dev)`) regardless
 /// of init outcome so the record is addressable; a failed init leaves
 /// the alarm set.
-pub fn wire_device_to_record(instance: &mut RecordInstance, mut dev: Box<dyn DeviceSupport>) {
+pub fn wire_device_to_record(instance: &mut RecordInstance, dev: Box<dyn DeviceSupport>) {
+    attach_device_to_record(instance, dev);
+    init_device_support(instance);
+}
+
+/// The BIND half of [`wire_device_to_record`]: C `iocInit.c::doInitRecord0`'s
+/// `precord->dset = pdevSup ? pdevSup->pdset : NULL` (`:530-533`), which
+/// happens BEFORE `prset->init_record(precord, 0)` and runs no driver code.
+///
+/// Split from the init half because C's two halves sit on opposite sides of
+/// `init_record`: every `<rec>Record.c init_record` opens by testing the dset
+/// this line bound (`if (!pdset) return S_dev_noDSET`) and only later calls
+/// `pdset->common.init_record`. Attaching and initialising in one step is what
+/// put the whole sequence after the record's init passes, so `init_record`
+/// could not see its own dset and ran the tail C's early return skips.
+pub fn attach_device_to_record(instance: &mut RecordInstance, mut dev: Box<dyn DeviceSupport>) {
     let name = instance.name.clone();
     dev.set_record_info(&name, instance.common.scan);
     dev.apply_record_info(&instance.info);
+    instance.device = Some(dev);
+}
+
+/// The INIT half: C `pdset->common.init_record(prec)`, the call every record
+/// type makes from inside its own `init_record` once the dset test above has
+/// passed (`aiRecord.c:115-124`).
+///
+/// No-op for a record that has no device attached — C reaches this line only
+/// past `if (!pdset) return S_dev_noDSET`.
+pub fn init_device_support(instance: &mut RecordInstance) {
+    let Some(mut dev) = instance.device.take() else {
+        return;
+    };
+    let name = instance.name.clone();
     match dev.init(&mut *instance.record) {
         Ok(DeviceInitOutcome::Live) => {}
         Ok(DeviceInitOutcome::Dead { alarm }) => {

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -991,9 +991,6 @@ struct IocBuild {
     acf: access_security::AcfCell,
     autosave_config: Option<autosave::SaveSetConfig>,
     autosave_startup: Option<Arc<Mutex<AutosaveStartupConfig>>>,
-    device_factories: HashMap<String, DeviceSupportFactory>,
-    dynamic_device_factory: Option<DynamicDeviceSupportFactory>,
-    subroutine_registry: HashMap<String, Arc<SubroutineFn>>,
     link_set_installers: Vec<LinkSetInstaller>,
     after_init_hooks: Vec<Box<dyn FnOnce() + Send>>,
     protocol: ProtocolStart,
@@ -1109,6 +1106,71 @@ pub(crate) fn build_from_shell(bridge: &crate::runtime::task::BlockingBridge) ->
     }
 }
 
+/// C `iocBuild_1`'s refusal (`iocInit.c:117-120`), which every caller of the
+/// build shares because C has one `iocBuild_1` and reaches it from both
+/// `iocBuild()` and `iocInit()` — which is why the sentence names `iocBuild`
+/// even when `iocInit` is the line that failed.
+///
+/// It is a function because the port had three copies of it, one per arm that
+/// could refuse, and a duplicated diagnostic drifts the moment one copy is
+/// touched.
+pub(crate) fn build_refusal() -> String {
+    format!(
+        "iocBuild: {} IOC can only be initialized from uninitialized or \
+         stopped state\n",
+        if crate::runtime::log::errlog_console_paints() {
+            crate::runtime::log::ERL_ERROR
+        } else {
+            "ERROR"
+        }
+    )
+}
+
+/// The build for a shell with no [`IocApplication`] behind it — every
+/// `CaServerBuilder` binary and every bare [`PvDatabase`] shell.
+///
+/// C has no such shell: `iocBuild_1` runs for everyone, so the state cell
+/// advances, `coreRelease()` prints and `Starting iocInit` is said whatever
+/// built the IOC. This arm did none of that. It closed the record load and
+/// returned, leaving `iocState` at [`IocState::Void`], which is why a
+/// measured `iocBuild`/`iocRun` pair answered `iocRun: WARNING IOC not
+/// paused` where C answers `iocRun: All initialization complete`, why a
+/// second `iocBuild` was accepted where C refuses it, and why the five-line
+/// `coreRelease` banner C puts between the two command echoes was missing
+/// from stdout.
+///
+/// `close_record_load` is the caller's half — it needs the shell's database
+/// and its blocking bridge — and it sits exactly where C's record work sits,
+/// after `coreRelease()` and inside [`IocState::Building`]. The transition
+/// itself stays here because [`set_ioc_state`] is private to this module and
+/// must remain the only writer.
+///
+/// The init hooks C announces around this (`initHookAtIocBuild`,
+/// `initHookAtBeginning`, `initHookAfterIocBuilt`) are deliberately not
+/// announced: they produce no output, so nothing measured says what a bare
+/// shell should do with them, and firing hooks nobody has asked for is not
+/// something a byte-parity fix should decide.
+pub(crate) fn build_without_application(close_record_load: impl FnOnce()) -> bool {
+    // C `iocBuild_1` (`iocInit.c:117-120`).
+    if get_ioc_state() != IocState::Void {
+        crate::runtime::log::errlog_printf(&build_refusal());
+        return false;
+    }
+    // C `iocInit.c:129`, before anything the build prints.
+    crate::runtime::log::errlog_printf("Starting iocInit\n");
+    // C `iocInit.c:147`: `coreRelease()` immediately before the state moves,
+    // and its `printf` (`misc/epicsRelease.c:23-27`) is the only stdout write
+    // on the whole path.
+    for line in crate::server::iocsh::misc_commands::core_release_block() {
+        println!("{line}");
+    }
+    set_ioc_state(IocState::Building);
+    close_record_load();
+    // C `iocBuild_3` (`iocInit.c:205`).
+    set_ioc_state(IocState::Built);
+    true
+}
+
 /// The iocsh `iocRun` line, and the run half of `iocInit`.
 ///
 /// `Refused` is not an error the caller should print: it only means this line
@@ -1139,9 +1201,6 @@ impl IocBuild {
             acf,
             autosave_config,
             autosave_startup,
-            device_factories,
-            dynamic_device_factory,
-            subroutine_registry,
             link_set_installers,
             after_init_hooks,
             protocol,
@@ -1367,26 +1426,20 @@ impl IocBuild {
 
         // Phase 2b: iocInit. C order is initDevSup() → initHookAfterInitDevSup
         // (autosave pass 0) → initDatabase() (per-record init_record, where
-        // devMotorAsyn's init_controller runs). Rust's per-record device init
-        // lives in `wire_device_support` — the initDatabase-era half of C's
-        // init, not initDevSup (whose analogue, device-factory registration,
-        // already happened) — so the pass-0 hook fires BEFORE it. A pass0-
-        // restored field must land as a plain pre-init field write (C dbPut
-        // before init_record); `DeviceSupport::init` then anchors/clears any
-        // command state the write armed (motor `clear_last_write`). Firing the
-        // hook after wiring let a restored motor VAL survive as a pending move
-        // command, dispatched as a real move on the first driver-status pass —
-        // and on a fast axis (VELO high) the Startup readback then caught the
-        // move mid-flight and synced the instantaneous position into VAL/DVAL.
+        // devMotorAsyn's init_controller runs).
+        //
+        // Both halves of C's `initDatabase` — the dset bind and the driver's
+        // own `init_record` — now run at the record's creation, from the
+        // database's own init owner, because C binds the dset BEFORE
+        // `init_record(0)` and a whole-database pass here could only bind it
+        // after. A pass0-restored field still lands as a plain pre-init field
+        // write (C dbPut before init_record) for the reason it always did:
+        // this hook fires before the startup script's `iocInit` line, and the
+        // records it restores were loaded before that. What changed is that
+        // `DeviceSupport::init` no longer waits for this point to anchor the
+        // command state such a write armed.
         announce!(InitHookState::AfterInitDevSup);
-        let record_count =
-            wire_device_support(&db, &device_factories, &dynamic_device_factory).await?;
-        // Retain the registry in the database for runtime re-resolution
-        // (aSub LFLG=READ / SUBL); `wire_subroutines` then performs the
-        // static init-time SNAM resolution (C `init_record`).
-        db.install_subroutine_registry(subroutine_registry.clone())
-            .await;
-        wire_subroutines(&db, &subroutine_registry).await;
+        let record_count = db.records_with_device_support().await;
         let io_intr_count = setup_io_intr(db.clone()).await;
         setup_property_posts(db.clone()).await;
         // C `dbInitLink`'s locality decision, committed once for the whole
@@ -1526,9 +1579,15 @@ impl IocBuild {
         };
 
         let total_records = db.all_record_names().await.len();
-        eprintln!(
-            "iocInit: {total_records} records, {record_count} with device support, {io_intr_count} I/O Intr"
-        );
+        // A line C does not have, kept because the three counts are what an
+        // operator checks an `st.cmd` by — but said through the errlog, which
+        // is where C puts everything the boot says. A raw `eprintln!` here
+        // was outside `eltc`'s reach: measured, `eltc 0` then `iocInit`
+        // silenced C's console completely and left this line and the CA
+        // server's on the port's.
+        crate::runtime::log::errlog_printf(&format!(
+            "iocInit: {total_records} records, {record_count} with device support, {io_intr_count} I/O Intr\n"
+        ));
 
         // C: rsrv init / iocBuild end. The Rust CA/PVA listener is
         // owned by the protocol runner, but PINI is already complete
@@ -2131,6 +2190,22 @@ impl IocApplication {
             iocsh::register_command(cmd);
         }
 
+        // C's device support table and its function registry are
+        // process-global and complete BEFORE the first `dbLoadRecords`: the
+        // registrars run from `registerRecordDeviceDriver`, which softMain
+        // calls before `iocsh(st.cmd)` (`softMain.cpp:181-232`). Install both
+        // on the database at that same point, because the record creation sink
+        // now consults them at C's positions — the dset bound ahead of
+        // `init_record(0)`, the SNAM resolved inside pass 1. Applying them
+        // afterwards, in a second whole-database pass, is exactly what let
+        // every record type's `init_record` run the tail C's early returns
+        // skip.
+        db.install_device_support_resolver(device_support_resolver(
+            device_factories,
+            dynamic_device_factory,
+        ));
+        db.install_subroutine_registry(subroutine_registry).await;
+
         // Add inline PVs then inline records — `IocBuilder::build`'s order
         // for the same two sources, and before the script for C's reason:
         // everything argv named is in the database when the script starts.
@@ -2152,9 +2227,6 @@ impl IocApplication {
             acf: acf.clone(),
             autosave_config: autosave_config.clone(),
             autosave_startup,
-            device_factories,
-            dynamic_device_factory,
-            subroutine_registry,
             link_set_installers,
             after_init_hooks,
             // C parity (`caservertask.c:492-500`): the server-side env var
@@ -2438,100 +2510,221 @@ impl IocApplication {
     }
 }
 
-/// Wire device support to all records that have DTYP set.
-pub(crate) async fn wire_device_support(
-    db: &PvDatabase,
-    factories: &HashMap<String, DeviceSupportFactory>,
-    dynamic_factory: &Option<DynamicDeviceSupportFactory>,
-) -> CaResult<usize> {
-    let names = db.all_record_names().await;
-    let mut count = 0;
-    for name in names {
-        if let Some(rec_arc) = db.get_record(&name) {
-            let mut instance = rec_arc.write();
-            let dtyp = instance.common.dtyp.clone();
-            if !crate::server::device_support::is_soft_dtyp(&dtyp) {
-                let ctx = DeviceSupportContext {
-                    dtyp: &dtyp,
-                    inp: &instance.common.inp,
-                    out: &instance.common.out,
-                };
-                let dev_opt = if let Some(factory) = factories.get(&dtyp) {
-                    Some(factory())
-                } else if let Some(dyn_factory) = dynamic_factory {
-                    dyn_factory(&ctx)
-                } else {
-                    None
-                };
-                if let Some(dev) = dev_opt {
-                    // Canonical device-support init order (M1/M2):
-                    // set_record_info → apply_record_info → init,
-                    // with init-failure logged and the record flagged
-                    // INVALID. Single owner of the contract, shared
-                    // with the IocBuilder build path.
-                    crate::server::device_support::wire_device_to_record(&mut instance, dev);
-                    count += 1;
-                } else {
-                    eprintln!(
-                        "warning: no device support registered for DTYP '{dtyp}' (record: {name})"
-                    );
-                }
-            }
+/// The process-wide device support table, seen the way C's `dbDTYPtoDevSup`
+/// sees it: a DTYP plus the record's links in, a dset (or nothing) out.
+///
+/// Held by [`PvDatabase`] rather than by the two builders because C's table is
+/// global and filled by registrars BEFORE any record exists, while the port's
+/// factories used to reach the records only after the whole database had been
+/// built — which is what put dset resolution after `init_record`.
+pub type DeviceSupportResolver =
+    Arc<dyn Fn(&DeviceSupportContext) -> Option<Box<dyn DeviceSupport>> + Send + Sync>;
+
+/// Fold the two registration shapes a builder collects — the DTYP-keyed
+/// context-free factories and the single dynamic factory — into the one
+/// lookup [`PvDatabase`] holds. DTYP-keyed first, dynamic as the fallback:
+/// the priority `attach_device_support` had.
+pub(crate) fn device_support_resolver(
+    factories: HashMap<String, DeviceSupportFactory>,
+    dynamic_factory: Option<DynamicDeviceSupportFactory>,
+) -> DeviceSupportResolver {
+    Arc::new(move |ctx: &DeviceSupportContext| {
+        if let Some(factory) = factories.get(ctx.dtyp) {
+            Some(factory())
+        } else if let Some(dyn_factory) = dynamic_factory.as_ref() {
+            dyn_factory(ctx)
+        } else {
+            None
         }
-    }
-    Ok(count)
+    })
 }
 
-/// Wire subroutine functions to sub records.
-async fn wire_subroutines(db: &PvDatabase, registry: &HashMap<String, Arc<SubroutineFn>>) {
-    if registry.is_empty() {
-        return;
+/// C `iocInit.c::doInitRecord0`'s `precord->dset = pdevSup ? pdevSup->pdset :
+/// NULL` (`:530-533`), and the refusal every `<rec>Record.c init_record` makes
+/// when that comes back NULL, for one record. Returns whether a device
+/// attached.
+///
+/// **The single owner**, for the reason [`wire_subroutine`] is one:
+/// `IocBuilder` wires its records as it installs them and `IocApplication`
+/// wires them from the database afterwards, and the two had already diverged —
+/// the builder route reported a missing DTYP not at all, so an IOC built
+/// through it booted in silence holding records that can never process. A DTYP
+/// nobody registered is the same broken record on both.
+///
+/// Called by [`PvDatabase::add_record`] — the creation sink — BEFORE the
+/// record's init passes, which is the whole point: C binds the dset first and
+/// every record type's `init_record` opens by testing it. It binds only; the
+/// driver's own `init_record` half runs from inside the passes
+/// ([`crate::server::device_support::init_device_support`]).
+pub(crate) fn attach_device_support(
+    instance: &mut record::RecordInstance,
+    name: &str,
+    resolve: Option<&DeviceSupportResolver>,
+) -> bool {
+    let dtyp = instance.common.dtyp.clone();
+    if crate::server::device_support::is_soft_dtyp(&dtyp) {
+        // A soft channel needs no dset. Its `"Async Soft Channel"` variant
+        // still owns an `add_record`, but that is C's `doResolveLinks` moment,
+        // which sits BETWEEN the two init passes — so the init owner runs it,
+        // not this one.
+        return false;
     }
-    let names = db.all_record_names().await;
-    for name in names {
-        if let Some(rec_arc) = db.get_record(&name) {
-            let mut instance = rec_arc.write();
-            // Both `sub` and `aSub` resolve their subroutine from SNAM via the
-            // function registry at init (C `subRecord.c` / `aSubRecord.c`
-            // `init_record` -> `registryFunctionFind`).
-            let rt = instance.record.record_type();
-            if rt == "sub" || rt == "aSub" {
-                // INAM: invoke the init routine exactly once at init, before
-                // SNAM resolution (C `subRecord.c` / `aSubRecord.c`
-                // `init_record`: `registryFunctionFind(inam)` then
-                // `(*psubroutine)(prec)`, return value discarded; a missing
-                // function is an init error -> stderr).
-                if let Some(crate::types::EpicsValue::String(inam)) =
-                    instance.record.get_field("INAM")
-                {
-                    let inam = inam.as_str_lossy();
-                    if !inam.is_empty() {
-                        match registry.get(inam.as_ref()) {
-                            Some(init_fn) => {
-                                let init_fn = init_fn.clone();
-                                if let Err(e) = init_fn(&mut *instance.record) {
-                                    eprintln!(
-                                        "iocInit: {name}.INAM '{inam}' init routine failed: {e}"
-                                    );
-                                }
-                            }
-                            None => eprintln!("iocInit: {name}.INAM function '{inam}' not found"),
-                        }
-                    }
-                }
-                // C `init_record`'s `prec->sadr = registryFunctionFind(...)`,
-                // assigned whatever the lookup returned. Unconditional so the
-                // invariant "`subroutine` is the resolution of the current
-                // SNAM" holds by construction rather than by this field
-                // happening to start out `None`.
-                if let Some(crate::types::EpicsValue::String(snam)) =
-                    instance.record.get_field("SNAM")
-                {
-                    instance.subroutine = registry.get(snam.as_str_lossy().as_ref()).cloned();
-                }
+    let ctx = DeviceSupportContext {
+        dtyp: &dtyp,
+        inp: &instance.common.inp,
+        out: &instance.common.out,
+    };
+    let dev_opt = resolve.and_then(|resolve| resolve(&ctx));
+    let Some(dev) = dev_opt else {
+        // Two reports, because C makes two and they answer different
+        // questions. This one is deliberately per RECORD, where C's `device
+        // support %s not found` is per DBD ENTRY: C's line names a `device()`
+        // line nobody linked and leaves the operator to find which records
+        // used it, while this names the record that will not work.
+        eprintln!("warning: no device support registered for DTYP '{dtyp}' (record: {name})");
+        // C's own per-record line, the one a site greps for by
+        // `recGblRecordError` and the one that carries the status. Silent for
+        // a record type that needs no device support — the table is the gate.
+        crate::server::recgbl::rec_gbl_no_device_support(instance.record.record_type(), name);
+        return false;
+    };
+    // The BIND half only (set_record_info → apply_record_info → attach). The
+    // driver's `init()` is C's `pdset->common.init_record`, which runs from
+    // inside `init_record` — after the dset test this line's outcome answers.
+    crate::server::device_support::attach_device_to_record(instance, dev);
+    true
+}
+
+/// C `subRecord.c`/`aSubRecord.c` `init_record`'s name resolution
+/// (`subRecord.c:107-130`, `aSubRecord.c:139-160`), for one record.
+///
+/// **The single owner**, for the reason [`setup_io_intr`] is one: `IocBuilder`
+/// wires its records as it installs them and `IocApplication` wires them from
+/// the database afterwards, and while each spelt this out for itself a
+/// diagnostic added to one route was missing from the other. A `sub` record
+/// whose SNAM names nothing is exactly the same broken record on both.
+///
+/// Both misses are `fprintf(stderr, "%s.SNAM " ERL_ERROR " function '%s' not
+/// found\n", ...)` in C — the console directly, not the errlog, which is why
+/// this writes `eprintln!` and not [`rec_gbl_record_error`]. The INAM half was
+/// worded `iocInit: <name>.INAM function ... not found` here and the SNAM half
+/// was not written at all, so an IOC that booted with an unresolved SNAM said
+/// nothing and then processed the record as a no-op.
+///
+/// Returns whether C's `init_record` REACHED ITS TAIL — `false` is C's `return
+/// S_db_BadSub` (either miss) and C's `prec->pact = TRUE; return 0` (an empty
+/// `sub` SNAM), both of which skip everything below them. The init owner
+/// ([`record::RecordInstance::run_init_passes`]) calls this from inside pass 1
+/// and honours the answer, so the tail is unreachable by construction rather
+/// than by a per-record-type opt-out.
+///
+/// [`rec_gbl_record_error`]: crate::server::recgbl::rec_gbl_record_error
+pub(crate) fn wire_subroutine(
+    instance: &mut record::RecordInstance,
+    name: &str,
+    registry: &HashMap<String, Arc<SubroutineFn>>,
+) -> bool {
+    // Both `sub` and `aSub` resolve their subroutine from SNAM via the
+    // function registry at init (C `registryFunctionFind`).
+    let rt = instance.record.record_type();
+    if rt != "sub" && rt != "aSub" {
+        return true;
+    }
+    let erl = crate::runtime::log::ERL_ERROR;
+    // INAM: invoke the init routine exactly once at init, before SNAM
+    // resolution (C `init_record`: `registryFunctionFind(inam)` then
+    // `(*psubroutine)(prec)`, return value discarded).
+    //
+    // A name that does not RESOLVE is C's `return S_db_BadSub`
+    // (`subRecord.c:110-114`, `aSubRecord.c:141-146`) — an early return, so
+    // everything below is skipped and the record keeps a null `sadr` however
+    // good its SNAM is. The routine's own status is discarded, so a routine
+    // that ran and failed is not an early return.
+    if let Some(crate::types::EpicsValue::String(inam_field)) = instance.record.get_field("INAM") {
+        let inam = inam_field.as_str_lossy();
+        if !inam.is_empty() {
+            let Some(init_fn) = registry.get(inam.as_ref()) else {
+                eprintln!("{name}.INAM {erl} function '{inam}' not found");
+                return false;
+            };
+            let init_fn = init_fn.clone();
+            if let Err(e) = init_fn(&mut *instance.record) {
+                eprintln!("iocInit: {name}.INAM '{inam}' init routine failed: {e}");
             }
         }
     }
+    // C resolves SNAM at init only for a record that will USE the resolution:
+    // `subRecord.c:123` always, `aSubRecord.c:151-158` only under `LFLG ==
+    // IGNORE`, because an `LFLG == READ` aSub reads its name from SUBL every
+    // cycle and resolves it there (`apply_asub_dynamic_sub`). That rule
+    // already had an owner — the record's own `is_subroutine_name_field`,
+    // which the put path gates on — so this asks it instead of re-deriving
+    // "sub or aSub" and reporting a miss C never went looking for.
+    if instance.record.is_subroutine_name_field("SNAM")
+        && let Some(crate::types::EpicsValue::String(snam_field)) =
+            instance.record.get_field("SNAM")
+    {
+        let snam = snam_field.as_str_lossy();
+        if snam.is_empty() {
+            // C `subRecord.c:118-122` — `epicsPrintf`, which is `errlogPrintf`
+            // (`errlog.h:90`), then `prec->pact = TRUE` and `return 0`. Both
+            // halves are this line's, because both are inside C's
+            // `init_record`: an INAM that failed above returned before them,
+            // so a record whose INAM missed is NOT parked however empty its
+            // SNAM is (softIoc-measured: `PACT: 0`). `aSubRecord.c:152` tests
+            // `snam[0] != 0` and neither reports nor returns, so it falls
+            // through to the tail below.
+            instance.subroutine = None;
+            if rt == "sub" {
+                crate::runtime::log::errlog_printf(&format!("{name}.SNAM is empty\n"));
+                instance.enter_pact();
+                return false;
+            }
+        } else {
+            // C `init_record`'s `prec->sadr = registryFunctionFind(...)`,
+            // assigned whatever the lookup returned, and `return S_db_BadSub`
+            // when that is NULL (`subRecord.c:125-129`, `aSubRecord.c:155-158`)
+            // — the second early return past the tail.
+            instance.subroutine = registry.get(snam.as_ref()).cloned();
+            if instance.subroutine.is_none() {
+                eprintln!("{name}.SNAM {erl} function '{snam}' not found");
+                return false;
+            }
+        }
+    }
+    // C's init tail: the lines BELOW every early return above, reached only by
+    // a record whose INAM and SNAM both resolved. That placement is the whole
+    // point — an unresolved name means C never seeds, and `dbpr REC 4` on
+    // `record(sub,"X"){field(SNAM,"noSuchSub") field(VAL,"5")}` reads back
+    // `MLST: 0 ALST: 0 LALM: 0` on softIoc R7.0.10 while the port read 5.
+    // It lives here rather than in `SubRecord::init_record` / the generic
+    // `seed_deadband_tracking` because both of those run before this function,
+    // where the resolution's outcome is not yet known.
+    match rt {
+        // `subRecord.c:130-132`: `prec->mlst = prec->alst = prec->lalm =
+        // prec->val`, so the first `monitor()` posts nothing for a value that
+        // has not moved since init.
+        "sub" => {
+            if let Some(val) = instance.record.get_field("VAL") {
+                for field in ["MLST", "ALST", "LALM"] {
+                    let _ = instance.record.put_field(field, val.clone());
+                }
+            }
+        }
+        // `aSubRecord.c:162`: `strcpy(prec->onam, prec->snam)`. That seed is
+        // what gives `fetch_values`' `strcmp(prec->snam, prec->onam)` (`:261`)
+        // its meaning — "the SUBL link delivered a name different from the one
+        // this record booted with", not "different from the empty string".
+        // Without it an `LFLG=READ` aSub whose SUBL is a constant re-resolved
+        // its own boot-time SNAM on the first cycle and bound the subroutine C
+        // deliberately leaves NULL.
+        _ => {
+            if let Some(snam_field) = instance.record.get_field("SNAM") {
+                let _ = instance.record.put_field("ONAM", snam_field);
+            }
+        }
+    }
+    true
 }
 
 /// C `scanAdd`'s `menuScanI_O_Intr` failure exit (`dbScan.c:272-293`): a record
@@ -2544,7 +2737,18 @@ async fn wire_subroutines(db: &PvDatabase, registry: &HashMap<String, Arc<Subrou
 /// `scanDelete` → `get_ioint_info(1)` hook and hands back the delta for
 /// `update_scan_index`, so the record also leaves the `IoIntr` scan bucket that
 /// `scanpiol` and `dbla` report from.
-async fn demote_io_intr_to_passive(db: &PvDatabase, name: &str, reason: &str) {
+///
+/// `message` is C's `pmessage` verbatim, trailing space included, and the
+/// report goes through [`rec_gbl_record_error`] rather than being spelt out
+/// here. Both matter to a site: C's line is `recGblRecordError: <message>
+/// <errSym> PV: <name>` and it goes to the *errlog*, so an operator grepping
+/// `recGblRecordError` or reading the IOC log server sees a demoted record.
+/// The port used to print its own sentence straight to `stderr`, which
+/// reaches neither. C names no record's new SCAN and neither does this — the
+/// demotion is `scanAdd`'s documented behaviour, not news.
+///
+/// [`rec_gbl_record_error`]: crate::server::recgbl::rec_gbl_record_error
+async fn demote_io_intr_to_passive(db: &PvDatabase, name: &str, message: &str) {
     let Some(rec_arc) = db.get_record(name) else {
         return;
     };
@@ -2563,7 +2767,9 @@ async fn demote_io_intr_to_passive(db: &PvDatabase, name: &str, reason: &str) {
     {
         db.update_scan_index(name, old_scan, new_scan, phas, phas);
     }
-    eprintln!("scanAdd: I/O Intr not valid ({reason}), {name} set to Passive");
+    // C passes `-1`, for which `errSymLookup` is skipped and the slot is
+    // empty (`recGbl.c:65-70`) — hence the doubled space in C's own output.
+    crate::server::recgbl::rec_gbl_record_error("", name, message);
 }
 
 /// Set up I/O Intr scanning for records with SCAN="I/O Intr".
@@ -2608,9 +2814,10 @@ pub(crate) async fn setup_io_intr(db: Arc<PvDatabase>) -> usize {
             continue;
         }
         let Some(mut dev) = inst.device.take() else {
-            // C `dbScan.c:272-276` — `precord->dset == NULL`.
+            // C `dbScan.c:272-276` — `precord->dset == NULL`. The trailing
+            // space is C's literal (`dbScan.c:275`), not a typo.
             if on_io_intr {
-                demote.push((name, "no DSET"));
+                demote.push((name, "scanAdd: I/O Intr not valid (no DSET) "));
             }
             continue;
         };
@@ -2657,13 +2864,15 @@ pub(crate) async fn setup_io_intr(db: Arc<PvDatabase>) -> usize {
             // C `dbScan.c:278-293` — device support with no `get_ioint_info`,
             // or one whose `get_ioint_info` yields no scan list. The port
             // collapses all three into "the device offers no interrupt
-            // receiver"; the observable is the same demotion.
-            demote.push((name, "no interrupt source from device support"));
+            // receiver"; the observable is the same demotion, and the message
+            // is C's first and dominant case (`dbScan.c:281-282`), the one a
+            // device support that never implemented the hook produces.
+            demote.push((name, "scanAdd: I/O Intr not valid (no get_ioint_info)"));
         }
         inst.device = Some(dev);
     }
-    for (name, reason) in demote {
-        demote_io_intr_to_passive(&db, &name, reason).await;
+    for (name, message) in demote {
+        demote_io_intr_to_passive(&db, &name, message).await;
     }
     count
 }
@@ -3093,9 +3302,7 @@ mod tests {
         // An empty IocApplication with no script or records should start and stop cleanly
         // We can't easily test run() because it blocks on REPL, so test the wiring functions
         let db = Arc::new(PvDatabase::new());
-        let factories = HashMap::new();
-        let count = wire_device_support(&db, &factories, &None).await.unwrap();
-        assert_eq!(count, 0);
+        assert_eq!(db.records_with_device_support().await, 0);
     }
 
     #[epics_macros_rs::epics_test]
@@ -3103,13 +3310,13 @@ mod tests {
         use crate::server::records::ai::AiRecord;
 
         let db = Arc::new(PvDatabase::new());
+        db.install_device_support_resolver(device_support_resolver(HashMap::new(), None));
         db.add_record("TEST", Box::new(AiRecord::new(0.0)))
             .await
             .unwrap();
 
-        let factories = HashMap::new();
-        let count = wire_device_support(&db, &factories, &None).await.unwrap();
-        assert_eq!(count, 0); // No DTYP set, so no wiring
+        // No DTYP set, so the record is a soft channel and binds no dset.
+        assert_eq!(db.records_with_device_support().await, 0);
     }
 
     /// Regression: `wire_device_support` (the IocApplication
@@ -3163,21 +3370,31 @@ mod tests {
         );
 
         let db = Arc::new(PvDatabase::new());
-        db.add_record("AI:WITH:INFO", Box::new(AiRecord::new(0.0)))
-            .await
-            .unwrap();
-        // Populate the record's info map — exactly what
-        // IocBuilder/iocsh now do after loading info(...) directives.
-        let rec = db.get_record("AI:WITH:INFO").unwrap();
-        {
-            let mut inst = rec.write();
-            inst.common.dtyp = "TestRecording".to_string();
-            inst.set_info("asyn:READBACK", "1");
-            inst.set_info("Q:group", "demo");
-        }
-
-        let count = wire_device_support(&db, &factories, &None).await.unwrap();
-        assert_eq!(count, 1, "device support must have attached");
+        db.install_device_support_resolver(device_support_resolver(factories, None));
+        // DTYP and the info(...) tags arrive WITH the record, because the bind
+        // now happens at creation — C's `doInitRecord0`, which reads the field
+        // set `dbLoadRecords` already wrote.
+        db.add_loaded_record(
+            "AI:WITH:INFO",
+            Box::new(AiRecord::new(0.0)),
+            crate::server::database::RecordLoad {
+                common_fields: vec![(
+                    "DTYP".to_string(),
+                    crate::types::EpicsValue::String("TestRecording".into()),
+                )],
+                info_tags: vec![
+                    ("asyn:READBACK".to_string(), "1".to_string()),
+                    ("Q:group".to_string(), "demo".to_string()),
+                ],
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            db.records_with_device_support().await,
+            1,
+            "device support must have attached"
+        );
 
         // The recording driver should have observed both tags via
         // apply_record_info — proves the hook fires from the
@@ -3224,20 +3441,6 @@ mod tests {
             .map(|i: usize| format!("LOAD:{:02}", (i * 7 + 3) % 24))
             .collect();
 
-        let db = Arc::new(PvDatabase::new());
-        for name in &names {
-            db.add_record(name, Box::new(AiRecord::new(0.0)))
-                .await
-                .unwrap();
-            let rec = db.get_record(name).unwrap();
-            let mut inst = rec.write();
-            inst.common.dtyp = "SeqDev".to_string();
-            // `DeviceSupportContext` carries the links, not the record name;
-            // echoing the name through INP is how the test observes which
-            // record is being wired.
-            inst.common.inp = format!("@{name}");
-        }
-
         let wired: StdArc<StdMutex<Vec<String>>> = StdArc::new(StdMutex::new(Vec::new()));
         let captured = wired.clone();
         let dynamic: Option<DynamicDeviceSupportFactory> =
@@ -3249,11 +3452,30 @@ mod tests {
                 Some(Box::new(NoopDev) as Box<dyn DeviceSupport>)
             }));
 
-        let factories: HashMap<String, DeviceSupportFactory> = HashMap::new();
-        let count = wire_device_support(&db, &factories, &dynamic)
+        let db = Arc::new(PvDatabase::new());
+        db.install_device_support_resolver(device_support_resolver(HashMap::new(), dynamic));
+        for name in &names {
+            db.add_loaded_record(
+                name,
+                Box::new(AiRecord::new(0.0)),
+                crate::server::database::RecordLoad::from_common_fields(vec![
+                    (
+                        "DTYP".to_string(),
+                        crate::types::EpicsValue::String("SeqDev".into()),
+                    ),
+                    // `DeviceSupportContext` carries the links, not the record
+                    // name; echoing the name through INP is how the test
+                    // observes which record is being wired.
+                    (
+                        "INP".to_string(),
+                        crate::types::EpicsValue::String(format!("@{name}").into()),
+                    ),
+                ]),
+            )
             .await
             .unwrap();
-        assert_eq!(count, names.len());
+        }
+        assert_eq!(db.records_with_device_support().await, names.len());
 
         let wired = std::mem::take(&mut *wired.lock().unwrap());
         assert_eq!(

--- a/crates/epics-base-rs/src/server/ioc_builder.rs
+++ b/crates/epics-base-rs/src/server/ioc_builder.rs
@@ -262,6 +262,21 @@ impl IocBuilder {
         // overhead for IOCs that use none).
         let breaktable_registry = db.add_breaktables(self.breaktables).await;
 
+        // C's device support table and function registry, installed on the
+        // database BEFORE the first record is created — `registerRecord\
+        // DeviceDriver` before `dbLoadRecords`. The creation sink binds each
+        // record's dset from the first ahead of `init_record(0)` and resolves
+        // INAM/SNAM against the second from inside pass 1, which is C's order;
+        // this build used to do both AFTER the record's passes had already
+        // run, so `init_record` could not see its own dset and ran the tail C
+        // returns before.
+        db.install_device_support_resolver(crate::server::ioc_app::device_support_resolver(
+            self.device_factories,
+            self.dynamic_device_factory,
+        ));
+        db.install_subroutine_registry(self.subroutine_registry)
+            .await;
+
         // 1. Simple PVs
         for (name, value) in self.pvs {
             db.add_pv(&name, value).await?;
@@ -444,77 +459,6 @@ impl IocBuilder {
                 // constant load, and nothing outside the owner may run either
                 // half.
                 db.rec_gbl_init_constant_links(&rec_arc);
-
-                let mut instance = rec_arc.write();
-
-                // Device support based on DTYP
-                let dtyp = instance.common.dtyp.clone();
-                if !crate::server::device_support::is_soft_dtyp(&dtyp) {
-                    let dev_opt = if let Some(factory) = self.device_factories.get(&dtyp) {
-                        Some(factory())
-                    } else if let Some(ref dyn_factory) = self.dynamic_device_factory {
-                        // Same fallback shape as
-                        // `ioc_app::wire_device_support` — universal
-                        // drivers (asyn etc.) need this to attach.
-                        let ctx = DeviceSupportContext {
-                            dtyp: &dtyp,
-                            inp: &instance.common.inp,
-                            out: &instance.common.out,
-                        };
-                        dyn_factory(&ctx)
-                    } else {
-                        None
-                    };
-                    if let Some(dev) = dev_opt {
-                        // Canonical device-support init order (M1/M2):
-                        // set_record_info → apply_record_info → init.
-                        // Previously this path ran `init` FIRST and
-                        // discarded its `Result` with `let _ =`; the
-                        // IocApplication path ran info-setup first and
-                        // partially handled the error. Both paths now
-                        // share `wire_device_to_record`, so a driver
-                        // author can write one correct `init()` and an
-                        // init failure is logged + flags the record.
-                        device_support::wire_device_to_record(&mut instance, dev);
-                    }
-                }
-                // Subroutine resolution for sub / aSub records (C
-                // `init_record` -> `registryFunctionFind` for both types).
-                let rt = instance.record.record_type();
-                if rt == "sub" || rt == "aSub" {
-                    // INAM: invoke the init routine once, before SNAM
-                    // resolution (C `init_record`: `registryFunctionFind(inam)`
-                    // then `(*psubroutine)(prec)`, return discarded; a missing
-                    // function is an init error -> stderr).
-                    if let Some(EpicsValue::String(inam)) = instance.record.get_field("INAM") {
-                        let inam = inam.as_str_lossy();
-                        if !inam.is_empty() {
-                            match self.subroutine_registry.get(inam.as_ref()) {
-                                Some(init_fn) => {
-                                    let init_fn = init_fn.clone();
-                                    if let Err(e) = init_fn(&mut *instance.record) {
-                                        eprintln!(
-                                            "iocInit: {}.INAM '{inam}' init routine failed: {e}",
-                                            def.name
-                                        );
-                                    }
-                                }
-                                None => eprintln!(
-                                    "iocInit: {}.INAM function '{inam}' not found",
-                                    def.name
-                                ),
-                            }
-                        }
-                    }
-                    // Unconditional, as in `IocApp` — see the invariant on
-                    // `field_io::snam_special_after_put`.
-                    if let Some(EpicsValue::String(snam)) = instance.record.get_field("SNAM") {
-                        instance.subroutine = self
-                            .subroutine_registry
-                            .get(snam.as_str_lossy().as_ref())
-                            .cloned();
-                    }
-                }
             }
         }
 
@@ -543,12 +487,6 @@ impl IocBuilder {
         if let Some(&load) = failed_loads.iter().min() {
             return Err(CaError::DbLoadFailed(self.sources[load].clone()));
         }
-
-        // Retain the registry in the database for runtime re-resolution
-        // (aSub LFLG=READ / SUBL); the static SNAM wiring above already
-        // performed init-time resolution (C `init_record`).
-        db.install_subroutine_registry(self.subroutine_registry.clone())
-            .await;
 
         // 4. Autosave restore
         if let Some(ref autosave_cfg) = self.autosave_config {

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -467,12 +467,39 @@ fn print_fields_list(ctx: &CommandContext, name: &str, fields: &[String]) {
     let mut line = String::from(name);
     let record = ctx.db().get_record(name);
     for field in fields {
+        // C asks `dbFindField` and then `dbGetString`, and nothing else. The
+        // port asked the RECORD for its own fields instead — `get_field`,
+        // which knows nothing of `dbCommon` — so every `dbl "" "DESC"`,
+        // `"SCAN"` and `"INP"` printed the bare separator C reserves for a
+        // field the type does not declare, and the fields it did know were
+        // rendered by Rust's `Display` rather than by C's static renderer:
+        // measured on `softIoc` R7.0.10-146, an unwritten `waveform.VAL` read
+        // `T:WF, "[]"` where C reads `T:WF, ""`.
         let value = record.as_ref().and_then(|rec| {
             let inst = rec.read();
-            inst.record
-                .get_field(field)
-                .map(|v| v.to_string())
-                .or_else(|| (field == "recordType").then(|| inst.record.record_type().to_string()))
+            if let Some(desc) = inst.field_desc(field) {
+                // `dbGetString`'s switch has no case for `DBF_NOACCESS`, so
+                // that class takes its `default: return(NULL)`
+                // (`dbStaticLib.c:2053`) and `printFieldsList` prints the
+                // empty string for it (`dbTest.c:145`).
+                if desc.no_access() {
+                    return Some(String::new());
+                }
+                return Some(
+                    inst.resolve_field(field)
+                        .map(|v| db_get_string(&inst, desc, &v))
+                        .unwrap_or_default(),
+                );
+            }
+            // A `DBF_NOACCESS` row this port carries by NAME alone — the
+            // `dbCommon` pointers, `RSET` and friends — still has a
+            // `dbFldDes` in C, so `dbFindField` finds it and the NULL above
+            // is what `dbGetString` answers.
+            if inst.resolves_noaccess_name(&field.to_ascii_uppercase()) {
+                return Some(String::new());
+            }
+            // C's one exception to `dbFindField` failing (`dbTest.c:135-137`).
+            (field == "recordType").then(|| inst.record.record_type().to_string())
         });
         match value {
             Some(v) => line.push_str(&format!(", \"{v}\"")),
@@ -566,7 +593,7 @@ fn cmd_dbl() -> CommandDef {
             };
 
             // C's `dbl` names no `dbIsAlias` filter, so the alias nodes in
-            // the type's list are listed with the records (`dbTest.c:180-185`)
+            // the type's list are listed with the records (`dbTest.c:182-188`)
             // — a site that builds its PV inventory with `dbl > pvlist` gets
             // the alias names its clients use.
             let nodes = db_nodes_type_major(ctx);
@@ -611,8 +638,8 @@ fn cmd_dbl() -> CommandDef {
 /// what keeps a multi-element array wrapping where C wraps it.
 ///
 /// `tab` is a parameter for the same reason it is one in C: `dbgf`
-/// passes 10 (`dbTest.c:512`) and `dbpr` passes 20 (`dbTest.c:444`),
-/// and those two are the only values C accepts (`dbTest.c:1287-1290`).
+/// passes 10 (`dbTest.c:377`) and `dbpr` passes 20 (`dbTest.c:442`),
+/// and those two are the only values C accepts (`dbTest.c:1286-1289`).
 struct TabBuffer {
     out: String,
     tab: usize,
@@ -834,8 +861,18 @@ fn printbuffer_elements(dbr: DbfCode, val: &EpicsValue) -> Vec<String> {
         (DbfCode::Enum, EpicsValue::Enum(v)) => vec![v.to_string()],
         (DbfCode::Enum, EpicsValue::EnumWithChoices { index, .. }) => vec![index.to_string()],
         (DbfCode::Enum, EpicsValue::EnumArray(v)) => v.iter().map(|e| e.to_string()).collect(),
-        _ => vec![format!("Bad DBR type {}", dbr as i16)],
+        _ => vec![bad_dbr_type_text(dbr)],
     }
+}
+
+/// C `printBuffer`'s `default:` arm (`dbTest.c:1147`).
+///
+/// The one arm of that switch that is NOT a loop over `no_elements` — a plain
+/// `sprintf(pmsg, "Bad DBR type %d", dbr_type)` — so it speaks even under a
+/// zero-element header. The codes it answers for are exactly those
+/// [`dbr_request`] has no row for.
+fn bad_dbr_type_text(dbr: DbfCode) -> String {
+    format!("Bad DBR type {}", dbr as i16)
 }
 
 /// One `printBuffer` block for a field read in a DBR type (`dbTest.c:984-1151`)
@@ -871,7 +908,7 @@ fn printbuffer_block(label: &str, dbr: DbfCode, val: &EpicsValue) -> Vec<String>
     )
 }
 
-/// One `printBuffer` value block (`dbTest.c:1140-1151`): the
+/// One `printBuffer` value block (`dbTest.c:984-1151`): the
 /// `DBF_<T>:` header, then either `failed.` or the element renderings,
 /// laid out through one tab buffer and flushed as one line.
 ///
@@ -881,8 +918,13 @@ fn printbuffer_block(label: &str, dbr: DbfCode, val: &EpicsValue) -> Vec<String>
 /// every type: the zero-element header is built as ONE message with
 /// `(empty)` appended (`strcat(pmsg, "(empty)")`, `dbTest.c:1144`) so
 /// the pair shares a single tab stop rather than being padded apart,
-/// and every element loop in the switch is bounded by `no_elements`,
-/// so `count == 0` prints no element text whatever `elements` holds.
+/// and every TYPED arm of the switch is a loop bounded by `no_elements`. That
+/// bound belongs to the arms, so the producers ([`printbuffer_elements`] and
+/// the callers that hand over a slice directly) supply exactly as many
+/// renderings as C would print and this prints whatever it is given. Gating on
+/// `count` here instead would also silence C's `default:` arm (`:1147`), which
+/// is a plain `sprintf` outside any loop and speaks under a zero-element
+/// header.
 fn printbuffer_lines(dbr: &str, count: usize, elements: Option<&[String]>) -> Vec<String> {
     let mut buf = TabBuffer::new(10);
     match count {
@@ -893,12 +935,11 @@ fn printbuffer_lines(dbr: &str, count: usize, elements: Option<&[String]>) -> Ve
     match elements {
         // `status != 0` prints `failed.` regardless of the count.
         None => buf.insert("failed."),
-        Some(values) if count > 0 => {
+        Some(values) => {
             for v in values {
                 buf.insert(v);
             }
         }
-        Some(_) => {}
     }
     buf.finish()
 }
@@ -943,6 +984,38 @@ fn dbgf_lines(ctx: &CommandContext, pname: &str, val: &EpicsValue) -> Vec<String
     native_readback_lines(DbfCode::String, &EpicsValue::String(text))
 }
 
+/// C `dbgf(pname)` (`dbTest.c:370-388`) once the name has resolved and the
+/// `lset` gate has passed — the read, and BOTH of its outcomes.
+///
+/// It is a function because C calls it from two places: `dbgf` itself, and the
+/// last statement of `dbpf`, which runs it whatever `dbPutField` returned
+/// (`dbTest.c:431-434`):
+///
+/// ```c
+///     status = dbPutField(&addr, dbrType, pvalue, n);
+///     free(array);
+///     dbgf(pname);
+///     return status;
+/// ```
+///
+/// The port had `dbpf` re-implement the successful half inline, so a put whose
+/// read-back then FAILED printed nothing where C prints the type header and
+/// `failed.` — `dbpf T:AI.RSET, "1"` on a `DBF_NOACCESS` field was silent on
+/// stdout against `softIoc` R7.0.10-146.
+fn dbgf_echo(ctx: &CommandContext, pname: &str) {
+    match ctx.db().get_pv(pname) {
+        Ok(val) => {
+            for line in dbgf_lines(ctx, pname, &val) {
+                ctx.println(&line);
+            }
+        }
+        // C `dbgf` returns 0 whatever `dbGetField` returned
+        // (`dbTest.c:388`): the failure is a printed line, not a failed
+        // command.
+        Err(_) => dbgf_failed(ctx, pname),
+    }
+}
+
 /// C `nameToAddr` (`dbTest.c:787-795`) — the one place every
 /// `dbTest.c` command reports a name it cannot resolve. C prints this
 /// line on stdout and the caller then returns -1 without printing
@@ -950,6 +1023,116 @@ fn dbgf_lines(ctx: &CommandContext, pname: &str, val: &EpicsValue) -> Vec<String
 /// error channel, which writes to stderr and prefixes `Error:`.
 fn print_pv_not_found(ctx: &CommandContext, pname: &str) {
     ctx.println(&format!("PV '{pname}' not found"));
+}
+
+/// C `nameToAddr` (`dbTest.c:787-795`) — the ONE resolution every `dbTest.c`
+/// command makes before it does anything else, and the only place the
+/// not-found line above is printed:
+///
+/// ```c
+/// static long nameToAddr(const char *pname, DBADDR *paddr)
+/// {
+///     long status = dbNameToAddr(pname, paddr);
+///     if (status) {
+///         printf("PV '%s' not found\n", pname);
+///     }
+///     return status;
+/// }
+/// ```
+///
+/// All seven callers — `dba` (`:96`), `dbgf` (`:363`), `dbpf` (`:405`),
+/// `dbpr` (`:451`), `dbtr` (`:475`), `dbtgf` (`:519`) and `dbtpf` (`:620`) —
+/// go through it, so they agree about what a name selects by construction.
+/// The port had seven spellings of the test instead, and measured against
+/// `softIoc` R7.0.10-146 on one `record(ai,"T:AI")` they disagreed in three
+/// directions at once:
+///
+/// * `dbpr` and `dbtr` asked `get_record(pname)` without splitting
+///   `<record>.<FIELD>`, so `dbpr T:AI.VAL` answered `PV 'T:AI.VAL' not
+///   found` where C printed the record;
+/// * `dba`, `dbpf` and `dbtgf` read "resolved but unreadable" as unresolved,
+///   so `dbpf T:AI.RSET` answered not-found where C reached `dbPutField` and
+///   printed `failed.`;
+/// * `dbtpf` asked only for the RECORD, so `dbtpf T:AI.NOSUCHFLD` printed
+///   twelve `Put as DBR_… Failed.` lines where C printed not-found.
+///
+/// `dbNameToAddr` resolves any field the `.dbd` DECLARES, `DBF_NOACCESS`
+/// ones included; a declared field's READ then fails later, inside `dbGet`.
+/// That distinction already has an owner in this port — `PvDatabase::get_pv`
+/// answers `ChannelNotFound` only for a name that does not resolve and
+/// `BadDbrType` for one that resolves and cannot be read — so this asks it
+/// and adds nothing of its own.
+///
+/// The record handle comes back beside the field because six of the seven
+/// callers need it, and C's `DBADDR` likewise carries `precord` and
+/// `pfldDes` together: a caller that re-looked-up the record could pick a
+/// different one than the name resolved to.
+fn name_to_addr(ctx: &CommandContext, pname: &str) -> Option<DbAddr> {
+    let (base, field) = parse_pv_name(pname);
+    let resolved = ctx
+        .db()
+        .get_record(base)
+        .filter(|_| !matches!(ctx.db().get_pv(pname), Err(CaError::ChannelNotFound(_))));
+    match resolved {
+        Some(rec) => {
+            let field = field.to_ascii_uppercase();
+            let fld_des = rec.read().field_desc(&field);
+            Some(DbAddr {
+                rec,
+                field,
+                fld_des,
+            })
+        }
+        None => {
+            print_pv_not_found(ctx, pname);
+            None
+        }
+    }
+}
+
+/// What [`name_to_addr`] resolved — the port's `DBADDR`, filled once and read
+/// by every `dbTest.c` command, never re-derived.
+///
+/// C's commands work this way because `dbNameToAddr` is the only thing that
+/// answers "does this name exist?": once it returns, `paddr->pfldDes` is
+/// present and `dbpr`, `dba`, `dbtgf` and the rest just read it. The port had
+/// the resolution in one place and the DESCRIPTOR in each caller, asked for
+/// with a second, narrower question — `field_desc`, `snapshot_for_field` —
+/// which is how a name that resolved could then be reported not-found:
+/// measured on `softIoc` R7.0.10-146, `dba T:AI.RSET` prints the descriptor
+/// block and `dbtgf T:AI.RSET` the option block plus twelve `failed.` lines,
+/// where this port printed nothing and `PV 'T:AI.RSET' not found`.
+struct DbAddr {
+    rec: Arc<parking_lot::RwLock<crate::server::record::RecordInstance>>,
+    /// C's `pfldDes->name`: uppercased, and `VAL` when the name carried no
+    /// dot.
+    field: String,
+    /// C's `paddr->pfldDes`, which is never null after `dbNameToAddr`.
+    ///
+    /// `None` here is the one shape C has no counterpart for: the `dbCommon`
+    /// `DBF_NOACCESS` internals this port carries by NAME only
+    /// (`RecordInstance::resolves_noaccess_name`). C has a `dbFldDes` for
+    /// every one of them; the generator carries a descriptor only for the
+    /// rows whose `extra(...)` names a plain scalar, so `RSET`, `MLOK`,
+    /// `MLIS`, `DSET`, `DPVT`, `RDES`, `LSET`, `ASP`, `PPN`, `PPNR`, `SPVT`
+    /// and `BKLNK` arrive with the name and nothing else. They are still
+    /// RESOLVED — the declaration is what C resolves against — so this is a
+    /// missing width, not a missing field.
+    fld_des: Option<&'static FieldDesc>,
+}
+
+impl DbAddr {
+    /// C's `paddr->field_type` and `paddr->dbr_field_type`.
+    ///
+    /// Every name-only row above is declared `DBF_NOACCESS` in `dbCommon.dbd`,
+    /// and `mapDBFToDBR` is the identity on it, so both words are
+    /// `DBF_NOACCESS` with no descriptor to consult.
+    fn types(&self, value: Option<&EpicsValue>) -> (DbfCode, DbfCode) {
+        match self.fld_des {
+            Some(fd) => field_addr_types(fd, value),
+            None => (DbfCode::NoAccess, DbfCode::NoAccess),
+        }
+    }
 }
 
 /// The byte width of one element of `code`, as C's `dbFldDes.size` carries
@@ -1068,19 +1251,11 @@ fn dbgf_failed(ctx: &CommandContext, pname: &str) {
 /// synthesised `DBF_STRING`/`SPC_ATTRIBUTE` descriptor (`dbStaticLib.c:1265-1272`).
 /// This port has no attribute table — that is the subject `dbPutAttribute` is
 /// still waiting on — so an attribute name reports not-found here.
-fn print_db_addr(ctx: &CommandContext, pname: &str) -> bool {
-    let (rec_name, field) = parse_pv_name(pname);
-    let Some(rec) = ctx.db().get_record(rec_name) else {
-        return false;
-    };
-    let field = if field.is_empty() { "VAL" } else { field };
-    let inst = rec.read();
-    let Some(fd) = inst.field_desc(field) else {
-        return false;
-    };
-
+fn print_db_addr(ctx: &CommandContext, addr: &DbAddr) {
+    let inst = addr.rec.read();
+    let field = addr.field.as_str();
     let value = inst.resolve_field(field);
-    let (field_type, dbr) = field_addr_types(fd, value.as_ref());
+    let (field_type, dbr) = addr.types(value.as_ref());
     // C: `no_elements = 1` (`dbAccess.c:635`), overwritten by `cvt_dbaddr`
     // with the CAPACITY for an array — `paddr->no_elements = prec->nelm`
     // (`waveformRecord.c::cvt_dbaddr`), never `NORD`. Reading the current
@@ -1093,11 +1268,17 @@ fn print_db_addr(ctx: &CommandContext, pname: &str) -> bool {
         .or_else(|| inst.record.get_field(field).map(|v| v.count()))
         .unwrap_or(1);
 
-    ctx.println(&format!(
-        "Record Address: {:p} Field Address: (none) Field Description: {:p}",
-        Arc::as_ptr(&rec),
-        fd as *const FieldDesc,
-    ));
+    match addr.fld_des {
+        Some(fd) => ctx.println(&format!(
+            "Record Address: {:p} Field Address: (none) Field Description: {:p}",
+            Arc::as_ptr(&addr.rec),
+            fd as *const FieldDesc,
+        )),
+        None => ctx.println(&format!(
+            "Record Address: {:p} Field Address: (none) Field Description: (none)",
+            Arc::as_ptr(&addr.rec),
+        )),
+    }
     ctx.println(&format!("   No Elements: {elements}"));
     ctx.println(&format!("   Record Type: {}", inst.record.record_type()));
     ctx.println(&format!(
@@ -1105,17 +1286,27 @@ fn print_db_addr(ctx: &CommandContext, pname: &str) -> bool {
         field_type as i16,
         field_type.name(),
     ));
-    match c_field_size(field_type, fd.size) {
+    match addr
+        .fld_des
+        .and_then(|fd| c_field_size(field_type, fd.size))
+    {
         Some(n) => ctx.println(&format!("    Field Size: {n}")),
         None => ctx.println("    Field Size: (none)"),
     }
-    ctx.println(&format!("       Special: {}", fd.special as i16));
+    // `special(SPC_NOMOD)` — the declaration every one of the name-only
+    // `DBF_NOACCESS` rows carries in `dbCommon.dbd` (`MLOK` :88, `MLIS` :95,
+    // `ASP` :192, `SPVT` :210, `RSET` :218, `DSET` :225, `RDES` :237,
+    // `LSET` :243, and so on), which is why C prints `Special: 1` for all of
+    // them. It is read off the `.dbd`, not inferred.
+    let special = addr
+        .fld_des
+        .map_or(Special::NoMod as i16, |fd| fd.special as i16);
+    ctx.println(&format!("       Special: {special}"));
     ctx.println(&format!(
         "DBR Field Type: {} = DBR_{}",
         dbr as i16,
         dbr.name(),
     ));
-    true
 }
 
 fn cmd_dba() -> CommandDef {
@@ -1136,13 +1327,13 @@ fn cmd_dba() -> CommandDef {
                     return Ok(CommandOutcome::Failed);
                 }
             };
-            // C `dbTest.c:96-97` -> `nameToAddr` (`:785-793`), which prints
-            // the not-found line itself and returns -1. `dba` has no
+            // C `dbTest.c:96-97` -> `nameToAddr`, which prints the
+            // not-found line itself and returns -1. `dba` has no
             // `dbt_requires_ioc_init` gate: C reads dbStatic only.
-            if !print_db_addr(ctx, name) {
-                print_pv_not_found(ctx, name);
+            let Some(addr) = name_to_addr(ctx, name) else {
                 return Ok(CommandOutcome::Failed);
-            }
+            };
+            print_db_addr(ctx, &addr);
             Ok(CommandOutcome::Continue)
         },
     )
@@ -1171,26 +1362,14 @@ fn cmd_dbgf() -> CommandDef {
             // `nameToAddr` cannot resolve. A field the record type DECLARES
             // resolves, and its read then fails inside `dbGetField`, which is
             // a different outcome and prints differently.
-            let got = ctx.db().get_pv(name);
-            if matches!(got, Err(CaError::ChannelNotFound(_))) {
-                print_pv_not_found(ctx, name);
+            if name_to_addr(ctx, name).is_none() {
                 return Ok(CommandOutcome::Failed);
             }
             // C tests `lset` only AFTER `nameToAddr` (`dbTest.c:366-368`).
             if !dbt_requires_ioc_init(ctx, "dbgf") {
                 return Ok(CommandOutcome::Failed);
             }
-            match got {
-                Ok(val) => {
-                    for line in dbgf_lines(ctx, name, &val) {
-                        ctx.println(&line);
-                    }
-                }
-                // C `dbgf` returns 0 whatever `dbGetField` returned
-                // (`dbTest.c:388`): the failure is a printed line, not a
-                // failed command.
-                Err(_) => dbgf_failed(ctx, name),
-            }
+            dbgf_echo(ctx, name);
             Ok(CommandOutcome::Continue)
         },
     )
@@ -1224,8 +1403,7 @@ fn cmd_dbpf() -> CommandDef {
 
             // C resolves the name before it puts (`dbTest.c:405-406`),
             // so an unknown PV never reaches `dbPutField`; C returns -1.
-            if ctx.db().get_pv(name).is_err() {
-                print_pv_not_found(ctx, name);
+            if name_to_addr(ctx, name).is_none() {
                 return Ok(CommandOutcome::Failed);
             }
             // C tests `lset` only AFTER `nameToAddr` (`dbTest.c:408-410`).
@@ -1356,14 +1534,18 @@ fn cmd_dbpf() -> CommandDef {
                 // typed error, and a token that is neither a number nor a valid
                 // choice is refused downstream by `put_string`/`bad_choice`
                 // rather than silently landing as index 0.
-                match dbf {
-                    crate::types::DbFieldType::Short | crate::types::DbFieldType::Enum => {
-                        EpicsValue::parse(dbf, value_str)
-                            .unwrap_or_else(|_| EpicsValue::String(value_str.trim().into()))
-                    }
-                    _ => EpicsValue::parse(dbf, value_str)
-                        .map_err(|e| format!("cannot parse '{value_str}' as {dbf:?}: {e}"))?,
-                }
+                //
+                // The fallback is not the menu arm's alone. C hands `dbpf`'s
+                // scalar text to `dbPutField` as `DBR_STRING` and never parses
+                // it itself (`dbTest.c:413`, `:431`), so text no conversion
+                // takes is a failed PUT — value unchanged, nothing printed by
+                // `dbpf`, and the closing `dbgf` still run. Parsing here and
+                // raising the error instead put `ERROR <file> line <n>: cannot
+                // parse 'notanumber' as Double` on stderr and skipped the
+                // read-back entirely, where `softIoc` R7.0.10-146 printed only
+                // `DBF_DOUBLE:         1.5`.
+                EpicsValue::parse(dbf, value_str)
+                    .unwrap_or_else(|_| EpicsValue::String(value_str.trim().into()))
             } else {
                 // No type info available, try as string
                 EpicsValue::String(value_str.clone().into())
@@ -1395,11 +1577,7 @@ fn cmd_dbpf() -> CommandDef {
             // `dbPutField` returned, so the read-back is that one
             // printer rather than a second rendering, and a rejected
             // put still shows the value the record kept.
-            if let Ok(val) = ctx.db().get_pv(name) {
-                for line in dbgf_lines(ctx, name, &val) {
-                    ctx.println(&line);
-                }
-            }
+            dbgf_echo(ctx, name);
 
             if put_failed {
                 Ok(CommandOutcome::Failed)
@@ -1414,9 +1592,9 @@ fn cmd_dbpf() -> CommandDef {
 /// dbStatic-side renderer, and the ONLY one its callers may use.
 ///
 /// C has two renderers for the same field and they disagree. This one answers
-/// `dbpr` (`dbTest.c:1198-1203`) and `dbReportDeviceConfig` (`:3629`, `:3637`,
-/// `:3641`, `:3645`); the other, `dbConvert`'s `DBR_STRING` path, answers
-/// `dbgf` and every link read, and is
+/// `dbpr` (`dbTest.c:1198-1203`) and `dbReportDeviceConfig`
+/// (`dbStaticLib.c:3621`, `:3632`, `:3638`, `:3645`, `:3649`); the other,
+/// `dbConvert`'s `DBR_STRING` path, answers `dbgf` and every link read, and is
 /// [`RecordInstance::field_as_dbr_string`](crate::server::record::RecordInstance::field_as_dbr_string).
 /// They part on the two enum edges (see [`dbpr_choice_text`]) and on every
 /// float: `realToString` here, `cvtDoubleToString` with the record's `PREC`
@@ -1891,12 +2069,14 @@ pub(super) fn dbpr_report(ctx: &CommandContext, name: &str, level: i32) -> bool 
     // without printing anything else (`dbTest.c:449-450`, `:789-791`).
     // `false` is that failure: `dbpr` turns it into its -1, and `dbtr`
     // ignores it exactly as C does (`dbTest.c:494-495`).
-    let rec = match ctx.db().get_record(name) {
-        Some(rec) => rec,
-        None => {
-            print_pv_not_found(ctx, name);
-            return false;
-        }
+    //
+    // The FIELD the name selected is resolved and then dropped, because
+    // that is what C does too: `dbpr` prints the whole record whatever
+    // field the address landed on, so `dbpr T:AI.DESC` and `dbpr T:AI`
+    // are the same report — but a field the record type does not declare
+    // still has to fail the resolution first.
+    let Some(DbAddr { rec, .. }) = name_to_addr(ctx, name) else {
+        return false;
     };
 
     // C `dbpr_report` (`dbTest.c:1156-1276`) walks the record
@@ -1913,6 +2093,17 @@ pub(super) fn dbpr_report(ctx: &CommandContext, name: &str, level: i32) -> bool 
         let aliases = ctx.db().aliases_for_record(&rec_name);
 
         let inst = rec.read();
+        // DELIBERATE NON-MATCH, measured at level 4: C's walk is over
+        // `papFldDes`, so it reaches the fourteen `dbCommon` `DBF_NOACCESS`
+        // internals too and prints `ASP : PTR (nil)`,
+        // `MLIS: ELL 0 [(nil) .. (nil)]`, `MLOK: 50 83 b8 61 03 58 00 00`,
+        // `DSET: PTR 0x7de2e55c3aa0` and the rest (`dbTest.c:1228-1266`).
+        // Every one of those is a C storage fact — a `void *` read at a struct
+        // offset, an `ELLLIST` header, a raw byte dump of an `epicsMutexId` —
+        // and this port carries those rows by NAME only, with no width and no
+        // pointer, so the walk below has nothing to print for them. They are
+        // resolvable and `dba` reports them ([`DbAddr::fld_des`]); what is
+        // absent is a value, not the field.
         let mut descs: Vec<&crate::server::record::FieldDesc> =
             crate::server::record::dbd_generated::DB_COMMON_FIELDS
                 .iter()
@@ -1987,7 +2178,7 @@ pub(super) fn dbpr_report(ctx: &CommandContext, name: &str, level: i32) -> bool 
     });
 
     // C `%-4s: %s` per field (`dbTest.c:1201-1203`), packed by
-    // `dbpr_msgOut` at tab stop 20 (`dbTest.c:444`).
+    // `dbpr_msgOut` at tab stop 20 (`dbTest.c:442`).
     let mut buf = TabBuffer::new(20);
     for (name, value) in &fields {
         buf.insert(&format!("{name:<4}: {value}"));
@@ -2084,7 +2275,7 @@ fn dbtgf_string_elements(
 }
 
 /// C `epicsTimeToStrftime(.., "%Y-%m-%d %H:%M:%S.%09f", ..)` as
-/// `printBuffer` calls it (`dbTest.c:1053-1057`). A stamp still at the
+/// `printBuffer` calls it (`dbTest.c:871-873`). A stamp still at the
 /// EPICS epoch is the uninitialized one and renders `<undefined>`
 /// (`epicsTime.cpp::strftime`).
 fn dbtgf_time_text(ts: crate::types::WallTime) -> String {
@@ -2115,9 +2306,9 @@ fn dbtgf_time_text(ts: crate::types::WallTime) -> String {
 /// rather than a format:
 ///
 /// * `dbAccessDefs.h:35-47` renumbered the option bits to insert
-///   `DBR_AMSG` (0x2) and `DBR_UTAG` (0x20), and `getOptions`
-///   (`dbAccess.c:336-360`) writes both payloads into the buffer —
-///   `DB_AMSG_SIZE` is 40 bytes. `printBuffer` (`dbTest.c:1000-1090`)
+///   `DBR_AMSG` (0x2) and `DBR_UTAG` (0x20), and `getOptions` writes
+///   both payloads into the buffer (`dbAccess.c:366-375`, `:408-416`)
+///   — `DB_AMSG_SIZE` is 40 bytes. `printBuffer` (`dbTest.c:827-983`)
 ///   was never given a step for either, so it reads `units`,
 ///   `precision`, `time` and every gr/ctrl/al block from the wrong
 ///   offset. Measured on `bin/linux-x86_64/softIoc`
@@ -2139,21 +2330,67 @@ fn dbtgf_time_text(ts: crate::types::WallTime) -> String {
 ///
 /// [`PropertySupport`]: crate::server::snapshot::PropertySupport
 fn dbtgf_option_lines(
+    inst: &crate::server::record::RecordInstance,
     field_type: DbfCode,
-    snap: &crate::server::snapshot::Snapshot,
+    snap: Option<&crate::server::snapshot::Snapshot>,
 ) -> Vec<String> {
     use crate::calc::engine::cvt::fmt_g;
 
-    let g = |v: f64| fmt_g(v, 6, false, false);
-    // C `(epicsInt32)` on the double limit (`dbAccess.c:373-374`), and
-    // `finite(x) ? (epicsInt32)x : 0` for the alarm limits (`:428-435`).
-    let l = |v: f64| -> i32 { if v.is_finite() { v as i32 } else { 0 } };
+    // Every limit reaches C's block as a plain `double` field of the record,
+    // which is 0.0 until something sets it. This port's `Snapshot` encodes
+    // "the record states no limit" as NaN, and that encoding has no C
+    // counterpart, so it is converted once here rather than left to leak into
+    // whichever of the six lines happens to read an unset field: measured on
+    // `softIoc` R7.0.10-146, `dbtgf T:AI.DESC` prints
+    // `alDouble: 0 < 0 .. 0 < 0` where this printed `nan < nan .. nan < nan`.
+    // C's own casts agree with the rule — `(epicsInt32)` on the graphic and
+    // control longs (`dbAccess.c:226-227`, `:266-267`) and
+    // `finite(x) ? (epicsInt32)x : 0` on the alarm longs (`:303-310`) — which
+    // is why the long lines were already right and only the double lines were
+    // not.
+    let finite = |v: f64| if v.is_finite() { v } else { 0.0 };
+    let g = move |v: f64| fmt_g(finite(v), 6, false, false);
+    let l = move |v: f64| -> i32 { finite(v) as i32 };
 
     let mut out = Vec::new();
-    out.push(format!(
-        "status = {}, severity = {}",
-        snap.alarm.status, snap.alarm.severity
-    ));
+    out.push(match snap {
+        Some(snap) => format!(
+            "status = {}, severity = {}",
+            snap.alarm.status, snap.alarm.severity
+        ),
+        // C's `getOptions` copies `DBR_STATUS` off `paddr->precord`
+        // (`dbAccess.c:196-206`) and never off the field, so an address with
+        // no value still reports the record's alarm.
+        None => format!(
+            "status = {}, severity = {}",
+            inst.common.stat, inst.common.sevr as u16
+        ),
+    });
+    let Some(snap) = snap else {
+        // C's remaining `getOptions` arms for an address whose field is
+        // neither numeric nor enum-like, measured on `softIoc` R7.0.10-146 as
+        // `dbtgf T:AI.RSET`: `units` stays a set option holding the empty
+        // string (`:213-232` clears the buffer for every non-float,
+        // non-integer class), `DBR_PRECISION` is cleared outright
+        // (`:234-247`), no record answers `get_enum_strs` off a
+        // `DBF_NOACCESS` address, and every limit falls to
+        // `recGblGetGraphicDouble`'s zeros because a record's
+        // `get_graphic_double` fills HOPR/LOPR only for `VAL`.
+        out.push("units = \"\"".to_string());
+        out.push("precision not returned".to_string());
+        out.push(format!(
+            "time = {}",
+            dbtgf_time_text(crate::types::WallTime::from(inst.common.time))
+        ));
+        out.push("enum strings not returned".to_string());
+        for name in ["gr", "ctrl"] {
+            out.push(format!("{name}Long: 0 .. 0"));
+            out.push(format!("{name}Double: 0 .. 0"));
+        }
+        out.push("alLong: 0 < 0 .. 0 < 0".to_string());
+        out.push("alDouble: 0 < 0 .. 0 < 0".to_string());
+        return out;
+    };
     match snap.units() {
         Some(u) => out.push(format!("units = \"{}\"", u.as_str_lossy())),
         None => out.push("units not returned".to_string()),
@@ -2162,12 +2399,21 @@ fn dbtgf_option_lines(
         Some(p) => out.push(format!("precision = {p}")),
         None => out.push("precision not returned".to_string()),
     }
-    // C prints `time = <undefined>` for EVERY field here, whatever the
-    // record's stamp is, because `printBuffer` walks past the `DBR_AMSG` and
-    // `DBR_UTAG` payloads it was never given a step for and reads `time` from
-    // the wrong offset. That is output C itself calls undefined, so this port
-    // prints the record's real stamp rather than reproduce the misread — the
-    // one line of this block that is deliberately not C's value.
+    // DELIBERATE NON-MATCH from here down, for one reason: `getOptions`
+    // (`dbAccess.c:191-311`) WRITES a `DBR_AMSG` and a `DBR_UTAG` payload that
+    // `printBuffer` (`dbTest.c:900-982`) has no step for, so every option C
+    // reads after the alarm words comes off an offset 48 bytes short. Measured
+    // on `softIoc` R7.0.10-146, `dbtgf T:AI.VAL` on an `ai` with `EGU=V`,
+    // `PREC=3`, `HOPR=10` prints `units = ""`, `precision = 0`,
+    // `grLong: 0 .. 0` and `alLong: 1076101120 < 0 .. 0 < 10` — the record's
+    // own numbers landing one field late. This port prints what `getOptions`
+    // put there, so `units`, `precision`, `time` and the six limit lines carry
+    // the record's values and C's do not. The blocks agree wherever the record
+    // states nothing, which is why `dbtgf T:AI.DESC` and `dbtgf T:AI.RSET`
+    // match byte for byte.
+    //
+    // `time` is the first line the skew reaches: C prints `<undefined>` for
+    // every field, whatever the record's stamp is.
     out.push(format!("time = {}", dbtgf_time_text(snap.timestamp)));
     // C `get_enum_strs` (`dbAccess.c:160-180`) reaches the record's
     // `get_enum_strs` / the field's menu ONLY for `paddr->field_type` in
@@ -2276,45 +2522,51 @@ fn cmd_dbtgf() -> CommandDef {
                     return Ok(CommandOutcome::Failed);
                 }
             };
-            let (base, field) = parse_pv_name(name);
-            let field = field.to_ascii_uppercase();
-            let Some(rec) = ctx.db().get_record(base) else {
-                print_pv_not_found(ctx, name);
+            let Some(addr) = name_to_addr(ctx, name) else {
                 return Ok(CommandOutcome::Failed);
             };
             if !dbt_requires_ioc_init(ctx, "dbtgf") {
                 return Ok(CommandOutcome::Failed);
             }
-            let Some((snap, class, native)) = ({
-                let inst = rec.read();
-                inst.snapshot_for_field(&field).map(|snap| {
-                    // C prints `addr.dbr_field_type` here with NO `DBR_STRING`
-                    // substitution — that is `dbgf`'s alone — so a menu field's
-                    // native line reads `DBF_ENUM`. The option block below is
-                    // decided by the other word, `addr.field_type`.
-                    let (class, dbr) = inst
-                        .field_desc(&field)
-                        .map_or((DbfCode::String, DbfCode::String), |fd| {
-                            field_addr_types(fd, Some(&snap.value))
-                        });
-                    (snap, class, dbr)
-                })
-            }) else {
-                print_pv_not_found(ctx, name);
-                return Ok(CommandOutcome::Failed);
-            };
+            // C prints `addr.dbr_field_type` here with NO `DBR_STRING`
+            // substitution — that is `dbgf`'s alone — so a menu field's
+            // native line reads `DBF_ENUM`. The option block below is decided
+            // by the other word, `addr.field_type`. Both come from the address
+            // `nameToAddr` already resolved: a name it accepted is never
+            // re-tried against a second, narrower question here, which is what
+            // made `dbtgf T:AI.RSET` answer not-found where C prints the block.
+            let inst = addr.rec.read();
+            let snap = inst.snapshot_for_field(&addr.field);
+            let (class, native) = addr.types(snap.as_ref().map(|s| &s.value));
 
-            for line in dbtgf_option_lines(class, &snap) {
+            for line in dbtgf_option_lines(&inst, class, snap.as_ref()) {
                 ctx.println(&line);
             }
             // C's first `dbGetField` asks for the native type with
-            // `no_elements = 0` (`dbTest.c:529-532`), so the native
-            // block is always the empty-array header.
-            for line in printbuffer_lines(native.name(), 0, Some(&[])) {
+            // `no_elements = 0` (`dbTest.c:529-532`), so every typed arm of
+            // `printBuffer`'s switch prints nothing under the header. The one
+            // code no arm answers takes the `default:` instead, which is not a
+            // loop and speaks under that same zero-element header.
+            let native_body = match dbr_request(native) {
+                Some(_) => Vec::new(),
+                None => vec![bad_dbr_type_text(native)],
+            };
+            for line in printbuffer_lines(native.name(), 0, Some(&native_body)) {
                 ctx.println(&line);
             }
             // C `long precision = 6` before it asks the record
-            // (`dbConvert.c:778-783`).
+            // (`dbConvert.c:778-784`).
+            let Some(snap) = snap else {
+                // Nothing to convert FROM: C's twelve `dbGetField` calls all
+                // land in `dbGet`'s validity gate and `printBuffer` prints the
+                // header and `failed.` for each (`dbTest.c:994-997`).
+                for (dbr, _) in DBTGF_REQUEST_TYPES {
+                    for line in printbuffer_lines(dbr, 1, None) {
+                        ctx.println(&line);
+                    }
+                }
+                return Ok(CommandOutcome::Continue);
+            };
             let precision = snap.precision().unwrap_or(6);
             for (dbr, target) in DBTGF_REQUEST_TYPES {
                 let float_string = (target == crate::types::DbFieldType::String)
@@ -2364,12 +2616,10 @@ fn cmd_dbtpf() -> CommandDef {
                     return Ok(CommandOutcome::Failed);
                 }
             };
-            let (base, field) = parse_pv_name(name);
-            let field = field.to_ascii_uppercase();
-            if ctx.db().get_record(base).is_none() {
-                print_pv_not_found(ctx, name);
+            let (base, _) = parse_pv_name(name);
+            let Some(DbAddr { field, .. }) = name_to_addr(ctx, name) else {
                 return Ok(CommandOutcome::Failed);
-            }
+            };
             if !dbt_requires_ioc_init(ctx, "dbtpf") {
                 return Ok(CommandOutcome::Failed);
             }
@@ -2617,7 +2867,7 @@ fn ca_dump_real_limits(limits: &[f64]) -> String {
 /// call `ca_dump_dbr` makes for every `DBR_TIME_*`.
 ///
 /// Six digits rather than [`dbtgf_time_text`]'s nine, and six is where
-/// `epicsTime.cpp:527-535` actually rounds: `frac = nsec + div[6]/2` with
+/// `epicsTime.cpp:234-239` actually rounds: `frac = nsec + div[6]/2` with
 /// `div[6] = 1000`, clamped below a whole second so the carry can never reach
 /// `%S`.
 fn ca_dump_time_stamp(ts: crate::types::WallTime) -> String {
@@ -2641,13 +2891,13 @@ fn ca_dump_time_stamp(ts: crate::types::WallTime) -> String {
 ///
 /// `value` is the reply's elements ALREADY converted to `dbr`'s family and
 /// `snap` is where its metadata comes from; C assembles the same two halves
-/// in `dbChannel_get` (`db_access.c:143-806`) and hands one packed struct
-/// here. Metadata a record type does not supply reads as zero, which is C's
-/// answer too — `getOptions` memsets the payload of every slot it has to turn
-/// off (`dbAccess.c:229-230`, `:376-393`).
+/// in `dbChannel_get_count` (`db_access.c:143-818`) and hands one packed
+/// struct here. Metadata a record type does not supply reads as zero, which
+/// is C's answer too — `getOptions` memsets the payload of every slot it has
+/// to turn off (`dbAccess.c:229-230`, `:376-393`).
 ///
 /// The returned text carries C's embedded newlines but not its final one; the
-/// caller's `println` is C's closing `printf("\n")` (`:586`).
+/// caller's `println` is C's closing `printf("\n")` (`test_event.cpp:586`).
 ///
 /// How many elements to print is a property of the REPLY, not a second
 /// argument: C has to pass a count because a C buffer has no length, and
@@ -2661,10 +2911,11 @@ fn ca_dump_time_stamp(ts: crate::types::WallTime) -> String {
 ///
 /// Three C oddities are reproduced rather than corrected, because they are
 /// what a user comparing the two IOCs sees: `DBR_STS_SHORT` prints a SIGNED
-/// short through `%u` (`:161`) where `DBR_TIME_SHORT` prints the same value
-/// through `%d` (`:262`); `DBR_CTRL_DOUBLE` prints its value with six decimals
-/// (`:561`) where every other real family prints four; and `DBR_STRING` stops
-/// at the first EMPTY element instead of at `count` (`:69`).
+/// short through `%u` (`test_event.cpp:163`) where `DBR_TIME_SHORT` prints
+/// the same value through `%d` (`:264`); `DBR_CTRL_DOUBLE` prints its value
+/// with six decimals (`:561`) where every other real family prints four; and
+/// `DBR_STRING` stops at the first EMPTY element instead of at `count`
+/// (`:69`).
 fn ca_dump_dbr(dbr: u16, snap: &crate::server::snapshot::Snapshot) -> String {
     use crate::types::{
         DBR_CHAR, DBR_CLASS_NAME, DBR_CTRL_CHAR, DBR_CTRL_DOUBLE, DBR_CTRL_ENUM, DBR_CTRL_FLOAT,
@@ -2691,10 +2942,11 @@ fn ca_dump_dbr(dbr: u16, snap: &crate::server::snapshot::Snapshot) -> String {
     // for the display and control pairs, which `get_graphics`/`get_control`
     // `memset` when the rset slot is NULL, and NaN for the alarm four, which
     // `get_alarm` leaves at its `struct dbr_alDouble ald` initialiser
-    // (`:294`, `:318-323`). Reading an absent alarm slot as zero here made
-    // `gft <bo> DBR_CTRL_DOUBLE` print four zeros where C prints four `nan`.
-    // Shared with the CA wire encoder rather than re-seeded, because two
-    // seeds for one C initialiser is how this diverged in the first place.
+    // (`dbAccess.c:294`, `:318-323`). Reading an absent alarm slot as zero
+    // here made `gft <bo> DBR_CTRL_DOUBLE` print four zeros where C prints
+    // four `nan`. Shared with the CA wire encoder rather than re-seeded,
+    // because two seeds for one C initialiser is how this diverged in the
+    // first place.
     let limits = crate::types::codec::get_limits(snap, 8);
     let int_limits = crate::types::codec::limits_as_integers(limits);
     let (lo_ctrl, hi_ctrl) = (limits[7], limits[6]);
@@ -2889,19 +3141,19 @@ struct CaChannel {
     field_size: Option<u16>,
     /// The precision `getDoubleString`/`getFloatString` render a `DBR_STRING`
     /// row with — the record's own `get_precision`, or C's initialiser 6 when
-    /// the record type has no such slot (`dbConvert.c:778-783`). This is NOT
+    /// the record type has no such slot (`dbConvert.c:778-784`). This is NOT
     /// the `DBR_PRECISION` option [`ca_dump_dbr`] prints, which `getOptions`
-    /// zeroes for a non-float field (`dbAccess.c:386-393`).
+    /// zeroes for a non-float field (`dbAccess.c:387-395`).
     string_precision: i16,
 }
 
 impl CaChannel {
-    /// C `dbChannel_create` (`dbChannel.c:395-421`) as `gft`/`pft` use it.
+    /// C `dbChannel_create` (`db_access.c:105-119`) as `gft`/`pft` use it.
     /// `None` is its NULL return, which both commands report as
     /// `Channel couldn't be created`.
     ///
     /// C reads `ACKT`/`ACKS` out of `dbCommon` on the same `DBRstatus` option
-    /// every reply carries (`dbAccess.c:336-345`), so `DBR_STSACK_STRING` sees
+    /// every reply carries (`dbAccess.c:352-365`), so `DBR_STSACK_STRING` sees
     /// them. The port's `Snapshot` leaves them `None` on the GET path, so they
     /// are filled from the record here rather than defaulted to zero.
     fn create(ctx: &CommandContext, pname: &str) -> Option<Self> {
@@ -3222,7 +3474,7 @@ fn cmd_pft() -> CommandDef {
                 }
                 chan.refresh(ctx);
                 // C `pft` asks for one element on every rung
-                // (`db_test.c:122-193`).
+                // (`db_test.c:123-181`).
                 match chan.get(dbr, 1) {
                     None => out.push_str(get_failed),
                     Some(reply) => {
@@ -3352,8 +3604,7 @@ fn cmd_dbtr() -> CommandDef {
                 }
             };
             let (base, _) = parse_pv_name(name);
-            let Some(rec) = ctx.db().get_record(base) else {
-                print_pv_not_found(ctx, name);
+            let Some(DbAddr { rec, .. }) = name_to_addr(ctx, name) else {
                 return Ok(CommandOutcome::Failed);
             };
             if !dbt_requires_ioc_init(ctx, "dbtr") {
@@ -3493,21 +3744,22 @@ fn jlink_report_lines(raw: &str, level: i32, indent: usize) -> Vec<String> {
 /// This port has the driver half. Two differences, both structural rather than
 /// elective:
 ///
-/// * C's `No driver entry table is present for %s` (`:733-736`) cannot happen
-///   here. It is what a `.dbd` `driver(drvXxx)` declaration prints when nothing
-///   registered `drvXxx`'s entry table, and this port has no run-time `.dbd`
-///   load to declare a name without one — see
+/// * C's `No driver entry table is present for %s` (`dbTest.c:733-736`)
+///   cannot happen here. It is what a `.dbd` `driver(drvXxx)` declaration
+///   prints when nothing registered `drvXxx`'s entry table, and this port has
+///   no run-time `.dbd` load to declare a name without one — see
 ///   [`crate::server::driver_support`].
-/// * The DEVICE-support half (`:746-768`) is absent. C walks each record type's
-///   `devList` and calls `pdset->report(level)` once per (record type, device
-///   support name), because a `dset` is one static table shared by every record
-///   of that DTYP. The port has no such object: device support is a
-///   `DeviceSupportFactory` that mints a fresh instance PER RECORD
-///   (`ioc_builder.rs:119`), so there is nothing to call `report` on once per
-///   record type, and calling it per record would be a different report.
+/// * The DEVICE-support half (`dbTest.c:746-768`) is absent. C walks each
+///   record type's `devList` and calls `pdset->report(level)` once per
+///   (record type, device support name), because a `dset` is one static table
+///   shared by every record of that DTYP. The port has no such object: device
+///   support is a `DeviceSupportFactory` that mints a fresh instance PER
+///   RECORD (`ioc_builder.rs:119`), so there is nothing to call `report` on
+///   once per record type, and calling it per record would be a different
+///   report.
 ///
-/// The `No database loaded` guard (`:715-718`) is likewise unreachable: a
-/// `CommandContext` always carries a database.
+/// The `No database loaded` guard (`dbTest.c:715-718`) is likewise
+/// unreachable: a `CommandContext` always carries a database.
 fn cmd_dbior() -> CommandDef {
     CommandDef::new(
         "dbior",
@@ -4226,8 +4478,8 @@ fn cmd_dbgrep() -> CommandDef {
 /// `scanIoInit` from device support. Before then C has nothing to walk, and
 /// each command says so in its own shape — `scanppl` prints
 /// `scanppl: dbScan subsystem not initialized` and returns -1
-/// (`dbScan.c:388-392`), while `scanpel` (`:414-428`) and `scanpiol`
-/// (`:434-455`) walk an empty list, print nothing and return 0.
+/// (`dbScan.c:388-392`), while `scanpel` (`:411-428`) and `scanpiol`
+/// (`:430-453`) walk an empty list, print nothing and return 0.
 ///
 /// The port's three read the SCAN-field index instead, which exists from the
 /// moment the records load — so all three reported a scan subsystem that did
@@ -4862,40 +5114,16 @@ fn cmd_db_load_records() -> CommandDef {
                 _ => "",
             };
 
-            // C passes a hard `0` for the search path (`dbAccess.c:803`), so
-            // a `dbLoadRecords` list can only ever come from the environment.
+            // C says NOTHING on the success path: `dbLoadRecords` calls
+            // the (always-NULL in base) `dbLoadRecordsHook` and returns 0
+            // (`dbAccess.c:804-807`). A progress line here is output no C
+            // IOC produces, on the stream a startup script's own output
+            // shares. The failure path is [`db_load_records`], which owns
+            // the summary and has already written it.
             let mut faults = db_loader::DbFaults::default();
-            match db_read_database(ctx, path, "", macros_str, &mut faults) {
-                // C says NOTHING on the success path: `dbLoadRecords`
-                // calls the (always-NULL in base) `dbLoadRecordsHook` and
-                // returns 0 (`dbAccess.c:804-806`). A progress line here
-                // is output no C IOC produces, on the stream a startup
-                // script's own output shares.
+            match db_load_records(ctx, path, parse_macro_string(macros_str), &mut faults) {
                 Ok(()) => Ok(CommandOutcome::Continue),
-                // C `dbAccess.c:807-811`: the summary the command adds on
-                // top of whatever the read already reported, on every
-                // failure alike, and the second line only the load-phase
-                // refusal gets.
-                //
-                // ```text
-                // epics> iocInit
-                // epics> dbLoadRecords("b.db")
-                // ERROR: Failed to load 'b.db'
-                //     Records cannot be loaded after iocInit!
-                // ```
-                //
-                // Written HERE and answered with `Failed` rather than
-                // returned as `Err(...)`: C's `dbLoadRecords` prints its own
-                // summary and hands `iocshSetError` a bare status, so the
-                // shell adds nothing. Returning text made the shell print a
-                // second copy of a diagnostic the read had already written.
-                Err(failure) => {
-                    ctx.eprintln(&format!("{ERL_ERROR}: Failed to load '{path}'"));
-                    if matches!(failure, DbReadFailure::AfterIocInit) {
-                        ctx.eprintln("    Records cannot be loaded after iocInit!");
-                    }
-                    Ok(CommandOutcome::Failed)
-                }
+                Err(_) => Ok(CommandOutcome::Failed),
             }
         },
     )
@@ -5014,6 +5242,24 @@ fn db_read_database(
     substitutions: &str,
     faults: &mut db_loader::DbFaults,
 ) -> Result<(), DbReadFailure> {
+    db_read_database_macros(ctx, file, path, parse_macro_string(substitutions), faults)
+}
+
+/// [`db_read_database`] with C's `substitutions` string already parsed.
+///
+/// C only ever has the string — `dbLoadTemplate` builds `sub_collect` by
+/// `strcat` and hands the text to `dbLoadRecords` (`dbLoadTemplate.y:51`),
+/// which parses it again in `macParseDefns`. This port keeps a template
+/// row's substitutions in the structure the `.substitutions` parser already
+/// produced, so the round trip through a comma-joined string — and the
+/// quoting rules that make it lossless — never has to happen for real.
+fn db_read_database_macros(
+    ctx: &CommandContext,
+    file: &str,
+    path: &str,
+    macros: HashMap<String, String>,
+    faults: &mut db_loader::DbFaults,
+) -> Result<(), DbReadFailure> {
     // A load OPENS the load phase; it does not close it — the boundary a
     // record's links are classified against is `iocInit`, after EVERY load
     // in the `st.cmd`, so a forward reference to a record loaded by a later
@@ -5027,13 +5273,15 @@ fn db_read_database(
         return Err(DbReadFailure::AfterIocInit);
     }
 
-    let macros = parse_macro_string(substitutions);
-
-    // C installs the search path inside the read (`:245-253`), before the
-    // open, so a load that cannot find its file has still replaced the list
-    // `dbDumpPath` reports.
+    // C installs the search path inside the read
+    // (`dbLexRoutines.c:245-253`), before the open, so a load that cannot
+    // find its file has still replaced the list `dbDumpPath` reports.
     let (config, file_path) = resolve_db_file(file, path);
     let Some(file_path) = file_path else {
+        // The name the caller wrote, deliberately, where C prints
+        // `macEnvExpand`'s result (`dbLexRoutines.c:274-286`) and so prints
+        // `'(null)'` for exactly the case an operator most needs named — a
+        // path built from a macro that was never defined.
         ctx.eprintln(&format!("{ERL_ERROR}: Can't open file '{file}'"));
         return Err(DbReadFailure::CannotOpen);
     };
@@ -5087,6 +5335,52 @@ fn db_read_database(
     ))?;
 
     Ok(())
+}
+
+/// C `dbLoadRecords` (`dbAccess.c:796-814`) past its `file == NULL` check:
+/// the read, and the SUMMARY C writes when the read failed.
+///
+/// The ONE owner of that summary. `dbLoadTemplate` does not reimplement a
+/// load — it calls `dbLoadRecords` once per row through `msiLoadRecords`
+/// (`dbLoadTemplate.y:49-57`), so a row's failure must carry exactly the
+/// lines a directly loaded file's does, naming the ROW's `.db`. Writing the
+/// summary at each call site instead is what let the template command print
+/// `Failed to load '<subs>.substitutions'` for a refusal that happened
+/// inside a row, and skip `Can't open file` for a row whose `.db` was
+/// missing.
+///
+/// ```text
+/// epics> iocInit
+/// epics> dbLoadRecords("b.db")
+/// ERROR: Failed to load 'b.db'
+///     Records cannot be loaded after iocInit!
+/// ```
+///
+/// Written here and answered with a bare status rather than an `Err(String)`:
+/// C's `dbLoadRecords` prints its own summary and hands `iocshSetError` an
+/// `int`, so the shell adds nothing. Returning text made the shell print a
+/// second copy of a diagnostic the read had already written.
+fn db_load_records(
+    ctx: &CommandContext,
+    file: &str,
+    macros: HashMap<String, String>,
+    faults: &mut db_loader::DbFaults,
+) -> Result<(), DbReadFailure> {
+    // C passes a hard `0` for the search path (`dbAccess.c:803`), so a
+    // `dbLoadRecords` list can only ever come from the environment — for a
+    // template row too, which is why `dbLoadTemplate`'s own path argument
+    // reaches only the `.substitutions` lookup and never the templates.
+    let read = db_read_database_macros(ctx, file, "", macros, faults);
+    // C `dbAccess.c:808-812`: the summary the command adds on top of
+    // whatever the read already reported, on every failure alike, and the
+    // second line only the load-phase refusal gets.
+    if let Err(failure) = &read {
+        ctx.eprintln(&format!("{ERL_ERROR}: Failed to load '{file}'"));
+        if matches!(failure, DbReadFailure::AfterIocInit) {
+            ctx.eprintln("    Records cannot be loaded after iocInit!");
+        }
+    }
+    read
 }
 
 /// Build the DB include config the way `dbReadCOM` does
@@ -5144,29 +5438,181 @@ fn resolve_db_file(
 /// `dbLoadRecords`, i.e. [`resolve_db_file`]'s rule.
 ///
 /// `search_path` is the command's third argument, which C substitutes
-/// for `EPICS_DB_INCLUDE_PATH` when it is non-empty (`:363-366`). It
+/// for `EPICS_DB_INCLUDE_PATH` when it is non-empty (`:365-368`). It
 /// reaches only this lookup: `dbLoadRecords` resets the path list from
 /// the environment for every template, so the argument never affects
 /// the templates the file names.
-fn resolve_substitutions_file(
-    path: &str,
-    search_path: &str,
-) -> (db_loader::DbLoadConfig, std::path::PathBuf) {
+fn resolve_substitutions_file(path: &str, search_path: &str) -> std::path::PathBuf {
     let config = db_load_config("");
     let direct = std::path::PathBuf::from(path);
-    if direct.exists() {
-        return (config, direct);
-    }
-    if direct.is_absolute() {
-        return (config, direct);
+    if direct.exists() || direct.is_absolute() {
+        return direct;
     }
     let search = if search_path.is_empty() {
-        config.include_paths.clone()
+        config.include_paths
     } else {
         db_loader::db_path(search_path)
     };
-    let file_path = db_loader::db_open_file(path, &search).unwrap_or(direct);
-    (config, file_path)
+    db_loader::db_open_file(path, &search).unwrap_or(direct)
+}
+
+/// C's `sub_collect+1` — the substitution string `dbLoadTemplate` hands to
+/// `dbLoadRecords`, and the one `msiLoadRecords` echoes when a row fails
+/// (`dbLoadTemplate.y:53`). The command's own macro argument goes in first
+/// (`:387-389`), then every accumulated `global {}` definition and the row's
+/// own values in file order (`:301-323`), comma separated.
+///
+/// Built for the echo alone: the load itself takes the parsed macro set, so
+/// nothing depends on this string round-tripping. Which values wear quotes
+/// is not a property of the text — C has one grammar rule per token kind
+/// (`dbLoadTemplate.y:220-255`, `:301-323`) and always writes them back as
+/// `"` — so it is the token's own quotedness that decides, carried here on
+/// `RowMacro`.
+/// C `yyerror` (`dbLoadTemplate.y:330-338`) — every substitutions-file
+/// fault, lexer or grammar, is these two lines:
+///
+/// ```text
+/// Substitution file error: <message>
+/// line <line_num>: '<yytext>'
+/// ```
+///
+/// `yyerror(NULL)` writes `Substitution file error.` for the first line.
+fn eprint_substitution_fault(ctx: &CommandContext, fault: &db_loader::SubstitutionFault) {
+    match &fault.message {
+        Some(message) => ctx.eprintln(&format!("Substitution file error: {message}")),
+        None => ctx.eprintln("Substitution file error."),
+    }
+    ctx.eprintln(&format!("line {}: '{}'", fault.line, fault.yytext));
+}
+
+fn c_sub_collect(cmd_collect: &str, row: &[db_loader::RowMacro]) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(row.len() + 1);
+    if !cmd_collect.is_empty() {
+        parts.push(cmd_collect.to_owned());
+    }
+    for macro_ in row {
+        let db_loader::RowMacro { name, value, .. } = macro_;
+        if macro_.quoted {
+            parts.push(format!("{name}=\"{value}\""));
+        } else {
+            parts.push(format!("{name}={value}"));
+        }
+    }
+    parts.join(",")
+}
+
+/// The two ways C can fail to give a record its type, told apart by the
+/// same question C asks: is the type DECLARED?
+///
+/// C `dbRecordHead` reaches `dbFindRecordType` first
+/// (`dbLexRoutines.c:1161-1167`), and a type no loaded `.dbd` declares stops
+/// there with `Record type '%s' for record '%s' not found`. A type that IS
+/// declared gets past it and dies one call later inside `dbAllocRecord`
+/// (`dbStaticRun.c:91-96`), because nothing filled in its `rec_size` — the
+/// `.dbd` was read but `x_RegisterRecordDeviceDriver` never ran, so the
+/// recordtype has a shape and no support:
+///
+/// ```c
+///     if (pdbRecordType->rec_size == 0) {
+///         printf("\t*** Did you run x_RegisterRecordDeviceDriver(pdbbase) yet? ***\n");
+///         epicsPrintf("dbAllocRecord(%s) with %s rec_size = 0\n",
+///                     precordName, pdbRecordType->name);
+///         return(S_dbLib_noRecSup);
+///     }
+/// ```
+///
+/// Both then fall out of `dbCreateRecord` into the same `yyerrorAbort`
+/// (`dbLexRoutines.c:1189-1194`), so only the lines ABOVE it differ.
+///
+/// The port's two populations are the same two. `record_fields` is the
+/// vendored `.dbd`s read as a table, so a type it knows is a type this port
+/// declares; `create_record` failing on one of those means no factory is
+/// registered for it — `aCalcout`, `swait`, `busy` and the rest of the
+/// module-owned types an application opts into with `register_record_type`.
+/// That is C's rec_size == 0 exactly: declared, unsupported. Reporting it as
+/// "not found" sent an operator looking for a missing `.dbd` when the `.dbd`
+/// is the one thing that IS there.
+///
+/// One deviation, stated because it is the port's structure and not a
+/// choice: `record_fields` answers for every type this crate vendors, not
+/// for the ones a given IOC has actually loaded `.dbd`s for, because the
+/// port resolves record types from a compile-time table rather than from
+/// `pdbbase`. So a type C would call "not found" (no `.dbd` loaded) is
+/// "declared, unsupported" here whenever the crate vendors its `.dbd`.
+fn record_type_unavailable(ctx: &CommandContext, record_type: &str, name: &str) -> RecordFault {
+    if crate::server::record::dbd_generated::record_fields(record_type).is_some() {
+        // C's `printf`, on stdout, tab included.
+        ctx.println("\t*** Did you run x_RegisterRecordDeviceDriver(pdbbase) yet? ***");
+        // C's `epicsPrintf`, which is errlog and therefore the error
+        // stream, and which carries its own terminator.
+        crate::runtime::log::errlog_printf(&format!(
+            "dbAllocRecord({name}) with {record_type} rec_size = 0\n"
+        ));
+        return RecordFault::Fatal(format!(
+            "{ERL_ERROR}: Can't create {record_type} record '{name}'"
+        ));
+    }
+    RecordFault::Fatal(format!(
+        "{ERL_ERROR}: Record type '{record_type}' for record '{name}' not found"
+    ))
+}
+
+/// Put each field the way C's parser does — one element at a time, so a value
+/// the applier refuses costs that FIELD and nothing else.
+///
+/// C reduces one `field(NAME,"value")` at a time, and every failure arm of
+/// `dbRecordField` ends in `yyerror(NULL)` and `return`
+/// (`dbLexRoutines.c:1405-1416` @`R7.0.10-146-g8f5015b663d764ad75df`):
+///
+/// ```c
+///     status = dbPutString(pdbentry,value);
+///     if (status) {
+///         ...
+///         yyerror(NULL);
+///         return;
+///     }
+/// ```
+///
+/// so the record stays, its remaining fields still load, and only the file's
+/// status goes non-zero. Handing the whole slice to [`db_loader::apply_fields`]
+/// made the FIRST refusal cost the record and every field behind it as well:
+/// measured against `softIoc` R7.0.10 on a `record(ai,"N1"){field(RSET,"1")}`,
+/// C's `dbl` listed `N1` and the port's listed nothing.
+///
+/// Splitting the call is sound because `apply_fields` is itself a loop over
+/// `fields` that carries nothing between iterations — `check_link_syntax` is
+/// per field and `common_fields` is append-only — so N one-field calls are the
+/// same load as one N-field call, minus the abort.
+///
+/// That makes the rule uniform: the menu screen above drops a refused field and
+/// keeps the record, and now the applier's own refusals — `DBF_NOACCESS`, an
+/// unparsable value, a link the syntax check rejects — do the same, rather than
+/// each apply site deciding for itself how much of the file a bad field costs.
+///
+/// The sentence is C's, built from what this site holds: the record, the field
+/// and the value. C's two remaining slots, `pdbentry->message` and
+/// `errSymLookup(status)`, are produced inside `db_loader` and reach here as a
+/// single `CaError` blob, so the port's own text stands in for both.
+fn apply_fields_one_at_a_time(
+    record: &mut Box<dyn crate::server::record::Record>,
+    record_name: &str,
+    fields: &[db_loader::DbFieldDef],
+    common_fields: &mut Vec<(String, EpicsValue)>,
+    faults: &mut db_loader::DbFaults,
+) {
+    for f in fields {
+        let Err(e) = db_loader::apply_fields(record, std::slice::from_ref(f), common_fields) else {
+            continue;
+        };
+        // C's lexer names the line; the parse is over by the time this runs, so
+        // the element's own recorded line takes that seat — as in the screen.
+        faults.seek(f.line, ")");
+        faults.report(db_loader::DbDiagnostic::new(format!(
+            "{ERL_ERROR}: Can't set '{record_name}.{}' to '{}' {e}",
+            f.name,
+            f.value.as_str_lossy(),
+        )));
+    }
 }
 
 /// How C classifies a per-record `.db` failure. `dbRecordHead` and
@@ -5346,31 +5792,42 @@ async fn install_record_defs(
                 // existing record instance.
                 {
                     let mut inst = rec_arc.write();
-                    if let Err(e) =
-                        db_loader::apply_fields(&mut inst.record, &def.fields, &mut common_fields)
-                    {
-                        // C `dbRecordField` ends every one of its failure
-                        // arms in `yyerror(NULL)` — a bad field name or an
-                        // unconvertible value skips that record, never the
-                        // file (`dbLexRoutines.c:1206-1380`).
-                        return Err(RecordFault::Recoverable(format!("{e}")));
-                    }
+                    apply_fields_one_at_a_time(
+                        &mut inst.record,
+                        &def.name,
+                        &def.fields,
+                        &mut common_fields,
+                        faults,
+                    );
                 }
                 rec_arc
             } else {
                 // C `dbFindRecordType` failing is `yyerrorAbort`
-                // (`dbLexRoutines.c:1159-1165`) — an unknown record type
+                // (`dbLexRoutines.c:1162-1167`) — an unknown record type
                 // stops the load on both sides.
-                let mut record = db_loader::create_record(&def.record_type)
-                    .map_err(|e| RecordFault::Fatal(format!("{e}")))?;
+                //
+                // The sentence is built HERE because C builds it here, out
+                // of the two things only this site holds: the type and the
+                // RECORD NAME. The factory sees neither, so forwarding its
+                // error put `DB parse error at line 0, column 0: unknown
+                // record type: 'nosuchtype'` on the stream — this port's own
+                // words, and a position it did not have. The factory's
+                // `register_record_type` hint is dropped with it: it is
+                // addressed to whoever builds the IOC, and `IocBuilder`
+                // (`ioc_builder.rs:305`) still shows it to them.
+                let mut record = db_loader::create_record(&def.record_type).map_err(|_| {
+                    record_type_unavailable(ctx, &def.record_type, &def.name)
+                })?;
                 // The breakpoint-table registry is installed by the
                 // creation sink; apply_fields only needs the LINR
                 // index, already resolved above.
-                if let Err(e) =
-                    db_loader::apply_fields(&mut record, &def.fields, &mut common_fields)
-                {
-                    return Err(RecordFault::Recoverable(format!("{e}")));
-                }
+                apply_fields_one_at_a_time(
+                    &mut record,
+                    &def.name,
+                    &def.fields,
+                    &mut common_fields,
+                    faults,
+                );
                 // Record + its whole loaded field set in one call: the
                 // sink applies the common fields and info tags, THEN
                 // runs C's `iocInit` passes, so the initial UDF
@@ -5380,18 +5837,28 @@ async fn install_record_defs(
                     common_fields: std::mem::take(&mut common_fields),
                     info_tags: def.info_tags.clone(),
                 };
-                if let Err(e) = ctx.db().add_loaded_record(&def.name, record, load).await {
+                if ctx
+                    .db()
+                    .add_loaded_record(&def.name, record, load)
+                    .await
+                    .is_err()
+                {
                     // C `dbCreateRecord` failing for anything other than
                     // `S_dbLib_recExists` is `yyerrorAbort`
-                    // (`dbLexRoutines.c:1187-1192`).
+                    // (`dbLexRoutines.c:1189-1194`), with the same
+                    // site-built shape as the type miss above.
                     return Err(RecordFault::Fatal(format!(
-                        "dbLoadRecords: '{}' rejected: {e}",
-                        def.name
+                        "{ERL_ERROR}: Can't create {} record '{}'",
+                        def.record_type, def.name
                     )));
                 }
                 ctx.db().get_record(&def.name).ok_or_else(|| {
+                    // No C counterpart: this is the port's own invariant
+                    // (the creation sink installed it) failing. It wears
+                    // the `ERROR:` prefix because it now leaves by the same
+                    // exit as the two above.
                     RecordFault::Fatal(format!(
-                        "dbLoadRecords: '{}' vanished between add_record and get_record",
+                        "{ERL_ERROR}: dbLoadRecords: '{}' vanished between add_record and get_record",
                         def.name
                     ))
                 })?
@@ -5514,7 +5981,17 @@ async fn install_record_defs(
             // this record are still read.
             Err(RecordFault::Recoverable(msg)) => faults.recoverable(msg),
             Err(RecordFault::Fatal(msg)) => {
-                ctx.println(&msg);
+                // C `yyerrorAbort(NULL)` (`dbYacc.y:385-389`) is
+                // `yyerror(NULL)` plus `yyAbort = TRUE`: the sentence is
+                // the site's own `fprintf`, and the abort adds exactly the
+                // bare `ERROR: ` and the position that a RECOVERED fault
+                // gets. So the two arms print through the SAME owner and
+                // differ only in whether the loop goes on — which is what
+                // makes it impossible for an abort to reach the operator
+                // without the file, line and source echo the rest carry.
+                // This arm used to `ctx.println` the message instead:
+                // stdout, unframed, and invisible to a `2>` startup log.
+                faults.recoverable(msg);
                 return Err(DbReadFailure::Rejected);
             }
         }
@@ -5574,7 +6051,7 @@ fn cmd_db_load_template() -> CommandDef {
         ],
         "dbLoadTemplate subFile [globalMacros] [path] - Load records from a .substitutions file",
         |args: &[ArgValue], ctx: &CommandContext| {
-            // C `dbLoadTemplate.y:344-347` diagnoses a missing or empty
+            // C `dbLoadTemplate.y:350-352` diagnoses a missing or empty
             // name itself, on stderr, and returns -1 —
             // `dbLoadTemplateCallFunc` passes that status to `iocshSetError`
             // (`dbtoolsIocRegister.c:33-36`), so the line FAILED.
@@ -5594,72 +6071,112 @@ fn cmd_db_load_template() -> CommandDef {
                 _ => "",
             };
 
-            // Same load-phase gate as `dbLoadRecords`: opens the load phase
-            // (idempotent across the several loads a script issues) and
-            // refuses with C's diagnostic once `iocInit` has run — C's
-            // `dbLoadTemplate` delegates to `dbReadDatabase`/`dbLoadRecords`,
-            // which fail identically after init (dbAccess.c:808-812).
-            if ctx.db().begin_load().is_err() {
-                ctx.eprintln(&format!("{ERL_ERROR}: Failed to load '{path}'"));
-                ctx.eprintln("    Records cannot be loaded after iocInit!");
+            // C refuses a ceiling below 1 before it opens anything
+            // (`dbLoadTemplate.y:355-360`), returning -1: `vars` and
+            // `sub_collect` are `malloc`ed from that number, so a
+            // non-positive one has no load to attempt. Reachable because
+            // `var dbTemplateMaxVars` writes the global unvalidated.
+            let max_vars = db_loader::db_template_max_vars();
+            if max_vars < 1 {
+                ctx.eprintln(&format!(
+                    "{ERL_ERROR}: dbTemplateMaxVars = {max_vars}, must be +ve"
+                ));
                 return Ok(CommandOutcome::Failed);
             }
 
-            let macros = parse_macro_string(macros_str);
-
-            let (config, file_path) = resolve_substitutions_file(path, search_path);
-
-            // C `dbLoadTemplate` issues one `dbLoadRecords` per row from
-            // the `pattern_definition` action (`dbLoadTemplate.y:186`), so
-            // each row's records are committed before the next row is even
-            // read and a failing row costs only the rows after it. Resolve,
-            // parse and install one row at a time for the same reason: the
-            // port used to concatenate every row's records and install the
-            // batch, which threw away the rows that had already succeeded.
-            let rows = db_loader::substitution_rows(&file_path, &macros)
-                .map_err(|e| format!("parse error: {e}"))?;
-
-            for (file, merged) in rows {
-                let template = db_loader::resolve_template(&file, &config.include_paths)
-                    .map_err(|e| format!("parse error: {e}"))?;
-                // Reported by the loader, like `dbLoadRecords`'s own read
-                // above; the row's summary is all that is owed here, and
-                // C names the row's `.db` in it rather than the
-                // `.substitutions` (`dbLoadTemplate.y:186` ->
-                // `dbAccess.c:808`).
-                let Ok(parsed) =
-                    db_loader::parse_db_opened_with_breaktables(&template, &merged, &config)
-                else {
-                    ctx.eprintln(&format!("{ERL_ERROR}: Failed to load '{file}'"));
-                    return Ok(CommandOutcome::Failed);
-                };
-                // Each row IS a `dbLoadRecords`, so its `breaktable(...)`
-                // definitions join the database registry exactly as that
-                // command's do, and a later row's `LINR` name resolves
-                // against them.
-                let breaktable_registry =
-                    ctx.block_on(async { ctx.db().add_breaktables(parsed.breaktables).await });
-                // Identical install path to `dbLoadRecords`: same
-                // duplicate-name merge, field application, load-then-init
-                // ordering and post-load passes, so a template-loaded record
-                // is indistinguishable from a directly loaded one.
-                let mut faults = parsed.faults;
-                if ctx
-                    .block_on(install_record_defs(
-                        ctx,
-                        parsed.records,
-                        parsed.unresolved_aliases,
-                        &breaktable_registry,
-                        &mut faults,
-                    ))
-                    .is_err()
-                {
-                    // Each row IS a `dbLoadRecords`, so C's summary names the
-                    // row's own file (`dbLoadTemplate.y:186` ->
-                    // `dbAccess.c:808`), not the `.substitutions`.
-                    ctx.eprintln(&format!("{ERL_ERROR}: Failed to load '{file}'"));
+            // C opens the `.substitutions` file HERE, and reports the open
+            // failure in its own words with `strerror(errno)`
+            // (`dbLoadTemplate.y:362-374`) — before `pdbbase` is touched, and
+            // returning -1 rather than a parser status. No other load in the
+            // port has that shape, and it is one half of what the merged
+            // `parse error: <e>` could not say.
+            let file_path = resolve_substitutions_file(path, search_path);
+            let text = match std::fs::read_to_string(&file_path) {
+                Ok(text) => text,
+                Err(e) => {
+                    ctx.eprintln(&format!(
+                        "dbLoadTemplate: error opening sub file {path}: {}",
+                        super::c_strerror(&e)
+                    ));
                     return Ok(CommandOutcome::Failed);
                 }
+            };
+
+            // The other half: the file opened and the parse had something
+            // to say about it. C reports through one `yyerror`
+            // (`dbLoadTemplate.y:330-338`) whether the lexer hit a
+            // character it does not know or the grammar hit a token it
+            // cannot shift, and only the second one stops it.
+            let subs = db_loader::parse_substitutions(&text);
+
+            // C `dbLoadTemplate` issues one `dbLoadRecords` per row from the
+            // `pattern_definition` action (`dbLoadTemplate.y:185`), so each
+            // row's records are committed before the next row is even read
+            // and a failing row costs only the rows after it. One row at a
+            // time for the same reason: the port used to concatenate every
+            // row's records and install the batch, which threw away the rows
+            // that had already succeeded.
+            //
+            // A fault is reported where the lexer reached it, which is
+            // after the rows before it and before the rows after it, so
+            // the two are walked as one stream in C's order.
+            for event in subs.events {
+                let load = match event {
+                    db_loader::SubstitutionEvent::Fault(fault) => {
+                        eprint_substitution_fault(ctx, &fault);
+                        continue;
+                    }
+                    // C's plain `fprintf(stderr, ...)` notices reach the
+                    // operator's console like every other line here, not a
+                    // log the console never shows.
+                    db_loader::SubstitutionEvent::Notice(text) => {
+                        ctx.eprintln(&text);
+                        continue;
+                    }
+                    db_loader::SubstitutionEvent::Load(load) => load,
+                };
+                // macLib is last-definition-wins and C builds `sub_collect`
+                // as `cmd_collect` then globals then the row's own values
+                // (`:301-323`, `:387-389`), so the row overrides a global
+                // and a global overrides the command's argument.
+                let mut merged = parse_macro_string(macros_str);
+                merged.extend(
+                    load.macros
+                        .iter()
+                        .map(|m| (m.name.clone(), m.value.clone())),
+                );
+                // Every row IS a `dbLoadRecords`, down to the `Can't open
+                // file` / `Failed to load` pair and the after-`iocInit`
+                // refusal, so it goes through the same owner rather than a
+                // second install path of its own — the `.dbd` side effects
+                // (`registrar`, `link`) included.
+                let mut faults = db_loader::DbFaults::default();
+                if db_load_records(ctx, &load.file, merged, &mut faults).is_err() {
+                    // C `msiLoadRecords` (`dbLoadTemplate.y:49-57`) names the
+                    // row that failed, then `yyerror` + `YYABORT`: the rows
+                    // after this one are never read, and `yyparse` fails the
+                    // command.
+                    ctx.eprintln(&format!(
+                        "dbLoadRecords(\"{}\", {})",
+                        load.file,
+                        c_sub_collect(macros_str, &load.macros)
+                    ));
+                    eprint_substitution_fault(
+                        ctx,
+                        &db_loader::SubstitutionFault::row_failed(&load),
+                    );
+                    return Ok(CommandOutcome::Failed);
+                }
+            }
+
+            // A grammar error is the only thing that fails the command:
+            // `dbLoadTemplate` returns `yyparse`'s status
+            // (`dbLoadTemplate.y:417`), which a recovered lexer fault does
+            // not change — measured, a `.substitutions` whose only defect
+            // is a stray `%` loads every row and returns 0.
+            if let Some(fault) = subs.stopped {
+                eprint_substitution_fault(ctx, &fault);
+                return Ok(CommandOutcome::Failed);
             }
 
             // Silent on success like the `dbLoadRecords` each row is:
@@ -5685,14 +6202,22 @@ fn cmd_epics_env_set() -> CommandDef {
             },
         ],
         "epicsEnvSet name value - Set an environment variable",
-        |args: &[ArgValue], _ctx: &CommandContext| {
-            let name = match &args[0] {
-                ArgValue::String(s) => s,
-                _ => return Err("invalid argument".to_string()),
+        |args: &[ArgValue], ctx: &CommandContext| {
+            // A missing argument is not the shell's to refuse: `cvtArg`
+            // stores NULL for an absent string and returns success
+            // (`iocsh.cpp:858-862`), and the command body is what notices.
+            // C's body writes its own sentence and marks the line errored
+            // with no diagnostic of the shell's own
+            // (`libComRegister.c:142-151`), so it carries no `ERROR <file>
+            // line <n>: ` frame — hence `eprintln` plus `Failed`, not
+            // `Err`, which would print a frame C does not.
+            let ArgValue::String(name) = &args[0] else {
+                ctx.eprintln("Missing environment variable name argument.");
+                return Ok(CommandOutcome::Failed);
             };
-            let value = match &args[1] {
-                ArgValue::String(s) => s,
-                _ => return Err("invalid argument".to_string()),
+            let ArgValue::String(value) = &args[1] else {
+                ctx.eprintln("Missing environment variable value argument.");
+                return Ok(CommandOutcome::Failed);
             };
 
             // C `epicsEnvSet` (`osdEnv.c:47-52`) clears the shell macro
@@ -5731,28 +6256,30 @@ fn cmd_ioc_init() -> CommandDef {
                 // C `iocBuild_1` (`iocInit.c:116-121`) refuses from any state
                 // but `iocVoid`, and `iocInit` is that refusal's caller.
                 crate::server::ioc_app::ShellTransition::Refused => {
-                    crate::runtime::log::errlog_printf(&format!(
-                        "iocBuild: {} IOC can only be initialized from \
-                         uninitialized or stopped state\n",
-                        if crate::runtime::log::errlog_console_paints() {
-                            crate::runtime::log::ERL_ERROR
-                        } else {
-                            "ERROR"
-                        }
-                    ));
+                    crate::runtime::log::errlog_printf(&crate::server::ioc_app::build_refusal());
                     return Ok(CommandOutcome::Failed);
                 }
                 crate::server::ioc_app::ShellTransition::NotOurs => {}
             }
             // No `IocApplication` build to drive: every `CaServerBuilder`
-            // binary and every bare `PvDatabase` shell reaches here, and for
-            // them `iocInit` has only ever meant closing the record-load
-            // phase. A link that forward-references a record loaded by a LATER
-            // `dbLoadRecords` in the same `st.cmd` must still classify as a
-            // local PV (R18-92), which is what that close runs.
-            ctx.block_on(async { ctx.db().ioc_init().await });
-            ctx.println("iocInit: record initialization complete (scan/device init follows)");
-            Ok(CommandOutcome::Continue)
+            // binary and every bare `PvDatabase` shell reaches here. C has no
+            // such shell — `iocInit()` is `iocBuild() || iocRun()` for
+            // everyone (`iocInit.c:111-113`) — so this arm runs the same two
+            // halves over the same state cell, and the record-load close is
+            // what it contributes to the build. A link that forward-references
+            // a record loaded by a LATER `dbLoadRecords` in the same `st.cmd`
+            // must still classify as a local PV (R18-92), which is what that
+            // close runs.
+            if !crate::server::ioc_app::build_without_application(|| {
+                ctx.block_on(async { ctx.db().ioc_init().await });
+            }) {
+                return Ok(CommandOutcome::Failed);
+            }
+            if crate::server::ioc_app::ioc_run() == 0 {
+                Ok(CommandOutcome::Continue)
+            } else {
+                Ok(CommandOutcome::Failed)
+            }
         },
     )
 }
@@ -6017,7 +6544,7 @@ pub(super) fn check_pdbbase(arg: &ArgValue) -> Result<(), String> {
 
 /// C `printf("%e", v)`: six fraction digits and a signed exponent of at least
 /// two digits. Rust's `{:.6e}` writes the digits but spells the exponent `e2`
-/// where C writes `e+02`, so `dbDumpBreaktable` (`dbStaticLib.c:3547-3548`)
+/// where C writes `e+02`, so `dbDumpBreaktable` (`dbStaticLib.c:3549-3550`)
 /// needs the fixup to emit C's bytes.
 fn c_exponential(v: f64) -> String {
     if !v.is_finite() {
@@ -6132,11 +6659,11 @@ fn dblsr_set_lines(
 
 /// `dblsr [record name] [interest level]` — Database Lockset report.
 ///
-/// C `dblsr` (`dbLock.c:871-909`), registered at `dbIocRegister.c:624`.
+/// C `dblsr` (`dbLock.c:874-939`), registered at `dbIocRegister.c:624`.
 ///
 /// A record name selects that record's set alone; `*`, `""` and a missing
 /// argument select every active set, which is C's own normalisation
-/// (`dbLock.c:875-876`). A name no record answers to prints `Record not
+/// (`dbLock.c:887-888`). A name no record answers to prints `Record not
 /// found`, and a record that has no lock set yet — the database is loaded but
 /// `iocInit` has not run — prints nothing at all (`:900-901`).
 fn cmd_dblsr() -> CommandDef {
@@ -6637,6 +7164,15 @@ fn cmd_dbnr() -> CommandDef {
             use crate::server::record::dbd_generated::RECORD_TYPES;
 
             let verbose = matches!(args[0], ArgValue::Int(v) if v != 0);
+
+            // DELIBERATE NON-MATCH under `verbose`: the row set is whatever
+            // record types are REGISTERED, which is C's rule
+            // (`dbFirstRecordType` over `pdbbase->recordTypeList`), applied to
+            // a different registry. This crate links every record type it
+            // ports, so `dbnr 1` lists rows base's `softIoc` has no support
+            // for — `acalcout`, `asyn`, `busy`, `scalcout`, `sseq`, `swait`,
+            // `transform` when those modules are built in. Every row for a
+            // type BOTH sides carry, and the whole of `dbnr 0`, is C's bytes.
 
             // C counts through one list per record type that holds records AND
             // alias nodes, so it reports `dbGetNRecords - dbGetNAliases`
@@ -8483,7 +9019,7 @@ mod tests {
                 true
             )
         );
-        // C `:414-428` / `:434-455` walk an empty list: no output, no refusal,
+        // C `:411-428` / `:430-453` walk an empty list: no output, no refusal,
         // and the line did NOT fail.
         assert_eq!(
             run_cmd_outcome(&ctx, "scanpel", &[]),
@@ -8609,9 +9145,9 @@ mod tests {
     /// `dbAccess.c` seeds the reply's three limit groups differently, and a
     /// record type with no `get_alarm_double` is where that shows: the
     /// display and control pairs are `memset` to zero, the alarm four keep
-    /// `struct dbr_alDouble ald = {epicsNAN, …}` (`:294`, `:318-323`). The
-    /// integral options are the same four through `finite(x) ? (epicsInt32) x
-    /// : 0` (`:305-312`), so they read zero.
+    /// `struct dbr_alDouble ald = {epicsNAN, …}` (`dbAccess.c:294`,
+    /// `:318-323`). The integral options are the same four through
+    /// `finite(x) ? (epicsInt32) x : 0` (`:303-310`), so they read zero.
     ///
     /// Measured on `bin/linux-x86_64/softIoc` (EPICS 7.0.10),
     /// `gft B:ONE` on `record(bo, "B:ONE")`, the six limits being
@@ -10166,7 +10702,7 @@ BO_REC
     /// required made the port answer with the registry's "missing
     /// required argument" on stderr and never run the body at all.
     /// The C texts are `dbTest.c:308`, `:359`, `:401`, `:445`,
-    /// `dbAccess.c:801`, `dbLoadTemplate.y:345` (stderr) and
+    /// `dbAccess.c:800`, `dbLoadTemplate.y:351` (stderr) and
     /// `asDbLib.c:244`.
     #[test]
     fn a_missing_argument_reaches_c_s_own_diagnostic() {
@@ -10207,7 +10743,7 @@ BO_REC
             assert_eq!(err, "must specify variable substitution file\n");
             assert!(
                 matches!(result, Ok(CommandOutcome::Failed)),
-                "dbLoadTemplate.y:344-347 returns -1 and                  dbtoolsIocRegister.c:33-36 sets it as the shell error"
+                "dbLoadTemplate.y:350-352 returns -1 and                  dbtoolsIocRegister.c:33-36 sets it as the shell error"
             );
         }
         // Already C-shaped; pinned here so the family stays closed.
@@ -10733,7 +11269,7 @@ record(ai, "P:FL")      { field(FLNK, "L:B") }
             // PV_LINK, target local, no CA/CP/CPP — `dbDbInitLink`.
             ("P:LOCAL", "INP", "DB_LINK L:B.VAL NPP NMS"),
             // PV_LINK, target LOCAL but CPP set: C skips `dbDbInitLink`
-            // entirely (`dbAccess.c:1104`), so the local target still
+            // entirely (`dbLink.c:118-122`), so the local target still
             // becomes a CA link. This port keeps such a link on the DB
             // link set on purpose; only the printed identity follows C.
             ("P:LOCALCP", "INP", "CA_LINK L:B.VAL CPP MS"),
@@ -12191,6 +12727,32 @@ record(mbboDirect, "MBD0") {{ }}
         (out, std::fs::read_to_string(&err_path).unwrap(), result)
     }
 
+    /// C `cvtArg` stores NULL for a string argument the line never
+    /// supplied and returns success (`iocsh.cpp:858-862`), so the shell
+    /// runs the command and the BODY is what refuses. Measured on
+    /// `bin/linux-x86_64/softIoc` (R7.0.10-146-g8f5015b663d764ad75df),
+    /// script `c.cmd`: `epicsEnvSet` alone → stderr `Missing environment
+    /// variable name argument.`, `epicsEnvSet ONLYONE` → stderr `Missing
+    /// environment variable value argument.` — both bare, with no `ERROR
+    /// c.cmd line 1: ` frame, because `showError` never ran.
+    #[test]
+    fn a_missing_epics_env_set_argument_is_the_bodys_own_unframed_sentence() {
+        let (_db, ctx) = make_ctx();
+
+        let (out, err, result) = run_capturing(&ctx, "epicsEnvSet", &[]);
+        assert_eq!(err, "Missing environment variable name argument.\n");
+        assert_eq!(out, "", "the refusal is a diagnostic, not output");
+        assert!(
+            matches!(result, Ok(CommandOutcome::Failed)),
+            "C's `iocshSetError(-1)` fails the line without a diagnostic \
+             of the shell's own, which `Err` would frame"
+        );
+
+        let (_out, err, result) = run_capturing(&ctx, "epicsEnvSet", &["ONLYONE"]);
+        assert_eq!(err, "Missing environment variable value argument.\n");
+        assert!(matches!(result, Ok(CommandOutcome::Failed)));
+    }
+
     /// The `bptTypeKdegC.dbd` this crate ships, the file C names in
     /// `dbLoadDatabase("$(EPICS_BASE)/dbd/bptTypeKdegC.dbd")`.
     const SHIPPED_BPT_TYPE_KDEGC: &str =
@@ -12841,7 +13403,7 @@ file "a.db" {
     }
 
     /// R4-7: C `dbLoadTemplate` calls `dbLoadRecords` from the
-    /// `pattern_definition` action (`dbLoadTemplate.y:186`), so row 1's
+    /// `pattern_definition` action (`dbLoadTemplate.y:193`), so row 1's
     /// records are in `pdbbase` before row 2 is read and only the rows
     /// after the failure are lost. The port concatenated every row's
     /// records and installed the batch, so one unloadable row threw away
@@ -12997,7 +13559,12 @@ record(ai, "IOC:AI2") { field(VAL, "2.5") field(EGU, "amps") }
         }
     }
 
-    /// A missing `.substitutions` file returns an error, not a panic.
+    /// A `.substitutions` file that cannot be opened is C's OWN failure, not
+    /// the parser's: `dbLoadTemplate` does the `fopen` itself and writes
+    /// `dbLoadTemplate: error opening sub file <f>: <strerror(errno)>`
+    /// (`dbLoadTemplate.y:371-374`) before `pdbbase` is touched, returning
+    /// -1. Measured on softIoc: `dbLoadTemplate: error opening sub file
+    /// nosuch.sub: No such file or directory`.
     #[test]
     fn db_load_template_file_not_found_errors() {
         let (db, ctx) = make_ctx();
@@ -13006,14 +13573,22 @@ record(ai, "IOC:AI2") { field(VAL, "2.5") field(EGU, "amps") }
 
         let err = load_template(&ctx, &missing, None)
             .expect_err("a nonexistent substitutions file must error");
-        assert!(
-            err.contains("parse error"),
-            "expected a parse error, got: {err}"
+        assert_eq!(
+            err,
+            format!(
+                "dbLoadTemplate: error opening sub file {}: No such file or directory\n",
+                missing.display()
+            )
         );
         assert!(!exists(&db, &ctx, "IOC:AI1"), "nothing is created on error");
     }
 
-    /// A malformed `.substitutions` file returns an error, not a panic.
+    /// A malformed `.substitutions` file is the OTHER failure: the file
+    /// opened and the grammar refused it, which C reports through `yyerror`
+    /// (`dbLoadTemplate.y:330-338`) as `Substitution file error: <msg>` plus
+    /// the lexer's position, returning `yyparse`'s status. Measured on this
+    /// exact file, `bin/linux-x86_64/softIoc` writes the two lines asserted
+    /// here byte for byte.
     #[test]
     fn db_load_template_malformed_substitutions_errors() {
         let (_db, ctx) = make_ctx();
@@ -13024,10 +13599,7 @@ record(ai, "IOC:AI2") { field(VAL, "2.5") field(EGU, "amps") }
 
         let err = load_template(&ctx, &subs, None)
             .expect_err("a malformed substitutions file must error");
-        assert!(
-            err.contains("parse error"),
-            "expected a parse error, got: {err}"
-        );
+        assert_eq!(err, "Substitution file error: syntax error\nline 1: '{'\n");
     }
 
     /// The command is registered under its EPICS-base name.

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -13565,18 +13565,30 @@ record(ai, "IOC:AI2") { field(VAL, "2.5") field(EGU, "amps") }
     /// (`dbLoadTemplate.y:371-374`) before `pdbbase` is touched, returning
     /// -1. Measured on softIoc: `dbLoadTemplate: error opening sub file
     /// nosuch.sub: No such file or directory`.
+    ///
+    /// The reason half of that line is the platform's, exactly as C's own
+    /// `strerror` is, so it is taken from a real failed open of the same path
+    /// rather than pinned: Windows spells this code "The system cannot find
+    /// the file specified." The glibc sentence the measurement above recorded
+    /// is asserted where glibc is what answers.
     #[test]
     fn db_load_template_file_not_found_errors() {
         let (db, ctx) = make_ctx();
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("nope.substitutions");
 
+        let reason = super::super::c_strerror(
+            &std::fs::read_to_string(&missing).expect_err("the path must not exist"),
+        );
+        #[cfg(all(unix, target_env = "gnu"))]
+        assert_eq!(reason, "No such file or directory");
+
         let err = load_template(&ctx, &missing, None)
             .expect_err("a nonexistent substitutions file must error");
         assert_eq!(
             err,
             format!(
-                "dbLoadTemplate: error opening sub file {}: No such file or directory\n",
+                "dbLoadTemplate: error opening sub file {}: {reason}\n",
                 missing.display()
             )
         );

--- a/crates/epics-base-rs/src/server/iocsh/core_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/core_commands.rs
@@ -515,7 +515,28 @@ fn cmd_echo() -> CommandDef {
 /// agree except on the fractional-second conversions EPICS adds on top
 /// of the C library's (`epicsTime.cpp`): `%f` is nanoseconds and `%0Nf`
 /// is N digits, which chrono spells `%9f` and `%Nf`.
-fn epics_strftime_to_chrono(fmt: &str) -> String {
+///
+/// C's `strftime` cannot fail: an unknown conversion is copied out
+/// literally, so `date "%Q"` prints `%Q`. chrono's `DelayedFormat` instead
+/// makes its `Display` return `Err`, and `to_string()` on that panics — the
+/// measured result of `date "%Q"` was `a Display implementation returned an
+/// error unexpectedly: Error` and a dead shell thread, against C's `%Q`.
+///
+/// A runtime guard around the render cannot fix that, because there is no
+/// answer to fall back TO: the whole line is lost for one bad conversion.
+/// So no specifier chrono rejects is allowed into the format string in the
+/// first place. Each one is rendered on its own against the very timestamp
+/// the line will print, and the ones that fail come out as `%%X` — chrono's
+/// literal per cent — which is glibc's pass-through and makes the result
+/// render by construction. `now` is a parameter for exactly that reason:
+/// the probe has to be the real render, not a guess about one.
+fn epics_strftime_to_chrono(fmt: &str, now: &chrono::DateTime<chrono::Local>) -> String {
+    use std::fmt::Write as _;
+    // chrono renders this specifier for this timestamp without erroring.
+    let renders = |spec: &str| {
+        let mut probe = String::new();
+        write!(probe, "{}", now.format(spec)).is_ok()
+    };
     let c: Vec<char> = fmt.chars().collect();
     let mut out = String::with_capacity(fmt.len());
     let mut i = 0;
@@ -545,8 +566,21 @@ fn epics_strftime_to_chrono(fmt: &str) -> String {
             i = j + 1;
             continue;
         }
-        out.push('%');
-        i += 1;
+        // Not one of EPICS' own conversions, so it is the C library's, and
+        // the only question is whether chrono knows it. A trailing bare `%`
+        // has no following character to ask about and is a literal in C.
+        match c.get(i + 1) {
+            Some(&ch) if renders(&format!("%{ch}")) => {
+                out.push('%');
+                out.push(ch);
+            }
+            Some(&ch) => {
+                out.push_str("%%");
+                out.push(ch);
+            }
+            None => out.push_str("%%"),
+        }
+        i += if i + 1 < c.len() { 2 } else { 1 };
     }
     out
 }
@@ -572,7 +606,7 @@ fn cmd_date() -> CommandDef {
                 _ => "%Y/%m/%d %H:%M:%S.%06f",
             };
             let now = chrono::Local::now();
-            ctx.println(&now.format(&epics_strftime_to_chrono(fmt)).to_string());
+            ctx.println(&now.format(&epics_strftime_to_chrono(fmt, &now)).to_string());
             Ok(CommandOutcome::Continue)
         },
     )
@@ -599,17 +633,43 @@ fn cmd_cd() -> CommandDef {
 /// success — it only calls `updatePWD()`. The cwd line the port used to
 /// echo here has no counterpart in C.
 fn chdir_handler(args: &[ArgValue], ctx: &CommandContext) -> CommandResult {
-    let ArgValue::String(dir) = &args[0] else {
-        // C tests `args[0].sval == NULL` BEFORE it reaches `iocshSetError`
-        // (`libComRegister.c:108-116`), so an absent directory warns on stderr
-        // and leaves the line successful; only a `chdir()` that actually fails
-        // sets the shell's error flag. Refusing the line here made `on error
-        // break` abandon the rest of a script C finishes.
-        ctx.eprintln("Invalid directory path, ignored");
-        return Ok(CommandOutcome::Continue);
+    // C's whole body is one `||` (`libComRegister.c:108-116`):
+    //
+    // ```c
+    // if (args[0].sval == NULL ||
+    //     iocshSetError(chdir(args[0].sval))) {
+    //     fprintf(stderr, "Invalid directory path, ignored\n");
+    // } else {
+    //     updatePWD();
+    // }
+    // ```
+    //
+    // `None` is the NULL arm. It SHORT-CIRCUITS, so `iocshSetError` never
+    // runs and the line stays successful; refusing it made `on error break`
+    // abandon the rest of a script C finishes. `Some(false)` is a `chdir()`
+    // that failed, and that return value IS what `iocshSetError` is handed,
+    // so that line — and only that line — is errored.
+    let changed = match &args[0] {
+        ArgValue::String(dir) => Some(set_working_dir(dir).is_ok()),
+        _ => None,
     };
-    set_working_dir(dir).map_err(|e| format!("chdir: {dir}: {e}"))?;
-    Ok(CommandOutcome::Continue)
+    if changed == Some(true) {
+        // C prints nothing on success; `updatePWD` is inside
+        // `set_working_dir`, the one owner of the cwd.
+        return Ok(CommandOutcome::Continue);
+    }
+    // ONE sentence for both failing arms, because C's `||` writes it once.
+    // It does not name the directory and it does not spell the errno: this
+    // site used to return `Err(format!("chdir: {dir}: {e}"))`, which the
+    // shell then framed, so an operator who typed a missing directory read
+    // `ERROR st.cmd line 11: chdir: topbin: No such file or directory (os
+    // error 2)` where C says six words and no `os error`.
+    ctx.eprintln("Invalid directory path, ignored");
+    Ok(if changed.is_none() {
+        CommandOutcome::Continue
+    } else {
+        CommandOutcome::Failed
+    })
 }
 
 /// `pwd` — print the current working directory. Mirrors C `pwd`.
@@ -638,10 +698,14 @@ fn cmd_epics_env_unset() -> CommandDef {
             arg_type: ArgType::String,
         }],
         "Remove variable name from the environment",
-        |args: &[ArgValue], _ctx: &CommandContext| {
-            let name = match &args[0] {
-                ArgValue::String(s) => s,
-                _ => return Err("epicsEnvUnset: missing name".into()),
+        |args: &[ArgValue], ctx: &CommandContext| {
+            // Same shape and the same sentence as `epicsEnvSet`'s missing
+            // name (`libComRegister.c:164-168`): written by the body, so
+            // unframed, and failing the line through `iocshSetError(-1)`
+            // rather than through a diagnostic of the shell's own.
+            let ArgValue::String(name) = &args[0] else {
+                ctx.eprintln("Missing environment variable name argument.");
+                return Ok(CommandOutcome::Failed);
             };
             // C `epicsEnvUnset` (`osdEnv.c:58-63`) clears the shell
             // macro first, exactly as `epicsEnvSet` does — otherwise an
@@ -854,7 +918,7 @@ fn cmd_epics_thread_show() -> CommandDef {
                 // argument was a name, not a handle.
                 let id = match super::registry::parse_iocsh_int(token) {
                     Ok(value) => value as u64,
-                    Err(()) => match crate::runtime::task::thread_by_name(token) {
+                    Err(_) => match crate::runtime::task::thread_by_name(token) {
                         Some(thread) => thread.id(),
                         None => {
                             ctx.eprintln(&format!("\t'{token}' is not a known thread name"));
@@ -923,7 +987,7 @@ fn cmd_epics_thread_resume() -> CommandDef {
             for token in argv {
                 let (kind, found) = match super::registry::parse_iocsh_int(token) {
                     Ok(id) => ("thread id", crate::runtime::task::thread_by_id(id as u64)),
-                    Err(()) => ("thread name", crate::runtime::task::thread_by_name(token)),
+                    Err(_) => ("thread name", crate::runtime::task::thread_by_name(token)),
                 };
                 let Some(thread) = found else {
                     ctx.eprintln(&format!("'{token}' is not a valid {kind}"));
@@ -1976,12 +2040,36 @@ mod tests {
 
         // The default carries the EPICS `%06f` fraction, which chrono
         // spells `%6f`.
+        let now = chrono::Local::now();
         assert_eq!(
-            epics_strftime_to_chrono("%Y/%m/%d %H:%M:%S.%06f"),
+            epics_strftime_to_chrono("%Y/%m/%d %H:%M:%S.%06f", &now),
             "%Y/%m/%d %H:%M:%S.%6f"
         );
-        assert_eq!(epics_strftime_to_chrono("%f"), "%9f");
-        assert_eq!(epics_strftime_to_chrono("%d%%%H"), "%d%%%H");
+        assert_eq!(epics_strftime_to_chrono("%f", &now), "%9f");
+        assert_eq!(epics_strftime_to_chrono("%d%%%H", &now), "%d%%%H");
+        // C's strftime copies an unknown conversion out literally; chrono
+        // would error on it, so it becomes chrono's literal per cent.
+        assert_eq!(epics_strftime_to_chrono("%Q", &now), "%%Q");
+        assert_eq!(epics_strftime_to_chrono("a%", &now), "a%%");
+    }
+
+    /// C `date "%Q"` prints `%Q`: `strftime` copies an unknown conversion
+    /// out and cannot fail. Measured against
+    /// `~/work/epics-base/bin/linux-x86_64/softIoc`; the port panicked the
+    /// shell thread instead.
+    #[test]
+    fn an_unknown_conversion_prints_itself_instead_of_panicking() {
+        let ctx = make_ctx();
+        let mut reg = CommandRegistry::new();
+        register(&mut reg);
+        let cmd = reg.get("date").unwrap();
+        let args = parse_args(&["%Q".to_string()], &cmd.args).unwrap();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        ctx.with_output(std::fs::File::create(&path).unwrap(), || {
+            cmd.handler.call(&args, &ctx).unwrap();
+        });
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "%Q\n");
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/iocsh/misc_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/misc_commands.rs
@@ -58,24 +58,21 @@ fn cmd_ioc_build() -> CommandDef {
                 // C `iocBuild_1` (`iocInit.c:116-121`) refuses from any state
                 // but `iocVoid`.
                 ShellTransition::Refused => {
-                    crate::runtime::log::errlog_printf(&format!(
-                        "iocBuild: {} IOC can only be initialized from \
-                         uninitialized or stopped state\n",
-                        if crate::runtime::log::errlog_console_paints() {
-                            crate::runtime::log::ERL_ERROR
-                        } else {
-                            "ERROR"
-                        }
-                    ));
+                    crate::runtime::log::errlog_printf(&crate::server::ioc_app::build_refusal());
                     Ok(CommandOutcome::Failed)
                 }
-                // No `IocApplication` lifecycle to drive. On such a shell the
-                // record-load close is the whole of what a build can mean, and
-                // it is what `iocInit` does there too.
+                // No `IocApplication` lifecycle to drive — a bare
+                // `PvDatabase` shell or a `CaServerBuilder` binary. C runs
+                // `iocBuild_1` for those too, so this arm does, and the
+                // record-load close is this shell's contribution to it.
                 ShellTransition::NotOurs => {
-                    ctx.block_on(async { ctx.db().ioc_init().await });
-                    ctx.println("iocBuild: record initialization complete");
-                    Ok(CommandOutcome::Continue)
+                    if crate::server::ioc_app::build_without_application(|| {
+                        ctx.block_on(async { ctx.db().ioc_init().await });
+                    }) {
+                        Ok(CommandOutcome::Continue)
+                    } else {
+                        Ok(CommandOutcome::Failed)
+                    }
                 }
             }
         },

--- a/crates/epics-base-rs/src/server/iocsh/mod.rs
+++ b/crates/epics-base-rs/src/server/iocsh/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod misc_commands;
 mod queue_commands;
 pub mod registry;
 mod registry_commands;
+mod rtems_commands;
 mod time_commands;
 /// The iocsh *variable* table — C `iocshRegisterVariable`
 /// (`iocsh.cpp:715-765`). Public because a knob registered this way can
@@ -27,6 +28,12 @@ pub mod vars;
 /// grammar so cross-crate macLib consumers (QSRV `dbLoadGroup`) reuse it
 /// rather than duplicating a raw comma splitter.
 pub use commands::macro_defn_pairs;
+
+/// The RTEMS operator commands — C `iocshRegisterRTEMS`. Re-exported because
+/// an RTEMS IOC's `main` is the only caller: C registers them from the RTEMS
+/// boot path rather than from a registrar every IOC runs, so a hosted
+/// `softioc-rs` must not reach them.
+pub use rtems_commands::register_rtems_commands;
 
 /// Declare `registrar()` lines that a sibling crate's compiled-in feature
 /// set provides, so `dbDumpRegistrar` reports them beside this crate's own.
@@ -504,6 +511,14 @@ impl IocShell {
     /// Enter the scope of one nested script, refusing past
     /// [`MAX_SCRIPT_DEPTH`] so a self-including script errors out at the
     /// include line instead of overflowing the thread stack.
+    ///
+    /// A DELIBERATE divergence, and the only one on this path: C sets no
+    /// depth at all — `iocshBody` simply re-enters itself (`:1233`) until
+    /// the process runs out of file descriptors. Measured on
+    /// `bin/linux-x86_64/softIoc` (R7.0.10-146-g8f5015b663d764ad75df), a
+    /// chain of 400 scripts each including the next runs to the bottom
+    /// and writes nothing to stderr. Matching that would trade a named
+    /// refusal for a stack overflow, so the cap stays and says so.
     fn enter_script(&self, path: &str) -> Result<ScopeGuard<'_>, String> {
         let depth = self
             .scopes
@@ -539,7 +554,7 @@ impl IocShell {
     /// the pushed `iocshLoad` scope and the environment (`:1033` `pairs[]
     /// = {"", "environ", NULL, NULL}` → `FLAG_USE_ENVIRONMENT`,
     /// `macCore.c:130-133`, `:589-594`). `Err` is C's NULL return: macLib
-    /// reports the undefined macro (`macCore.c:911-916`) and
+    /// reports the undefined macro (`macCore.c:895-900`) and
     /// `iocsh.cpp:1184-1187` skips the line instead of running it with the
     /// placeholder text. The `.db` and ACF readers deliberately keep the
     /// lenient rule — `macCreateHandle(&h, NULL)` with a warning
@@ -570,7 +585,7 @@ impl IocShell {
         });
         // C `macDefExpand` returns `NULL` on ANY negative length, so a
         // recursive reference fails the line exactly as an undefined one
-        // does (`macCore.c:216-224`, `iocsh.cpp:1189-1192`).
+        // does (`macCore.c:216-224`, `iocsh.cpp:1184-1187`).
         (!expanded.errored()).then_some(expanded.text)
     }
 
@@ -890,7 +905,7 @@ impl IocShell {
         };
 
         // C `cvtArg` failing breaks out of the argument loop WITHOUT reaching
-        // the call (`:1284-1288`), so the `:1251` set stands.
+        // the call (`:1288-1291`), so the `:1251` set stands.
         let args = match parse_args(arg_tokens, &def.args) {
             Ok(args) => args,
             Err(e) => return (Err(e), Dispatch::Nothing),
@@ -1655,10 +1670,10 @@ fn format_show_error(source: Option<&SourceFile>, msg: &str, color: bool) -> Str
 /// A script failure, and whether the operator has been told about it.
 ///
 /// C's `iocshBody` prints every diagnostic where it happens — the open
-/// failure at `:1053-1058`, a line's at `:1189` through `showError`, the
-/// error reaction's at `:1127-1132` — and returns a bare -1, so its two
-/// callers (`<` at `:1233`, `iocshLoadCallFunc` at `:1494`) set a flag and
-/// print nothing. This port has one failure C cannot produce, the include
+/// failure at `:1053-1058`, a line's at `:1302-1303` through `showError`,
+/// the error reaction's at `:1122-1143` — and returns a bare -1, so its
+/// two callers (`<` at `:1233`, `iocshLoadCallFunc` at `:1494`) set a flag
+/// and print nothing. This port has one failure C cannot produce, the include
 /// depth cap, which nothing has printed; without this distinction a caller
 /// must either say every failure twice or swallow that one.
 enum ScriptFailure {
@@ -1802,6 +1817,17 @@ pub(crate) fn join_backslash_continuations(input: &str) -> Vec<(usize, String)> 
         }
     }
     if !current.is_empty() {
+        // A DELIBERATE divergence: C loses this line. `epicsReadline`
+        // accumulates into a buffer and, on EOF, does `free (line);
+        // return NULL;` without ever looking at how much it had
+        // (`epicsReadline.c:87-96`), so a script whose last line has no
+        // trailing newline runs every line but that one, silently.
+        // Measured on `bin/linux-x86_64/softIoc`
+        // (R7.0.10-146-g8f5015b663d764ad75df): a two-line script ending
+        // `epicsEnvShow A` with no `\n` echoes and runs only the first
+        // line; adding the newline runs both. Matching that would mean
+        // dropping an operator's command with no diagnostic anywhere, so
+        // the port runs it.
         out.push((start_line.unwrap_or(1), current));
     }
     out
@@ -1836,7 +1862,10 @@ fn parse_redirect(line: &str) -> (&str, Option<Redirect>) {
 
     let mut i = 0;
     while i < bytes.len() {
-        let syntax = scan.feed(bytes[i]);
+        // C computes the gate from the state BEFORE the byte, then lets
+        // the byte update it (`iocsh.cpp:271-273`).
+        let syntax = scan.is_syntax();
+        scan.feed(bytes[i]);
         match bytes[i] {
             b'>' if syntax => {
                 // C parity: if the char before `>` is a single ASCII
@@ -2074,7 +2103,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         // `dbLoadTemplate` with an empty subFile diagnoses and returns
-        // (C `dbLoadTemplate.y:344-347`). The message is stderr, so `2>`
+        // (C `dbLoadTemplate.y:350-352`). The message is stderr, so `2>`
         // must capture it.
         let err = dir.path().join("err.txt");
         shell
@@ -2362,13 +2391,19 @@ mod tests {
     #[test]
     fn test_execute_line_missing_required_arg() {
         let shell = make_shell();
-        // Neither `dbgf` nor `dbpf` belongs here any more: C answers a
-        // missing name with its own usage line (`dbTest.c:358-361`,
-        // `:400-403`), so both registrations mark their arguments
-        // optional. `epicsEnvSet` still declares its two required,
-        // which is what this exercises.
+        // No command has "required" arguments as far as the shell is
+        // concerned: `cvtArg` defaults every absent one and returns
+        // success (`iocsh.cpp:809-812`), so a short line always reaches
+        // the body. `epicsEnvSet` is one whose body refuses, and it does
+        // so C's way — its own sentence on stderr plus
+        // `iocshSetError(-1)` (`libComRegister.c:142-146`), which is a
+        // failed line carrying no diagnostic for the shell to frame.
         let result = shell.execute_line("epicsEnvSet");
-        assert!(result.is_err());
+        assert!(
+            matches!(result, Ok(CommandOutcome::Failed)),
+            "the shell must neither refuse the line nor frame the body's \
+             sentence"
+        );
     }
 
     /// C `epicsEnvSet` clears the shell macro of the same name before
@@ -3417,9 +3452,15 @@ mod tests {
 
         // macros non-empty x env ref present x iocshLoad (and, through
         // the third line, x `<` include).
+        // The macro list has to be quoted: C's `split()` separates on
+        // `,` as readily as on a blank (`iocsh.cpp:271`), so the bare
+        // form hands `iocshLoad` only `PORT=L0` and the rest becomes a
+        // further argument it never reads. Measured — `iocshLoad
+        // inner2.cmd PORT=L0,SUBDIR=sub` leaves `$(SUBDIR)` undefined
+        // inside the loaded script, while the quoted form defines it.
         shell
             .execute_line(&format!(
-                "iocshLoad {} PORT=L0,SUBDIR=sub",
+                "iocshLoad {} \"PORT=L0,SUBDIR=sub\"",
                 script_token(&loaded)
             ))
             .expect("iocshLoad with macros must not break env references");
@@ -3480,7 +3521,7 @@ mod tests {
     }
 
     /// I-R3-2: an undefined macro makes `macDefExpand` return NULL
-    /// (`macCore.c:911-913` + `:220`, `macEnv.c:59-61`) and
+    /// (`macCore.c:895-896` + `:220`, `macEnv.c:59-61`) and
     /// `iocsh.cpp:1184-1187` skips the line entirely. The port passed
     /// `$(P)` through as literal text and ran the command, installing a
     /// four-character literal as the IOC prefix.
@@ -3798,9 +3839,9 @@ mod tests {
     /// script failure. Measured on `softIoc` R7.0.10-146 with
     /// `nosuchcmd` / `dbl` / `exit`: stderr carries
     /// `ERROR a.cmd line 1: Command 'nosuchcmd' not registered.`, `dbl`
-    /// runs, and the process exits 0 — C leaves `ret` at its `:1037`
-    /// zero because only the Break and Halt arms (`:1127`, `:1132`)
-    /// assign it.
+    /// runs, and the process exits 0 — C leaves `ret` at its
+    /// `iocsh.cpp:1037` zero because only the Break and Halt arms
+    /// (`:1127`, `:1132`) assign it.
     #[test]
     fn an_unregistered_command_does_not_fail_the_script() {
         let shell = make_shell();
@@ -4096,7 +4137,8 @@ mod tests {
             .expect("the halted shell must be a SUSPEND row, not an OK one");
         assert!(
             halted.show_line().ends_with(" SUSPEND"),
-            "C's STATE column reads SUSPEND (osdThreadExtra.c:48-52), got {:?}",
+            "C's STATE column reads SUSPEND \
+             (os/Linux/osdThreadExtra.c:49-54), got {:?}",
             halted.show_line()
         );
         assert!(halted.resume(), "epicsThreadResume must find it suspended");

--- a/crates/epics-base-rs/src/server/iocsh/registry.rs
+++ b/crates/epics-base-rs/src/server/iocsh/registry.rs
@@ -399,12 +399,28 @@ impl CommandRegistry {
     }
 }
 
-/// Tokenize a command line supporting both C++ EPICS and space-separated syntax.
+/// Break a command line into words the way C `split()` does
+/// (`iocsh.cpp:255-376`).
 ///
-/// C++ syntax: `command("arg1", arg2, $(VAR))` — parens delimit args, commas separate.
-/// Blanks between the name and `(` are insignificant, as in C's uniform
-/// separator set (iocsh.cpp:271).
-/// Legacy syntax: `command "arg1" arg2` — whitespace separates.
+/// C has ONE separator set — `strchr(" \t(),\r", c)` (`:271`) — and no
+/// notion of two syntaxes: `cmd(a, b)`, `cmd (a, b)` and `cmd a b` are
+/// the same line to it, and a `)` or a `,` anywhere outside a quote ends
+/// a word wherever it appears. Deciding between a "call" and a "legacy"
+/// shape first, and then giving each its own splitter, is what made
+/// `dbl)` an unregistered command and `dbl , ai` a three-token line here
+/// while C ran both.
+///
+/// Quotes are removed wherever they appear rather than stripped from the
+/// ends afterwards, so `echo(a"b"c)` is the one token `abc` (measured),
+/// and a backslash is special only OUTSIDE a quote — inside one it is
+/// ordinary data, which is why `epicsEnvSet X "a\\b"` sets two
+/// backslashes and `epicsEnvSet X "hello \"world\""` is an unbalanced
+/// quote rather than an escaped one (both measured).
+///
+/// The state behind all of that is [`ShellScan`], the same instance
+/// shape [`lint_line`] and [`super::parse_redirect`] run: C keeps one
+/// `quote`/`backslash` pair and answers every question from it, so a
+/// second implementation here could only disagree with them.
 ///
 /// C parity (`iocsh.cpp:1184` `macDefExpand` → `:1215` `tokenize.split`):
 /// macros are expanded across the WHOLE line *before* it is split into
@@ -415,252 +431,48 @@ impl CommandRegistry {
 /// ([`super::IocShell::execute_line`]) owns that one expansion; this
 /// function must not perform a second one.
 pub(crate) fn tokenize(line: &str) -> Vec<String> {
-    let line = line.trim();
-    if line.is_empty() {
-        return Vec::new();
-    }
+    // Only ASCII bytes can be a separator, a quote or an escape, and
+    // every byte of a multi-byte character is >= 0x80, so one such byte
+    // stands for the whole character: classifying per character reaches
+    // the same words C reaches per byte, without ever cutting a token
+    // inside a UTF-8 sequence.
+    const NON_ASCII: u8 = 0x80;
 
-    // Find the command name: everything up to first '(' or whitespace.
-    let cmd_end = line.find([' ', '\t', '(']).unwrap_or(line.len());
-    let cmd_name = &line[..cmd_end];
-    if cmd_name.is_empty() {
-        return Vec::new();
-    }
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut inword = false;
+    let mut scan = ShellScan::default();
 
-    // The whole line was expanded once by the caller, so the tokens are
-    // pushed verbatim (no per-token substitution).
-    let mut tokens = vec![cmd_name.to_string()];
-
-    // C `split()` has one uniform separator set — `strchr(" \t(),\r", c)`
-    // (iocsh.cpp:271) — so blanks between the command name and its `(`
-    // carry no meaning there: `cmd (args)` and `cmd(args)` tokenize
-    // identically. Skip them before deciding which syntax this line uses,
-    // instead of letting a space win the race against the paren.
-    let rest = &line[cmd_end..];
-    if let Some(call_args) = rest.trim_start_matches([' ', '\t']).strip_prefix('(') {
-        // C++ syntax: command(arg1, arg2, ...)
-        let paren_end = find_closing_paren(call_args);
-        let args_str = &call_args[..paren_end];
-
-        if !args_str.trim().is_empty() {
-            for arg in split_comma_args(args_str) {
-                tokens.push(arg);
+    for ch in line.chars() {
+        let byte = if ch.is_ascii() { ch as u8 } else { NON_ASCII };
+        match scan.feed(byte) {
+            // C `:275-278` `continue`s past the word builder, so the
+            // backslash neither starts a word nor ends one.
+            SplitRole::Escape => {}
+            // C `:312-317`: a separator closes an open word and, when
+            // none is open (`:331`), is simply skipped — which is why a
+            // run of them yields no empty tokens.
+            SplitRole::Separator => {
+                if inword {
+                    tokens.push(std::mem::take(&mut current));
+                    inword = false;
+                }
+            }
+            // C `:345-346` writes nothing for the quote itself, but the
+            // word has begun: `epicsEnvSet X ""` passes an empty token,
+            // not an absent one.
+            SplitRole::Quote => inword = true,
+            SplitRole::Data => {
+                current.push(ch);
+                inword = true;
             }
         }
-    } else {
-        // Legacy space-separated syntax
-        for arg in split_space_args(rest) {
-            tokens.push(arg);
-        }
     }
-
+    // C `:353-354` terminates the word the end of the line leaves open.
+    if inword {
+        tokens.push(current);
+    }
     tokens
-}
-
-/// Find the closing ')' in a string, respecting quoted strings, `$(...)`
-/// macro references, and `${...}` macro references (which C macLib treats
-/// equivalently — see macCore.c:777). A `)` inside a `${...}` body (e.g.
-/// `${foo(bar)}`) must NOT be mistaken for the outer call's closing paren.
-/// Returns the byte offset of ')' or the string length if not found.
-///
-/// Quoting and escaping follow the same rules as `lint_line` and the
-/// splitters, so the three scanners agree on where the call ends: both
-/// `"` and `'` quote, and a backslash escapes the next character in and
-/// out of quotes (C split(), measured: `echo(a\))` prints `a)`,
-/// `echo('a)b')` prints `a)b`).
-fn find_closing_paren(s: &str) -> usize {
-    // `0` = not in a quote; otherwise the opening quote byte.
-    let mut quote = 0u8;
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        let ch = bytes[i];
-        if ch == b'\\' {
-            i += 2; // skip the escaped char too
-            continue;
-        }
-        if quote != 0 {
-            if ch == quote {
-                quote = 0;
-            }
-        } else if ch == b'"' || ch == b'\'' {
-            quote = ch;
-        } else if ch == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
-            // Skip $(...) — find the matching ')' for the macro ref
-            if let Some(end) = bytes[i + 2..].iter().position(|&c| c == b')') {
-                i += 2 + end + 1; // skip past the macro's ')'
-                continue;
-            }
-        } else if ch == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'{' {
-            // Skip ${...} — find the matching '}' for the macro ref so any
-            // ')' inside the macro body doesn't terminate the outer call.
-            if let Some(end) = bytes[i + 2..].iter().position(|&c| c == b'}') {
-                i += 2 + end + 1; // skip past the macro's '}'
-                continue;
-            }
-        } else if ch == b')' {
-            return i;
-        }
-        i += 1;
-    }
-    s.len()
-}
-
-/// Split comma-separated arguments, respecting quoted strings.
-/// Trims whitespace around each argument and strips outer quotes.
-///
-/// both `"` and `'` open a quoted string; the quote is closed
-/// only by the *same* character it was opened with — matching C
-/// `iocsh.cpp` `split()` (`if ((c == '"') || (c == '\'')) quote = c;`).
-/// Outside a quote a backslash consumes itself and takes the next
-/// character literally (`iocsh.cpp:275-278,326`): `\,` does not split,
-/// `\"` does not open a quote. Escapes are interpreted in the first
-/// pass, exactly once; the second pass only trims and strips the outer
-/// quotes of a part whose first non-blank character was a *functional*
-/// quote — an escape-produced quote is data and stays. (The previous
-/// shape re-ran escape processing in the second pass, collapsing
-/// `"a\\\\b"` twice.)
-fn split_comma_args(s: &str) -> Vec<String> {
-    // First, split on commas respecting quoted strings. `opens_quoted`
-    // remembers whether the part's first non-blank char was a functional
-    // opening quote — the only parts the second pass may strip.
-    let mut raw_parts: Vec<(String, bool)> = Vec::new();
-    let mut current = String::new();
-    let mut opens_quoted = false;
-    // `0` = not in a quote; otherwise the opening quote char.
-    let mut quote: char = '\0';
-    let mut chars = s.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if quote != '\0' {
-            if ch == '\\' {
-                if let Some(&next) = chars.peek() {
-                    match next {
-                        '"' | '\'' | '\\' => {
-                            current.push(chars.next().unwrap());
-                        }
-                        _ => {
-                            current.push(ch);
-                        }
-                    }
-                } else {
-                    current.push(ch);
-                }
-            } else if ch == quote {
-                quote = '\0';
-                current.push(ch);
-            } else {
-                current.push(ch);
-            }
-        } else if ch == '\\' {
-            // C split() outside a quote: the backslash is consumed and
-            // the next character is literal — it neither splits nor
-            // opens a quote. A trailing backslash is lint_line's
-            // "Trailing backslash." and never gets here.
-            if let Some(next) = chars.next() {
-                current.push(next);
-            }
-        } else if ch == '"' || ch == '\'' {
-            if current.chars().all(char::is_whitespace) {
-                opens_quoted = true;
-            }
-            quote = ch;
-            current.push(ch);
-        } else if ch == ',' {
-            raw_parts.push((std::mem::take(&mut current), opens_quoted));
-            opens_quoted = false;
-        } else {
-            current.push(ch);
-        }
-    }
-    raw_parts.push((current, opens_quoted));
-
-    // Now process each part: trim whitespace, then strip outer quotes.
-    let mut args = Vec::new();
-    for (part, opens_quoted) in raw_parts {
-        let trimmed = part.trim();
-        if trimmed.is_empty() && args.is_empty() {
-            continue; // skip leading empty
-        }
-        let outer_quote = trimmed
-            .chars()
-            .next()
-            .filter(|c| (*c == '"' || *c == '\'') && opens_quoted);
-        if let Some(q) = outer_quote {
-            if trimmed.len() >= 2 && trimmed.ends_with(q) {
-                args.push(trimmed[1..trimmed.len() - 1].to_string());
-                continue;
-            }
-        }
-        args.push(trimmed.to_string());
-    }
-
-    args
-}
-
-/// Split space/tab separated arguments, respecting quoted strings.
-///
-/// both `"` and `'` delimit a quoted string; the quote is closed
-/// only by the matching character — mirrors C `iocsh.cpp` `split()`.
-/// Outside a quote a backslash consumes itself and takes the next
-/// character literally (`iocsh.cpp:275-278,326`): `echo \"hello\"`
-/// yields the token `"hello"`, `a\ b` is one token `a b`.
-fn split_space_args(s: &str) -> Vec<String> {
-    let mut args = Vec::new();
-    let mut current = String::new();
-    // `0` = not in a quote; otherwise the opening quote char.
-    let mut quote: char = '\0';
-    let mut has_token = false;
-    let mut chars = s.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if quote != '\0' {
-            if ch == '\\' {
-                if let Some(&next) = chars.peek() {
-                    match next {
-                        '"' | '\'' | '\\' => {
-                            current.push(chars.next().unwrap());
-                        }
-                        _ => {
-                            current.push(ch);
-                        }
-                    }
-                } else {
-                    current.push(ch);
-                }
-            } else if ch == quote {
-                quote = '\0';
-            } else {
-                current.push(ch);
-            }
-        } else if ch == '\\' {
-            // C split() outside a quote: consume the backslash, take the
-            // next character literally — a `\"` is data, a `\ ` is not a
-            // separator. A trailing backslash is lint_line's
-            // "Trailing backslash." and never gets here.
-            if let Some(next) = chars.next() {
-                current.push(next);
-                has_token = true;
-            }
-        } else if ch == '"' || ch == '\'' {
-            quote = ch;
-            has_token = true;
-        } else if ch == ' ' || ch == '\t' {
-            if has_token {
-                args.push(std::mem::take(&mut current));
-                has_token = false;
-            }
-        } else {
-            current.push(ch);
-            has_token = true;
-        }
-    }
-
-    if has_token {
-        args.push(current);
-    }
-
-    args
 }
 
 /// Scan a command line for the malformed-input conditions C
@@ -707,31 +519,63 @@ pub(crate) struct ShellScan {
     backslash: bool,
 }
 
+/// What C `split()`'s word builder does with one byte, given the
+/// `quote`/`backslash` state before it (`iocsh.cpp:306-349`).
+pub(crate) enum SplitRole {
+    /// In C's separator set `" \t(),\r"` (`:271`) and not covered by a
+    /// quote or an escape: it closes an open word and starts none.
+    Separator,
+    /// The quote character that opened or closed a quoted run: consumed,
+    /// written to no token (`:345-346`, `:307-309`), but a word has
+    /// begun.
+    Quote,
+    /// The backslash that armed the escape (`:275-278`): consumed, and
+    /// it neither starts nor ends a word.
+    Escape,
+    /// Everything else, including any byte inside a quote and the one
+    /// byte an escape covers — appended to the current word.
+    Data,
+}
+
 impl ShellScan {
-    /// Feed the next byte and report whether it is SYNTAX — C's
-    /// `!quote && !backslash`. Quote characters, escapes and everything
-    /// they cover are data and answer `false`.
-    pub(crate) fn feed(&mut self, c: u8) -> bool {
+    /// C's `!quote && !backslash` (`:271`, `:273`, `:311`) for the byte
+    /// about to be fed — the gate every syntactic decision in `split()`
+    /// sits behind. Read it BEFORE [`Self::feed`] consumes the byte.
+    pub(crate) fn is_syntax(&self) -> bool {
+        self.quote == 0 && !self.backslash
+    }
+
+    /// Feed the next byte and report what C's loop does with it.
+    pub(crate) fn feed(&mut self, c: u8) -> SplitRole {
         if self.backslash {
+            // C `:325-327`: whatever it is, the escaped byte is data,
+            // and `:350` clears the flag.
             self.backslash = false;
-            return false;
+            return SplitRole::Data;
         }
         if self.quote != 0 {
+            // C `:307-309`: only the byte that opened the quote closes
+            // it. Everything else inside is data — a backslash included,
+            // because `:273` sits inside the `!quote` block and never
+            // arms one here.
             if c == self.quote {
                 self.quote = 0;
+                return SplitRole::Quote;
             }
-            return false;
+            return SplitRole::Data;
         }
         match c {
             b'\\' => {
                 self.backslash = true;
-                false
+                SplitRole::Escape
             }
             b'"' | b'\'' => {
                 self.quote = c;
-                false
+                SplitRole::Quote
             }
-            _ => true,
+            // C `:271`, in full and in order.
+            b' ' | b'\t' | b'(' | b')' | b',' | b'\r' => SplitRole::Separator,
+            _ => SplitRole::Data,
         }
     }
 
@@ -744,15 +588,32 @@ impl ShellScan {
     }
 }
 
+/// Why C `cvtArg` refused an `iocshArgInt` token. C has two sentences
+/// here and reaches them from two different conditions, so one error
+/// value cannot stand for both: [`IntArgError::OutOfRange`] is the arm
+/// where `strtol` AND the `strtoul` retry under it both set `ERANGE`
+/// (`iocsh.cpp:824-831`), and [`IntArgError::Invalid`] is the `*endp`
+/// arm below that (`:833-837`). C returns from the range arm before it
+/// ever looks at `*endp`, so trailing garbage cannot downgrade an
+/// out-of-range value to an invalid one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum IntArgError {
+    /// C `iocsh.cpp:833-837` — `strtol` left characters unconsumed.
+    Invalid,
+    /// C `iocsh.cpp:824-831` — the value fits neither `long` nor
+    /// `unsigned long`.
+    OutOfRange,
+}
+
 /// Parse an `iocshArgInt` token the way C `cvtArg` does
-/// (`iocsh.cpp:814-836`): `strtol(arg, &endp, 0)`. Base-0 means a
+/// (`iocsh.cpp:820-842`): `strtol(arg, &endp, 0)`. Base-0 means a
 /// `0x`/`0X` prefix is hex and a leading `0` is octal — so `dbpr REC 010`
 /// is 8, not 10, and `postEvent 0x10` is 16, not an error. On signed
 /// overflow C retries with `strtoul` (`0xFFFFFFFFFFFFFFFF` → the same
 /// bit pattern reinterpreted into the signed `long`), and an empty arg
 /// defaults to 0. Trailing non-numeric characters are rejected, matching
 /// C's `if (*endp)` "Invalid integer" check.
-pub(super) fn parse_iocsh_int(token: &str) -> Result<i64, ()> {
+pub(super) fn parse_iocsh_int(token: &str) -> Result<i64, IntArgError> {
     // C `if (arg && *arg)` — an empty token defaults to 0.
     if token.is_empty() {
         return Ok(0);
@@ -762,7 +623,7 @@ pub(super) fn parse_iocsh_int(token: &str) -> Result<i64, ()> {
     if s.is_empty() {
         // Whitespace-only: strtol converts nothing and leaves *endp set
         // → C reports "Invalid integer".
-        return Err(());
+        return Err(IntArgError::Invalid);
     }
     let (neg, body) = match s.as_bytes()[0] {
         b'-' => (true, &s[1..]),
@@ -770,7 +631,7 @@ pub(super) fn parse_iocsh_int(token: &str) -> Result<i64, ()> {
         _ => (false, s),
     };
     // Base-0 prefix detection on the unsigned magnitude.
-    let (radix, digits): (u32, &str) =
+    let (radix, rest): (u32, &str) =
         if let Some(hex) = body.strip_prefix("0x").or_else(|| body.strip_prefix("0X")) {
             (16, hex)
         } else if body.len() > 1 && body.starts_with('0') {
@@ -780,20 +641,96 @@ pub(super) fn parse_iocsh_int(token: &str) -> Result<i64, ()> {
         } else {
             (10, body)
         };
+    // `strtol` converts the LONGEST valid prefix and points `endp` at the
+    // first character it could not use, so the digit run and what follows
+    // it are two separate facts: the run alone decides `ERANGE`, the
+    // leftover alone decides `*endp`. Reading them as one — parsing the
+    // whole tail and calling any failure the same thing — is what made
+    // `99999999999999999999abc` "invalid" here where C calls it out of
+    // range.
+    let run_len = rest
+        .find(|c: char| !c.is_digit(radix))
+        .unwrap_or(rest.len());
+    let (digits, leftover) = rest.split_at(run_len);
     if digits.is_empty() {
-        // e.g. a bare sign, or `0x` with no hex digits.
-        return Err(());
+        // strtol converted nothing — a bare sign, `0x` with no hex digit,
+        // octal `08` — so `endp == arg` and C takes the `*endp` arm.
+        return Err(IntArgError::Invalid);
     }
     // Signed first; on overflow fall back to unsigned (C `strtol`
     // ERANGE → `strtoul`) and reinterpret the bit pattern into the
-    // signed result exactly as C stores it in `long ival`. An invalid
-    // digit fails both parses → error (matches C's `*endp` check, e.g.
-    // octal `08`).
+    // signed result exactly as C stores it in `long ival`. `digits` holds
+    // only characters valid for the radix, so the unsigned parse can fail
+    // for one reason: the magnitude does not fit.
     let parsed = match i64::from_str_radix(digits, radix) {
         Ok(v) => v,
-        Err(_) => u64::from_str_radix(digits, radix).map_err(|_| ())? as i64,
+        Err(_) => u64::from_str_radix(digits, radix).map_err(|_| IntArgError::OutOfRange)? as i64,
     };
+    if !leftover.is_empty() {
+        return Err(IntArgError::Invalid);
+    }
     Ok(if neg { parsed.wrapping_neg() } else { parsed })
+}
+
+/// C `epicsStrtod(s, &endp)` under the `*endp == '\0'` whole-token check
+/// both of its iocsh callers apply — `cvtArg`'s double arm
+/// (`iocsh.cpp:844-856`) and `varHandler`'s (`:1431-1442`). One owner
+/// here because C has one function: a second port could only disagree
+/// with this one about which arguments the shell accepts.
+///
+/// Rust's own `f64` parser takes the decimal, exponent, `inf` and `nan`
+/// spellings C's does, but not the C99 hex form — which glibc's `strtod`
+/// accepts, so C accepts it too. Measured on `bin/linux-x86_64/softIoc`
+/// (R7.0.10-146-g8f5015b663d764ad75df): `var seqDLYlimit 0x10` leaves
+/// the variable reading `double seqDLYlimit = 16`, `var seqDLYlimit
+/// 0x1p3` leaves it at 8, and `epicsThreadSleep 0x10` sleeps 16.32 s.
+/// The hex arm below is that form; every other spelling goes to Rust's
+/// parser.
+pub(super) fn epics_strtod_whole(token: &str) -> Option<f64> {
+    // C's `strtod` skips leading whitespace before it converts anything,
+    // so a quoted `" 1"` is 1 to C and must be here.
+    let s = token.trim_start();
+    if s.is_empty() {
+        return None;
+    }
+    let (neg, body) = match s.as_bytes()[0] {
+        b'-' => (true, &s[1..]),
+        b'+' => (false, &s[1..]),
+        _ => (false, s),
+    };
+    let Some(hex) = body.strip_prefix("0x").or_else(|| body.strip_prefix("0X")) else {
+        return s.parse::<f64>().ok();
+    };
+    let (digits, exponent) = match hex.split_once(['p', 'P']) {
+        Some((digits, exponent)) => (digits, Some(exponent)),
+        None => (hex, None),
+    };
+    let (int_part, frac_part) = digits.split_once('.').unwrap_or((digits, ""));
+    if int_part.is_empty() && frac_part.is_empty() {
+        // `0x` with no hex digit: C's `strtod` converts the leading `0`
+        // and leaves `endp` on the `x`, which the whole-token check
+        // rejects.
+        return None;
+    }
+    let mut value = 0.0f64;
+    for c in int_part.chars() {
+        value = value * 16.0 + f64::from(c.to_digit(16)?);
+    }
+    let mut scale = 1.0f64 / 16.0;
+    for c in frac_part.chars() {
+        value += f64::from(c.to_digit(16)?) * scale;
+        scale /= 16.0;
+    }
+    if let Some(exponent) = exponent {
+        // `p<exp>` is a power of TWO, and C wants at least one decimal
+        // digit after it — without one `strtod` stops before the `p` and
+        // the whole-token check refuses the argument. The clamp only
+        // saturates to the infinity and the zero C's `strtod` returns
+        // for an exponent that far out.
+        let exponent = exponent.parse::<i64>().ok()?.clamp(-4096, 4096) as i32;
+        value *= 2f64.powi(exponent);
+    }
+    Some(if neg { -value } else { value })
 }
 
 /// Parse tokens into argument values according to argument descriptors.
@@ -841,15 +778,23 @@ pub(crate) fn parse_args(tokens: &[String], descs: &[ArgDesc]) -> Result<Vec<Arg
             // into the same default as an absent one. Only a non-empty
             // token that fails to parse is an error.
             ArgType::Int | ArgType::Double if token.is_empty() => ArgValue::Missing,
-            ArgType::Int => parse_iocsh_int(token).map(ArgValue::Int).map_err(|_| {
-                format!(
-                    "argument '{}': expected integer, got '{}'",
-                    desc.name, token
-                )
-            })?,
-            ArgType::Double => token.parse::<f64>().map(ArgValue::Double).map_err(|_| {
-                format!("argument '{}': expected number, got '{}'", desc.name, token)
-            })?,
+            // The sentence is C's own, and quotes the offending VALUE and
+            // nothing else. C names no argument here: `cvtArg` is handed
+            // the `iocshArg` but reads only its `type`
+            // (`iocsh.cpp:813-819`), so the name never reaches the text.
+            // The frame `showError` puts around it — `ERROR <file> line
+            // <n>: ` — already says which line, and adding the parameter
+            // name is the only thing on this stream that stops a site
+            // script's grep from matching.
+            ArgType::Int => parse_iocsh_int(token)
+                .map(ArgValue::Int)
+                .map_err(|why| match why {
+                    IntArgError::OutOfRange => format!("Integer '{token}' out of range."),
+                    IntArgError::Invalid => format!("Invalid integer '{token}'."),
+                })?,
+            ArgType::Double => epics_strtod_whole(token)
+                .map(ArgValue::Double)
+                .ok_or_else(|| format!("Invalid double '{token}'."))?,
             // Handled above: an `Argv` parameter never reaches the
             // one-token path.
             ArgType::Argv => unreachable!(),
@@ -880,17 +825,32 @@ mod tests {
         );
     }
 
+    /// C arms the backslash inside `if (!quote && !backslash)`
+    /// (`iocsh.cpp:273-278`), so within a quoted run a backslash is
+    /// ordinary data and the very next byte still closes the quote if it
+    /// matches. Measured on `bin/linux-x86_64/softIoc`
+    /// (R7.0.10-146-g8f5015b663d764ad75df) through `epicsEnvSet` +
+    /// `epicsEnvShow`, which pass their argument on untranslated where
+    /// `echo` would run it through `dbTranslateEscape`:
+    /// `epicsEnvSet X "a\\b"` → `X=a\\b`, and
+    /// `epicsEnvSet("X", "a\\\\b")` → `X=a\\\\b`.
     #[test]
-    fn test_tokenize_escaped_quotes() {
-        assert_eq!(
-            tokenize(r#"cmd "hello \"world\"""#),
-            vec!["cmd", r#"hello "world""#]
-        );
+    fn a_backslash_inside_a_quote_is_data() {
+        assert_eq!(tokenize(r#"cmd "a\\b""#), vec!["cmd", r#"a\\b"#]);
+        assert_eq!(tokenize(r#"cmd("a\\\\b")"#), vec!["cmd", r#"a\\\\b"#]);
     }
 
+    /// The same rule read from the other side: `\"` inside a quoted run
+    /// does not escape the quote, so the quote closes there and the one
+    /// that follows `world` opens a run nothing closes. Measured —
+    /// `epicsEnvSet X "hello \"world\""` answers `ERROR u1.cmd line 1:
+    /// Unbalanced quote.` and sets nothing.
     #[test]
-    fn test_tokenize_escaped_backslash() {
-        assert_eq!(tokenize(r#"cmd "a\\b""#), vec!["cmd", r#"a\b"#]);
+    fn an_escaped_quote_inside_a_quote_leaves_the_line_unbalanced() {
+        assert_eq!(
+            lint_line(r#"cmd "hello \"world\"""#),
+            Some("Unbalanced quote.")
+        );
     }
 
     /// C split() outside a quote (iocsh.cpp:275-278,326): the backslash
@@ -917,14 +877,6 @@ mod tests {
         // passed them and the splitters then mis-parsed.
         assert_eq!(lint_line(r#"echo \"hello\""#), None);
         assert_eq!(lint_line(r#"echo(a\,b)"#), None);
-    }
-
-    /// Escapes are interpreted exactly once: the call splitter's second
-    /// pass no longer re-processes them, so an in-quote `\\\\` (four
-    /// backslashes in the script) yields two, not one.
-    #[test]
-    fn call_syntax_escapes_are_not_double_processed() {
-        assert_eq!(tokenize(r#"cmd("a\\\\b")"#), vec!["cmd", r#"a\\b"#]);
     }
 
     #[test]
@@ -990,6 +942,31 @@ mod tests {
             tokenize(r#"dbLoadRecords("path/to/file.db","P=SIM1:,R=cam1:")"#),
             vec!["dbLoadRecords", "path/to/file.db", "P=SIM1:,R=cam1:"]
         );
+    }
+
+    /// C has one separator set and applies it everywhere, so a `)` or a
+    /// `,` outside a quote ends a word wherever it stands — there is no
+    /// "call syntax" for it to be inside of. Measured on
+    /// `bin/linux-x86_64/softIoc` (R7.0.10-146-g8f5015b663d764ad75df),
+    /// each line its own script against an empty database: `dbl)` and
+    /// `dbl , ai` both print nothing and raise nothing, where this port
+    /// answered `Command 'dbl)' not registered.` and passed `,` as a
+    /// record type; `echo(a"b"c)` prints `abc`, so a quote is removed
+    /// wherever it sits and not merely stripped off the ends; and
+    /// `echo(a,,b)` prints `a`, so a run of separators yields no empty
+    /// argument between them.
+    #[test]
+    fn one_separator_set_applies_off_the_call_shape_too() {
+        assert_eq!(tokenize("dbl)"), vec!["dbl"]);
+        assert_eq!(tokenize("dbl )"), vec!["dbl"]);
+        assert_eq!(tokenize("dbl , ai"), vec!["dbl", "ai"]);
+        assert_eq!(tokenize(r#"echo(a"b"c)"#), vec!["echo", "abc"]);
+        assert_eq!(tokenize(r#"echo "a"b"c""#), vec!["echo", "abc"]);
+        assert_eq!(tokenize("echo(a,,b)"), vec!["echo", "a", "b"]);
+        // An opening quote begins a word even when it closes at once, so
+        // an empty argument stays distinguishable from an absent one —
+        // `cvtArg` keeps `""` and NULL apart (`iocsh.cpp:858-862`).
+        assert_eq!(tokenize(r#"cmd "" x"#), vec!["cmd", "", "x"]);
     }
 
     #[test]
@@ -1176,12 +1153,101 @@ mod tests {
         assert_eq!(parse_iocsh_int("0xFFFFFFFFFFFFFFFF"), Ok(-1));
         assert_eq!(parse_iocsh_int("18446744073709551615"), Ok(-1));
         // Errors: trailing garbage, invalid octal digit, bare/oversized.
-        assert!(parse_iocsh_int("10abc").is_err());
-        assert!(parse_iocsh_int("08").is_err());
-        assert!(parse_iocsh_int("0x").is_err());
-        assert!(parse_iocsh_int("0x1FFFFFFFFFFFFFFFF").is_err());
-        assert!(parse_iocsh_int("   ").is_err());
-        assert!(parse_iocsh_int("abc").is_err());
+        // Which of C's two sentences each one earns is the point — C
+        // returns from the `ERANGE` arm before the `*endp` check, so a
+        // magnitude that fits neither `long` nor `unsigned long` is out
+        // of range even when garbage follows it.
+        assert_eq!(parse_iocsh_int("10abc"), Err(IntArgError::Invalid));
+        assert_eq!(parse_iocsh_int("08"), Err(IntArgError::Invalid));
+        assert_eq!(parse_iocsh_int("0x"), Err(IntArgError::Invalid));
+        assert_eq!(parse_iocsh_int("   "), Err(IntArgError::Invalid));
+        assert_eq!(parse_iocsh_int("abc"), Err(IntArgError::Invalid));
+        assert_eq!(
+            parse_iocsh_int("0x1FFFFFFFFFFFFFFFF"),
+            Err(IntArgError::OutOfRange)
+        );
+        assert_eq!(
+            parse_iocsh_int("99999999999999999999"),
+            Err(IntArgError::OutOfRange)
+        );
+        assert_eq!(
+            parse_iocsh_int("99999999999999999999abc"),
+            Err(IntArgError::OutOfRange)
+        );
+        // `LONG_MIN` itself is in range for `strtol`, and reaches the
+        // same value here through the unsigned retry.
+        assert_eq!(parse_iocsh_int("-9223372036854775808"), Ok(i64::MIN));
+    }
+
+    /// C `cvtArg` quotes the offending VALUE and never the parameter
+    /// name, and its integer refusal has two distinct sentences
+    /// (`iocsh.cpp:824-831`, `:833-837`). Measured on
+    /// `bin/linux-x86_64/softIoc` (R7.0.10-146-g8f5015b663d764ad75df):
+    /// `dbpr A1 notanumber` → `ERROR c.cmd line 1: Invalid integer
+    /// 'notanumber'.`, `dbpr A1 99999999999999999999` → `ERROR c.cmd
+    /// line 1: Integer '99999999999999999999' out of range.`,
+    /// `epicsThreadSleep 0.1abc` → `ERROR c.cmd line 1: Invalid double
+    /// '0.1abc'.`
+    #[test]
+    fn numeric_refusals_are_cs_own_sentences() {
+        let int_desc = vec![ArgDesc {
+            name: "level",
+            arg_type: ArgType::Int,
+        }];
+        assert_eq!(
+            parse_args(&["notanumber".to_string()], &int_desc).unwrap_err(),
+            "Invalid integer 'notanumber'."
+        );
+        assert_eq!(
+            parse_args(&["99999999999999999999".to_string()], &int_desc).unwrap_err(),
+            "Integer '99999999999999999999' out of range."
+        );
+        let double_desc = vec![ArgDesc {
+            name: "seconds",
+            arg_type: ArgType::Double,
+        }];
+        assert_eq!(
+            parse_args(&["0.1abc".to_string()], &double_desc).unwrap_err(),
+            "Invalid double '0.1abc'."
+        );
+    }
+
+    /// `epicsStrtod` is glibc's `strtod` here, so C takes the C99 hex
+    /// form. Measured on `bin/linux-x86_64/softIoc`
+    /// (R7.0.10-146-g8f5015b663d764ad75df): `var seqDLYlimit 0x10` then
+    /// `var seqDLYlimit` prints `double seqDLYlimit = 16`, `0x1p3`
+    /// prints `8`, `inf` prints `inf`, and `epicsThreadSleep 0x10`
+    /// sleeps 16.32 s rather than raising `Invalid double '0x10'.`
+    #[test]
+    fn epics_strtod_takes_cs_hex_form() {
+        assert_eq!(epics_strtod_whole("0x10"), Some(16.0));
+        assert_eq!(epics_strtod_whole("0X10"), Some(16.0));
+        assert_eq!(epics_strtod_whole("0x1p3"), Some(8.0));
+        assert_eq!(epics_strtod_whole("-0x1.8p1"), Some(-3.0));
+        assert_eq!(epics_strtod_whole("0x.8"), Some(0.5));
+        assert_eq!(epics_strtod_whole("inf"), Some(f64::INFINITY));
+        assert!(epics_strtod_whole("nan").is_some_and(f64::is_nan));
+        // The decimal spellings are unchanged.
+        assert_eq!(epics_strtod_whole("0.5"), Some(0.5));
+        assert_eq!(epics_strtod_whole("1e3"), Some(1000.0));
+        assert_eq!(epics_strtod_whole(" 1"), Some(1.0));
+        // `strtod` stops where the token stops being a number, and the
+        // whole-token check then refuses it.
+        assert_eq!(epics_strtod_whole("0.1abc"), None);
+        assert_eq!(epics_strtod_whole("0x"), None);
+        assert_eq!(epics_strtod_whole("0x1p"), None);
+        assert_eq!(epics_strtod_whole("0x1g"), None);
+        assert_eq!(epics_strtod_whole(""), None);
+        // The one port serves both callers, so `var` agrees with the
+        // argument converter about what a double is.
+        let descs = vec![ArgDesc {
+            name: "seconds",
+            arg_type: ArgType::Double,
+        }];
+        assert!(matches!(
+            parse_args(&["0x10".to_string()], &descs).unwrap()[0],
+            ArgValue::Double(v) if v == 16.0
+        ));
     }
 
     #[test]

--- a/crates/epics-base-rs/src/server/iocsh/rtems_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/rtems_commands.rs
@@ -1,0 +1,419 @@
+//! The operator commands EPICS base registers from `iocshRegisterRTEMS`
+//! (`libcom/RTEMS/posix/rtems_init.c:692-705` @R7.0.10).
+//!
+//! Five of base's six: `netstat`, `heapSpace`, `zoneset`, `rt` and
+//! `setlogmask`. The sixth, `nfsMount`, names an API that does not exist on
+//! the network stack this port targets — see
+//! [`epics_rtems_boot::shell`] for the argument, which is where the rest of
+//! the reasoning about these commands lives too.
+//!
+//! # Why this file is not reached from `register_builtins`
+//!
+//! C registers these from `iocshRegisterRTEMS`, which the RTEMS boot path
+//! calls — not from a `*IocRegister.c` that every IOC runs. An IOC has them
+//! because it booted on RTEMS, so the port hooks them the same way:
+//! [`register_rtems_commands`] is called by the RTEMS IOC binaries' `main`
+//! and by nothing else. A hosted `softioc-rs` does not grow the names, exactly
+//! as a Linux `softIoc` does not.
+//!
+//! That is a different rule from `ClockTime_Init`/`ClockTime_Shutdown` in
+//! `time_commands.rs`, which C registers from libCom's own initialisation
+//! under `#if defined(vxWorks) || defined(__rtems__)` — a compile-time OS
+//! condition, ported as one. Two C mechanisms, two seats.
+//!
+//! # Where the work happens
+//!
+//! The behaviour is `epics_rtems_boot`'s: it owns the RTEMS and libbsd calls,
+//! and it is the crate the RTEMS image already links. This file is the shell
+//! face — argument descriptors, C's usage text, C's diagnostics — and it lives
+//! here because [`CommandDef`] is this crate's type and `epics-rtems-boot` is
+//! one of its dependencies. **Deviation, forced:** the brief's literal reading
+//! puts the whole command in `epics-rtems-boot`; a `CommandDef` there would be
+//! a dependency cycle.
+//!
+//! # Output routing
+//!
+//! `heapSpace` and `setlogmask` print through [`CommandContext`], so a `>`
+//! redirect in the shell captures them. C's callbacks use `printf`, which
+//! writes to the process's stdout and is *not* what `epicsGetThreadStdout`
+//! redirects — so this port's output is redirectable where base's is not.
+//! `netstat` and `rt` are not: their text is written by C code inside libbsd
+//! and the RTEMS shell, straight to descriptor 1, on both this port and base.
+
+use epics_rtems_boot::shell::{self, ShellError};
+use epics_rtems_boot::stats::{self, HeapSpace};
+
+use super::registry::*;
+
+/// Register the RTEMS operator commands on the process command table — C
+/// `iocshRegisterRTEMS` (`rtems_init.c:692-705`).
+///
+/// Call it from an RTEMS IOC's `main`, before the shell starts. C calls
+/// `rtems_shell_init_environment()` here as its last act (`:704`); this port
+/// does that inside the `rt` lookup instead, so the ordering holds by
+/// construction rather than by remembering to register in the right order.
+pub fn register_rtems_commands() {
+    for def in rtems_command_defs() {
+        super::register_command(def);
+    }
+}
+
+/// The definitions, in C's registration order.
+///
+/// Split out from [`register_rtems_commands`] so the set can be tested on a
+/// host, where the process command table is a hosted IOC's and must not grow
+/// these names.
+fn rtems_command_defs() -> Vec<CommandDef> {
+    vec![
+        cmd_netstat(),
+        cmd_heap_space(),
+        cmd_zoneset(),
+        cmd_rt(),
+        cmd_setlogmask(),
+    ]
+}
+
+/// `netstat <level>` — C `netStatFuncDef`/`netStatCallFunc`
+/// (`rtems_init.c:545-551`).
+///
+/// C's callback has no failure path: `rtems_netstat` returns nothing and the
+/// command is registered without `iocshSetError`. The only failure here is a
+/// build with no RTEMS behind it, which the registration above cannot produce.
+fn cmd_netstat() -> CommandDef {
+    CommandDef::new(
+        "netstat",
+        vec![ArgDesc {
+            name: "level",
+            arg_type: ArgType::Int,
+        }],
+        "show network status",
+        |args: &[ArgValue], _ctx: &CommandContext| {
+            let level = match args.first() {
+                Some(ArgValue::Int(n)) => *n as i32,
+                _ => 0,
+            };
+            shell::netstat(level).map_err(|e| e.to_string())?;
+            Ok(CommandOutcome::Continue)
+        },
+    )
+}
+
+/// `heapSpace` — C `heapSpaceFuncDef`/`heapSpaceCallFunc`
+/// (`rtems_init.c:562-590`).
+fn cmd_heap_space() -> CommandDef {
+    CommandDef::new(
+        "heapSpace",
+        vec![],
+        "show malloc statistic",
+        |_args: &[ArgValue], ctx: &CommandContext| {
+            let Some(heap) = stats::heap_space() else {
+                return Err("heapSpace: no malloc statistics on this build".to_string());
+            };
+            ctx.print_fmt(format_args!("{}", heap_space_line(heap)));
+            Ok(CommandOutcome::Continue)
+        },
+    )
+}
+
+/// C's one line of `heapSpace` output, byte for byte
+/// (`rtems_init.c:573-577`).
+///
+/// Pure, so the two branches and their boundary are testable on a host that
+/// has no heap to read.
+///
+/// The number is [`HeapSpace::free`] — C's
+/// `size - (lifetime_allocated - lifetime_freed)`, computed there in `double`
+/// after an unsigned subtraction and here saturating, which is the deviation
+/// `HeapSpace::free` documents.
+fn heap_space_line(heap: HeapSpace) -> String {
+    let free = heap.free() as f64;
+    // C's threshold and its two units. `%.1f` in both arms.
+    if free >= (1024 * 1024) as f64 {
+        format!("Heap space: {:.1} MB", free / (1024.0 * 1024.0))
+    } else {
+        format!("Heap space: {:.1} kB", free / 1024.0)
+    }
+}
+
+/// `zoneset <zone string>` — C `zonesetFuncDef`/`zonesetCallFunc`
+/// (`rtems_init.c:637-647`).
+///
+/// C's `zoneset` returns non-zero only when `setenv`/`unsetenv` fails, which
+/// `iocshSetError` then fails the line on.
+fn cmd_zoneset() -> CommandDef {
+    CommandDef::new(
+        "zoneset",
+        vec![ArgDesc {
+            name: "zone string",
+            arg_type: ArgType::String,
+        }],
+        "set timezone (obsolete?)",
+        |args: &[ArgValue], _ctx: &CommandContext| {
+            // C reads `args[0].sval`, which is NULL when the line ended
+            // before this argument — that is the branch that unsets TZ.
+            let zone = match args.first() {
+                Some(ArgValue::String(s)) => Some(s.as_str()),
+                _ => None,
+            };
+            // SAFETY: `zoneset` writes the environment, which is unsound while
+            // another thread reads it. This is C's hazard unchanged: base's
+            // `zonesetCallFunc` calls `setenv` from the shell thread of a
+            // running IOC. The operator typing it is asserting the same thing
+            // base's operator asserts.
+            unsafe { shell::zoneset(zone) }.map_err(|e| e.to_string())?;
+            Ok(CommandOutcome::Continue)
+        },
+    )
+}
+
+/// `rt <cmd> <args...>` — C `rtshellFuncDef`/`rtshellCallFunc`
+/// (`rtems_init.c:495-523`).
+///
+/// C's `args[1].aval` starts at the token that named the shell command, so
+/// `av[0]` is that name and `ac` counts it. This port's [`ArgValue::Argv`]
+/// carries the tokens *after* the descriptors that precede it, so the name has
+/// to be put back at the front — see
+/// [`epics_rtems_boot::shell::run_shell_command`], whose contract is that
+/// `argv[0]` is the command name.
+fn cmd_rt() -> CommandDef {
+    CommandDef::new(
+        "rt",
+        vec![
+            ArgDesc {
+                name: "cmd",
+                arg_type: ArgType::String,
+            },
+            ArgDesc {
+                name: "args",
+                arg_type: ArgType::Argv,
+            },
+        ],
+        "run rtems shell command",
+        |args: &[ArgValue], _ctx: &CommandContext| {
+            let argv = rt_argv(args);
+            match shell::run_shell_command(&argv) {
+                // C `iocshSetError(ret)` plus `if(ret) fprintf(stderr, ...)`.
+                Ok(0) => Ok(CommandOutcome::Continue),
+                Ok(status) => Err(format!("ERR: {status}")),
+                // C `rtems_shell_lookup_cmd` returning NULL, including the
+                // NULL name a bare `rt` hands it.
+                Err(ShellError::NoSuchCommand) => Err("ERR: No such command".to_string()),
+                Err(other) => Err(other.to_string()),
+            }
+        },
+    )
+}
+
+/// C's `argv` for the shell command: the name first, then the rest of the
+/// line.
+///
+/// Its own function so the reconstruction is testable without a shell — this
+/// is the one place the two argv conventions meet, and a handler that got it
+/// wrong would silently drop the shell command's first argument.
+fn rt_argv(args: &[ArgValue]) -> Vec<String> {
+    let mut argv = Vec::new();
+    if let Some(ArgValue::String(cmd)) = args.first() {
+        argv.push(cmd.clone());
+    }
+    if let Some(ArgValue::Argv(rest)) = args.get(1) {
+        argv.extend(rest.iter().cloned());
+    }
+    argv
+}
+
+/// `setlogmask <level name>` — C `setlogmaskFuncDef`/`setlogmaskCallFunc`
+/// (`rtems_init.c:655-686`).
+///
+/// With no argument C prints the usage and the level names and does *not*
+/// fail the line; with an unknown name it prints one line and fails.
+fn cmd_setlogmask() -> CommandDef {
+    CommandDef::new(
+        "setlogmask",
+        vec![ArgDesc {
+            name: "level name",
+            arg_type: ArgType::String,
+        }],
+        "Set syslog() threshold level",
+        |args: &[ArgValue], ctx: &CommandContext| {
+            let Some(ArgValue::String(name)) = args.first() else {
+                ctx.print_fmt(format_args!(
+                    "{}",
+                    setlogmask_usage(&shell::log_priority_names())
+                ));
+                return Ok(CommandOutcome::Continue);
+            };
+            match shell::set_log_priority(name) {
+                Ok(()) => Ok(CommandOutcome::Continue),
+                // C prints this and calls `iocshSetError(-1)`.
+                Err(ShellError::UnknownLevel) => Err("Error: unknown log level.".to_string()),
+                Err(other) => Err(other.to_string()),
+            }
+        },
+    )
+}
+
+/// C's no-argument `setlogmask` output (`rtems_init.c:665-671`), without the
+/// trailing newline [`CommandContext::print_fmt`] adds.
+fn setlogmask_usage(levels: &[String]) -> String {
+    let mut out = String::from("Usage: setlogmask <level>\n\n  Level names:");
+    for level in levels {
+        out.push_str("\n    ");
+        out.push_str(level);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// C's six minus `nfsMount`, under C's names and C's arities. A name or an
+    /// arity that drifts here is a command an operator's existing script stops
+    /// finding.
+    #[test]
+    fn the_set_is_c_s_names_and_arities() {
+        let defs = rtems_command_defs();
+        let shape: Vec<(String, usize)> = defs
+            .iter()
+            .map(|d| (d.name.clone(), d.args.len()))
+            .collect();
+        assert_eq!(
+            shape,
+            vec![
+                ("netstat".to_string(), 1),
+                ("heapSpace".to_string(), 0),
+                ("zoneset".to_string(), 1),
+                ("rt".to_string(), 2),
+                ("setlogmask".to_string(), 1),
+            ],
+            "C `iocshRegisterRTEMS` order, names and argument counts"
+        );
+    }
+
+    /// `nfsMount` must stay out. Registering a name whose implementation
+    /// cannot exist would put it in `help`, which is worse than its absence —
+    /// see `epics_rtems_boot::shell` for why the API is gone.
+    #[test]
+    fn nfs_mount_is_not_registered() {
+        assert!(!rtems_command_defs().iter().any(|d| d.name == "nfsMount"));
+    }
+
+    /// C's usage strings verbatim, because `help` prints them.
+    #[test]
+    fn the_usage_text_is_c_s() {
+        let defs = rtems_command_defs();
+        let usage = |name: &str| {
+            defs.iter()
+                .find(|d| d.name == name)
+                .expect("registered above")
+                .usage
+                .clone()
+        };
+        assert_eq!(usage("netstat"), "show network status");
+        assert_eq!(usage("heapSpace"), "show malloc statistic");
+        assert_eq!(usage("zoneset"), "set timezone (obsolete?)");
+        assert_eq!(usage("rt"), "run rtems shell command");
+        assert_eq!(usage("setlogmask"), "Set syslog() threshold level");
+    }
+
+    /// C's argument names and types, which `help` renders into the synopsis
+    /// line an operator reads.
+    #[test]
+    fn the_argument_descriptors_are_c_s() {
+        let defs = rtems_command_defs();
+        let arg = |name: &str, i: usize| {
+            let d = defs.iter().find(|d| d.name == name).expect("registered");
+            (
+                d.args[i].name,
+                format!("{:?}", d.args[i].arg_type).to_string(),
+            )
+        };
+        assert_eq!(arg("netstat", 0), ("level", "Int".to_string()));
+        assert_eq!(arg("zoneset", 0), ("zone string", "String".to_string()));
+        assert_eq!(arg("rt", 0), ("cmd", "String".to_string()));
+        assert_eq!(arg("rt", 1), ("args", "Argv".to_string()));
+        assert_eq!(arg("setlogmask", 0), ("level name", "String".to_string()));
+    }
+
+    /// The unit boundary is C's `x >= 1024*1024`, and the number is C's
+    /// `size - (allocated - freed)`.
+    #[test]
+    fn the_heap_space_line_is_c_s_two_branches() {
+        let heap = |free: u64| HeapSpace {
+            size: free,
+            lifetime_allocated: 0,
+            lifetime_freed: 0,
+        };
+        assert_eq!(
+            heap_space_line(heap(1024 * 1024)),
+            "Heap space: 1.0 MB",
+            "the boundary itself is the MB branch in C"
+        );
+        assert_eq!(
+            heap_space_line(heap(1024 * 1024 - 1)),
+            "Heap space: 1024.0 kB",
+            "one byte below it is still kB, as in C"
+        );
+        assert_eq!(heap_space_line(heap(0)), "Heap space: 0.0 kB");
+        assert_eq!(
+            heap_space_line(HeapSpace {
+                size: 8 * 1024 * 1024,
+                lifetime_allocated: 6 * 1024 * 1024,
+                lifetime_freed: 2 * 1024 * 1024,
+            }),
+            "Heap space: 4.0 MB",
+            "C subtracts the live bytes from the heap size"
+        );
+    }
+
+    /// The shell command's own `argv[0]` is its name — the convention this
+    /// port's `Argv` does not carry, and the one every `getopt` in the RTEMS
+    /// shell assumes.
+    #[test]
+    fn rt_puts_the_command_name_back_at_argv_zero() {
+        let args = vec![
+            ArgValue::String("stackuse".to_string()),
+            ArgValue::Argv(vec!["-v".to_string(), "2".to_string()]),
+        ];
+        assert_eq!(rt_argv(&args), vec!["stackuse", "-v", "2"]);
+    }
+
+    /// A shell command with no arguments still gets its own name, so `ac` is
+    /// 1 and not 0 — C's `aval.ac` counts the name too.
+    #[test]
+    fn rt_with_no_arguments_still_passes_the_name() {
+        let args = vec![
+            ArgValue::String("stackuse".to_string()),
+            ArgValue::Argv(vec![]),
+        ];
+        assert_eq!(rt_argv(&args), vec!["stackuse"]);
+    }
+
+    /// A bare `rt` has no name to look up. C hands `rtems_shell_lookup_cmd` a
+    /// NULL and prints `ERR: No such command`; an empty argv is how that
+    /// reaches the same answer here.
+    #[test]
+    fn a_bare_rt_produces_an_empty_argv() {
+        assert!(rt_argv(&[ArgValue::Missing, ArgValue::Argv(vec![])]).is_empty());
+    }
+
+    /// C's usage block, indentation included (`rtems_init.c:665-671`).
+    #[test]
+    fn the_setlogmask_usage_is_c_s_block() {
+        let levels = vec!["emerg".to_string(), "alert".to_string()];
+        assert_eq!(
+            setlogmask_usage(&levels),
+            "Usage: setlogmask <level>\n\n  Level names:\n    emerg\n    alert"
+        );
+    }
+
+    /// A build with no RTEMS behind it has no level names, and the block must
+    /// still be the block — C prints the header before the loop.
+    #[test]
+    fn the_setlogmask_usage_survives_an_empty_level_list() {
+        assert_eq!(
+            setlogmask_usage(&[]),
+            "Usage: setlogmask <level>\n\n  Level names:"
+        );
+    }
+}

--- a/crates/epics-base-rs/src/server/iocsh/vars.rs
+++ b/crates/epics-base-rs/src/server/iocsh/vars.rs
@@ -12,7 +12,7 @@
 //! # What a softIoc has here that this table does not
 //!
 //! Measured on `softIoc` R7.0.10: a bare `var` lists 24 names, and the
-//! same command here lists one. The 24 arrive by two routes —
+//! same command here lists 12. The 24 arrive by two routes —
 //! `registerAllRecordDeviceDrivers.cpp` copies the 22 `variable()` lines
 //! of `softIoc.dbd` into the iocsh table, and `libComRegister.c:518-520`
 //! adds `asCheckClientIP` and `freeListBypass` directly. The gap is not a
@@ -21,16 +21,17 @@
 //! either implements with the default hard-wired or does not have at all.
 //! Each of the 24, with its reason:
 //!
-//! **Registered here (11).** `asCheckClientIP`, from
+//! **Registered here (12).** `asCheckClientIP`, from
 //! `access_commands`; `dbRecordsOnceOnly` and `dbQuietMacroWarnings`,
-//! from `commands`; and the eight knobs `seeded_knobs` seeds:
+//! from `commands`; and the nine knobs `seeded_knobs` seeds:
 //! `boHIGHlimit`, `boHIGHprecision`, `calcoutODLYlimit`,
 //! `calcoutODLYprecision`, `histogramSDELprecision`, `seqDLYlimit`,
-//! `seqDLYprecision` and `callbackParallelThreadsDefault`. All eight were
-//! a `const` or a computing function until they were registered; a name
-//! in this table has to reach a global something actually reads, or `var
-//! seqDLYlimit 5000` lists and echoes a value nothing uses, which looks
-//! like it worked. Three of them are C `double`s, which is what
+//! `seqDLYprecision`, `callbackParallelThreadsDefault` and
+//! `dbTemplateMaxVars`. All nine were a `const` or a computing function
+//! until they were registered; a name in this table has to reach a global
+//! something actually reads, or `var seqDLYlimit 5000` lists and echoes a
+//! value nothing uses, which looks like it worked. Three of them are C
+//! `double`s, which is what
 //! [`crate::server::iocsh::vars::VarAccess::Double`] is for.
 //!
 //! **C `printf` debug switches with no counterpart here (7).**
@@ -41,15 +42,14 @@
 //! guards `printf`/`errlogPrintf` statements in its own C file, and this
 //! port carries no equivalent statements for the knob to switch on.
 //!
-//! **Behaviour this port does not have (6).** `dbBptNotMonotonic` — the
+//! **Behaviour this port does not have (5).** `dbBptNotMonotonic` — the
 //! lax breakpoint-table rules it opts into are not modelled, so the
 //! strict ones always apply ([`crate::server::cvt_bpt`]).
 //! `dbConvertStrict` — it picks between two string→field parsers
 //! (`dbStaticRun.c:409-430`) and there is only one here.
 //! `dbRecordsAbcSorted` — it sorts the record list
-//! as the database loads (`dbLexRoutines.c:334`). `dbTemplateMaxVars` —
-//! it bounds a fixed-size array in `dbLoadTemplate.y:159`, and the
-//! substitution loader here has no such array. `dbThreadRealtimeLock` —
+//! as the database loads (`dbLexRoutines.c:334`).
+//! `dbThreadRealtimeLock` —
 //! it gates the `mlockall` at `iocInit.c:225`, and nothing in this
 //! workspace calls `mlockall`. `freeListBypass` — it turns off the
 //! recycling pool in `freeListLib.c:61`, which Rust allocation replaces.
@@ -130,6 +130,18 @@ fn seeded_knobs() -> Vec<VarDef> {
                         value as i32,
                     )
                 },
+            },
+        },
+        // C `dbTemplateMaxVars` — `dbCore.dbd:29`, like
+        // `callbackParallelThreadsDefault` above: an `int` global in
+        // `dbLoadTemplate.y:45` that `pattern_name` reads at the point of
+        // use (`:159`), so `var dbTemplateMaxVars 200` raises the ceiling
+        // for the next `dbLoadTemplate` and not only for the next IOC.
+        VarDef {
+            name: "dbTemplateMaxVars",
+            access: VarAccess::Int {
+                get: || crate::server::db_loader::db_template_max_vars() as i64,
+                set: |value| crate::server::db_loader::set_db_template_max_vars(value as i32),
             },
         },
         VarDef {
@@ -249,22 +261,6 @@ fn strtol_base0(s: &str) -> Option<i64> {
     Some(if neg { -magnitude } else { magnitude })
 }
 
-/// C `epicsStrtod(s, &endp)` under the same whole-string check
-/// (`iocsh.cpp:1426-1435`), so the leading-whitespace rule is
-/// [`strtol_base0`]'s and not a second one.
-///
-/// Rust's `f64` parser takes the decimal, exponent and `inf`/`nan`
-/// spellings C's does. It does not take glibc's hex-float form
-/// (`0x1p3`), which is the one input C would accept and this rejects as
-/// `Invalid double`.
-fn strtod_whole(s: &str) -> Option<f64> {
-    let s = s.trim_start();
-    if s.is_empty() {
-        return None;
-    }
-    s.parse::<f64>().ok()
-}
-
 /// C `varHandler(v, NULL)` — `int %s = %d` / `double %s = %g` on stdout
 /// (`iocsh.cpp:1400-1408`). The `%g` is a bare one, so six significant
 /// digits, and [`crate::server::records::printf::format_g`] is the port's glibc-differenced printer for
@@ -330,14 +326,24 @@ fn cmd_var() -> CommandDef {
                     }
                 }
                 if !found && let Some(name) = name {
-                    return Err(format!("No known vars match '{name}'."));
+                    // C `varCallFunc` writes both of its refusals straight
+                    // to `epicsGetStderr()` and fails the line with a bare
+                    // `iocshSetError(1)` (`iocsh.cpp:1460-1464`,
+                    // `:1468-1472`) — no `showError`, so no `ERROR <file>
+                    // line <n>: ` frame around either sentence. Returning
+                    // `Err` here added one.
+                    ctx.eprintln(&format!("No known vars match '{name}'."));
+                    return Ok(CommandOutcome::Failed);
                 }
                 return Ok(CommandOutcome::Continue);
             };
 
             // With a value the name is looked up exactly, not globbed.
             let Some(def) = name.and_then(|name| table.get(name)) else {
-                return Err(format!("No known var '{}'.", name.unwrap_or_default()));
+                // The set path's own sentence, unframed for the same
+                // reason (`iocsh.cpp:1468-1472`).
+                ctx.eprintln(&format!("No known var '{}'.", name.unwrap_or_default()));
+                return Ok(CommandOutcome::Failed);
             };
             match &def.access {
                 VarAccess::Int { set, .. } => match strtol_base0(value) {
@@ -349,7 +355,9 @@ fn cmd_var() -> CommandDef {
                         ctx.eprintln(&format!("Invalid integer, var '{}' not changed.", def.name))
                     }
                 },
-                VarAccess::Double { set, .. } => match strtod_whole(value) {
+                // C reaches `epicsStrtod` from here and from `cvtArg`
+                // alike, so both go through the one port of it.
+                VarAccess::Double { set, .. } => match super::registry::epics_strtod_whole(value) {
                     Some(parsed) => set(parsed),
                     None => {
                         ctx.eprintln(&format!("Invalid double, var '{}' not changed.", def.name))
@@ -380,24 +388,65 @@ mod tests {
         ctx
     }
 
+    /// The command's stdout when the line succeeds, and the bytes it put
+    /// on the DIAGNOSTIC stream when the line fails — C's `var` refusals
+    /// are written there and the line is failed by a bare
+    /// `iocshSetError(1)`, so the stream is the only place the sentence
+    /// exists and there is no shell diagnostic to read instead.
     fn run_var(ctx: &CommandContext, tokens: &[&str]) -> Result<String, String> {
         let mut reg = CommandRegistry::new();
         super::super::commands::register_builtins(&mut reg);
         let cmd = reg.get("var").expect("`var` must be registered").clone();
         let tokens: Vec<String> = tokens.iter().map(|t| (*t).to_string()).collect();
         let args = parse_args(&tokens, &cmd.args).unwrap();
-        let tmp = tempfile::NamedTempFile::new().unwrap();
-        let path = tmp.path().to_path_buf();
-        let mut failure = None;
-        ctx.with_output(std::fs::File::create(&path).unwrap(), || {
-            if let Err(e) = cmd.handler.call(&args, ctx) {
-                failure = Some(e);
-            }
+        let out_tmp = tempfile::NamedTempFile::new().unwrap();
+        let err_tmp = tempfile::NamedTempFile::new().unwrap();
+        let (out_path, err_path) = (out_tmp.path().to_path_buf(), err_tmp.path().to_path_buf());
+        let mut failed = false;
+        ctx.with_error(std::fs::File::create(&err_path).unwrap(), || {
+            ctx.with_output(std::fs::File::create(&out_path).unwrap(), || {
+                failed = matches!(
+                    cmd.handler.call(&args, ctx),
+                    Ok(CommandOutcome::Failed) | Err(_)
+                );
+            });
         });
-        match failure {
-            Some(e) => Err(e),
-            None => Ok(std::fs::read_to_string(&path).unwrap()),
+        if failed {
+            Err(std::fs::read_to_string(&err_path).unwrap())
+        } else {
+            Ok(std::fs::read_to_string(&out_path).unwrap())
         }
+    }
+
+    /// `dbTemplateMaxVars` is a `.dbd` `variable()` knob (`dbCore.dbd:29`)
+    /// over the `int` at `dbLoadTemplate.y:45`, so C reaches it with `var`
+    /// and the substitution parser reads the global at the point of use.
+    ///
+    /// Measured on softIoc: `var dbTemplateMaxVars 200` then
+    /// `var dbTemplateMaxVars` prints `int dbTemplateMaxVars = 200`, and
+    /// the next `dbLoadTemplate` accepts 200 pattern names.
+    #[test]
+    fn var_reads_and_writes_db_template_max_vars() {
+        use crate::server::db_loader::{db_template_max_vars, set_db_template_max_vars};
+
+        let ctx = make_ctx();
+        let restore = db_template_max_vars();
+        assert_eq!(restore, 100, "C `int dbTemplateMaxVars = 100`");
+        assert_eq!(
+            run_var(&ctx, &["dbTemplateMaxVars"]).unwrap(),
+            "int dbTemplateMaxVars = 100\n"
+        );
+        assert_eq!(run_var(&ctx, &["dbTemplateMaxVars", "200"]).unwrap(), "");
+        assert_eq!(
+            db_template_max_vars(),
+            200,
+            "`var` must reach the global the parser reads, not a copy"
+        );
+        assert_eq!(
+            run_var(&ctx, &["dbTemplateMaxVars"]).unwrap(),
+            "int dbTemplateMaxVars = 200\n"
+        );
+        set_db_template_max_vars(restore);
     }
 
     /// C keeps `asCheckClientIP` in the iocsh *variable* table
@@ -441,13 +490,20 @@ mod tests {
                 .contains("int asCheckClientIP = 1")
         );
 
+        // Measured on `bin/linux-x86_64/softIoc`
+        // (R7.0.10-146-g8f5015b663d764ad75df), script `w3.cmd` holding
+        // `var nosuchvar 5` then `var nosuchvar`: stderr carried
+        // `No known var \'nosuchvar\'.` and `No known vars match
+        // \'nosuchvar\'.` and nothing else — neither line wore the
+        // `ERROR w3.cmd line <n>: ` frame the shell puts on its own
+        // diagnostics.
         assert_eq!(
             run_var(&ctx, &["noSuchVar"]).unwrap_err(),
-            "No known vars match 'noSuchVar'."
+            "No known vars match 'noSuchVar'.\n"
         );
         assert_eq!(
             run_var(&ctx, &["noSuchVar", "1"]).unwrap_err(),
-            "No known var 'noSuchVar'."
+            "No known var 'noSuchVar'.\n"
         );
 
         // C parses with `strtol(s, &endp, 0)`, and an unparsable value
@@ -608,10 +664,15 @@ mod tests {
     /// C's double arm rejects the same shapes its int arm does and says
     /// so in its own words (`iocsh.cpp:1431-1434`), leaving the value
     /// alone without failing the command.
+    ///
+    /// `0x1p3` is NOT one of them: `epicsStrtod` is glibc's `strtod`
+    /// here, so C takes the C99 hex form — measured, `var seqDLYlimit
+    /// 0x1p3` then `var seqDLYlimit` prints `double seqDLYlimit = 8`,
+    /// and `0x10` prints `16`.
     #[test]
     fn an_unparsable_double_leaves_the_knob_alone() {
         let ctx = make_ctx();
-        for token in ["nope", "1.0 ", "", "0x1p3"] {
+        for token in ["nope", "1.0 ", ""] {
             assert_eq!(run_var(&ctx, &["seqDLYlimit", token]).unwrap(), "");
             assert_eq!(
                 run_var(&ctx, &["seqDLYlimit"]).unwrap(),
@@ -620,7 +681,13 @@ mod tests {
             );
         }
         // The shapes it does take, including C's leading-whitespace skip.
-        for (token, want) in [("1e3", "1000"), (" 2.5", "2.5"), ("-0.5", "-0.5")] {
+        for (token, want) in [
+            ("1e3", "1000"),
+            (" 2.5", "2.5"),
+            ("-0.5", "-0.5"),
+            ("0x1p3", "8"),
+            ("0x10", "16"),
+        ] {
             assert_eq!(run_var(&ctx, &["seqDLYlimit", token]).unwrap(), "");
             assert_eq!(
                 run_var(&ctx, &["seqDLYlimit"]).unwrap(),

--- a/crates/epics-base-rs/src/server/recgbl.rs
+++ b/crates/epics-base-rs/src/server/recgbl.rs
@@ -653,6 +653,148 @@ pub fn rec_gbl_record_error(status_text: &str, record_name: &str, message: &str)
     ));
 }
 
+/// The two `devSup.h` statuses a record reports when its device support is
+/// not there, and the text `errSymLookup` renders them as.
+///
+/// No IOC links a symbol table for `M_devSup` — the numbers live in
+/// `devSup.h`, not in a generated `*ErrSymTbl.c` — so `errSymLookup` falls
+/// through to its `"Error (%d,%d)"` spelling and *that*, not a phrase, is what
+/// the operator reads and what a site's log filter matches. Deriving the text
+/// from the module and number is what keeps a call site from hard-coding
+/// `"Error (514,3)"` next to a number it no longer agrees with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DevSupStatus {
+    /// `S_dev_noDSET` — DTYP named device support nobody registered, so
+    /// `dbDTYPtoDevSup` handed the record a NULL dset.
+    NoDset,
+    /// `S_dev_missingSup` — a dset exists but does not implement the transfer
+    /// the record needs. This port cannot construct that state (a device is
+    /// attached or it is not), so only the record's `process()` refusal, which
+    /// C reaches through the same `!pdset` arm, uses it.
+    MissingSup,
+}
+
+impl DevSupStatus {
+    /// `M_devSup` is `(514 << 16)`; the numbers are `devSup.h`'s.
+    #[must_use]
+    pub const fn status(self) -> u32 {
+        match self {
+            Self::NoDset => (514 << 16) | 3,
+            Self::MissingSup => (514 << 16) | 5,
+        }
+    }
+
+    /// `errSymLookup`'s fallback spelling for a status with no symbol table.
+    #[must_use]
+    pub fn text(self) -> String {
+        let status = self.status();
+        format!("Error ({},{})", status >> 16, status & 0xffff)
+    }
+}
+
+/// What a record type calls itself when it refuses to run without device
+/// support: `(init_record message, process message)`, exactly the `pmessage`
+/// its `<rec>Record.c` hands `recGblRecordError`.
+///
+/// One table, because "this record type cannot run without a dset" is one fact
+/// about the type reported at two moments, and splitting it is how the two
+/// halves drift. A record type ABSENT from the table needs no device support —
+/// `calc`, `sub`, `fanout`, `seq` and friends — and must go on processing
+/// normally; the absence is the gate, so no caller repeats the list.
+///
+/// The second element is `None` for a type whose C `process()` has no dset
+/// check at all: `calcout` (and the `calc` module's `scalcout`/`acalcout`,
+/// which copy it) refuse only at init. `printf` is absent from the table
+/// entirely — `printfRecord.c:355` says "Device support is optional" and
+/// returns 0.
+///
+/// The spellings that look like typos are C's and are transcribed as they are,
+/// because the operator greps for the string C emits: `calcout`, `scalcout`
+/// and `acalcout` omit the space after the colon, `subArray` reports as `sa`
+/// and `waveform` as `wf`, and `sCalcoutRecord.c:246` reports its own
+/// missing-support half as `calcout:init_record`.
+#[must_use]
+pub fn dev_sup_refusal(record_type: &str) -> Option<(&'static str, Option<&'static str>)> {
+    Some(match record_type {
+        // base `std/rec` — one row per `<rec>Record.c` that tests `!prec->dset`.
+        "aai" => ("aai: init_record", Some("read_aai")),
+        "aao" => ("aao: init_record", Some("write_aao")),
+        "ai" => ("ai: init_record", Some("read_ai")),
+        "ao" => ("ao: init_record", Some("write_ao")),
+        "bi" => ("bi: init_record", Some("read_bi")),
+        "bo" => ("bo: init_record", Some("write_bo")),
+        "calcout" => ("calcout:init_record", None),
+        "histogram" => ("histogram: init_record", Some("read_histogram")),
+        "int64in" => ("int64in: init_record", Some("read_int64in")),
+        "int64out" => ("int64out: init_record", Some("write_int64out")),
+        "longin" => ("longin: init_record", Some("read_longin")),
+        "longout" => ("longout: init_record", Some("write_longout")),
+        "lsi" => ("lsi: init_record", Some("lsi: read_string")),
+        "lso" => ("lso: init_record", Some("lso: write_string")),
+        // Both mbbi flavours report as `read_mbbi` and both mbbo flavours as
+        // `write_mbbo` — `mbbiDirectRecord.c:142`, `mbboDirectRecord.c:175`.
+        "mbbi" => ("mbbi: init_record", Some("read_mbbi")),
+        "mbbiDirect" => ("mbbiDirect: init_record", Some("read_mbbi")),
+        "mbbo" => ("mbbo: init_record", Some("write_mbbo")),
+        "mbboDirect" => ("mbboDirect: init_record", Some("write_mbbo")),
+        "stringin" => ("stringin: init_record", Some("read_stringin")),
+        "stringout" => ("stringout: init_record", Some("write_stringout")),
+        "subArray" => ("sa: init_record", Some("read_sa")),
+        "waveform" => ("wf: init_record", Some("read_wf")),
+        // Module record types this port also serves.
+        "busy" => ("busy: init_record", Some("write_busy")),
+        "scalcout" => ("scalcout:init_record", None),
+        "acalcout" => ("acalcout:init_record", None),
+        _ => return None,
+    })
+}
+
+/// C `<rec>Record.c init_record`'s `!prec->dset` refusal — the per-RECORD line
+/// an IOC owes for every record whose DTYP named device support nobody
+/// registered.
+///
+/// C reports this once per record and separately reports `device support %s
+/// not found` once per unlinked `device()` line in the DBD. The two are not
+/// alternatives: the DBD line names support nobody registered and leaves the
+/// operator to find which records used it, this one names a record that will
+/// not work. A record type with no dset requirement is silent, which is why
+/// the gate is [`dev_sup_refusal`] and not the caller.
+pub fn rec_gbl_no_device_support(record_type: &str, record_name: &str) {
+    if let Some((init_message, _)) = dev_sup_refusal(record_type) {
+        for _ in 0..init_dset_checks(record_type) {
+            rec_gbl_record_error(&DevSupStatus::NoDset.text(), record_name, init_message);
+        }
+    }
+}
+
+/// How many of `initDatabase`'s two `init_record` calls reach the record type's
+/// `!prec->dset` test — which is how many times a record with no dset is
+/// reported.
+///
+/// Nearly every type opens `init_record` with `if (pass == 0) return 0;` and
+/// tests `dset` below it, so only pass 1 reports. `aai` and `aao` test it
+/// FIRST, above the pass gate (`aaiRecord.c:118-123`, `aaoRecord.c:125-131`),
+/// because their pass 0 has real work to do — the device support may set
+/// `bptr`, and the record allocates the buffer itself if it did not — and that
+/// work cannot start without a dset. Both calls therefore report, and softIoc
+/// R7.0.10 writes their line twice per record; measured over
+/// `scripts/compat-smoke.sh`, 18 of the port's missing lines were the second
+/// copy. Every C record type this port serves was checked for the placement:
+/// these two are the whole set.
+const fn init_dset_checks(record_type: &str) -> u8 {
+    match record_type.as_bytes() {
+        b"aai" | b"aao" => 2,
+        _ => 1,
+    }
+}
+
+/// The message C's `process()` reports before refusing a cycle it has no dset
+/// for, or `None` when this record type's `process()` has no such check.
+#[must_use]
+pub fn dev_sup_process_refusal(record_type: &str) -> Option<&'static str> {
+    dev_sup_refusal(record_type).and_then(|(_, process)| process)
+}
+
 /// C `recGblDbaddrError` (`recGbl.c:73-91` @R7.0.10) — the same report keyed
 /// on a field address rather than a record, so the PV it names is
 /// `record.FIELD`.

--- a/crates/epics-base-rs/src/server/record/record_instance.rs
+++ b/crates/epics-base-rs/src/server/record/record_instance.rs
@@ -220,8 +220,40 @@ pub(crate) fn ambient_write_origin() -> u64 {
 /// (C `dbNotifyAdd`), and every record [`Self::leave`]s when its
 /// processing completes (C `dbNotifyCompletion`). The oneshot fires on
 /// the `leave` that drops `pending` to zero.
+///
+/// Membership is BOTH counted and named, because the two questions have
+/// different answers here and C only ever has to ask one of them. C keeps
+/// no count at all — `ellCount(&pnotifyPvt->waitList)` (`dbNotify.c:460`)
+/// IS its count, so its list answers "has the chain settled?" and "which
+/// records must a cancel release?" at once. The port cannot merge them:
+/// `pending` also carries contributions that own no record slot (the
+/// initiator's own hold, and a `dbCaPutLinkCallback` awaiting its network
+/// completion — `links.rs`), which C models as `state` rather than as list
+/// entries. So `pending` answers settlement and the `joined` list answers
+/// cancellation, each with one meaning on every path.
 pub struct NotifyWaitSet {
     pending: AtomicUsize,
+    /// C `notifyPvt::waitList` (`dbNotify.c:73`) — every record that took
+    /// this set into its `notify` slot, so a cancel can sweep them the way
+    /// `dbNotifyCancel` walks the wait list (`:428-430`).
+    ///
+    /// Append-only, and deliberately so: C deletes a member on completion
+    /// only because `ellCount` is its settlement count, which `pending`
+    /// already is here. Keeping a completed member listed costs a slot
+    /// re-check and cannot lose one, whereas removing on completion would
+    /// make the list the second thing that has to be right for a cancel to
+    /// reach a record.
+    ///
+    /// Names, not handles: the sweep needs the record's write lock anyway,
+    /// and the authority on membership is the record's own slot — a stale
+    /// name simply fails the `Arc::ptr_eq` and is skipped. That makes
+    /// over-listing harmless and under-listing the only failure, which is
+    /// what the append-only rule then makes unrepresentable.
+    ///
+    /// Written in exactly one place, [`RecordInstance::take_notify_slot`],
+    /// which is also the only writer of the slot itself — so "every record
+    /// holding this set is named here" holds by construction.
+    joined: StdMutex<Vec<Box<str>>>,
     tx: StdMutex<Option<crate::runtime::sync::oneshot::Sender<()>>>,
     /// C `dbChannelRecord(ppn->chan)` — the record the notify was ISSUED
     /// against, as opposed to the records that joined its chain.
@@ -233,10 +265,14 @@ pub struct NotifyWaitSet {
     ///
     /// Set at construction and never afterwards. The only mint of an
     /// entry-bearing set is [`RecordInstance::install_or_queue_notify`],
-    /// which passes its own record, and the only other writer of the slot
+    /// which passes its own record, and the other path into the slot
     /// ([`RecordInstance::join_put_notify`]) clones a set it did not make —
     /// so "the entry names the record whose slot minted it" holds by
     /// construction rather than by a check.
+    ///
+    /// It is NOT the membership test. Every member, entry or joined, is named
+    /// in [`Self::joined`]; this only says which member `dbNotifyDump` prints
+    /// a block for (`dbNotify.c:659-660`).
     ///
     /// [`PvDatabase::new_put_notify`]: crate::server::database::PvDatabase::new_put_notify
     entry: Option<Box<str>>,
@@ -254,6 +290,7 @@ impl NotifyWaitSet {
     pub fn new(tx: crate::runtime::sync::oneshot::Sender<()>) -> Arc<Self> {
         Arc::new(Self {
             pending: AtomicUsize::new(1),
+            joined: StdMutex::new(Vec::new()),
             tx: StdMutex::new(Some(tx)),
             entry: None,
         })
@@ -265,6 +302,7 @@ impl NotifyWaitSet {
     fn for_entry_record(record: &str, tx: crate::runtime::sync::oneshot::Sender<()>) -> Arc<Self> {
         Arc::new(Self {
             pending: AtomicUsize::new(1),
+            joined: StdMutex::new(Vec::new()),
             tx: StdMutex::new(Some(tx)),
             entry: Some(record.into()),
         })
@@ -299,6 +337,43 @@ impl NotifyWaitSet {
     /// vs async-pending ([`ProcessCompletion::Async`]) completion.
     pub fn completed(&self) -> bool {
         self.pending.load(Ordering::Acquire) == 0
+    }
+
+    /// Record `name` took this set into its `notify` slot — C
+    /// `ellSafeAdd(&pnotifyPvt->waitList, &precord->ppnr->waitNode)`
+    /// (`dbNotify.c:227`/`:258`/`:498`).
+    ///
+    /// Private to this module and called from the one slot writer
+    /// ([`RecordInstance::take_notify_slot`]), so joining the list and taking
+    /// the slot are one act and cannot be done separately.
+    fn record_joined(&self, name: &str) {
+        self.joined.lock().unwrap().push(name.into());
+    }
+
+    /// Every record that has held this set — C's wait list as
+    /// `dbNotifyCancel` enumerates it (`dbNotify.c:428`).
+    ///
+    /// A snapshot, because the sweep must take record write locks and cannot
+    /// hold this mutex while it does. Growth after the snapshot is not a
+    /// missed member: a record can only join a set that is still answerable,
+    /// and this is read only of a set that is not.
+    pub(crate) fn joined_records(&self) -> Vec<Box<str>> {
+        self.joined.lock().unwrap().clone()
+    }
+
+    /// Nobody is left to answer: the completion never fired (the sender is
+    /// still here) and the client that would have received it is gone.
+    ///
+    /// This is the condition C detects at client teardown —
+    /// `rsrvFreePutNotify` sees `pNotify->busy` and calls `dbNotifyCancel`
+    /// (`camessage.c:1630-1638`). A set that already fired holds no sender and
+    /// is NOT unanswerable: it completed.
+    pub(crate) fn is_unanswerable(&self) -> bool {
+        self.tx
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|tx| tx.is_closed())
     }
 }
 
@@ -799,6 +874,18 @@ pub struct RecordInstance {
     pub device: Option<Box<dyn super::super::device_support::DeviceSupport>>,
     // Subroutine (for sub records)
     pub subroutine: Option<Arc<SubroutineFn>>,
+    /// The by-name function registry this record's PENDING `init_record` pass
+    /// 1 will resolve INAM/SNAM against — C `registryFunctionFind`, reading a
+    /// process-global table from inside `init_record`.
+    ///
+    /// One meaning on every path: armed by the creation sink immediately
+    /// before [`Self::run_init_passes`], consumed (and cleared) by the pass
+    /// itself. It exists because the lookup's failure is an EARLY RETURN — the
+    /// init tail must not run past it — and only the init owner can honour
+    /// that, while only the database holds the registry. Resolving from
+    /// outside the passes, as both builders used to, put the lookup after the
+    /// tail it is supposed to skip.
+    init_subroutines: Option<Arc<HashMap<String, Arc<SubroutineFn>>>>,
     /// PACT (C `precord->pact`) — the re-entrancy guard, and the record's
     /// "busy" state for every put that lands on it.
     ///
@@ -1273,6 +1360,7 @@ impl RecordInstance {
             parsed_tsel: ParsedLink::None,
             device: None,
             subroutine: None,
+            init_subroutines: None,
             pact: AtomicBool::new(false),
             notify: None,
             notify_restart_list: std::collections::VecDeque::new(),
@@ -1322,6 +1410,52 @@ impl RecordInstance {
     /// [`crate::server::database::PvDatabase::add_loaded_record`], which takes
     /// the load and the record together so no path can init a half-loaded
     /// record.
+    /// Hand the record the function registry its pending init pass 1 resolves
+    /// INAM/SNAM against. The creation sink's line; see [`Self::
+    /// init_subroutines`].
+    pub(crate) fn arm_init_subroutines(
+        &mut self,
+        registry: Arc<HashMap<String, Arc<SubroutineFn>>>,
+    ) {
+        self.init_subroutines = Some(registry);
+    }
+
+    /// C's `if (!pdset) { recGblRecordError(S_dev_noDSET, prec, "init_record");
+    /// return S_dev_noDSET; }` — whether this record's `init_record` gets past
+    /// its own first statement.
+    ///
+    /// Three terms, each one C's:
+    /// * [`crate::server::recgbl::dev_sup_refusal`] IS the set of record types
+    ///   whose `init_record` opens with that test — the same table that
+    ///   supplies the message, so the refusal and the return can never
+    ///   disagree about which types make it.
+    /// * a soft DTYP (`""`, `Soft Channel`, `Raw Soft Channel`, `Async Soft
+    ///   Channel`) resolves to a dset C always links, so the test passes.
+    ///   `""` counts because C's DTYP index 0 is the record type's FIRST
+    ///   `device()` line, which for every soft record type is the soft
+    ///   channel.
+    /// * anything else needs a device the resolver produced. `None` after the
+    ///   creation sink has run its bind is C's `pdevSup == NULL`.
+    pub(crate) fn init_record_reaches_body(&self) -> bool {
+        self.device.is_some()
+            || crate::server::device_support::is_soft_dtyp(&self.common.dtyp)
+            || crate::server::recgbl::dev_sup_refusal(self.record.record_type()).is_none()
+    }
+
+    /// C `registryFunctionFind` inside `init_record` pass 1, for the record
+    /// types that make it. Returns whether the pass reached its tail.
+    ///
+    /// Unarmed (`init_subroutines` is `None`) means no registry was handed
+    /// over — an iocsh `dbLoadRecords` merge re-running the passes on a record
+    /// that already resolved. Nothing to look up again, and C's tail is
+    /// reached.
+    fn resolve_init_subroutine(&mut self, name: &str) -> bool {
+        match self.init_subroutines.take() {
+            Some(registry) => crate::server::ioc_app::wire_subroutine(self, name, &registry),
+            None => true,
+        }
+    }
+
     pub(crate) fn run_init_passes(&mut self, name: &str) {
         // C's `precord->pact = FALSE` — a record cannot be mid-process at init,
         // so this release provably frees nothing: no client put has run, so the
@@ -1336,11 +1470,50 @@ impl RecordInstance {
         {
             self.common.sevr = AlarmSeverity::from_u16(self.common.udfs as u16);
         }
+        // C `<rec>Record.c::init_record`'s FIRST statement, for the 26 record
+        // types that make it: `if (!pdset) { recGblRecordError(S_dev_noDSET,
+        // …); return S_dev_noDSET; }` (`aiRecord.c:105-110`,
+        // `aoRecord.c:107-110`, …). Everything below it — `ao`'s `prec->init =
+        // TRUE`, `ai`'s and `sub`'s MLST/ALST/LALM seed, `mbbo`'s SDEF fold —
+        // is unreachable for a record whose dset is NULL, and running the
+        // passes anyway is what left those cells set where softIoc reads 0.
+        //
+        // It is the OWNER's test, not each record's, for one structural
+        // reason: `Record::init_record` is on the record BODY, which cannot
+        // see `RecordInstance::device`. Asking every record type to re-derive
+        // the answer is the per-cell patch this replaces.
+        if !self.init_record_reaches_body() {
+            return;
+        }
         if let Err(e) = self.record.init_record(0) {
             eprintln!("init_record(0) failed for {name}: {e}");
         }
+        // C `iocInit.c::doResolveLinks` (`:545-570`), the pass BETWEEN the two
+        // `init_record` calls: for each device link the record type declares,
+        // `pdsxt->add_record(precord)` and then `dbInitLink` for that same
+        // link. This is that call, and it keeps C's position — before the link
+        // it complains about is initialised, after pass 0 has run.
+        crate::server::builtin_devices::soft_callback::add_record(self, name);
         if let Err(e) = self.record.init_record(1) {
             eprintln!("init_record(1) failed for {name}: {e}");
+        }
+        // C `pdset->common.init_record(prec)` — the driver's own init, which
+        // every record type calls from INSIDE `init_record` once the dset test
+        // above has passed (`aiRecord.c:115-124`, `aoRecord.c:121-133`). It
+        // ran after both passes and after the constant-link seed while device
+        // support was attached by a whole-database pass; it is here now
+        // because the dset is bound before the passes. Residual difference
+        // from C, not closed by this move: C calls it BEFORE the record's own
+        // tail (`prec->mlst = prec->val`) and the port's tail is inside
+        // `init_record(1)`, so a driver `init` that defines VAL is still not
+        // reflected in the trackers seeded a line earlier.
+        crate::server::device_support::init_device_support(self);
+        // C `subRecord.c:107-129` / `aSubRecord.c:139-160` — the INAM call and
+        // the SNAM lookup, also inside pass 1. `false` is C's early return
+        // (`S_db_BadSub`, or the empty-SNAM `pact = TRUE; return 0`), so the
+        // tail below is skipped exactly where C skips it.
+        if !self.resolve_init_subroutine(name) {
+            return;
         }
         // The UDF tail of pass 1. `init_record` cannot reach UDF (a common
         // field), so the record types whose C `init_record` ends in
@@ -1368,12 +1541,17 @@ impl RecordInstance {
             self.common.udf = 0;
             let _ = crate::server::recgbl::rec_gbl_reset_alarms(&mut self.common);
         }
-        // C `init_record` can END with `prec->pact = TRUE` to disable a record
-        // it cannot process (`subRecord.c:119-123`, an empty SNAM). PACT has one
-        // owner, so the record answers the predicate and the owner parks it —
-        // after the passes, so the `leave_pact()` above cannot undo it. The
-        // release is not lost: a put to a `pact_park_fields()` field re-asks,
-        // the way C's `special()` does.
+        // C `init_record` can park a record it cannot process with `prec->pact
+        // = TRUE`. The only such line in base is `subRecord.c:119-123`, and it
+        // sits WITH the empty-SNAM report and the return, so the resolution
+        // step above performs it: a record whose INAM missed returned before
+        // that line and is not parked however empty its SNAM is (softIoc reads
+        // `PACT: 0`). This asks the record type for the same transition on the
+        // paths that reach the tail — an iocsh `dbLoadRecords` merge re-running
+        // the passes with no registry to resolve against. It is after the
+        // passes so the `leave_pact()` above cannot undo it, and the park is
+        // not permanent: a put to a `pact_park_fields()` field re-asks, the way
+        // C's `special()` does.
         if self.record.parks_pact() {
             self.enter_pact();
         }
@@ -1730,18 +1908,37 @@ impl RecordInstance {
             return None;
         }
         let notify = NotifyWaitSet::for_entry_record(&self.name, completion);
-        self.notify = Some(notify.clone());
+        self.take_notify_slot(notify.clone());
         Some(notify)
+    }
+
+    /// Take `ws` into this record's put-notify slot.
+    ///
+    /// **The only writer of [`Self::notify`] that installs a set** — the other
+    /// two ([`Self::abandon_put_notify`], [`Self::release_notify`]) only clear
+    /// it. Everything that makes a record a member of a wait-set happens here,
+    /// so C's `precord->ppn = ppn` and its `ellSafeAdd(&waitList, ...)`
+    /// (`dbNotify.c:226-227`, `:257-258`, `:497-498`) stay the single act they
+    /// are in C. Split across two call sites, they were what let a member exist
+    /// that no cancel could name.
+    fn take_notify_slot(&mut self, ws: Arc<NotifyWaitSet>) {
+        debug_assert!(
+            self.notify.is_none(),
+            "the slot must be tested free in the same critical section"
+        );
+        ws.record_joined(&self.name);
+        self.notify = Some(ws);
     }
 
     /// C `dbNotifyAdd` (dbNotify.c:477-501): a link target joins the wait-set
     /// of the put-notify driving the chain, so the initiator's completion
     /// waits for this record's cycle too.
     ///
-    /// The second and last writer of `Self::notify`; the first is
-    /// [`Self::install_or_queue_notify`]. Both live here so the slot has no
-    /// assignment site outside this module — an open-coded one elsewhere is
-    /// how a wait-set came to be installed without the record's write gate.
+    /// One of the two callers of `take_notify_slot`, the sole writer; the
+    /// other is [`Self::install_or_queue_notify`]. All three live here so
+    /// the slot has no assignment site outside this module — an open-coded one
+    /// elsewhere is how a wait-set came to be installed without the record's
+    /// write gate.
     ///
     /// A record already carrying a wait-set keeps it (C's `if (!pto->ppn …)`
     /// at `:492`), so this never displaces a live one, and the `enter` is
@@ -1751,8 +1948,8 @@ impl RecordInstance {
             return;
         }
         if let Some(ws) = src {
-            self.notify = Some(ws.clone());
             ws.enter();
+            self.take_notify_slot(ws.clone());
         }
     }
 
@@ -1777,6 +1974,71 @@ impl RecordInstance {
             taken.as_ref().is_some_and(|ws| Arc::ptr_eq(ws, claimed)),
             "only the claim owner may clear the put-notify slot"
         );
+    }
+
+    /// The set in this record's slot if it can never be answered — the test
+    /// half of C `dbNotifyCancel` (`dbNotify.c:385-430`), reached from
+    /// `rsrvFreePutNotify` (`camessage.c:1630-1638`) when a client is torn down
+    /// with its put-callback still busy.
+    ///
+    /// # Invariant (CONTRACT)
+    ///
+    /// A record's put-notify slot MUST NOT stay occupied by a notify nobody
+    /// can be answered from. Without the release such a record is wedged for
+    /// good: every later put-notify queues on `notify_restart_list` behind a
+    /// completion that can never arrive and writes nothing — C
+    /// `processNotifyCommon` tests ownership ABOVE `putCallback` — so the next
+    /// client hangs too, and the one after it.
+    ///
+    /// This is what makes honouring a record type's forward-link gate safe at
+    /// all. `busy` left at VAL=1 withholds the `ca_put_callback` exactly as C
+    /// does (`busyRecord.c:271`); the client then gives up and exits, and that
+    /// exit is the teardown modelled here.
+    ///
+    /// Two triggers reach it, and both are needed. The CA server calls it at
+    /// client teardown, which is C's own moment
+    /// (`rsrvFreePutNotify`, `camessage.c:1630-1638`), and it also runs at
+    /// every ownership test, which catches a set whose client died on a
+    /// transport the teardown hook does not cover. Only the first closes the
+    /// case where a SECOND client is already queued on a record's restart list
+    /// when the first dies: nothing then arrives to test ownership, and C's
+    /// `restartCheck` would have handed that record to the queued client.
+    ///
+    /// The set names its own members ([`NotifyWaitSet::joined_records`]), so
+    /// the sweep reaches a chain target exactly as C's `notifyProcessInProgress`
+    /// arm does (`dbNotify.c:428-430`) rather than stopping at the entry.
+    /// That distinction is not cosmetic: a chain target is the likelier victim,
+    /// because the record whose cycle never ends is precisely the one this
+    /// exists for — a `busy` left at VAL=1 withholds `recGblFwdLink` by
+    /// contract, so its slot would otherwise be held by a dead set forever.
+    ///
+    /// See [`PvDatabase::cancel_unanswerable_notify`], the owner that runs it
+    /// across the whole set.
+    ///
+    /// [`PvDatabase::cancel_unanswerable_notify`]: crate::server::database::PvDatabase::cancel_unanswerable_notify
+    pub(crate) fn unanswerable_notify(&self) -> Option<Arc<NotifyWaitSet>> {
+        self.notify
+            .as_ref()
+            .filter(|ws| ws.is_unanswerable())
+            .cloned()
+    }
+
+    /// Drop this record's claim on `dead` — C `restartCheck`'s
+    /// `precord->ppn = 0` (`dbNotify.c:157`) as `dbNotifyCancel` reaches it.
+    ///
+    /// The record's own slot is the authority on membership, so this is
+    /// `Arc::ptr_eq`-gated: a name the sweep carries for a record that has
+    /// since completed and taken a different notify releases nothing.
+    ///
+    /// Returns whether the slot was freed, so the caller can promote the
+    /// restart-list head (C `restartCheck`) exactly as a completion would.
+    #[must_use = "a freed slot owes the restart list a drain"]
+    pub(crate) fn release_notify(&mut self, dead: &Arc<NotifyWaitSet>) -> bool {
+        if self.notify.as_ref().is_some_and(|ws| Arc::ptr_eq(ws, dead)) {
+            self.notify = None;
+            return true;
+        }
+        false
     }
 
     /// Whether a put-notify owns this record — C `precord->ppn != NULL`.
@@ -8520,5 +8782,119 @@ mod link_field_rendering_tests {
         ] {
             assert_eq!(render_link_field(class, text), want, "{class:?} {text:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod unanswerable_notify_tests {
+    use super::*;
+    use crate::server::records::calc::CalcRecord;
+
+    fn rec(name: &str) -> RecordInstance {
+        RecordInstance::new(name.into(), CalcRecord::default())
+    }
+
+    /// The ordinary case: the client is still waiting, so the slot is its own.
+    /// C only reaches `dbNotifyCancel` from a teardown.
+    #[test]
+    fn a_waiting_client_keeps_the_slot() {
+        let mut r = rec("A");
+        let (tx, _rx) = crate::runtime::sync::oneshot::channel();
+        r.install_or_queue_notify(tx).expect("slot was free");
+        assert!(r.unanswerable_notify().is_none());
+        assert!(r.has_notify(), "a live put-callback must not be cancelled");
+    }
+
+    /// C `rsrvFreePutNotify` (`camessage.c:1630-1638`): the client went away
+    /// with its put-callback still busy, so the notify leaves the record.
+    #[test]
+    fn a_departed_client_releases_the_slot() {
+        let mut r = rec("A");
+        let (tx, rx) = crate::runtime::sync::oneshot::channel();
+        r.install_or_queue_notify(tx).expect("slot was free");
+        drop(rx);
+        let dead = r.unanswerable_notify().expect("nobody can answer it");
+        assert!(r.release_notify(&dead));
+        assert!(
+            !r.has_notify(),
+            "the record must be free for the next put-notify"
+        );
+    }
+
+    /// A notify that COMPLETED is not unanswerable — it answered. The sender is
+    /// spent, so a receiver dropped afterwards says nothing about the slot.
+    #[test]
+    fn a_completed_notify_is_not_cancelled() {
+        let mut r = rec("A");
+        let (tx, rx) = crate::runtime::sync::oneshot::channel();
+        let set = r.install_or_queue_notify(tx).expect("slot was free");
+        set.leave();
+        drop(rx);
+        assert!(r.unanswerable_notify().is_none());
+    }
+
+    /// The set names every record that holds it, entry and `dbNotifyAdd`
+    /// target alike — C `pnotifyPvt->waitList` (`dbNotify.c:227`/`:498`), which
+    /// `dbNotifyCancel` walks at `:428`.
+    #[test]
+    fn the_set_names_the_entry_and_every_chain_target() {
+        let mut entry = rec("A");
+        let mut target = rec("B");
+        let (tx, _rx) = crate::runtime::sync::oneshot::channel();
+        let set = entry.install_or_queue_notify(tx).expect("slot was free");
+        target.join_put_notify(Some(&set));
+        let members: Vec<String> = set
+            .joined_records()
+            .into_iter()
+            .map(|n| n.to_string())
+            .collect();
+        assert_eq!(members, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    /// A chain target releases too. It holds the same wait-set through
+    /// `dbNotifyAdd`, and the record whose cycle never ends is exactly the one
+    /// that keeps it — a `busy` FLNK target left at VAL=1 declines its own
+    /// `recGblFwdLink` by contract, so nothing else would ever free it. C
+    /// empties the whole wait list (`dbNotify.c:428-430`) before it looks at
+    /// the entry at all.
+    #[test]
+    fn a_chain_target_holding_the_same_set_releases_too() {
+        let mut entry = rec("A");
+        let mut target = rec("B");
+        let (tx, rx) = crate::runtime::sync::oneshot::channel();
+        let set = entry.install_or_queue_notify(tx).expect("slot was free");
+        target.join_put_notify(Some(&set));
+        drop(rx);
+        let dead = target.unanswerable_notify().expect("nobody can answer it");
+        assert!(Arc::ptr_eq(&dead, &set));
+        assert!(target.release_notify(&dead));
+        assert!(!target.has_notify(), "B must be free for the next put");
+        assert!(entry.release_notify(&dead));
+        assert!(!entry.has_notify());
+    }
+
+    /// The record's own slot is the authority, not the name the sweep carries:
+    /// a member that has since completed and taken a LIVE notify keeps it.
+    /// C re-tests `precord->ppn` for the same reason (`restartCheck`'s
+    /// `assert(precord->ppn)`, `dbNotify.c:154`).
+    #[test]
+    fn a_member_that_moved_on_to_a_live_notify_is_left_alone() {
+        let mut entry = rec("A");
+        let mut target = rec("B");
+        let (tx, rx) = crate::runtime::sync::oneshot::channel();
+        let dead = entry.install_or_queue_notify(tx).expect("slot was free");
+        target.join_put_notify(Some(&dead));
+        drop(rx);
+
+        // B finished its contribution and a fresh client took it.
+        assert!(target.release_notify(&dead));
+        let (tx2, _rx2) = crate::runtime::sync::oneshot::channel();
+        target.install_or_queue_notify(tx2).expect("slot was free");
+
+        assert!(
+            !target.release_notify(&dead),
+            "the stale name must not evict the live notify"
+        );
+        assert!(target.has_notify());
     }
 }

--- a/crates/epics-base-rs/src/server/record/record_trait.rs
+++ b/crates/epics-base-rs/src/server/record/record_trait.rs
@@ -2313,15 +2313,56 @@ pub trait Record: Send + Sync + 'static {
         )
     }
 
-    /// Whether async processing has completed and put_notify can respond.
-    /// Records that return AsyncPendingNotify should return false while
-    /// async work is in progress, and true when done.
-    /// Default: true (synchronous records are always complete).
+    /// Has this cycle REACHED the record's `recGblFwdLink` line?
+    ///
+    /// C `if (!pact && prec->pact) return(0)` — device support took the write
+    /// asynchronously, so `process()` returns before the tail and the client's
+    /// `ca_put_callback` is still owed. A record that returns
+    /// `AsyncPendingNotify` answers `false` until its device round-trip is
+    /// done. Default: true, the synchronous record that runs to its own tail.
+    ///
+    /// One of the two inputs to `complete_put_notify`; see
+    /// [`Self::should_fire_forward_link`] for the other and for the invariant
+    /// they share.
     fn is_put_complete(&self) -> bool {
         true
     }
 
-    /// Whether this record should fire its forward link after processing.
+    /// Does this cycle TAKE the record's `recGblFwdLink` line, having reached
+    /// it?
+    ///
+    /// # Invariant (CONTRACT)
+    ///
+    /// A cycle completes an outstanding put-notify if and only if it runs
+    /// `recGblFwdLink`. C `recGbl.c:290-303` is why: `if (pdbc->ppn)
+    /// dbNotifyCompletion(pdbc)` sits INSIDE the function a record type
+    /// chooses whether to call, so declining the forward link withholds the
+    /// client's `ca_put_callback` by construction. The two are one decision in
+    /// C and must stay one here — mca's own source says so where it makes the
+    /// choice: "Process forward-linked record. Tell EPICS dbPutNotify
+    /// mechanism that processing is finished." (`mcaRecord.c:820-826`).
+    ///
+    /// The single owner of that decision is
+    /// `database::processing::complete_put_notify`, which reads this method
+    /// and [`Self::is_put_complete`] together. A record type states its C gate
+    /// HERE and nowhere else; it must not carry a second, separately-drifting
+    /// `is_put_complete` override to say the same thing.
+    ///
+    /// Six types gate the call, each transcribing one C line:
+    ///
+    /// - `busy` (`busyRecord.c:271`): `if ((prec->val == 0) || (prec->oval ==
+    ///   0)) recGblFwdLink(prec);`
+    /// - `motor` (`motorRecord.cc:1509`): `if (pmr->dmov != 0)`
+    /// - `mca` (`mcaRecord.c:824`): `if (!pmca->acqg)`
+    /// - `scaler` (`scalerRecord.c:475`): `if ((pscal->pcnt==0) && (pscal->us
+    ///   == USER_STATE_IDLE))` inside the `ss == SCALER_STATE_IDLE` arm
+    /// - `epid` (`epidRecord.c:201`): the UDF-gated `return(0)` above the
+    ///   `:212` call
+    /// - `throttle` (`throttleRecord.c:308`): the call is commented out in
+    ///   `process()` and fired only from `valuePut`'s real-OUT-write branch
+    ///   (`:582`)
+    ///
+    /// Default: true — the standard record, which calls it unconditionally.
     fn should_fire_forward_link(&self) -> bool {
         true
     }
@@ -4629,7 +4670,62 @@ pub fn coerce_put_value<R: Record + ?Sized>(
             )));
         }
     }
+    // The float/double rows of C's DBR_STRING put column render through the
+    // record's `get_precision`, seeded 6: `putFloatString`/`putDoubleString`
+    // (`dbConvert.c:1558`/`:1600`) for the array path,
+    // `cvt_f_st`/`cvt_d_st` (`dbFastLinkConv.c:1216`/`:1333`) for the scalar
+    // one that `dbAccess.c:1391` actually takes. `convert_to` cannot express
+    // it — it is field-blind by contract, and precision is the record's — so
+    // the row belongs here, next to the menu and enum rows it also cannot
+    // express. Rendering through the GET direction's own converter is what
+    // keeps `dbtgf REC.DESC` and a `caput` of the same number agreeing.
+    if target == DbFieldType::String
+        && let Some(rendered) =
+            crate::types::codec::dbr_string_at_precision(&value, put_string_precision(record))
+    {
+        return Ok(Converted::Stored(rendered));
+    }
     Ok(Converted::Stored(value.convert_to(target)))
+}
+
+/// C's `prset->get_precision` answer for a **`DBF_STRING`** destination — the
+/// precision `putFloatString`/`putDoubleString` render a numeric put with.
+///
+/// The seed is 6 and only `get_precision` overwrites it
+/// (`dbConvert.c:1562-1568`, `dbFastLinkConv.c:1220-1228`). For a STRING field
+/// the shared tail is a no-op: `recGblGetPrec`'s switch has no `DBF_STRING`
+/// case (`recGbl.c:141-142`), so whatever the body seeded survives. And no
+/// `get_precision` in base or in the ported modules names a `DBF_STRING` field
+/// in its own switch, so the answer is per RECORD rather than per field: it is
+/// `PREC` for every body that seeds `*precision = prec->prec` ahead of the tail
+/// — ai, ao, aai, aao, aSub, calc, calcout, compress, dfanout, sel, seq, sub,
+/// subArray, waveform, sCalcout, aCalcout, epid, mca, motor, scaler, sseq,
+/// swait, throttle, transform. The two ported types that do not seed:
+///
+/// * `histogram` — a switch with no seed and no case a dbCommon field reaches,
+///   so the caller's 6 arrives at `cvtDoubleToString`
+///   (`histogramRecord.c:420-438`).
+/// * `asyn` — `*precision = 0;` before the tail (`asynRecord.c::get_precision`).
+///
+/// `bo`, `busy`, `mbbiDirect` and `mbboDirect` are unseeded too and need no arm:
+/// none of them declares `PREC`, so the fallback is already C's 6. No record
+/// type declares `PREC` while NULLing `get_precision` (checked across base and
+/// the ported modules), which is what lets "has a PREC field" stand in for
+/// "supplies the slot" without a second table to keep in step.
+///
+/// A negative PREC is not clamped, for the reason
+/// [`crate::types::codec`]'s GET side spells out: C hands the `long` to
+/// `cvtDoubleToString`'s `epicsUInt16` parameter and the conversion
+/// reinterprets it.
+fn put_string_precision<R: Record + ?Sized>(record: &R) -> u16 {
+    match record.record_type() {
+        "histogram" => 6,
+        "asyn" => 0,
+        _ => record
+            .get_field("PREC")
+            .and_then(|v| v.as_int_i64())
+            .map_or(6, |p| p as i16 as u16),
+    }
 }
 
 /// C `putStringString`'s truncation: a `DBF_STRING` field stores at most

--- a/crates/epics-base-rs/src/server/records/busy.rs
+++ b/crates/epics-base-rs/src/server/records/busy.rs
@@ -373,17 +373,18 @@ impl Record for BusyRecord {
         true
     }
 
-    // NO `is_put_complete` override — busy completes its put-callback
-    // synchronously, like bo. C `busyRecord.c:273` clears `pact = FALSE` at the
-    // tail of every process cycle; only async device support that set `pact`
-    // itself (`:254`) holds the callback, and the soft support this port models
-    // (`devBusySoft.c::write_busy` is a bare `dbPutLink`, never touching `pact`)
-    // does not. A prior `is_put_complete() == self.val == 0` modelled the
-    // asynBusy hold, but this record's `process()` is synchronous (never returns
-    // `AsyncPendingNotify`), so the phantom hold only wedged the put-notify:
-    // once VAL was driven to 1 the callback never completed, and every following
-    // `ca_put_callback` was refused, so the
-    // out-of-range VAL puts C posts (2, 3 → "Illegal_Value") never processed.
+    // NO `is_put_complete` override, and none is wanted: the gate above is the
+    // whole of it. `is_put_complete` answers a different C question — did
+    // device support take the cycle async (`busyRecord.c:254`) — and busy's
+    // `process()` is synchronous, so the answer is always yes.
+    //
+    // Withholding the client's `ca_put_callback` while VAL stays 1 is
+    // `should_fire_forward_link` alone: `dbNotifyCompletion` lives inside the
+    // `recGblFwdLink` the line above declines to call, and the framework reads
+    // the two together in `complete_put_notify`. A second override saying
+    // `val == 0` here would be the same C fact written twice, which is how the
+    // deleted `is_put_complete() == (self.val == 0)` came to say it in the one
+    // place the framework then honoured without the forward-link half.
     fn get_field(&self, name: &str) -> Option<EpicsValue> {
         match name {
             "VAL" => Some(EpicsValue::Enum(self.val)),

--- a/crates/epics-base-rs/src/server/records/sub_record.rs
+++ b/crates/epics-base-rs/src/server/records/sub_record.rs
@@ -107,17 +107,22 @@ impl Record for SubRecord {
         crate::server::record::calc_class_link_backed_metadata_field(field)
     }
 
-    fn init_record(&mut self, pass: u8) -> CaResult<()> {
-        if pass == 0 {
-            // C `subRecord.c::init_record` (lines 130-132) seeds the
-            // monitor/archive/alarm trackers from the loaded VAL so the
-            // first process does not post or alarm on an unchanged value.
-            self.mlst = self.val;
-            self.alst = self.val;
-            self.lalm = self.val;
-        }
-        Ok(())
-    }
+    // C `subRecord.c::init_record` returns at `:99` for `pass == 0` and does
+    // ALL of its work in pass 1: the constant-link loads, INAM, SNAM, and only
+    // then `prec->mlst = prec->alst = prec->lalm = prec->val` (`:130-132`).
+    // That tail is unreachable for a record whose SNAM is empty (`:122`) or
+    // unregistered (`:128`), so it is performed by the SNAM resolution owner
+    // (`ioc_app::wire_subroutine`) and not from here — this ran in pass 0,
+    // before the resolution existed, and seeded the trackers of records C
+    // leaves at zero.
+
+    /// Empty for the reason the note above `record_type` gives: `sub`'s
+    /// tracker seed is `subRecord.c:130-132`, the tail below `init_record`'s
+    /// two early returns, and only a record whose SNAM actually resolved
+    /// reaches it. The generic tail runs before the resolution and so cannot
+    /// answer that; `ioc_app::wire_subroutine`, which performs the resolution,
+    /// does it there.
+    fn seed_deadband_tracking(&mut self) {}
 
     /// C `subRecord.c:119-123`: an empty `SNAM` names no subroutine, so
     /// `init_record` prints `"%s.SNAM is empty"`, sets `prec->pact = TRUE` and
@@ -334,17 +339,26 @@ mod tests {
         }
     }
 
-    /// `init_record(0)` seeds MLST/ALST/LALM from the loaded VAL so the
-    /// first process does not post or alarm on an unchanged value
-    /// (C `subRecord.c::init_record` lines 130-132).
+    /// Neither init hook seeds MLST/ALST/LALM: C reaches
+    /// `subRecord.c:130-132` only past `init_record`'s INAM and SNAM early
+    /// returns, so the seed belongs to the SNAM resolution owner
+    /// (`ioc_app::wire_subroutine`, covered by
+    /// `tests/snam_is_resolved_only_where_c_resolves_it.rs`). Seeding here
+    /// gave an unresolved-SNAM record `MLST: 5` where softIoc reads `MLST: 0`.
     #[test]
-    fn init_seeds_trackers_from_val() {
+    fn the_record_itself_seeds_no_tracker() {
         let mut rec = SubRecord::default();
         rec.put_field("VAL", EpicsValue::Double(7.0)).unwrap();
         rec.init_record(0).unwrap();
-        assert_eq!(rec.get_field("MLST"), Some(EpicsValue::Double(7.0)));
-        assert_eq!(rec.get_field("ALST"), Some(EpicsValue::Double(7.0)));
-        assert_eq!(rec.get_field("LALM"), Some(EpicsValue::Double(7.0)));
+        rec.init_record(1).unwrap();
+        rec.seed_deadband_tracking();
+        for field in ["MLST", "ALST", "LALM"] {
+            assert_eq!(
+                rec.get_field(field),
+                Some(EpicsValue::Double(0.0)),
+                "{field}"
+            );
+        }
     }
 
     /// BRSV round-trips as a `menuAlarmSevr` index (C `subRecord.c` BRSV,

--- a/crates/epics-base-rs/src/types/codec.rs
+++ b/crates/epics-base-rs/src/types/codec.rs
@@ -182,7 +182,40 @@ fn convert_value_to_dbr_string(
     // renders `%*.*e` (compiled: `caget -S` of a PREC=-1 ai gives
     // ` 3.70000000000000018e+00`). Clamping to 0 printed `4` instead.
     let prec = snapshot.precision().map(|p| p as u16).unwrap_or(6);
+    if let Some(rendered) = dbr_string_at_precision(value, prec) {
+        return Ok(rendered);
+    }
     Ok(match value {
+        // C `getEnumString` (dbConvert.c, `[DBF_ENUM][DBR_STRING]`) hands the
+        // value to the field's own string source — the record's `get_enum_str`
+        // rset, a menu's choice list, a device's choice list — and renders what
+        // comes back. See `enum_label`.
+        EpicsValue::Enum(v) => EpicsValue::String(enum_label(snapshot, *v)),
+        EpicsValue::EnumArray(a) => {
+            EpicsValue::StringArray(a.iter().map(|v| enum_label(snapshot, *v)).collect())
+        }
+        other => other.get_convert(DbFieldType::String)?,
+    })
+}
+
+/// The float/double rows of C's `DBR_STRING` column, **in both directions**.
+///
+/// `getFloatString`/`getDoubleString` (`dbConvert.c:735`/`:772`),
+/// `putFloatString`/`putDoubleString` (`:1558`/`:1600`) and the scalar twins
+/// `cvt_f_st`/`cvt_d_st` (`dbFastLinkConv.c:1216`/`:1333`) are four copies of
+/// one body: seed `long precision = 6`, overwrite it from
+/// `prset->get_precision`, render through `cvtFloatToString` /
+/// `cvtDoubleToString`. Every other numeric row of that column —
+/// `cvtCharToString` through `cvtUInt64ToString` — carries no precision at
+/// all, which is why this answers `None` for them and leaves them to the
+/// plain `convert_to` / `get_convert` projection.
+///
+/// One function because the two directions have to agree: the put path used
+/// Rust's `Display` and stored `1.0` into a `PREC=3` `DESC` as `"1"` where
+/// `dbtpf` gave `"1.000"` — one field reading back two ways depending on which
+/// door the value came through.
+pub(crate) fn dbr_string_at_precision(value: &EpicsValue, prec: u16) -> Option<EpicsValue> {
+    Some(match value {
         EpicsValue::Double(v) => EpicsValue::String(cvt_double_to_string(*v, prec).into()),
         EpicsValue::Float(v) => EpicsValue::String(cvt_float_to_string(*v, prec).into()),
         EpicsValue::DoubleArray(a) => EpicsValue::StringArray(
@@ -195,15 +228,7 @@ fn convert_value_to_dbr_string(
                 .map(|v| cvt_float_to_string(*v, prec).into())
                 .collect(),
         ),
-        // C `getEnumString` (dbConvert.c, `[DBF_ENUM][DBR_STRING]`) hands the
-        // value to the field's own string source — the record's `get_enum_str`
-        // rset, a menu's choice list, a device's choice list — and renders what
-        // comes back. See `enum_label`.
-        EpicsValue::Enum(v) => EpicsValue::String(enum_label(snapshot, *v)),
-        EpicsValue::EnumArray(a) => {
-            EpicsValue::StringArray(a.iter().map(|v| enum_label(snapshot, *v)).collect())
-        }
-        other => other.get_convert(DbFieldType::String)?,
+        _ => return None,
     })
 }
 

--- a/crates/epics-base-rs/tests/a_dtyp_nobody_registered_is_reported.rs
+++ b/crates/epics-base-rs/tests/a_dtyp_nobody_registered_is_reported.rs
@@ -1,0 +1,116 @@
+//! A record whose DTYP names device support nobody registered says so.
+//!
+//! ```c
+//! if(!(pdset = (aidset *)(prec->dset))) {
+//!     recGblRecordError(S_dev_noDSET, prec, "ai: init_record");
+//!     return(S_dev_noDSET);
+//! }
+//! ```
+//! (`aiRecord.c:105-109`, and the same three lines in 21 more
+//! `<rec>Record.c` files.) `M_devSup` has no linked symbol table, so
+//! `errSymLookup` renders `S_dev_noDSET` as `Error (514,3)`.
+//!
+//! Measured on `softIoc` R7.0.10 through `scripts/compat-smoke.sh`: 211 of
+//! these lines over 6 startup scripts, against none from this port. The PV
+//! sets of those same 6 cases are identical, so the records exist on both
+//! sides and the missing line is the whole difference at init.
+//!
+//! The `IocBuilder` route reported nothing at all — not even the port's own
+//! `warning:` — which is why both tests here drive that route.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("\n")
+}
+
+async fn ioc(db_text: &str) -> Arc<PvDatabase> {
+    IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+/// The record type needs a dset, so C's line is owed — and the record is
+/// still built, exactly as C builds it.
+#[epics_macros_rs::epics_test]
+async fn a_record_type_that_needs_a_dset_reports_the_missing_one() {
+    let sink = listen();
+    let db = ioc("record(ai, \"T:A\") { field(DTYP,\"asynInt32\") }\n").await;
+
+    let log = heard(&sink);
+    assert!(
+        log.contains("recGblRecordError: ai: init_record Error (514,3) PV: T:A"),
+        "C `aiRecord.c:107` through `recGbl.c:68-70`, got {log:?}"
+    );
+    assert!(
+        db.get_pv("T:A.VAL").is_ok(),
+        "C reports and keeps the record; `doInitRecord0` discards the status"
+    );
+}
+
+/// A record type C never tests `prec->dset` in stays silent. The table is
+/// the gate, so a `calc` with a nonsense DTYP earns the port's own warning
+/// and nothing that claims to be C's.
+#[epics_macros_rs::epics_test]
+async fn a_record_type_that_needs_no_dset_stays_silent() {
+    let sink = listen();
+    let _db = ioc("record(calc, \"T:C\") { field(DTYP,\"asynInt32\") }\n").await;
+
+    let log = heard(&sink);
+    assert!(
+        !log.contains("init_record Error (514,3)"),
+        "calcRecord.c has no dset check at all, got {log:?}"
+    );
+}
+
+/// `aai` and `aao` test `dset` ABOVE `init_record`'s `if (pass == 0) return 0`
+/// (`aaiRecord.c:118-123`, `aaoRecord.c:125-131`), so both of `initDatabase`'s
+/// calls report and softIoc writes the line twice for one record. Measured on
+/// R7.0.10: two `recGblRecordError: aao: init_record Error (514,3) PV:
+/// testErrors:AaoInt8Out` lines for a single record.
+#[epics_macros_rs::epics_test]
+async fn the_two_array_types_report_once_per_init_pass() {
+    let sink = listen();
+    let _db = ioc(concat!(
+        "record(aao, \"T:AAO\") { field(DTYP,\"nobodyRegisteredThis\") }\n",
+        "record(aai, \"T:AAI\") { field(DTYP,\"nobodyRegisteredThis\") }\n",
+        "record(ao,  \"T:AO\")  { field(DTYP,\"nobodyRegisteredThis\") }\n",
+    ))
+    .await;
+
+    let log = heard(&sink);
+    let count = |needle: &str| log.matches(needle).count();
+    assert_eq!(
+        count("aao: init_record Error (514,3) PV: T:AAO"),
+        2,
+        "C `aaoRecord.c:125-131` is above the pass gate, got {log:?}"
+    );
+    assert_eq!(
+        count("aai: init_record Error (514,3) PV: T:AAI"),
+        2,
+        "C `aaiRecord.c:118-123` is above the pass gate, got {log:?}"
+    );
+    assert_eq!(
+        count("ao: init_record Error (514,3) PV: T:AO"),
+        1,
+        "C `aoRecord.c` tests dset below `if (pass == 0) return 0`, got {log:?}"
+    );
+}

--- a/crates/epics-base-rs/tests/a_record_carries_the_line_its_head_ended_on.rs
+++ b/crates/epics-base-rs/tests/a_record_carries_the_line_its_head_ended_on.rs
@@ -1,0 +1,109 @@
+//! **A parsed record remembers where its HEAD ended, not where its body did.**
+//!
+//! C decides a record exists in the `record_head` action — `dbCreateRecord`
+//! runs from it (`dbYacc.y:227-235`, `dbLexRoutines.c:1128`) — so every
+//! refusal of the head is reported with the closing `)` still the last token
+//! the lexer matched. Measured on `softIoc` built from `~/work/epics-base`
+//! (`R7.0.10`), an unknown record type prints:
+//!
+//! ```text
+//! ERROR: Record type 'nosuchtype' for record 'U1' not found
+//! ERROR:  at or before ')' in path "."  file "unk.db" line 1
+//!
+//!  1 | record(nosuchtype, "U1") {
+//! ```
+//!
+//! and, with the same head split over two lines, ` … line 2` and the echo of
+//! line 2 — the line the `)` sits on, never the line of the `{` or of the `}`
+//! far below.
+//!
+//! [`DbRecordDef`] had no line at all, so a consumer refusing a record after
+//! the parse had nothing to locate it with and printed the refusal bare. This
+//! gate is on the parsed value rather than on a stream because the loader that
+//! prints it is a different owner; what this file has to guarantee is that the
+//! number handed over is C's.
+//!
+//! [`DbRecordDef`]: epics_base_rs::server::db_loader::DbRecordDef
+
+use std::collections::HashMap;
+
+use epics_base_rs::server::db_loader::parse_db;
+
+/// One case per shape the head can take, not one per file story.
+///
+///   * `head_and_body_on_one_line` — the ordinary shape;
+///   * `split_head` — the `)` a line below the `record`, which is the case
+///     that tells a head line from a record-start line;
+///   * `no_body` — `record(ai,"X")` with no braces, C's first `record_body`
+///     alternative;
+///   * `after_blank_and_comment` — the count is over the FLATTENED text, so
+///     lines C reads and discards still advance it;
+///   * `body_spanning_lines` — the body's own length must not move the head.
+#[test]
+fn the_line_is_the_one_the_closing_paren_sits_on() {
+    for (what, text, want) in [
+        (
+            "head_and_body_on_one_line",
+            "record(ai, \"R1\") { field(DESC, \"x\") }\n",
+            1,
+        ),
+        (
+            "split_head",
+            "record(ai,\n       \"R1\")\n{\n    field(DESC, \"x\")\n}\n",
+            2,
+        ),
+        ("no_body", "record(ai, \"R1\")\n", 1),
+        (
+            "after_blank_and_comment",
+            "\n# a comment\n\nrecord(ai, \"R1\") {\n}\n",
+            4,
+        ),
+        (
+            "body_spanning_lines",
+            "record(ai, \"R1\") {\n    field(DESC, \"x\")\n    field(SCAN, \"1 second\")\n}\n",
+            1,
+        ),
+    ] {
+        let recs = parse_db(text, &HashMap::new()).expect("the fixture parses");
+        assert_eq!(recs.len(), 1, "{what}: one record");
+        assert_eq!(recs[0].line, want, "{what}");
+    }
+}
+
+/// Two records in one file each get their own head line, and the second is not
+/// the first's.
+///
+/// The boundary a single-record case cannot show: the parser reuses one `line`
+/// counter across the whole text, so a head line captured at the wrong moment
+/// reads as the PREVIOUS record's, or as the line the loop happened to reach.
+#[test]
+fn each_record_carries_its_own_head_line() {
+    let text = "record(ai, \"R1\") {\n    field(DESC, \"x\")\n}\n\nrecord(bo, \"R2\") {\n}\n";
+    let recs = parse_db(text, &HashMap::new()).expect("the fixture parses");
+    assert_eq!(
+        recs.iter().map(|r| r.line).collect::<Vec<_>>(),
+        vec![1, 5],
+        "each head line is its own"
+    );
+}
+
+/// A record with no text behind it carries `0`, which is the loader's "print
+/// no position" — the same value [`DbFieldDef::new`] uses for a field built
+/// the same way.
+///
+/// [`DbFieldDef::new`]: epics_base_rs::server::db_loader::DbFieldDef::new
+#[test]
+fn a_record_built_by_hand_has_no_line() {
+    use epics_base_rs::server::db_loader::{DbFieldDef, DbRecordDef};
+
+    let built = DbRecordDef {
+        record_type: "ai".into(),
+        name: "R1".into(),
+        fields: vec![DbFieldDef::new("DESC", "x")],
+        aliases: Vec::new(),
+        info_tags: Vec::new(),
+        line: 0,
+    };
+    assert_eq!(built.line, 0);
+    assert_eq!(built.fields[0].line, 0);
+}

--- a/crates/epics-base-rs/tests/a_record_with_no_dset_refuses_to_process.rs
+++ b/crates/epics-base-rs/tests/a_record_with_no_dset_refuses_to_process.rs
@@ -1,0 +1,102 @@
+//! A record whose DTYP resolved to nothing does not process — it goes PACT.
+//!
+//! ```c
+//! if ((pdset==NULL) || (pdset->write_ao==NULL)) {
+//!     prec->pact=TRUE;
+//!     recGblRecordError(S_dev_missingSup, prec, "write_ao");
+//!     return(S_dev_missingSup);
+//! }
+//! ```
+//! (`aoRecord.c:172-176`; the first statement of `process` in 20
+//! `<rec>Record.c` files.)
+//!
+//! The port used to run the whole cycle instead. Measured against `softIoc`
+//! R7.0.10 on `asyn`'s `testErrors` IOC, whose `asyn*` DTYPs are declared by
+//! the DBD and registered by nobody: C left `testErrors:AoInt32` at `PACT 1`,
+//! `STAT UDF`, `TIME <undefined>`; this port left it `PACT 0`, `STAT
+//! NO_ALARM` and stamped, and printed none of C's 28 refusal lines.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::types::EpicsValue;
+
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("\n")
+}
+
+async fn ioc(db_text: &str) -> Arc<PvDatabase> {
+    IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+/// The refusal, the PACT it takes, and the fact that the PACT is what stops
+/// the second report — C prints one line per record however often the record
+/// is scanned, because `dbProcess` turns every later entry away.
+#[epics_macros_rs::epics_test]
+async fn the_first_cycle_refuses_and_the_record_stays_active() {
+    let sink = listen();
+    let db = ioc(
+        "record(ao, \"T:A\") { field(DTYP,\"asynInt32\") field(OUT,\"T:B\") }\n\
+                  record(ai, \"T:B\") {}\n",
+    )
+    .await;
+
+    db.process_record("T:A").await.unwrap();
+    let after_one = heard(&sink);
+    assert!(
+        after_one.contains("recGblRecordError: write_ao Error (514,5) PV: T:A"),
+        "C `aoRecord.c:174` through `recGbl.c:68-70`, got {after_one:?}"
+    );
+    assert_eq!(
+        db.get_pv("T:A.PACT").unwrap(),
+        EpicsValue::Char(1),
+        "C `prec->pact = TRUE`, and nothing releases it"
+    );
+
+    db.process_record("T:A").await.unwrap();
+    let after_two = heard(&sink);
+    assert_eq!(
+        after_two.matches("write_ao Error (514,5)").count(),
+        1,
+        "the PACT guard turns the second entry away before the refusal, got {after_two:?}"
+    );
+}
+
+/// A record type C never tests `prec->dset` in keeps processing. `calc` has
+/// no dset check anywhere, so a nonsense DTYP must not make it inert.
+#[epics_macros_rs::epics_test]
+async fn a_record_type_with_no_dset_check_still_processes() {
+    let sink = listen();
+    let db = ioc("record(calc, \"T:C\") { field(DTYP,\"asynInt32\") field(CALC,\"7\") }\n").await;
+
+    db.process_record("T:C").await.unwrap();
+    let log = heard(&sink);
+    assert!(
+        !log.contains("Error (514,5)"),
+        "calcRecord.c `process` has no dset test, got {log:?}"
+    );
+    assert_eq!(
+        db.get_pv("T:C.VAL").unwrap(),
+        EpicsValue::Double(7.0),
+        "the cycle ran"
+    );
+    assert_eq!(db.get_pv("T:C.PACT").unwrap(), EpicsValue::Char(0));
+}

--- a/crates/epics-base-rs/tests/a_syntax_error_is_located_by_its_token.rs
+++ b/crates/epics-base-rs/tests/a_syntax_error_is_located_by_its_token.rs
@@ -1,0 +1,174 @@
+//! **A `.db` parse abort is located by C's `yytext`, and worded as bison words
+//! it.**
+//!
+//! `dbYacc.y` declares no `%error-verbose` and no per-production message, so
+//! every grammar rejection in C prints the same three words —
+//! `yyerror("syntax error")` — and the ` at or before '%s'` clause that follows
+//! quotes `yytext`, the token the lexer had matched (`dbYacc.y:370-383`). The
+//! token is the whole of what tells one rejection from another.
+//!
+//! This port wrote its own sentence and its own locator: `ERROR: expected ')',
+//! got '}'` over ` at or before column 1`. Both halves diverged, and the second
+//! is the one that costs an operator something — a column counts characters in
+//! a line the echo below already prints, where C names the text.
+//!
+//! Every expected byte below was captured from `softIoc` built from
+//! `~/work/epics-base` (`R7.0.10`) loading these exact files, with two known
+//! subtractions noted per case: C's `WARNING: dbReadCOM: Parser stack dirty
+//! w/o error. 1` counts half-built objects on a `tempList` this parser does not
+//! have, and C's `in path "."` names its own cwd where this gate names the
+//! directory it wrote the fixture into.
+//!
+//! ANSI is stripped before comparing; whether the escapes are emitted has its
+//! own gate. Unix only: what is captured is the process console.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+/// Run one iocsh line with fd 2 pointed at a file, and give back what it wrote.
+fn stderr_of(line: &str, db: Arc<PvDatabase>) -> String {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let owned = line.to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_line(&owned)).join();
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+    ran.expect("the shell thread").ok();
+
+    strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"))
+}
+
+/// C's SGR sequences, dropped — `errlog` strips its own the same way when the
+/// console is not a terminal (`errlog.c:672-681`).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// One case per token SHAPE the locator has to be able to name, not one per
+/// malformed-file story: a punctuation character, a quoted string WITH its
+/// quotes, a bareword, and the two arity boundaries of one argument list.
+///
+///   * `punct` — `record(ai, "A1" {`: the offending token is `{`;
+///   * `quoted` — `field(DESC "x")`: C quotes `"x"`, the whole `tokenSTRING`
+///     the lexer matched, where naming the character would say `"`;
+///   * `bareword_kw` — `recrd(...)`: the unknown keyword itself;
+///   * `bareword_val` — `field(DESC, x y)`: the second bareword, mid-value;
+///   * `next_line` — a field left unclosed, so the token that rejects is a `}`
+///     one LINE below and the position must follow it there;
+///   * `too_many` — `record(ai, "", extra)`: C's grammar has one production per
+///     arity, so the rejection is at the COMMA that would open the third
+///     argument and the empty name is never reached;
+///   * `too_few` — `alias("C8")` at file scope: the `)` that ended a
+///     two-argument list after one.
+const CASES: &[(&str, &str, &str, u32)] = &[
+    ("punct.db", "record(ai, \"A1\" {\n}\n", "{", 1),
+    (
+        "quoted.db",
+        "record(ai, \"A2\") {\n    field(DESC \"x\")\n}\n",
+        "\"x\"",
+        2,
+    ),
+    ("bareword_kw.db", "recrd(ai, \"A5\") {\n}\n", "recrd", 1),
+    (
+        "bareword_val.db",
+        "record(ai, \"A6\") {\n    field(DESC, x y)\n}\n",
+        "y",
+        2,
+    ),
+    (
+        "next_line.db",
+        "record(ai, \"A4\") {\n    field(DESC, \"x\"\n}\n",
+        "}",
+        3,
+    ),
+    ("too_many.db", "record(ai, \"\", extra) {\n}\n", ",", 1),
+    ("too_few.db", "alias(\"C8\")\n", ")", 1),
+];
+
+/// The whole of what C writes for each shape, byte for byte.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn every_rejection_says_syntax_error_and_names_its_token() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (name, body, _, _) in CASES {
+        std::fs::write(dir.path().join(name), body).expect("write the .db");
+    }
+    let found_under = dir.path().display().to_string();
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", &found_under) };
+
+    for (name, body, token, line) in CASES {
+        let got = stderr_of(
+            &format!("dbLoadRecords(\"{name}\")"),
+            Arc::new(PvDatabase::new()),
+        );
+        let source = body
+            .lines()
+            .nth(*line as usize - 1)
+            .expect("the echoed line");
+        let want = format!(
+            "\
+ERROR: syntax error
+ at or before '{token}' in path \"{found_under}\"  file \"{name}\" line {line}
+
+ {line} | {source}
+
+ERROR: Failed to load '{name}'
+"
+        );
+        assert_eq!(
+            got, want,
+            "{name}\n--- got ---\n{got}\n--- want ---\n{want}"
+        );
+    }
+
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+}
+
+/// The boundary the arity move must NOT cross: a list with exactly `max`
+/// arguments still parses, and one with exactly `min` still parses.
+///
+/// The rejection moved from "after the `)`, counting what was collected" to
+/// "at the comma that opens one argument too many", which is a much earlier
+/// gate; these are the two counts either side of it.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn the_arity_boundaries_themselves_still_load() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("ok.db"),
+        "record(ai, \"OK1\") {\n    alias(\"OK1:A\")\n}\nalias(\"OK1\", \"OK1:B\")\n",
+    )
+    .expect("write the .db");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of("dbLoadRecords(\"ok.db\")", Arc::new(PvDatabase::new()));
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    assert_eq!(got, "", "a well-formed file must say nothing: {got}");
+}

--- a/crates/epics-base-rs/tests/an_unterminated_macro_reference_is_said_out_loud.rs
+++ b/crates/epics-base-rs/tests/an_unterminated_macro_reference_is_said_out_loud.rs
@@ -1,0 +1,259 @@
+//! **macLib's third error arm: a macro reference whose closing delimiter never
+//! matched its opener.**
+//!
+//! C `refer` (`macCore.c:862-875`) does three things when `*r != close`: it
+//! rewinds the output pointer to where the reference began and copies the raw
+//! text from the `$` through the last character `trans` scanned — the whole
+//! rest of the string — verbatim; it sets `entry->error`; and it writes
+//!
+//! ```text
+//! macLib: unterminated macro reference in <type> <name>
+//! ```
+//!
+//! with `macExpandString`'s fake `"string"` entry, whose `name` is the caller's
+//! whole source string (`macCore.c:208-209`). Because `entry->error` is set,
+//! `macExpandString` returns a negative length and the `.db` reader's own
+//! per-line warning (`dbLexRoutines.c:378-387`) fires under it — two lines, not
+//! one.
+//!
+//! This port had none of it. `refer` returned `None` at the depth check and the
+//! caller pushed a bare `$` and carried on scanning, which meant three
+//! divergences at once: no `macLib:` line, no error flag and so no `WARNING:`
+//! line either, and — because the caller re-entered `trans` one character past
+//! the `$` — any `$(…)` in the tail got expanded a second time where C never
+//! looks at it again.
+//!
+//! Every expected byte below was captured from `softIoc` built from
+//! `~/work/epics-base` (`R7.0.10`), loading these exact files. ANSI is stripped
+//! before comparing, for the reason the sibling gate
+//! `db_load_diagnostics_say_where` gives: whether the escapes are emitted is a
+//! property of the console predicate and has its own gate.
+//!
+//! Unix only: what is captured is the process console, and the only way to
+//! capture it is to point fd 2 somewhere else and put it back.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::db_loader::{MacroExpandOptions, MacroFault, expand_macros};
+use epics_base_rs::server::iocsh::IocShell;
+
+/// The four shapes the unterminated arm has to cover, one per line, each on a
+/// `#` comment so the only thing the load can produce is the diagnostics — C
+/// expands every line it reads, comments included (`db_yyinput`).
+///
+///   * line 2 — a plain `$(` with no `)` anywhere after it;
+///   * line 3 — the `${` opener, whose `close` is `}`;
+///   * line 4 — a MISMATCHED delimiter: `$(A}` closes nothing, and the `)` that
+///     follows belongs to the inner `$(Q)`, which the name translation consumes;
+///   * line 5 — two openers and no closer at all.
+///
+/// Lines 2-4 each carry a `$(Q)` in the tail, and `Q` IS defined. That is the
+/// discriminator: C never re-scans the tail, so `$(Q)` survives as text.
+const FAMILY_DB: &str = "record(ai, \"T1\") {}\n\
+                         #x$(A $(Q) y\n\
+                         #p${A $(Q) q\n\
+                         #m$(A} $(Q) n\n\
+                         #$(A$(B z\n";
+
+/// Run one iocsh line with fd 2 pointed at a file, and give back what it wrote.
+///
+/// The two families this gates reach the operator by two different routes —
+/// `errlogPrintf`'s console fallback for macLib's line, `eprintln!` for the
+/// loader's — and the only place they are one stream again is the process
+/// console, which is also the only place their order is the operator's order.
+fn stderr_of(line: &str, db: Arc<PvDatabase>) -> String {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let owned = line.to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_line(&owned)).join();
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+    ran.expect("the shell thread").ok();
+
+    strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"))
+}
+
+/// C's SGR sequences, dropped. `errlog` strips its own the same way when the
+/// console is not a terminal (`errlog.c:672-681`); this is the test's copy so
+/// the gate holds whichever way the harness's console answers.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Write `FAMILY_DB` where a bare `dbLoadRecords` name will find it, and give
+/// back the directory (kept alive by the caller) and its path.
+fn family_db_dir() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("fam.db"), FAMILY_DB).expect("write the .db");
+    dir
+}
+
+/// The whole of what C writes for the four shapes, byte for byte.
+///
+/// Note the blank line under each `macLib:` line: `entry->name` is the `fgets`
+/// line and still carries its own `\n`, and `errlogPrintf`'s format adds a
+/// second one. That is why the notice must be raised on the raw line and not on
+/// a trimmed copy.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn an_unterminated_reference_names_the_string_and_the_line() {
+    let dir = family_db_dir();
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of(
+        "dbLoadRecords(\"fam.db\",\"Q=ZZZ\")",
+        Arc::new(PvDatabase::new()),
+    );
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+macLib: unterminated macro reference in string #x$(A $(Q) y
+
+WARNING: 'fam.db' line 2 has undefined macros
+macLib: unterminated macro reference in string #p${A $(Q) q
+
+WARNING: 'fam.db' line 3 has undefined macros
+macLib: unterminated macro reference in string #m$(A} $(Q) n
+
+WARNING: 'fam.db' line 4 has undefined macros
+macLib: unterminated macro reference in string #$(A$(B z
+
+WARNING: 'fam.db' line 5 has undefined macros
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// `dbQuietMacroWarnings` drops the `macLib:` line and keeps the loader's.
+///
+/// C sets `entry->error` BEFORE it consults `FLAG_SUPPRESS_WARNINGS`
+/// (`macCore.c:869-874`), so `macExpandString` still returns a negative length
+/// and `db_yyinput` still warns. Measured on `softIoc` with `var
+/// dbQuietMacroWarnings 1` over the same file: the four `macLib:` notices go,
+/// all four `WARNING:` lines stay. A suppression that swallowed both would
+/// leave a `.db` whose text is raw `$(` with nothing said about it at all.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn suppressing_the_notice_does_not_clear_the_error_flag() {
+    let dir = family_db_dir();
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    epics_base_rs::server::db_loader::set_db_quiet_macro_warnings(true);
+    let got = stderr_of(
+        "dbLoadRecords(\"fam.db\",\"Q=ZZZ\")",
+        Arc::new(PvDatabase::new()),
+    );
+    epics_base_rs::server::db_loader::set_db_quiet_macro_warnings(false);
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+WARNING: 'fam.db' line 2 has undefined macros
+WARNING: 'fam.db' line 3 has undefined macros
+WARNING: 'fam.db' line 4 has undefined macros
+WARNING: 'fam.db' line 5 has undefined macros
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// The tail of an unterminated reference is text, not input.
+///
+/// This is the half the diagnostics cannot show. C's copy loop runs from the
+/// `$` to the end of the string and nothing after it is looked at again, so a
+/// perfectly resolvable `$(Q)` sitting in the tail comes out as the four
+/// characters `$(Q)`. Measured on `softIoc` with `Q=ZZZ` by putting each shape
+/// in a `field(DESC, …)` split across lines so the `.db` line itself carries no
+/// `)`, and reading back what the loader refused to set:
+///
+/// ```text
+/// ERROR: Can't set 'T1.DESC' to 'x$(A $(Q) y'  : Bad Field value
+/// ERROR: Can't set 'T2.DESC' to 'p${A $(Q) q'  : Bad Field value
+/// ERROR: Can't set 'T3.DESC' to 'm$(A} $(Q) n'  : Bad Field value
+/// ERROR: Can't set 'T4.DESC' to '$(A$(B x'  : Bad Field value
+/// ```
+///
+/// Before the fix this port wrote `x$(A ZZZ y` for the first of those: the
+/// caller re-scanned from one character past the `$`, and the `$(Q)` it found
+/// there had already been consumed as part of the unterminated reference's
+/// name.
+#[test]
+fn the_tail_after_an_unterminated_reference_is_copied_not_expanded() {
+    let macros = HashMap::from([("Q".to_string(), "ZZZ".to_string())]);
+    for raw in [
+        "\"x$(A $(Q) y\"\n",
+        "\"p${A $(Q) q\"\n",
+        "\"m$(A} $(Q) n\"\n",
+        "\"$(A$(B x\"\n",
+    ] {
+        let got = expand_macros(
+            raw,
+            &macros,
+            MacroExpandOptions {
+                suppress_warnings: true,
+                ..MacroExpandOptions::default()
+            },
+        );
+        assert_eq!(got.text, raw, "the whole tail must survive verbatim");
+        let copied = &raw[raw.find('$').expect("a $ in the fixture")..];
+        assert_eq!(
+            got.fault(),
+            Some(MacroFault::Unterminated(copied)),
+            "the fault must name the text that was copied through"
+        );
+    }
+}
+
+/// A reference that IS terminated must not be dragged into the new arm, and a
+/// `$` that is not a reference at all must still be a plain character.
+///
+/// The depth counter is what decides, and it counts `$(`/`${` openers against
+/// `)`/`}` closers — so `$(A$(B))` is balanced and resolves, while `$(A$(B)` is
+/// not and is copied. The pair is here because the fix moved the unterminated
+/// case from "return `None`, let the caller cope" to "consume the rest of the
+/// input", and that is a much bigger hammer to hold to the correct side of the
+/// boundary.
+#[test]
+fn a_balanced_reference_is_still_expanded() {
+    let macros = HashMap::from([
+        ("A".to_string(), "outer".to_string()),
+        ("B".to_string(), "A".to_string()),
+        ("Q".to_string(), "ZZZ".to_string()),
+    ]);
+    let opts = MacroExpandOptions {
+        suppress_warnings: true,
+        ..MacroExpandOptions::default()
+    };
+    for (raw, want) in [
+        ("$($(B)) tail $(Q)", "outer tail ZZZ"),
+        ("${A} tail $(Q)", "outer tail ZZZ"),
+        ("no reference here: $ ( ) $", "no reference here: $ ( ) $"),
+        ("trailing dollar $", "trailing dollar $"),
+    ] {
+        let got = expand_macros(raw, &macros, opts);
+        assert_eq!(got.text, want, "expanding {raw:?}");
+        assert!(!got.errored(), "{raw:?} must not report a fault");
+    }
+}

--- a/crates/epics-base-rs/tests/async_soft_channel_refuses_a_non_pv_inp.rs
+++ b/crates/epics-base-rs/tests/async_soft_channel_refuses_a_non_pv_inp.rs
@@ -1,0 +1,89 @@
+//! `"Async Soft Channel"` on an input record demands a PV link in INP.
+//!
+//! `devAiSoftCallback.c:76-93` and its six input twins report
+//! `S_db_badField` from `add_record` when `plink->type != PV_LINK`. Measured
+//! on `softIoc` R7.0.10 over `asyncSoftTest.db`: seven lines, one per input
+//! record whose INP is `{const:N}`, and none for the `ai0`-style records whose
+//! INP names a PV or for any of the output records — the ten output
+//! `dev*SoftCallback.c` files declare no `dsxt` at all.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("\n")
+}
+
+async fn ioc(db_text: &str) -> Arc<PvDatabase> {
+    IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+/// The three boundaries of C's one live test, on one input record type:
+/// a JSON constant refuses, a PV name passes, an unset INP refuses.
+#[epics_macros_rs::epics_test]
+async fn only_a_pv_link_passes_add_record() {
+    let sink = listen();
+    let db = ioc(
+        "record(ai, \"T:CONST\") { field(DTYP,\"Async Soft Channel\") field(INP,{const:9}) }\n\
+         record(ai, \"T:PV\")    { field(DTYP,\"Async Soft Channel\") field(INP,\"T:CONST\") }\n\
+         record(ai, \"T:EMPTY\") { field(DTYP,\"Async Soft Channel\") }\n",
+    )
+    .await;
+
+    let log = heard(&sink);
+    for name in ["T:CONST", "T:EMPTY"] {
+        assert!(
+            log.contains(&format!(
+                "recGblRecordError: devAiSoftCallback (add_record) Illegal INP field \
+                 Illegal field value PV: {name}"
+            )),
+            "{name} has no PV link, got {log:?}"
+        );
+    }
+    assert!(
+        !log.contains("PV: T:PV"),
+        "a PV_LINK INP is what add_record is looking for, got {log:?}"
+    );
+    assert!(
+        db.get_pv("T:CONST.VAL").is_ok(),
+        "`doResolveLinks` discards the status, so the record is still built"
+    );
+}
+
+/// An OUTPUT `"Async Soft Channel"` record has no `add_record` in C, and a
+/// non-Async soft channel has no callback dset at all. Neither may be
+/// reported.
+#[epics_macros_rs::epics_test]
+async fn nothing_else_is_checked() {
+    let sink = listen();
+    let _db = ioc(
+        "record(ao, \"T:AO\") { field(DTYP,\"Async Soft Channel\") field(OUT,{const:1}) }\n\
+         record(ai, \"T:PLAIN\") { field(DTYP,\"Soft Channel\") field(INP,{const:9}) }\n",
+    )
+    .await;
+
+    let log = heard(&sink);
+    assert!(
+        !log.contains("add_record"),
+        "devAoSoftCallback.c declares no dsxt and devAiSoft.c has no add_record, got {log:?}"
+    );
+}

--- a/crates/epics-base-rs/tests/bare_shell_build_runs_c_iocbuild.rs
+++ b/crates/epics-base-rs/tests/bare_shell_build_runs_c_iocbuild.rs
@@ -1,0 +1,186 @@
+//! **A shell with no `IocApplication` still runs C's `iocBuild_1`.**
+//!
+//! C has no "bare" shell: `iocInit()` is `iocBuild() || iocRun()`
+//! (`iocInit.c:111-113`) for everyone, so `iocBuild_1` always runs and always
+//! does four visible things (`iocInit.c:117-148`,
+//! R7.0.10-146-g8f5015b663d764ad75df):
+//!
+//! ```c
+//!     if (iocState != iocVoid) {
+//!         errlogPrintf("iocBuild: " ERL_ERROR " IOC can only be initialized "
+//!                      "from uninitialized or stopped state\n");
+//!         return -1;
+//!     }
+//!     ...
+//!     errlogPrintf("Starting iocInit\n");
+//!     ...
+//!     coreRelease();
+//!     iocState = iocBuilding;
+//! ```
+//!
+//! and `iocRun` closes with `errlogPrintf("iocRun: %s\n", ...)` (`:273`).
+//!
+//! The port's `NotOurs` arm — every `CaServerBuilder` binary and every bare
+//! `PvDatabase` shell — closed the record load and returned, leaving
+//! `iocState` at `iocVoid`. Measured against
+//! `~/work/epics-base/bin/linux-x86_64/softIoc`, that lost the whole
+//! lifecycle: `iocBuild` then `iocRun` answered `iocRun: WARNING IOC not
+//! paused` where C answers `iocRun: All initialization complete`; a second
+//! `iocBuild` was accepted where C refuses it; `iocPause` after `iocInit`
+//! said `WARNING IOC not running`; and the five-line `coreRelease` banner C
+//! puts on stdout between the two command echoes was absent.
+//!
+//! The sink rule this also pins is uniform and countable: `iocInit.c` holds
+//! twenty-four `errlogPrintf` calls and zero plain `printf` calls, so
+//! `coreRelease()`'s banner (`misc/epicsRelease.c:23-27`) is the only stdout
+//! write on the whole path.
+//!
+//! Every case here changes process-global IOC state, so each is its own test
+//! and therefore its own process.
+//!
+//! Unix only: what is asserted is the process console.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Run one script through a fresh shell; give back (stdout, stderr).
+fn run(script_body: &str) -> (String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("t.cmd");
+    std::fs::write(&script, script_body).expect("write the script");
+
+    let out_sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    let err_sink = tempfile::NamedTempFile::new().expect("stderr capture");
+    // SAFETY: the shell writes through fds 1 and 2 for the length of one
+    // script and this test owns the process, so nothing else holds either.
+    let saved = unsafe {
+        let saved = (libc::dup(1), libc::dup(2));
+        libc::dup2(out_sink.as_file().as_raw_fd(), 1);
+        libc::dup2(err_sink.as_file().as_raw_fd(), 2);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.display().to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    // SAFETY: restoring the two descriptors this call replaced.
+    unsafe {
+        libc::dup2(saved.0, 1);
+        libc::dup2(saved.1, 2);
+        libc::close(saved.0);
+        libc::close(saved.1);
+    }
+    assert!(ran.is_ok(), "the shell panicked");
+    (
+        strip_ansi(&std::fs::read_to_string(out_sink.path()).expect("stdout capture")),
+        strip_ansi(&std::fs::read_to_string(err_sink.path()).expect("stderr capture")),
+    )
+}
+
+/// The banner's two `Rev.` lines carry this tree's own VCS stamp, as C's carry
+/// C's, so its shape is what can be asserted.
+fn assert_banner(lines: &[&str], out: &str) {
+    assert_eq!(lines.len(), 5, "stdout was {out:?}");
+    assert!(lines[0].starts_with("###"), "stdout was {out:?}");
+    assert!(lines[1].starts_with("## EPICS"), "stdout was {out:?}");
+    assert!(lines[2].starts_with("## Rev. "), "stdout was {out:?}");
+    assert!(lines[3].starts_with("## Rev. Date "), "stdout was {out:?}");
+    assert!(lines[4].starts_with("###"), "stdout was {out:?}");
+}
+
+/// `iocBuild` then `iocRun`: C's banner lands between the two echoes and the
+/// run reaches `iocBuilt`, so `iocRun` reports the completion, not a warning.
+#[epics_macros_rs::epics_test]
+async fn build_then_run_completes_instead_of_warning() {
+    let (out, err) = run("iocBuild\niocRun\n");
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.first(), Some(&"iocBuild"), "stdout was {out:?}");
+    assert_eq!(lines.last(), Some(&"iocRun"), "stdout was {out:?}");
+    assert_banner(&lines[1..lines.len() - 1], &out);
+    assert_eq!(
+        err,
+        "Starting iocInit\niocRun: All initialization complete\n"
+    );
+}
+
+/// C `iocBuild_1` refuses from any state but `iocVoid`, and says so under the
+/// name `iocBuild` whichever command called it.
+#[epics_macros_rs::epics_test]
+async fn a_second_build_is_refused() {
+    let (_out, err) = run("iocBuild\niocBuild\n");
+    assert_eq!(
+        err,
+        "Starting iocInit\niocBuild: ERROR IOC can only be initialized from \
+         uninitialized or stopped state\n"
+    );
+}
+
+/// The same refusal reached through `iocInit`, which is where C's `iocBuild:`
+/// prefix looks surprising and is nonetheless what C prints.
+#[epics_macros_rs::epics_test]
+async fn a_second_init_is_refused_under_the_build_name() {
+    let (_out, err) = run("iocInit\niocInit\n");
+    assert_eq!(
+        err,
+        "Starting iocInit\niocRun: All initialization complete\niocBuild: ERROR \
+         IOC can only be initialized from uninitialized or stopped state\n"
+    );
+}
+
+/// `iocPause` and a resuming `iocRun` only work because the build advanced the
+/// state cell; before the fix both answered a warning.
+#[epics_macros_rs::epics_test]
+async fn init_pause_run_is_the_full_c_sequence() {
+    let (_out, err) = run("iocInit\niocPause\niocRun\n");
+    assert_eq!(
+        err,
+        "Starting iocInit\niocRun: All initialization complete\niocPause: IOC \
+         suspended\niocRun: IOC restarted\n"
+    );
+}
+
+/// `eltc 0` owns the console, and the reason every boot line must go through
+/// the errlog rather than a bare `eprintln!` is that this is the only switch
+/// C gives an operator for them. Measured: `eltc 0` then `iocInit` left C's
+/// stderr empty while the port kept writing — through raw `eprintln!` — the
+/// record-count line (`ioc_app.rs`) and the CA server's port line
+/// (`epics-ca-rs`'s `ca_server.rs`), both now routed here.
+#[epics_macros_rs::epics_test]
+async fn eltc_zero_silences_everything_the_build_says() {
+    let (_out, err) = run("eltc 0\niocInit\n");
+    assert_eq!(err, "", "eltc 0 leaves C's console empty");
+}
+
+/// `coreRelease` on its own still prints the same five lines, so the assertion
+/// above is about where the build prints and not about a mute shell.
+#[epics_macros_rs::epics_test]
+async fn core_release_still_prints_its_banner_on_stdout() {
+    let (out, _err) = run("coreRelease\n");
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.first(), Some(&"coreRelease"), "stdout was {out:?}");
+    assert_banner(&lines[1..], &out);
+}

--- a/crates/epics-base-rs/tests/blocking_put_releases_on_client_drop.rs
+++ b/crates/epics-base-rs/tests/blocking_put_releases_on_client_drop.rs
@@ -1,0 +1,168 @@
+//! A blocking external PUT (`record[block=true]`) whose awaiting future is
+//! dropped must hand the record back, the way C's CA server does from
+//! `rsrvFreePutNotify` (`rsrv/camessage.c:1630-1638`):
+//!
+//! ```c
+//! void rsrvFreePutNotify(struct client *pClient, ...)
+//! {
+//!     if (pNotify->busy) { dbNotifyCancel(&pNotify->dbPutNotify); }
+//! }
+//! ```
+//!
+//! pvxs has no such call because on that transport the blocking put IS the
+//! operation's future: the native PVA server spawns the PUT EXEC body and
+//! keeps its abort handle on the op, so DESTROY_CHANNEL and connection
+//! teardown alike drop `ChannelState::ops`, abort the task and drop the
+//! future mid-await. The release therefore belongs to the future itself.
+//!
+//! The case that only a teardown release closes is a SECOND client already
+//! parked on the record's restart list. Nothing then arrives to test
+//! ownership, so a release that runs only at the next put's arrival never
+//! runs at all — the queued client waits on a completion that can never come.
+//! `busy` at VAL=1 is the record that makes it permanent: it withholds
+//! `recGblFwdLink` by contract (`busyRecord.c:271`).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll, Wake, Waker};
+
+use epics_base_rs::server::database::{ProcessMode, PvDatabase};
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::records::busy::BusyRecord;
+use epics_base_rs::types::EpicsValue;
+
+const DB: &str = r#"
+record(busy, "B") { field(ZNAM,"Done") field(ONAM,"Busy") }
+"#;
+
+async fn build() -> Arc<PvDatabase> {
+    IocBuilder::new()
+        .register_record_type("busy", || Box::new(BusyRecord::default()))
+        .db_string(DB, &std::collections::HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+struct Woken(AtomicBool);
+
+impl Wake for Woken {
+    fn wake(self: Arc<Self>) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Drive `f` in place until it parks — poll it, and keep polling for as long
+/// as it asks to be woken again. A blocking put on a `busy` left at VAL=1
+/// parks on a completion that never comes, which is exactly the state an
+/// aborted PVA PUT EXEC task is in when its future is dropped.
+fn drive_until_parked<F: Future + Unpin>(f: &mut F) -> Poll<F::Output> {
+    let woken = Arc::new(Woken(AtomicBool::new(false)));
+    let waker = Waker::from(woken.clone());
+    let mut cx = Context::from_waker(&waker);
+    for _ in 0..64 {
+        woken.0.store(false, Ordering::SeqCst);
+        match Pin::new(&mut *f).poll(&mut cx) {
+            Poll::Ready(v) => return Poll::Ready(v),
+            Poll::Pending if !woken.0.load(Ordering::SeqCst) => return Poll::Pending,
+            Poll::Pending => {}
+        }
+    }
+    panic!("the put never parked");
+}
+
+fn val(db: &PvDatabase) -> Option<EpicsValue> {
+    db.get_record("B").unwrap().read().record.get_field("VAL")
+}
+
+/// Client A blocks on a put that `busy` will never answer; client B blocks
+/// behind it on the restart list; A's transport dies. B must be handed the
+/// record. Without the release in A's future this deadlocks B forever: the
+/// arrival-time sweep needs an arrival, and B arrived before A died.
+#[epics_macros_rs::epics_test]
+async fn a_dropped_blocking_put_hands_the_record_to_the_queued_client() {
+    let db = build().await;
+
+    let mut first = Box::pin(db.put_field_from_client(
+        "B",
+        "VAL",
+        EpicsValue::Double(1.0),
+        ProcessMode::Passive,
+        true,
+    ));
+    assert!(
+        drive_until_parked(&mut first).is_pending(),
+        "VAL=1 withholds the callback, so the blocking put cannot return"
+    );
+    assert!(
+        db.get_record("B").unwrap().read().has_notify(),
+        "client A owns B's put-notify slot"
+    );
+
+    let mut second = Box::pin(db.put_field_from_client(
+        "B",
+        "VAL",
+        EpicsValue::Double(0.0),
+        ProcessMode::Passive,
+        true,
+    ));
+    assert!(
+        drive_until_parked(&mut second).is_pending(),
+        "client B queues behind A"
+    );
+    assert_eq!(
+        val(&db),
+        Some(EpicsValue::Enum(1)),
+        "a queued put-notify writes nothing until it is replayed"
+    );
+
+    // The PVA op is aborted and its body dropped mid-await.
+    drop(first);
+
+    second.await.expect("client B's put must complete");
+    assert_eq!(
+        val(&db),
+        Some(EpicsValue::Enum(0)),
+        "restartCheck hands the record to the queued client, which then writes"
+    );
+}
+
+/// The disarm boundary: a blocking put that DID complete must not sweep on
+/// the way out. `process=false` writes without a notify at all, and a
+/// settled Passive put returns `ProcessCompletion::Sync`, so the release
+/// must key on the await having been reached and abandoned — not on the
+/// future being dropped.
+#[epics_macros_rs::epics_test]
+async fn a_completed_blocking_put_leaves_the_slot_alone() {
+    let db = build().await;
+
+    // VAL=0 settles inside the put, so this returns rather than parking.
+    db.put_field_from_client(
+        "B",
+        "VAL",
+        EpicsValue::Double(0.0),
+        ProcessMode::Passive,
+        true,
+    )
+    .await
+    .expect("a settling put completes");
+    assert!(
+        !db.get_record("B").unwrap().read().has_notify(),
+        "a completed put leaves no slot behind"
+    );
+
+    // A second client can still park and be answered normally afterwards.
+    let mut held = Box::pin(db.put_field_from_client(
+        "B",
+        "VAL",
+        EpicsValue::Double(1.0),
+        ProcessMode::Passive,
+        true,
+    ));
+    assert!(drive_until_parked(&mut held).is_pending());
+    assert!(db.get_record("B").unwrap().read().has_notify());
+}

--- a/crates/epics-base-rs/tests/busy_val_notify_posts_each_change.rs
+++ b/crates/epics-base-rs/tests/busy_val_notify_posts_each_change.rs
@@ -1,19 +1,24 @@
-//! busy completes its put-callback SYNCHRONOUSLY (like bo), so a sequence of
-//! `ca_put_callback` writes to VAL each processes and posts `DBE_VALUE`.
+//! A `busy` record left at VAL=1 withholds its put-callback, exactly as C
+//! does — and the NEXT `ca_put_callback` still lands.
 //!
-//! C `busyRecord.c:273` clears `pact = FALSE` at the tail of every process
-//! cycle; the soft device support this port models (`devBusySoft.c::write_busy`
-//! is a bare `dbPutLink`, never touching `pact`) leaves the record synchronous,
-//! so `dbNotifyCompletion` fires each `ca_put_callback` immediately and the
-//! next put is not refused.
+//! C `busyRecord.c:271` calls `recGblFwdLink(prec)` only for `val == 0 ||
+//! oval == 0`, and `recGblFwdLink` (`recGbl.c:295`) is where
+//! `dbNotifyCompletion` lives. So a put that leaves VAL non-zero leaves the
+//! client's callback outstanding on purpose; that is the record type's whole
+//! contract, and `caput -c` on it is meant to hang until something writes
+//! "Done".
 //!
-//! Regression: busy previously overrode `is_put_complete() == (val == 0)`,
-//! modelling the asynBusy hold. But busy's `process()` is synchronous (never
-//! `AsyncPendingNotify`), so the hold was a phantom: once VAL was driven to 1
-//! the put-callback never completed, and every following `ca_put_callback` was
-//! refused. The oracle's `caput 1;2;2;3` then
-//! posted only the first event (VAL=1 "Busy") instead of C's three
-//! (Busy → Illegal_Value(2) → Illegal_Value(3)).
+//! Two regressions in one file, because they are two halves of one bug:
+//!
+//! 1. A deleted `is_put_complete() == (self.val == 0)` override said the
+//!    right thing through the wrong method — the framework honoured it
+//!    without the forward-link half — and, worse, it exposed (2).
+//! 2. With the callback legitimately withheld, the client gives up and exits.
+//!    If the record's notify slot is not released then (C
+//!    `rsrvFreePutNotify` → `dbNotifyCancel`, `camessage.c:1637`), the record
+//!    is wedged for good: every later put queues behind a completion that can
+//!    never arrive and writes nothing, so `caput 1;2;2;3` posts one event
+//!    instead of C's three.
 
 use epics_base_rs::server::database::PvDatabase;
 use epics_base_rs::server::event_queue::EventReader;
@@ -45,10 +50,11 @@ fn drain(rx: &mut EventReader) -> Vec<EpicsValue> {
     out
 }
 
-/// The oracle's `camonitor` + `caput 1;2;2;3` on VAL: three VALUE events
-/// (1, 2, 3), the repeated 2 coalesced by the `mlst != val` monitor gate. Each
-/// `ca_put_callback` (WRITE_NOTIFY) must complete synchronously so the next one
-/// is not refused.
+/// The oracle's `camonitor` + `caput -c 1;2;2;3` on VAL: three VALUE events
+/// (1, 2, 3), the repeated 2 coalesced by the `mlst != val` monitor gate.
+/// Every put after the first arrives while the previous client's callback is
+/// still outstanding and its receiver already dropped — the sequential
+/// `caput -c` the oracle runs — and every one of them must still write.
 #[epics_macros_rs::epics_test]
 async fn busy_val_notify_sequence_posts_each_change() {
     let db = build().await;
@@ -60,15 +66,16 @@ async fn busy_val_notify_sequence_posts_each_change() {
     };
 
     for v in [1.0f64, 2.0, 2.0, 3.0] {
-        // The WRITE_NOTIFY (`ca_put_callback`) path: `Ok` — never refused —
-        // and no held completion receiver (synchronous).
         let held = db
             .put_record_field_from_ca("B", "VAL", EpicsValue::Double(v))
             .await
             .unwrap_or_else(|e| panic!("caput B {v}: {e:?}"));
+        // VAL is non-zero on every one of these, so C skips `recGblFwdLink`
+        // and the callback stays owed. Dropping `held` at the end of the
+        // iteration is the client giving up and exiting.
         assert!(
-            held.is_sync(),
-            "busy put-callback must complete synchronously (val={v})"
+            !held.is_sync(),
+            "busy withholds the put-callback while VAL is non-zero (val={v})"
         );
     }
 
@@ -87,4 +94,28 @@ async fn busy_val_notify_sequence_posts_each_change() {
     // "Illegal_Value").
     let inst = r.read();
     assert_eq!(inst.record.get_field("VAL"), Some(EpicsValue::Enum(3)));
+}
+
+/// The other direction of the same gate: a put that lands VAL back on 0 runs
+/// `recGblFwdLink`, so the callback completes on that cycle.
+#[epics_macros_rs::epics_test]
+async fn a_busy_put_back_to_done_completes_its_callback() {
+    let db = build().await;
+
+    let held = db
+        .put_record_field_from_ca("B", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert!(!held.is_sync(), "VAL=1 withholds the callback");
+    drop(held);
+
+    let held = db
+        .put_record_field_from_ca("B", "VAL", EpicsValue::Double(0.0))
+        .await
+        .unwrap();
+    assert!(
+        held.is_sync(),
+        "VAL=0 satisfies busyRecord.c:271, so the cycle reaches recGblFwdLink \
+         and completes the put-notify"
+    );
 }

--- a/crates/epics-base-rs/tests/calc_osv_put.rs
+++ b/crates/epics-base-rs/tests/calc_osv_put.rs
@@ -41,12 +41,33 @@ async fn scalcout_osv_accepts_string_and_numeric_puts() {
     assert_eq!(db.get_pv("S.OSV").unwrap(), EpicsValue::String("".into()));
 
     // A numeric put converts to its string form (C `dbFastPutConvert`
-    // DBR_DOUBLE→DBF_STRING), also accepted.
+    // DBR_DOUBLE→DBF_STRING), also accepted — and that row is
+    // `cvt_d_st`, which renders at the record's `get_precision`.
+    // `sCalcoutRecord.c:616-618` seeds `*precision = pcalc->prec` and `OSV` is
+    // not `VAL`, so `recGblGetPrec` runs and leaves a `DBF_STRING` field's seed
+    // alone — the answer is PREC, and scalcout's `.dbd` default PREC is 0.
+    //
+    // Fat softIoc @`R7.0.10`, `record(scalcout,"S"){}`:
+    //
+    // ```text
+    // dbgf S.PREC   -> DBF_SHORT: 0
+    // dbtpf S.OSV 1.5 -> Put as DBR_DOUBLE Ok, result as DBF_STRING: "2"
+    // ```
+    db.put_record_field_from_ca("S", "OSV", EpicsValue::Double(1.5))
+        .await
+        .expect("caput OSV 1.5 must be accepted");
+    assert_eq!(db.get_pv("S.OSV").unwrap(), EpicsValue::String("2".into()));
+
+    // ...and the same put at `PREC=3` gives `"1.500"` on the same softIoc,
+    // which is what makes the digits PREC's and not `Display`'s.
+    db.put_record_field_from_ca("S", "PREC", EpicsValue::Short(3))
+        .await
+        .expect("PREC is writable");
     db.put_record_field_from_ca("S", "OSV", EpicsValue::Double(1.5))
         .await
         .expect("caput OSV 1.5 must be accepted");
     assert_eq!(
         db.get_pv("S.OSV").unwrap(),
-        EpicsValue::String("1.5".into())
+        EpicsValue::String("1.500".into())
     );
 }

--- a/crates/epics-base-rs/tests/database_tests.rs
+++ b/crates/epics-base-rs/tests/database_tests.rs
@@ -9603,7 +9603,11 @@ async fn sub_record_mdel_gates_val_monitor() {
     let mut rec = sub_with_snam("noop");
     rec.val = 100.0;
     rec.mdel = 10.0;
-    rec.init_record(0).unwrap(); // MLST seeded to 100
+    // C `subRecord.c:130` seeds MLST from VAL at the END of `init_record`,
+    // past the SNAM resolution, so the port performs it in the resolution
+    // owner (`ioc_app::wire_subroutine`). This record is built by hand and
+    // never goes through it, so the post-init state is set directly.
+    rec.mlst = 100.0;
     db.add_record("SUB_MDEL", Box::new(rec)).await.unwrap();
 
     // Helper: set VAL directly (no subroutine), process, read back MLST.

--- a/crates/epics-base-rs/tests/db_load_diagnostics_say_where.rs
+++ b/crates/epics-base-rs/tests/db_load_diagnostics_say_where.rs
@@ -7,7 +7,7 @@
 //! wrote 9, and all 21 missing ones were position:
 //!
 //! 1. macLib's own notice, `macLib: macro INP is undefined (expanding string
-//!    …)` — `errlogPrintf` in `macCore.c:913-917`, raised inside the expander
+//!    …)` — `errlogPrintf` in `macCore.c:897-900`, raised inside the expander
 //!    for every unresolved reference;
 //! 2. the loader's per-line warning, `WARNING: '<file>' line <N> has undefined
 //!    macros` — `db_yyinput` (`dbLexRoutines.c:384-387`), raised where the line
@@ -279,7 +279,7 @@ async fn var_reaches_the_quiet_knob_the_loader_reads() {
 /// genuine syntax error in a real `.db`.
 ///
 /// C reaches it through the SAME `yyerror` as every recovered fault, only
-/// through the arm that carries a message (`dbYacc.y:373-374`) — `yyparse`
+/// through the arm that carries a message (`dbYacc.y:372-373`) — `yyparse`
 /// calls it with `"syntax error"`, `dbLex.l` with `"Invalid character '%c'"`
 /// — so an abort names its file, its line and its source exactly as a
 /// recovered fault does. Measured on this file, `softIoc` writes:
@@ -298,16 +298,14 @@ async fn var_reaches_the_quiet_knob_the_loader_reads() {
 /// expected 'field', got 'qqq'`, and it named neither the file nor the source
 /// — the harm this whole gate exists for, on the input an operator hits most.
 ///
-/// Three deviations, all deliberate, none of them position:
+/// Two of the three deviations it then had are gone. The message is bison's
+/// own `syntax error` — `dbYacc.y` declares no `%error-verbose`, so every
+/// grammar rejection prints those three words and the token is what tells
+/// them apart — and the ` at or before` clause quotes that token rather than
+/// a column of this port's invention.
 ///
-/// * the message is this parser's own sentence rather than yacc's
-///   `syntax error`. It names the token C leaves to the ` at or before`
-///   clause, and `ERROR: <sentence>` is the shape C's own lexer diagnostics
-///   already have.
-/// * the clause reads ` at or before column 6` where C reads ` at or before
-///   'qqq'`. C's lexer always holds a `yytext`; this recursive-descent parser
-///   holds a column instead, and naming the column it has is true where
-///   quoting a token it never recorded would be a guess.
+/// One deviation is left:
+///
 /// * `WARNING: dbReadCOM: Parser stack dirty w/o error. 1` is absent. It
 ///   counts the half-built objects left on C's `tempList`
 ///   (`dbLexRoutines.c:303-305`); this parser has no such list.
@@ -329,8 +327,8 @@ async fn a_syntax_error_names_its_file_line_and_source() {
 
     let want = format!(
         "\
-ERROR: expected 'field', got 'qqq'
- at or before column 6 in path \"{found_under}\"  file \"syn.db\" line 3
+ERROR: syntax error
+ at or before 'qqq' in path \"{found_under}\"  file \"syn.db\" line 3
 
  3 |   qqq
 
@@ -392,12 +390,45 @@ ERROR: Failed to load 'a.db'
 /// said why, and `MacroExpansion` recorded nothing for the per-line warning
 /// to fire on.
 ///
-/// Two deviations, both from the engine and not the wording. C detects a
-/// cycle once per macro TABLE entry, in the `expand()` pass it runs while the
-/// table is dirty (`macCore.c:646-679`), so it names both ends and this
-/// lazily-expanding one names the end it reached first. And because C's
-/// pre-expansion resolves `A` before the `.db` line asks for it, C's
-/// placeholder is the other member of the pair.
+/// Both notices, their order and the placeholder are now the engine's own:
+/// it runs C's `expand()` pass over the macro table before it looks at the
+/// caller's string (`macCore.c:646-679`), so the cycle is found once per
+/// table ENTRY — naming both ends, seated on the entry and not on the
+/// string — and `$(A)` copies the value that pass built, which is
+/// `$(B,recursive)`.
+///
+/// The COUNT is the assertion. C creates one `MAC_HANDLE` per `.db` and
+/// expands the table on first use (`dbReadCOM`,
+/// `dbLexRoutines.c:256-300`), so the pair is printed once for the whole
+/// file however many lines mention the cycle; measured on `softIoc
+/// R7.0.10` with these exact two files, C's whole stream is
+///
+/// ```text
+/// macLib: macro A is recursive (expanding macro B)
+/// macLib: macro B is recursive (expanding macro A)
+/// WARNING: 'rec.db' line 2 has undefined macros
+/// C1.DESC Has unexpanded macro
+/// ERROR: Can't set 'C1.DESC' to '$(B,recursive)'  : Bad Field value
+/// ```
+///
+/// This port's file reader used to build a `MacroTable` per LINE, so the
+/// pair repeated three times for three lines; `expand_includes_mapped`
+/// now holds one for the whole include tree, which is why the count here
+/// is C's.
+///
+/// The load is driven by `dbLoadTemplate`, so the refusal is a ROW's, and C
+/// closes it with `msiLoadRecords`' echo of the call it made and
+/// `yyerror("Error while reading included file")` before `YYABORT`
+/// (`dbLoadTemplate.y:49-57`). Measured, C's last three lines here are
+///
+/// ```text
+/// dbLoadRecords("rec.db", A="$(B)",B="$(A)")
+/// Substitution file error: Error while reading included file
+/// line 2: '}'
+/// ```
+///
+/// All three of those lines are matched, the last one being the lexer parked
+/// on the brace that closed the failing row.
 #[epics_macros_rs::epics_test]
 #[serial_test::serial(db_load_stderr)]
 async fn a_recursive_macro_is_refused_and_said_out_loud() {
@@ -419,17 +450,23 @@ async fn a_recursive_macro_is_refused_and_said_out_loud() {
     let got = stderr_of("dbLoadTemplate(\"rec.sub\")", Arc::new(PvDatabase::new()));
     unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
 
+    // ONE pair for the file, as C prints it — three lines of `rec.db`,
+    // one table, one expansion pass.
     let want = format!(
         "\
+macLib: macro A is recursive (expanding macro B)
 macLib: macro B is recursive (expanding macro A)
 WARNING: 'rec.db' line 2 has undefined macros
 C1.DESC Has unexpanded macro
-ERROR: Can't set 'C1.DESC' to '$(A,recursive)'  : Bad Field value
+ERROR: Can't set 'C1.DESC' to '$(B,recursive)'  : Bad Field value
 ERROR:  at or before ')' in path \"{found_under}\"  file \"rec.db\" line 2
 
- 2 |   field(DESC, \"$(A,recursive)\")
+ 2 |   field(DESC, \"$(B,recursive)\")
 
 ERROR: Failed to load 'rec.db'
+dbLoadRecords(\"rec.db\", A=\"$(B)\",B=\"$(A)\")
+Substitution file error: Error while reading included file
+line 2: '}}'
 "
     );
     assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");

--- a/crates/epics-base-rs/tests/db_load_keeps_the_record_a_field_refused.rs
+++ b/crates/epics-base-rs/tests/db_load_keeps_the_record_a_field_refused.rs
@@ -1,0 +1,187 @@
+//! **A `.db` field the loader refuses costs that FIELD, never the record.**
+//!
+//! C reduces one `field(NAME,"value")` element at a time and every failure
+//! arm of `dbRecordField` ends in `yyerror(NULL)` and `return`
+//! (`dbLexRoutines.c:1405-1416` @`R7.0.10-146-g8f5015b663d764ad75df`), so the
+//! record it belongs to stays in the database, the fields after it in the
+//! same block still load, and only the file's status goes non-zero.
+//!
+//! The port handed the whole field slice to one `apply_fields` call, so the
+//! FIRST refusal aborted the record and every field behind it. Measured
+//! against `~/work/epics-base/bin/linux-x86_64/softIoc` on the fixture below,
+//! driven with `dbLoadRecords("<file>")` then `dbl` from a startup script with
+//! stdin on `/dev/null`: C's `dbl` printed `N1` and `N2`, the port's printed
+//! nothing at all.
+//!
+//! Boundaries, one case each: the refusal is the FIRST of two fields in its
+//! block (does the sibling behind it still load), the refusal is on a record
+//! that is not the last in the file (does the file keep going), and the
+//! refusal comes from a different arm — a JSON link naming no registered type
+//! rather than a `DBF_NOACCESS` field — so the rule is the applier's, not one
+//! arm's.
+//!
+//! Unix only: what is asserted is the process console, and reaching it means
+//! pointing fds 1 and 2 somewhere else and putting them back.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Write `body` as `name` in a fresh directory, load it into a fresh
+/// database, and give back that database, the load's stderr, and the
+/// directory C would have echoed in its ` in path "…"` clause.
+fn load(name: &str, body: &str) -> (Arc<PvDatabase>, String, String) {
+    use std::os::fd::AsRawFd;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join(name), body).expect("write the .db");
+    let found_under = dir.path().display().to_string();
+    let db = Arc::new(PvDatabase::new());
+
+    let err_sink = tempfile::NamedTempFile::new().expect("stderr capture");
+    // SAFETY: the process-global env and fd 2 are why this test is `serial`;
+    // nothing else holds either while they are swapped.
+    let saved_err = unsafe {
+        std::env::set_var("EPICS_DB_INCLUDE_PATH", &found_under);
+        let saved = libc::dup(2);
+        libc::dup2(err_sink.as_file().as_raw_fd(), 2);
+        saved
+    };
+
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let line = format!("dbLoadRecords(\"{name}\")");
+    let shell_db = Arc::clone(&db);
+    let ran =
+        std::thread::spawn(move || IocShell::new(shell_db, bridge).execute_line(&line)).join();
+
+    // Restore BEFORE anything can panic, or the failure report has nowhere
+    // to go.
+    // SAFETY: restoring the descriptor this call replaced.
+    unsafe {
+        libc::dup2(saved_err, 2);
+        libc::close(saved_err);
+        std::env::remove_var("EPICS_DB_INCLUDE_PATH");
+    }
+    ran.expect("the shell thread").ok();
+
+    (
+        db,
+        strip_ansi(&std::fs::read_to_string(err_sink.path()).expect("stderr capture")),
+        found_under,
+    )
+}
+
+/// The names `dbl` would list, in load order.
+async fn listed(db: &PvDatabase) -> Vec<String> {
+    let mut names = db.all_record_names().await;
+    names.sort();
+    names
+}
+
+/// A `DBF_NOACCESS` field, C's `dbPutString` arm at `dbStaticLib.c:2646-2650`.
+///
+/// `RSET` is refused, `EGU` behind it in the same block is not, and `N2` after
+/// it in the file is not — which is the whole of what C keeps here.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_refused_noaccess_field_loses_the_field_and_keeps_the_record() {
+    let (db, err, dir) = load(
+        "noacc.db",
+        "record(ai, \"N1\") {\n    field(RSET, \"1\")\n    field(EGU, \"volts\")\n}\n\
+         record(ai, \"N2\") {\n    field(PREC, \"2\")\n}\n",
+    );
+
+    assert_eq!(
+        listed(&db).await,
+        ["N1", "N2"],
+        "C's dbl printed N1 then N2"
+    );
+
+    let rec = db.get_record("N1").expect("N1 survives its refused field");
+    let held = rec.read();
+    assert_eq!(
+        held.record
+            .get_field("EGU")
+            .map(|v| v.to_string())
+            .as_deref(),
+        Some("volts"),
+        "the field BEHIND the refusal still loads, as it does in C",
+    );
+    drop(held);
+
+    // C's own sentence, minus the two slots this port cannot fill from a
+    // single error value — `pdbentry->message` and `errSymLookup(status)`,
+    // which C prints as `Can't set array field before iocInit() : Bad Field
+    // value`. The frame, the position and the source echo are C's.
+    assert!(
+        err.starts_with("ERROR: Can't set 'N1.RSET' to '1' "),
+        "C names the record, the field and the value; got:\n{err}"
+    );
+    assert!(
+        err.contains(&format!(
+            "ERROR:  at or before ')' in path \"{dir}\"  file \"noacc.db\" line 2\n\n \
+             2 |     field(RSET, \"1\")\n"
+        )),
+        "the refusal carries C's position and source echo; got:\n{err}"
+    );
+    assert!(
+        err.ends_with("ERROR: Failed to load 'noacc.db'\n"),
+        "the file's status still goes non-zero; got:\n{err}"
+    );
+    assert_eq!(
+        err.matches("ERROR: Can't set").count(),
+        1,
+        "one refusal, not one per field behind it; got:\n{err}"
+    );
+}
+
+/// A different arm of the same applier: a JSON link naming no registered
+/// link type, which C reports as `dbJLinkInit: Link type 'bogus' not found`
+/// and then refuses through the same `dbRecordField` failure path.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_refused_json_link_loses_the_field_and_keeps_the_record() {
+    let (db, err, _) = load(
+        "json.db",
+        "record(ai, \"J1\") {\n    field(INP, \"{\\\"bogus\\\":}\")\n    field(EGU, \"amps\")\n}\n",
+    );
+
+    assert_eq!(listed(&db).await, ["J1"], "C's dbl printed J1");
+    let rec = db.get_record("J1").expect("J1 survives its refused link");
+    let held = rec.read();
+    assert_eq!(
+        held.record
+            .get_field("EGU")
+            .map(|v| v.to_string())
+            .as_deref(),
+        Some("amps"),
+        "the field BEHIND the refusal still loads, as it does in C",
+    );
+    drop(held);
+
+    assert!(
+        err.starts_with("ERROR: Can't set 'J1.INP' to '{\"bogus\":}' "),
+        "C prints the value with its quotes stripped and escapes translated; got:\n{err}"
+    );
+    assert!(
+        err.ends_with("ERROR: Failed to load 'json.db'\n"),
+        "the file's status still goes non-zero; got:\n{err}"
+    );
+}

--- a/crates/epics-base-rs/tests/db_load_template_says_which_row.rs
+++ b/crates/epics-base-rs/tests/db_load_template_says_which_row.rs
@@ -1,0 +1,850 @@
+//! **A `dbLoadTemplate` failure MUST say which row failed, in the words C
+//! uses for that row.**
+//!
+//! C `dbLoadTemplate` (`modules/database/src/ioc/dbtemplate/dbLoadTemplate.y`)
+//! is not a loader. It opens the `.substitutions` file, parses it, and runs
+//! one `dbLoadRecords` per substitution row through `msiLoadRecords` (`:49-57`),
+//! so every diagnostic an operator sees comes from one of exactly three
+//! places and each of them says something different:
+//!
+//! 1. the open — `dbLoadTemplate: error opening sub file <f>: <strerror>`
+//!    (`:371-374`), before `pdbbase` is touched, returning -1;
+//! 2. the grammar — `yyerror` (`:330-338`) writing the message and the
+//!    lexer's position, `dbLoadTemplate` returning `yyparse`'s status;
+//! 3. a ROW — the full `dbLoadRecords` diagnostic set for that row's `.db`
+//!    (`dbAccess.c:808-812`), then `msiLoadRecords`' echo of the failing
+//!    call and `yyerror("Error while reading included file")`, then
+//!    `YYABORT`, which abandons every row after it.
+//!
+//! The port collapsed all three onto one sentence — `parse error: DB parse
+//! error at line 0, column 0: template file not found: 'missing.db'` —
+//! returned as an `Err(String)` for whichever caller happened to catch it to
+//! render. That named no row, no `.substitutions` line, and never wrote
+//! `Can't open file` or `Failed to load` at all; and the one place the port
+//! did write `Failed to load` for a template, the after-`iocInit` refusal, it
+//! named the `.substitutions` file where C names the row's `.db`.
+//!
+//! Every `want` below is `softIoc` R7.0.10-146 stderr, captured on the same
+//! input, ANSI stripped. Deviations are named per test; the only one left is
+//! wording — where C says `syntax error` this parser names the token it
+//! wanted instead.
+//!
+//! Unix only, for the reason the sibling gate
+//! (`db_load_diagnostics_say_where.rs`) is: what is captured is the process
+//! console, and capturing it means pointing fd 2 elsewhere and putting it
+//! back.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+/// Run one iocsh line with fd 2 pointed at a file, and give back what it
+/// wrote. Same capture as `db_load_diagnostics_say_where.rs`: the two
+/// families under test reach the operator by different routes and the
+/// process console is the only place they are one stream again.
+fn stderr_of(line: &str, db: Arc<PvDatabase>) -> String {
+    ran_capturing(line, db).0
+}
+
+/// The same capture, plus the status the shell gave the line — C's
+/// `dbLoadTemplate` hands back `yyparse`'s value and a recovered lexer
+/// fault does not change it, so the two have to be read together.
+fn ran_capturing(line: &str, db: Arc<PvDatabase>) -> (String, Result<(), String>) {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let owned = line.to_string();
+    let ran =
+        std::thread::spawn(move || IocShell::new(db, bridge).execute_line_reported(&owned)).join();
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+    let status = ran.expect("the shell thread");
+
+    (
+        strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture")),
+        status,
+    )
+}
+
+/// C's SGR sequences, dropped — the port's copy of what `errlog` does when
+/// the console is not a terminal (`errlog.c:672-681`), so the gate holds
+/// whichever way the harness's console answers.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The open, which is C's alone: `dbLoadTemplate` opens the
+/// `.substitutions` file itself and reports the failure with its own
+/// wording and `strerror(errno)` (`dbLoadTemplate.y:362-374`), returning -1
+/// before a parser or `pdbbase` is involved.
+///
+/// Measured, script `dbLoadTemplate("nosuch.sub")`:
+///
+/// ```text
+/// dbLoadTemplate: error opening sub file nosuch.sub: No such file or directory
+/// ```
+///
+/// Byte for byte, including the name as the operator wrote it rather than
+/// the path the search resolved. The port wrote `parse error: DB parse error
+/// at line 0, column 0: cannot read substitutions file
+/// '<abs>/nosuch.sub': No such file or directory (os error 2)`.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_missing_substitutions_file_gets_cs_open_diagnostic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of(
+        "dbLoadTemplate(\"nosuch.sub\")",
+        Arc::new(PvDatabase::new()),
+    );
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    assert_eq!(
+        got, "dbLoadTemplate: error opening sub file nosuch.sub: No such file or directory\n",
+        "\n--- got ---\n{got}"
+    );
+}
+
+/// The grammar, which is C's second place: the file opened and `yyparse`
+/// refused it, so `yyerror` writes the message and the lexer's position
+/// (`dbLoadTemplate.y:330-338`).
+///
+/// Measured on this exact file:
+///
+/// ```text
+/// Substitution file error: syntax error
+/// line 2: '='
+/// ```
+///
+/// Both lines are C's, byte for byte. The sentence is bison's one constant:
+/// C sets no `parse.error verbose`, so every shape the grammar can refuse
+/// reaches `yyerror` with `syntax error` and nothing else. The failing
+/// lookahead supplies both the line and the `yytext`, exactly as bison's
+/// does.
+///
+/// Also asserted: the file is distinguishable from a row failure — C returns
+/// `yyparse`'s status here and nothing was loaded.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_broken_substitutions_file_gets_cs_grammar_diagnostic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("good.db"), "record(ai, \"A1\") {}\n").expect("write the .db");
+    std::fs::write(
+        dir.path().join("bad.sub"),
+        "file good.db {\n{ N=1 = 2 }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let got = stderr_of("dbLoadTemplate(\"bad.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+Substitution file error: syntax error
+line 2: '='
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("A1").is_none(),
+        "C never reaches a row when the grammar refuses the file"
+    );
+}
+
+/// A ROW, which is the case the collapsed message hid entirely: the
+/// `.substitutions` file is fine and one row names a `.db` that is not
+/// there.
+///
+/// Measured, `mix.sub` = a good row then a missing one:
+///
+/// ```text
+/// ERROR: Can't open file 'missing.db'
+/// ERROR: Failed to load 'missing.db'
+/// dbLoadRecords("missing.db", N=2)
+/// Substitution file error: Error while reading included file
+/// line 5: '}'
+/// ```
+///
+/// Five lines from four different C functions, and the port wrote none of
+/// them. The first two are `dbReadCOM` and `dbLoadRecords`
+/// (`dbLexRoutines.c:284-286`, `dbAccess.c:808`) — the row IS a
+/// `dbLoadRecords`, so it carries that command's whole diagnostic set. The
+/// third is `msiLoadRecords` echoing the call it made
+/// (`dbLoadTemplate.y:53`), which is the only line that says WHICH row. The
+/// fourth is `yyerror` before `YYABORT`.
+///
+/// The fifth is the position `yyerror` always prints: the lexer parked on the
+/// brace that closed the failing row.
+///
+/// The record from the row BEFORE the failure stays, which is C's `YYABORT`
+/// semantics — each row is committed by its own `dbLoadRecords` before the
+/// next is read — and is asserted here because it is the half a batching
+/// port silently loses.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_row_whose_db_is_missing_reports_it_as_the_dbloadrecords_it_is() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("good.db"), "record(ai, \"A1\") {}\n").expect("write the .db");
+    std::fs::write(
+        dir.path().join("mix.sub"),
+        "file good.db {\n{ N=1 }\n}\nfile missing.db {\n{ N=2 }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let got = stderr_of("dbLoadTemplate(\"mix.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+ERROR: Can't open file 'missing.db'
+ERROR: Failed to load 'missing.db'
+dbLoadRecords(\"missing.db\", N=2)
+Substitution file error: Error while reading included file
+line 5: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("A1").is_some(),
+        "the row before the failing one is committed by its own dbLoadRecords"
+    );
+}
+
+/// The after-`iocInit` refusal, which the port answered with the wrong file
+/// name.
+///
+/// C has no load-phase gate in `dbLoadTemplate` at all: it opens and parses
+/// the `.substitutions` file, and the FIRST row's `dbLoadRecords` is what
+/// meets `dbReadCOM`'s `getIocState() != iocVoid` (`dbLexRoutines.c:236-238`).
+/// So the name in the refusal is the row's `.db`, and the refusal is followed
+/// by the same `msiLoadRecords` / `yyerror` pair every row failure gets.
+/// Measured, `iocInit` then `dbLoadTemplate("ok.sub")`:
+///
+/// ```text
+/// ERROR: Failed to load 'good.db'
+///     Records cannot be loaded after iocInit!
+/// dbLoadRecords("good.db", N=1)
+/// Substitution file error: Error while reading included file
+/// line 2: '}'
+/// ```
+///
+/// The port wrote `ERROR: Failed to load 'ok.sub'` and the indented line, and
+/// stopped — naming the file the operator did not fail to load, and leaving
+/// out the row identity.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_template_row_after_iocinit_names_the_rows_db() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("good.db"), "record(ai, \"A1\") {}\n").expect("write the .db");
+    std::fs::write(dir.path().join("ok.sub"), "file good.db {\n{ N=1 }\n}\n")
+        .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    db.ioc_init().await;
+    let got = stderr_of("dbLoadTemplate(\"ok.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+ERROR: Failed to load 'good.db'
+    Records cannot be loaded after iocInit!
+dbLoadRecords(\"good.db\", N=1)
+Substitution file error: Error while reading included file
+line 2: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// C's lexer does not abandon the file over a character it does not know.
+/// The catch-all rule (`dbLoadTemplate_lex.l:47-56`) reports through
+/// `yyerror` and returns no token, so flex resumes at the very next
+/// character and `yyparse` never learns anything happened.
+///
+/// Measured on this exact file, `dbLoadTemplate("pct.sub")` then `dbl`:
+///
+/// ```text
+/// Substitution file error: invalid character '%'
+/// line 2: '%'
+/// ```
+///
+/// with `A1` in `dbl` and a zero status. The port aborted the lex, so the
+/// row was never loaded and the command failed: one stray byte built a
+/// smaller database than C's, which is the only one of this file's
+/// deviations that costs records rather than words.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_stray_character_is_reported_and_the_row_still_loads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("rec.db"), "record(ai, \"$(N)\") {}\n").expect("write the .db");
+    std::fs::write(dir.path().join("pct.sub"), "file rec.db {\n{ N=A1 } %\n}\n")
+        .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (got, status) = ran_capturing("dbLoadTemplate(\"pct.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+Substitution file error: invalid character '%'
+line 2: '%'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("A1").is_some(),
+        "C loads the row and so must this: a recovered character costs one character"
+    );
+    assert!(
+        status.is_ok(),
+        "C returns yyparse's status, which a recovered lexer fault does not touch: {status:?}"
+    );
+}
+
+/// The same recovery inside a row, where the character C drops leaves a
+/// token sequence the grammar cannot take. Both reports come out, in the
+/// order the lexer reached them, and the row is lost — to the syntax error,
+/// not to the stray character.
+///
+/// Measured on this exact file:
+///
+/// ```text
+/// Substitution file error: invalid character '%'
+/// line 2: '%'
+/// Substitution file error: syntax error
+/// line 2: '}'
+/// ```
+///
+/// Both messages and both position lines are C's, byte for byte.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_stray_character_inside_a_row_reports_twice_in_cs_order() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("rec.db"), "record(ai, \"$(N)\") {}\n").expect("write the .db");
+    std::fs::write(dir.path().join("mid.sub"), "file rec.db {\n{ N=A%1 }\n}\n")
+        .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (got, status) = ran_capturing("dbLoadTemplate(\"mid.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+Substitution file error: invalid character '%'
+line 2: '%'
+Substitution file error: syntax error
+line 2: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("A").is_none() && db.get_record("A1").is_none(),
+        "the grammar never reduced this row, so C loads nothing from it"
+    );
+    assert!(
+        status.is_err(),
+        "a grammar error IS yyparse's non-zero status"
+    );
+}
+
+/// And the rows a stopped parse got through stay loaded. C runs each row's
+/// `dbLoadRecords` from the grammar action as the row is reduced
+/// (`dbLoadTemplate.y:193`), so by the time `yyparse` fails on a later line
+/// the earlier rows are already in `pdbbase` — it returns non-zero over a
+/// database that is not empty.
+///
+/// Measured on this exact file, `A1` is in `dbl` and stderr is
+///
+/// ```text
+/// Substitution file error: syntax error
+/// line 5: '='
+/// ```
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_row_before_a_syntax_error_stays_loaded() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("rec.db"), "record(ai, \"$(N)\") {}\n").expect("write the .db");
+    std::fs::write(
+        dir.path().join("two.sub"),
+        "file rec.db {\n{ N=A1 }\n}\nfile rec.db {\n{ N=B1 = 2 }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (got, status) = ran_capturing("dbLoadTemplate(\"two.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+Substitution file error: syntax error
+line 5: '='
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("A1").is_some(),
+        "the first row's dbLoadRecords already ran; a later syntax error cannot undo it"
+    );
+    assert!(
+        db.get_record("B1").is_none(),
+        "the failing row loads nothing"
+    );
+    assert!(
+        status.is_err(),
+        "a grammar error IS yyparse's non-zero status"
+    );
+}
+
+/// The echo says which values arrived in quotes, because C's grammar has
+/// one rule per token kind — `WORD EQUALS WORD` writes `name=value` and
+/// `WORD EQUALS QUOTE` writes `name="value"` (`dbLoadTemplate.y:301-323`)
+/// — and always writes the quotes back as `"`. Nothing about the text
+/// decides it: `N="1"` and `M=2` substitute the same kind of value and
+/// echo differently.
+///
+/// Measured on this exact file:
+///
+/// ```text
+/// dbLoadRecords("nope.db", N="1",M=2,P="a b")
+/// ```
+///
+/// The port's lexer had collapsed `WORD` and `QUOTE`, so the echo had to
+/// guess from the text: it quoted whatever a `WORD` could not have held and
+/// wrote `N=1` for C's `N="1"`.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_quoted_value_echoes_with_the_quotes_c_gives_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("q.sub"),
+        "file nope.db {\n{ N=\"1\", M=2, P=\"a b\" }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of("dbLoadTemplate(\"q.sub\")", Arc::new(PvDatabase::new()));
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+ERROR: Can't open file 'nope.db'
+ERROR: Failed to load 'nope.db'
+dbLoadRecords(\"nope.db\", N=\"1\",M=2,P=\"a b\")
+Substitution file error: Error while reading included file
+line 2: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// The other half of the same rule: `pattern_value` is `QUOTE` or `WORD`
+/// (`dbLoadTemplate.y:220-255`), quoting the value against the name the
+/// `pattern` line gave it. Measured on this exact file:
+///
+/// ```text
+/// dbLoadRecords("nope.db", N="1",M=2)
+/// ```
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_quoted_pattern_value_echoes_with_the_quotes_c_gives_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("qp.sub"),
+        "file nope.db {\npattern { N, M }\n{ \"1\", 2 }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of("dbLoadTemplate(\"qp.sub\")", Arc::new(PvDatabase::new()));
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+ERROR: Can't open file 'nope.db'
+ERROR: Failed to load 'nope.db'
+dbLoadRecords(\"nope.db\", N=\"1\",M=2)
+Substitution file error: Error while reading included file
+line 3: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// And the line in that frame is the row's CLOSING brace, not its first.
+/// C's row rules all end in `C_BRACE` and bison reduces them without
+/// reading a lookahead, so the lexer is still parked on the brace that
+/// closed the row when `msiLoadRecords` reports — which for a row written
+/// across two lines is the second of them.
+///
+/// Measured on this exact file:
+///
+/// ```text
+/// dbLoadRecords("nope.db", N=P2,M=q)
+/// Substitution file error: Error while reading included file
+/// line 3: '}'
+/// ```
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_multiline_rows_frame_names_its_closing_brace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("multi.sub"),
+        "file nope.db {\n{ N=P2,\n  M=q }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of("dbLoadTemplate(\"multi.sub\")", Arc::new(PvDatabase::new()));
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+ERROR: Can't open file 'nope.db'
+ERROR: Failed to load 'nope.db'
+dbLoadRecords(\"nope.db\", N=P2,M=q)
+Substitution file error: Error while reading included file
+line 3: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// A value past the last `pattern` name is a stderr line in C, not a log
+/// entry: `pattern_value` writes it with `fprintf(stderr, ...)` when the
+/// value is reduced (`dbLoadTemplate.y:233`, `:250`), so it lands on the
+/// same console as every other diagnostic here and it names the value's
+/// own line — measured, a third value on line 3 under a row whose brace
+/// closes on line 4 reports line 3.
+///
+/// Measured on this exact file:
+///
+/// ```text
+/// dbLoadTemplate: Too many values given, line 3.
+/// ERROR: Can't open file 'nope.db'
+/// ERROR: Failed to load 'nope.db'
+/// dbLoadRecords("nope.db", A="1",B="2")
+/// Substitution file error: Error while reading included file
+/// line 4: '}'
+/// ```
+///
+/// The port had this one on `tracing::warn!`, which the operator watching
+/// stderr never sees.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_surplus_pattern_value_is_reported_on_stderr() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("many.sub"),
+        "file nope.db {\npattern { A, B }\n{ \"1\", \"2\", \"3\"\n}\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of("dbLoadTemplate(\"many.sub\")", Arc::new(PvDatabase::new()));
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+dbLoadTemplate: Too many values given, line 3.
+ERROR: Can't open file 'nope.db'
+ERROR: Failed to load 'nope.db'
+dbLoadRecords(\"nope.db\", A=\"1\",B=\"2\")
+Substitution file error: Error while reading included file
+line 4: '}'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// The deprecated `WORD { … }` row: C accepts it and says so
+/// (`dbLoadTemplate.y:199-203`, `:281-285`), and the line it names is
+/// `line_num` at the row's action — the closing brace, not the word's own
+/// line, though the sentence is about the word.
+///
+/// Measured on this exact file, where `rowname` is on line 3 and the row
+/// closes on line 4:
+///
+/// ```text
+/// dbLoadTemplate: Substitution file uses deprecated syntax.
+///     the string 'rowname' on line 4 that comes just before the
+///     '{' character is extraneous and should be removed.
+/// ```
+///
+/// The port took the word and said nothing, which is the one option C does
+/// not offer: it accepts the file and warns.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_deprecated_row_is_accepted_and_reported() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("good.db"), "record(ai, \"$(N)\") {}\n").expect("write the .db");
+    std::fs::write(
+        dir.path().join("dep.sub"),
+        "file good.db {\npattern { N }\nrowname\n{ A1 }\n}\n",
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (got, status) = ran_capturing("dbLoadTemplate(\"dep.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+dbLoadTemplate: Substitution file uses deprecated syntax.
+    the string 'rowname' on line 4 that comes just before the
+    '{' character is extraneous and should be removed.
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("A1").is_some(),
+        "C accepts the deprecated row and loads it"
+    );
+    assert!(status.is_ok(), "warning only: yyparse still returns 0");
+}
+
+/// C's grammar takes a `WORD` and only a `WORD` where a name goes:
+/// `pattern_name: WORD` (`dbLoadTemplate.y:154`) and
+/// `variable_definition: WORD EQUALS …` (`:301`, `:312`). Quoting one is a
+/// syntax error there, so accepting it here would only move the failure to
+/// the IOC that finally reads the file.
+///
+/// Measured on both files, C says:
+///
+/// ```text
+/// Substitution file error: syntax error
+/// line 2: '"N"'
+/// ```
+///
+/// Both lines are C's; the position line keeps `yytext`'s own quotes.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_quoted_name_is_refused_the_way_c_refuses_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("qname.sub"),
+        "file nope.db {\npattern { \"N\" }\n{ 1 }\n}\n",
+    )
+    .expect("write the pattern-name file");
+    std::fs::write(
+        dir.path().join("qmacro.sub"),
+        "file nope.db {\n{ \"N\"=1 }\n}\n",
+    )
+    .expect("write the macro-name file");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (name_got, name_status) = ran_capturing("dbLoadTemplate(\"qname.sub\")", db.clone());
+    let (macro_got, macro_status) = ran_capturing("dbLoadTemplate(\"qmacro.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+Substitution file error: syntax error
+line 2: '\"N\"'
+";
+    assert_eq!(
+        name_got, want,
+        "\n--- got ---\n{name_got}\n--- want ---\n{want}"
+    );
+    assert_eq!(
+        macro_got, want,
+        "\n--- got ---\n{macro_got}\n--- want ---\n{want}"
+    );
+    assert!(
+        name_status.is_err() && macro_status.is_err(),
+        "yyparse fails"
+    );
+}
+
+/// End of input, where C's two lines part company: the FIRST is still
+/// bison's constant and the SECOND is a read of a freed lex buffer.
+///
+/// Measured over eleven files that end mid-grammar, three runs each, on
+/// `bin/linux-x86_64/softIoc` (R7.0.10-146-g8f5015b663d764ad75df). The
+/// sentence was `Substitution file error: syntax error` every time and the
+/// line number never moved. The `yytext` under it was empty in six (this
+/// file among them), the last matched token in one, and uninitialised heap
+/// in four — where three consecutive runs of the SAME file printed three
+/// different byte strings, because flex has deleted the buffer `yytext`
+/// points into by the time `yyerror` runs.
+///
+/// So the first line is asserted as C's byte for byte, and the empty
+/// `yytext` is this port's deliberate stand-in for bytes that are not
+/// reproducible and must not be reproduced. For this file it is also C's
+/// own answer, so the whole two-line stream matches. The line number is
+/// C's: 3, because both newlines ran `line_num++`.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn end_of_input_matches_cs_sentence_and_line() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("rec.db"), "record(ai, \"$(N)\") {}\n").expect("write the .db");
+    std::fs::write(dir.path().join("eof.sub"), "file rec.db {\n{ N=A1 \n")
+        .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (got, status) = ran_capturing("dbLoadTemplate(\"eof.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let mut lines = got.lines();
+    assert_eq!(
+        lines.next(),
+        Some("Substitution file error: syntax error"),
+        "the line a script greps is C's\n--- got ---\n{got}"
+    );
+    assert_eq!(
+        lines.next(),
+        Some("line 3: ''"),
+        "C's line number, and the stand-in for its unreproducible yytext\n--- got ---\n{got}"
+    );
+    assert_eq!(lines.next(), None, "\n--- got ---\n{got}");
+    assert!(status.is_err(), "yyparse fails");
+}
+
+/// C's `pattern` line fills a fixed `vars` array sized `dbTemplateMaxVars`
+/// (`dbLoadTemplate.y:43`, `:376-377`), and `pattern_name` reports a name past
+/// it through `yyerror(NULL)` — the message-less form, so the first line is
+/// `Substitution file error.` with a period — then DROPS the name and
+/// carries on (`:154-171`). Each further name reports again, and the row
+/// binds only the names that fit.
+///
+/// Measured with 102 pattern names and 100 values, `dbLoadTemplate` then
+/// `dbl`:
+///
+/// ```text
+/// More than dbTemplateMaxVars = 100 macro variables used
+/// Substitution file error.
+/// line 2: 'N100'
+/// More than dbTemplateMaxVars = 100 macro variables used
+/// Substitution file error.
+/// line 2: 'N101'
+/// ```
+///
+/// with the record loaded and a zero status. C exports the ceiling as an
+/// iocsh variable and so does this port, so this case is the default 100
+/// and the next test raises it. The `sub_collect` buffer C sizes from the
+/// same number is not modelled: every `strcat` into it is unguarded
+/// (`:220-255`, `:301-323`), so overrunning it is an overflow with no
+/// diagnostic to match, and the substitution string here is a `String`.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_pattern_name_past_dbtemplatemaxvars_is_reported_and_dropped() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("n0.db"), "record(ai, \"$(N0)\") {}\n").expect("write the .db");
+    let names = (0..102)
+        .map(|i| format!("N{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let values = (0..100)
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    std::fs::write(
+        dir.path().join("cap.sub"),
+        format!("file n0.db {{\npattern {{ {names} }}\n{{ {values} }}\n}}\n"),
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    let (got, status) = ran_capturing("dbLoadTemplate(\"cap.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+More than dbTemplateMaxVars = 100 macro variables used
+Substitution file error.
+line 2: 'N100'
+More than dbTemplateMaxVars = 100 macro variables used
+Substitution file error.
+line 2: 'N101'
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+    assert!(
+        db.get_record("0").is_some(),
+        "the names that fit still bind and the row still loads"
+    );
+    assert!(status.is_ok(), "yyerror(NULL) does not abort: C returns 0");
+}
+
+/// The ceiling is a knob, not a constant: `dbCore.dbd:29` declares
+/// `variable(dbTemplateMaxVars,int)` over the `int` at
+/// `dbLoadTemplate.y:45`, and `pattern_name` reads that global at the
+/// point of use, so raising it in a startup script raises what the NEXT
+/// `dbLoadTemplate` accepts.
+///
+/// Measured: with `var dbTemplateMaxVars 200`, the 102-name file that
+/// reports twice at the default loads silently.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn var_db_template_max_vars_raises_the_ceiling() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("n0.db"), "record(ai, \"$(N0)\") {}\n").expect("write the .db");
+    let names = (0..102)
+        .map(|i| format!("N{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let values = (0..100)
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    std::fs::write(
+        dir.path().join("cap.sub"),
+        format!("file n0.db {{\npattern {{ {names} }}\n{{ {values} }}\n}}\n"),
+    )
+    .expect("write the .substitutions");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let db = Arc::new(PvDatabase::new());
+    ran_capturing("var dbTemplateMaxVars 200", db.clone())
+        .1
+        .expect("var must succeed");
+    let (got, status) = ran_capturing("dbLoadTemplate(\"cap.sub\")", db.clone());
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    assert_eq!(got, "", "\n--- got ---\n{got}");
+    assert!(db.get_record("0").is_some(), "every name fits now");
+    assert!(status.is_ok());
+}
+
+/// And a ceiling below 1 is refused before anything is opened: C sizes
+/// `vars` and `sub_collect` with `malloc` from that number, so it checks
+/// first and returns -1 (`dbLoadTemplate.y:355-360`). `var` writes the
+/// global unvalidated — C's `varHandler` stores through a raw pointer —
+/// so this is the only place the value is judged.
+///
+/// Measured, `var dbTemplateMaxVars 0` then `dbLoadTemplate("cap.sub")`:
+///
+/// ```text
+/// ERROR: dbTemplateMaxVars = 0, must be +ve
+/// ```
+///
+/// and nothing else — no `error opening sub file`, because the file is
+/// never reached.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_non_positive_db_template_max_vars_is_refused_before_the_open() {
+    let db = Arc::new(PvDatabase::new());
+    ran_capturing("var dbTemplateMaxVars 0", db.clone())
+        .1
+        .expect("var must succeed");
+    let (got, status) = ran_capturing("dbLoadTemplate(\"nosuch.sub\")", db.clone());
+    ran_capturing("var dbTemplateMaxVars 100", db.clone())
+        .1
+        .expect("var must succeed");
+
+    assert_eq!(
+        got, "ERROR: dbTemplateMaxVars = 0, must be +ve\n",
+        "\n--- got ---\n{got}"
+    );
+    assert!(status.is_err(), "C returns -1 here");
+}

--- a/crates/epics-base-rs/tests/db_parse_context_matches_c.rs
+++ b/crates/epics-base-rs/tests/db_parse_context_matches_c.rs
@@ -1,0 +1,249 @@
+//! **A `.db` rejection reaches the operator through ONE owner, on stderr,
+//! with C's sentence.**
+//!
+//! Measured against `~/work/epics-base/bin/linux-x86_64/softIoc`
+//! (R7.0.10-146-g8f5015b663d764ad75df) driven with
+//! `dbLoadRecords("<file>")` from a startup script, stdin on `/dev/null`,
+//! ANSI stripped, `softMain`'s trailing `epics> ` prompt dropped. The
+//! search path is handed to both shells through `EPICS_DB_INCLUDE_PATH`,
+//! which is the only thing C's ` in path "…"` clause echoes — C printed
+//! `"."` when the file sat in its cwd and the directory's own name when
+//! it did not.
+//!
+//! Two of these three already matched C byte for byte before this file
+//! existed, `Did you mean` included: the diagnostic machinery — the
+//! similarity scorer, the confusion map, the ` at or before` locator,
+//! `yyFailed`'s once-only rule and the ` N | <source>` echo — is ported.
+//! They are here because that is worth a regression gate, and because
+//! the third one is what a missing case actually looks like.
+//!
+//! There is NO caret. `rg` over `modules/database/src/ioc/dbStatic/`
+//! finds no `^` written to any stream; what C prints is a gcc-style
+//! gutter, ` %d | %s` (`dbYacc.y:381`), and nothing under it.
+//!
+//! Unix only: what is asserted is the process console, and reaching it
+//! means pointing fds 1 and 2 somewhere else and putting them back.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Both streams of one `dbLoadRecords` line.
+///
+/// BOTH, not just stderr: the defect this file gates is a diagnostic
+/// that went to stdout, and a test that reads only stderr cannot see
+/// the difference between "printed on the wrong stream" and "printed".
+fn streams_of(line: &str, db: Arc<PvDatabase>) -> (String, String) {
+    use std::os::fd::AsRawFd;
+    let out_sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    let err_sink = tempfile::NamedTempFile::new().expect("stderr capture");
+    // SAFETY: the shell writes through fds 1 and 2 for the length of one
+    // line and this test is `serial`, so nothing else holds either while
+    // they are swapped.
+    let (saved_out, saved_err) = unsafe {
+        let saved = (libc::dup(1), libc::dup(2));
+        libc::dup2(out_sink.as_file().as_raw_fd(), 1);
+        libc::dup2(err_sink.as_file().as_raw_fd(), 2);
+        saved
+    };
+
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let owned = line.to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_line(&owned)).join();
+
+    // Restore BEFORE anything can panic, or the failure report has
+    // nowhere to go.
+    // SAFETY: restoring the two descriptors this call replaced.
+    unsafe {
+        libc::dup2(saved_out, 1);
+        libc::dup2(saved_err, 2);
+        libc::close(saved_out);
+        libc::close(saved_err);
+    }
+    ran.expect("the shell thread").ok();
+
+    (
+        strip_ansi(&std::fs::read_to_string(out_sink.path()).expect("stdout capture")),
+        strip_ansi(&std::fs::read_to_string(err_sink.path()).expect("stderr capture")),
+    )
+}
+
+/// Write `body` as `name` in a fresh directory, load it, and give back
+/// `(stdout, stderr)` with the directory's own name folded away.
+fn load(name: &str, body: &str) -> (String, String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join(name), body).expect("write the .db");
+    let found_under = dir.path().display().to_string();
+
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", &found_under) };
+    let (out, err) = streams_of(
+        &format!("dbLoadRecords(\"{name}\")"),
+        Arc::new(PvDatabase::new()),
+    );
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+    (out, err, found_under)
+}
+
+/// An unknown FIELD, with C's suggestion under it: the whole shape,
+/// byte for byte.
+///
+/// `DESC` is what C's weighted `epicsStrSimilarity`
+/// (`dbLexRoutines.c:1242-1385`) proposes for `NOSUCHFLD`, prompt string
+/// and all, and the two spaces before `at or before` are `yyerror(NULL)`
+/// writing a bare `ERROR: ` that the position's own clause continues.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn an_unknown_field_carries_cs_suggestion_and_position() {
+    let (out, err, dir) = load(
+        "bad2.db",
+        "record(ai, \"A2\") {\n    field(NOSUCHFLD, \"3\")\n}\n",
+    );
+    assert_eq!(out, "", "C writes no diagnostic to stdout");
+    assert_eq!(
+        err,
+        format!(
+            "\
+ERROR: ai record 'A2' doesn't have a field 'NOSUCHFLD'
+    Did you mean \"DESC\"?  (Descriptor)
+ERROR:  at or before ')' in path \"{dir}\"  file \"bad2.db\" line 2
+
+ 2 |     field(NOSUCHFLD, \"3\")
+
+ERROR: Failed to load 'bad2.db'
+"
+        )
+    );
+}
+
+/// A menu choice one letter off, through `dbStaticLib.c:2670-2704`'s
+/// unweighted scorer this time. Same shape, different suggester — which
+/// is why both are gated and not just one.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_misspelt_menu_choice_carries_cs_suggestion_and_position() {
+    let (out, err, dir) = load(
+        "bad5.db",
+        "record(ai, \"A5\") {\n    field(SCAN, \"1 secnd\")\n}\n",
+    );
+    assert_eq!(out, "", "C writes no diagnostic to stdout");
+    assert_eq!(
+        err,
+        format!(
+            "\
+ERROR: Can't set 'A5.SCAN' to '1 secnd' using menu menuScan : Illegal choice
+    Did you mean \"1 second\"?
+ERROR:  at or before ')' in path \"{dir}\"  file \"bad5.db\" line 2
+
+ 2 |     field(SCAN, \"1 secnd\")
+
+ERROR: Failed to load 'bad5.db'
+"
+        )
+    );
+}
+
+/// An unknown RECORD TYPE — C's `yyerrorAbort` class, and the one that
+/// was leaving by a different door.
+///
+/// C `dbRecordHead` (`dbLexRoutines.c:1162-1167`) builds the sentence out
+/// of the type and the record NAME, neither of which the port's record
+/// factory sees, so this port forwarded the factory's error instead and
+/// an operator read `DB parse error at line 0, column 0: unknown record
+/// type: 'nosuchtype'` — on STDOUT, where a `2>` startup log never saw
+/// it, in this port's own words, naming a position it did not have.
+///
+/// Two things C prints here that this assertion does not, both deliberate:
+///
+/// 1. the position (` at or before ')' … line 1` and the source echo).
+///    C's lexer is still parked on the record head; this port checks the
+///    type in the install loop, after the text is gone, and
+///    `DbRecordDef` carries no line the way `DbFieldDef` does. Naming a
+///    line it does not hold would be a guess, so it names none —
+///    `db_loader`'s struct is where that line would have to start.
+/// 2. a SECOND `ERROR: syntax error` with the same source line echoed
+///    under it again. That is bison unwinding its stack after `yyAbort`,
+///    not a second thing wrong with the file, and this port has no bison
+///    stack to unwind. Same for C's `WARNING: dbReadCOM: Parser stack
+///    dirty w/o error. 1` (`dbLexRoutines.c:303-306`), which reports
+///    `ellCount(&tempList)` — a C parser-internal list with no
+///    counterpart here.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn an_unknown_record_type_gets_cs_sentence_on_cs_stream() {
+    let (out, err, _dir) = load(
+        "bad4.db",
+        "record(nosuchtype, \"A4\") {\n    field(VAL, \"1\")\n}\n",
+    );
+    assert_eq!(
+        out, "",
+        "the rejection belongs on stderr; C never writes one to stdout"
+    );
+    assert_eq!(
+        err,
+        "\
+ERROR: Record type 'nosuchtype' for record 'A4' not found
+ERROR: Failed to load 'bad4.db'
+"
+    );
+}
+
+/// A record type the port DECLARES but cannot construct — C's rec_size == 0,
+/// not C's "not found".
+///
+/// Measured on `softIoc` with a `.dbd` that declares `recordtype(zzz)` and no
+/// `registerRecordDeviceDriver` to fill in its size:
+///
+/// ```text
+/// stdout: \t*** Did you run x_RegisterRecordDeviceDriver(pdbbase) yet? ***
+/// stderr: dbAllocRecord(Z1) with zzz rec_size = 0
+///         ERROR: Can't create zzz record 'Z1'
+/// ```
+///
+/// `swait` is this port's version of that state: `stdRecords.dbd` does not
+/// carry it, the crate vendors its `.dbd` anyway, and an application opts
+/// into the factory with `register_record_type`. Until it does, the type has
+/// a shape and no support — which is what C's `rec_size == 0` means, and why
+/// this is not the `Record type … not found` line the case below gets.
+///
+/// The hint goes to STDOUT and the size line to stderr because that is where
+/// C puts them: `printf` and `epicsPrintf` respectively
+/// (`dbStaticRun.c:92-94`). An operator redirecting only one of the two
+/// streams sees half of C's answer, and would have seen none of ours.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_declared_but_unregistered_record_type_is_cs_rec_size_zero() {
+    let (out, err, _dir) = load(
+        "unreg.db",
+        "record(swait, \"Z1\") {\n    field(SCAN, \"Passive\")\n}\n",
+    );
+    assert_eq!(
+        out, "\t*** Did you run x_RegisterRecordDeviceDriver(pdbbase) yet? ***\n",
+        "C's printf half, on stdout"
+    );
+    assert_eq!(
+        err,
+        "\
+dbAllocRecord(Z1) with swait rec_size = 0
+ERROR: Can't create swait record 'Z1'
+ERROR: Failed to load 'unreg.db'
+"
+    );
+}

--- a/crates/epics-base-rs/tests/dbl_field_list_is_dbgetstring.rs
+++ b/crates/epics-base-rs/tests/dbl_field_list_is_dbgetstring.rs
@@ -1,0 +1,171 @@
+//! **`dbl`'s field list is `dbFindField` + `dbGetString`, and nothing else.**
+//!
+//! C's `printFieldsList` (`dbTest.c:127-147`,
+//! R7.0.10-146-g8f5015b663d764ad75df) is three lines of decision per field:
+//!
+//! ```c
+//!     long status = dbFindField(pdbentry, papfields[ifield]);
+//!     if (status) {
+//!         if (!strcmp(papfields[ifield], "recordType")) pvalue = dbGetRecordTypeName(pdbentry);
+//!         else { printf(", "); continue; }
+//!     }
+//!     else pvalue = dbGetString(pdbentry);
+//!     printf(", \"%s\"", (pvalue ? pvalue : ""));
+//! ```
+//!
+//! so there are exactly three outcomes: a bare `, ` for a name the record type
+//! does not declare, `, ""` for one it declares that `dbGetString` has no arm
+//! for, and `, "<text>"` from the static renderer otherwise.
+//!
+//! The port asked the RECORD for its own fields — `Record::get_field`, which
+//! knows nothing of `dbCommon` — and rendered with Rust's `Display`. Measured
+//! against `~/work/epics-base/bin/linux-x86_64/softIoc` on the fixture below,
+//! that lost every `dbCommon` field to the bare separator (`DESC`, `SCAN`,
+//! `INP`, `EGU`, `PREC`, `FLNK`) and printed an unwritten `waveform.VAL` as
+//! `T:WF, "[]"` where C prints `T:WF, ""`.
+//!
+//! Unix only: what is asserted is the process console.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+/// Four record types, chosen for the four renderings: a numeric with a
+/// `dbCommon` string and a link (`ai`), a `DBF_NOACCESS` array VAL
+/// (`waveform`), an enum VAL (`bo`), and a type with no `EGU`/`PREC` of its
+/// own so the bare-separator case has a record (`bo` again, and `mbbi`).
+const DB: &str = "\
+record(ai, \"T:AI\") {
+    field(DESC, \"an analog in\")
+    field(EGU, \"V\")
+    field(PREC, \"3\")
+    field(VAL, \"1.5\")
+    field(INP, \"T:BO\")
+}
+record(waveform, \"T:WF\") {
+    field(FTVL, \"DOUBLE\")
+    field(NELM, \"4\")
+}
+record(bo, \"T:BO\") {
+    field(ZNAM, \"Off\")
+    field(ONAM, \"On\")
+    field(VAL, \"1\")
+}
+record(mbbi, \"T:MB\") {
+    field(ZRVL, \"10\")
+    field(ZRST, \"zero\")
+}
+";
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Load the fixture, run one `dbl`, and give back only what it listed.
+fn dbl(fields: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("t.db"), DB).expect("write the .db");
+    let line = format!("dbl \"\" \"{fields}\"");
+    let script = dir.path().join("t.cmd");
+    std::fs::write(
+        &script,
+        format!("dbLoadRecords(\"t.db\")\niocInit\n{line}\n"),
+    )
+    .expect("write the script");
+
+    let sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    // SAFETY: the shell writes through fd 1 for the length of one script and
+    // this test is `serial`, so nothing else holds it while it is swapped.
+    let saved = unsafe {
+        std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path());
+        let saved = libc::dup(1);
+        libc::dup2(sink.as_file().as_raw_fd(), 1);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.display().to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    // SAFETY: restoring the descriptor this call replaced.
+    unsafe {
+        libc::dup2(saved, 1);
+        libc::close(saved);
+        std::env::remove_var("EPICS_DB_INCLUDE_PATH");
+    }
+    assert!(ran.is_ok(), "the shell panicked running {line}");
+
+    let out = strip_ansi(&std::fs::read_to_string(sink.path()).expect("stdout capture"));
+    out.split_once(&format!("{line}\n"))
+        .map(|(_, a)| a.to_string())
+        .unwrap_or_else(|| panic!("the shell never echoed {line}; got:\n{out}"))
+}
+
+/// One case per rendering `dbGetString` has, plus the two non-`dbGetString`
+/// outcomes. Every block is `softIoc`'s own bytes.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn every_field_list_shape_is_cs() {
+    // A numeric VAL, an enum VAL rendered as its INDEX (C's `DBF_ENUM` arm
+    // is the number, not the choice), and a DBF_NOACCESS array VAL as "".
+    assert_eq!(
+        dbl("VAL"),
+        "T:AI, \"1.5\"\nT:BO, \"1\"\nT:MB, \"0\"\nT:WF, \"\"\n"
+    );
+    // A dbCommon string: present on every record type, empty where unset.
+    assert_eq!(
+        dbl("DESC"),
+        "T:AI, \"an analog in\"\nT:BO, \"\"\nT:MB, \"\"\nT:WF, \"\"\n"
+    );
+    // A dbCommon MENU, rendered as its CHOICE (C's `DBF_MENU` arm).
+    assert_eq!(
+        dbl("SCAN"),
+        "T:AI, \"Passive\"\nT:BO, \"Passive\"\nT:MB, \"Passive\"\nT:WF, \"Passive\"\n"
+    );
+    // A link, rebuilt by `dbGetString`'s DB_LINK arm with its pp/ms words —
+    // and `bo`, which declares no INP at all, taking the bare separator.
+    assert_eq!(
+        dbl("INP"),
+        "T:AI, \"T:BO NPP NMS\"\nT:BO, \nT:MB, \"\"\nT:WF, \"\"\n"
+    );
+    // The pseudo-field C answers from `dbGetRecordTypeName`.
+    assert_eq!(
+        dbl("recordType"),
+        "T:AI, \"ai\"\nT:BO, \"bo\"\nT:MB, \"mbbi\"\nT:WF, \"waveform\"\n"
+    );
+    // A `dbCommon` DBF_NOACCESS pointer: declared, so `dbFindField` finds it
+    // and `dbGetString`'s default arm answers NULL.
+    assert_eq!(
+        dbl("RSET"),
+        "T:AI, \"\"\nT:BO, \"\"\nT:MB, \"\"\nT:WF, \"\"\n"
+    );
+    // Several fields at once, with one name nothing declares last so the
+    // trailing bare separator is visible.
+    assert_eq!(
+        dbl("VAL DESC NOSUCH"),
+        "T:AI, \"1.5\", \"an analog in\", \nT:BO, \"1\", \"\", \n\
+         T:MB, \"0\", \"\", \nT:WF, \"\", \"\", \n"
+    );
+    // Record-own fields, absent from two of the four types.
+    assert_eq!(
+        dbl("EGU PREC"),
+        "T:AI, \"V\", \"3\"\nT:BO, , \nT:MB, , \nT:WF, \"\", \"0\"\n"
+    );
+}

--- a/crates/epics-base-rs/tests/dbpf_always_ends_in_dbgf.rs
+++ b/crates/epics-base-rs/tests/dbpf_always_ends_in_dbgf.rs
@@ -1,0 +1,136 @@
+//! **`dbpf` prints no diagnostic of its own, and always ends in `dbgf`.**
+//!
+//! C's whole tail is three statements (`dbTest.c:431-434`,
+//! R7.0.10-146-g8f5015b663d764ad75df):
+//!
+//! ```c
+//!     status = dbPutField(&addr, dbrType, pvalue, n);
+//!     free(array);
+//!     dbgf(pname);
+//!     return status;
+//! ```
+//!
+//! so the read-back runs whatever the put returned, and every word an operator
+//! sees comes from INSIDE the put — `recGblDbaddrError`, a record's own
+//! `special()` — never from `dbpf`. C also never parses the scalar text: it
+//! hands it to `dbPutField` as `DBR_STRING` and lets the conversion fail there.
+//!
+//! The port broke that on both sides. Text no `EpicsValue::parse` took raised
+//! `ERROR <file> line <n>: cannot parse 'notanumber' as Double` and returned
+//! before the read-back; and the read-back itself was an inline copy of only
+//! `dbgf`'s successful half, so a put whose read then failed printed nothing.
+//! Measured against `~/work/epics-base/bin/linux-x86_64/softIoc` on the
+//! fixture below, C printed `DBF_DOUBLE:         1.5` and
+//! `DBF_CHAR:           failed.` for those two.
+//!
+//! Unix only: what is asserted is the process console.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+const DB: &str = "record(ai, \"T:AI\") {\n    field(PREC, \"3\")\n    field(VAL, \"1.5\")\n}\n";
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Load the fixture, run `line`, and give back what it printed on stdout
+/// after the shell's echo of the line, plus everything on stderr.
+fn answer_to(line: &str) -> (String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("t.db"), DB).expect("write the .db");
+    let script = dir.path().join("t.cmd");
+    std::fs::write(
+        &script,
+        format!("dbLoadRecords(\"t.db\")\niocInit\n{line}\n"),
+    )
+    .expect("write the script");
+
+    let out_sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    let err_sink = tempfile::NamedTempFile::new().expect("stderr capture");
+    // SAFETY: the shell writes through fds 1 and 2 for the length of one
+    // script and this test is `serial`, so nothing else holds either.
+    let saved = unsafe {
+        std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path());
+        let saved = (libc::dup(1), libc::dup(2));
+        libc::dup2(out_sink.as_file().as_raw_fd(), 1);
+        libc::dup2(err_sink.as_file().as_raw_fd(), 2);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.display().to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    // SAFETY: restoring the two descriptors this call replaced.
+    unsafe {
+        libc::dup2(saved.0, 1);
+        libc::dup2(saved.1, 2);
+        libc::close(saved.0);
+        libc::close(saved.1);
+        std::env::remove_var("EPICS_DB_INCLUDE_PATH");
+    }
+    assert!(ran.is_ok(), "the shell panicked running {line}");
+
+    let out = strip_ansi(&std::fs::read_to_string(out_sink.path()).expect("stdout capture"));
+    // C's build says two errlog lines of its own around the script's `iocInit`
+    // (`iocInit.c:129` and `:273`); they are the shell's, not the command's,
+    // so they are not part of what `dbpf` said.
+    let err = strip_ansi(&std::fs::read_to_string(err_sink.path()).expect("stderr capture"))
+        .replace("Starting iocInit\n", "")
+        .replace("iocRun: All initialization complete\n", "");
+    let after = out
+        .split_once(&format!("{line}\n"))
+        .map(|(_, a)| a.to_string())
+        .unwrap_or_else(|| panic!("the shell never echoed {line}; got:\n{out}"));
+    (after, err)
+}
+
+/// Text no conversion takes is a FAILED PUT, not a parse error: C leaves the
+/// field alone, says nothing, and still echoes what the record kept.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn unconvertible_text_is_a_failed_put_and_still_echoes() {
+    let (out, err) = answer_to("dbpf T:AI, \"notanumber\"");
+    assert_eq!(out, "DBF_DOUBLE:         1.5       \n");
+    assert_eq!(err, "", "C's dbpf writes nothing to stderr of its own");
+}
+
+/// A put whose read-back fails still prints `dbgf`'s failure line. `DBF_CHAR`
+/// is what C prints here, off the end of its 13-entry `dbr[]` table for
+/// `DBR_NOACCESS` (17); this port names the type it actually has, a deviation
+/// signed off with the rest of that out-of-bounds read.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_put_whose_readback_fails_still_prints_dbgfs_failure_line() {
+    let (out, _) = answer_to("dbpf T:AI.RSET, \"1\"");
+    assert_eq!(out, "DBF_NOACCESS:       failed.   \n");
+}
+
+/// The successful case is unchanged, and still goes through the same printer.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_put_that_lands_echoes_the_new_value() {
+    let (out, err) = answer_to("dbpf T:AI, \"2.5\"");
+    assert_eq!(out, "DBF_DOUBLE:         2.5       \n");
+    assert_eq!(err, "");
+}

--- a/crates/epics-base-rs/tests/dbtest_resolves_a_name_one_way.rs
+++ b/crates/epics-base-rs/tests/dbtest_resolves_a_name_one_way.rs
@@ -1,0 +1,197 @@
+//! **Every `dbTest.c` command resolves a name through the same rule.**
+//!
+//! C routes all seven — `dba`, `dbgf`, `dbpf`, `dbpr`, `dbtr`, `dbtgf`,
+//! `dbtpf` — through one `nameToAddr` (`dbTest.c:787-795`), so what
+//! `<record>[.<FIELD>]` selects, and when `PV '%s' not found` is printed,
+//! cannot differ between them.
+//!
+//! The port had seven spellings of the test, and measured against
+//! `~/work/epics-base/bin/linux-x86_64/softIoc`
+//! (R7.0.10-146-g8f5015b663d764ad75df) on the fixture below they disagreed in
+//! three directions at once: `dbpr`/`dbtr` never split off the field, so
+//! `dbpr T:AI.VAL` answered not-found where C printed the record;
+//! `dba`/`dbpf`/`dbtgf` read "declared but unreadable" as unresolved, so
+//! `dbpf T:AI.RSET` answered not-found where C reached the put; and `dbtpf`
+//! asked only for the record, so `dbtpf T:AI.NOSUCHFLD` printed twelve
+//! `Put as DBR_… Failed.` lines where C printed not-found.
+//!
+//! The boundary is the same three values for every command, so it is tested
+//! that way rather than by command: a field the type declares AND serves, a
+//! field it declares and does NOT serve (`DBF_NOACCESS`), and a name it does
+//! not declare at all. What each command prints once the name HAS resolved is
+//! not this file's subject — only whether it resolved.
+//!
+//! Unix only: what is asserted is the process console.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+const DB: &str = "\
+record(ai, \"T:AI\") {
+    field(DESC, \"an analog in\")
+    field(EGU, \"V\")
+    field(PREC, \"3\")
+    field(VAL, \"1.5\")
+}
+";
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Load the fixture, run `line`, and give back what it put on stdout —
+/// without the shell's own echo of the line, which C prints too and which
+/// says nothing about the resolution.
+fn answer_to(line: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("t.db"), DB).expect("write the .db");
+    let script = dir.path().join("t.cmd");
+    std::fs::write(
+        &script,
+        format!("dbLoadRecords(\"t.db\")\niocInit\n{line}\n"),
+    )
+    .expect("write the script");
+
+    let sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    // SAFETY: the shell writes through fd 1 for the length of one script and
+    // this test is `serial`, so nothing else holds it while it is swapped.
+    let saved = unsafe {
+        std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path());
+        let saved = libc::dup(1);
+        libc::dup2(sink.as_file().as_raw_fd(), 1);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.display().to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    // SAFETY: restoring the descriptor this call replaced.
+    unsafe {
+        libc::dup2(saved, 1);
+        libc::close(saved);
+        std::env::remove_var("EPICS_DB_INCLUDE_PATH");
+    }
+    assert!(ran.is_ok(), "the shell panicked running {line}");
+
+    let text = strip_ansi(&std::fs::read_to_string(sink.path()).expect("stdout capture"));
+    // Drop the echoed script lines: the two setup lines, this line, and
+    // whatever `iocInit` announced.
+    text.split_once(&format!("{line}\n"))
+        .map(|(_, after)| after.to_string())
+        .unwrap_or_else(|| panic!("the shell never echoed {line}; got:\n{text}"))
+}
+
+/// The line C's `nameToAddr` prints, and the only thing the caller then
+/// prints (`dbTest.c:789-791`).
+fn not_found(pname: &str) -> String {
+    format!("PV '{pname}' not found\n")
+}
+
+/// Every command must resolve a field the record type declares and serves.
+///
+/// `DESC` rather than `VAL` on purpose: `VAL` is what a bare record name
+/// already defaults to (`parse_pv_name`), so it cannot tell a command that
+/// splits the name from one that ignores everything after the dot.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_served_field_resolves_for_every_command() {
+    for line in [
+        "dba T:AI.DESC",
+        "dbgf T:AI.DESC",
+        "dbpf T:AI.DESC, \"x\"",
+        "dbpr T:AI.DESC",
+        "dbtr T:AI.DESC",
+        "dbtgf T:AI.DESC",
+        "dbtpf T:AI.DESC, \"x\"",
+    ] {
+        let got = answer_to(line);
+        assert!(
+            !got.contains("not found"),
+            "`{line}` must resolve, as C's dbNameToAddr does; got:\n{got}"
+        );
+        assert!(!got.is_empty(), "`{line}` printed nothing at all");
+    }
+}
+
+/// A `DBF_NOACCESS` field is DECLARED, so C resolves it and the read or write
+/// fails afterwards, inside `dbGet`/`dbPut` — `dbgf T:AI.RSET` prints a type
+/// header and `failed.`, never the not-found line.
+///
+/// `dba` is not in this list: it resolves the name here too, but the block it
+/// then prints needs a per-field descriptor the port's generated tables do
+/// not carry for a `dbCommon` `DBF_NOACCESS` row. `dbtgf` is not in it for the
+/// same reason — it needs a readable snapshot to print its option block.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_declared_but_unreadable_field_resolves_too() {
+    for line in ["dbgf T:AI.RSET", "dbpf T:AI.RSET, \"1\"", "dbpr T:AI.RSET"] {
+        let got = answer_to(line);
+        assert!(
+            !got.contains("not found"),
+            "`{line}`: a declared DBF_NOACCESS field resolves in C; got:\n{got}"
+        );
+    }
+}
+
+/// A name the record type does not declare resolves nowhere, and every
+/// command says so with C's one line and nothing else.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn an_undeclared_field_is_not_found_for_every_command() {
+    for (line, pname) in [
+        ("dba T:AI.NOSUCHFLD", "T:AI.NOSUCHFLD"),
+        ("dbgf T:AI.NOSUCHFLD", "T:AI.NOSUCHFLD"),
+        ("dbpf T:AI.NOSUCHFLD, \"1\"", "T:AI.NOSUCHFLD"),
+        ("dbpr T:AI.NOSUCHFLD", "T:AI.NOSUCHFLD"),
+        ("dbtr T:AI.NOSUCHFLD", "T:AI.NOSUCHFLD"),
+        ("dbtgf T:AI.NOSUCHFLD", "T:AI.NOSUCHFLD"),
+        ("dbtpf T:AI.NOSUCHFLD, \"1\"", "T:AI.NOSUCHFLD"),
+        ("dba NOSUCH", "NOSUCH"),
+        ("dbgf NOSUCH", "NOSUCH"),
+        ("dbpf NOSUCH, \"1\"", "NOSUCH"),
+        ("dbpr NOSUCH", "NOSUCH"),
+        ("dbtr NOSUCH", "NOSUCH"),
+        ("dbtgf NOSUCH", "NOSUCH"),
+        ("dbtpf NOSUCH, \"1\"", "NOSUCH"),
+    ] {
+        assert_eq!(answer_to(line), not_found(pname), "`{line}`");
+    }
+}
+
+/// `dbpr` prints the WHOLE record whatever field the address landed on —
+/// C's `dbpr_report` walks the record's field table and never looks at
+/// `paddr->pfldDes` — so these three lines are one report, byte for byte.
+///
+/// The block is `softIoc`'s own, measured at level 0 on the fixture above.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn dbpr_ignores_the_field_the_name_selected() {
+    const LEVEL0: &str = "\
+AMSG:               ASG :               DESC: an analog in  DISA: 0             
+DISV: 1             NAME: T:AI          NAMSG:              RVAL: 0             
+SEVR: NO_ALARM      STAT: UDF           SVAL: 0             TPRO: 0             
+VAL : 1.5           
+";
+    for line in ["dbpr T:AI", "dbpr T:AI.VAL", "dbpr T:AI.DESC"] {
+        assert_eq!(answer_to(line), LEVEL0, "`{line}`");
+    }
+}

--- a/crates/epics-base-rs/tests/dbtest_serves_a_name_only_noaccess_field.rs
+++ b/crates/epics-base-rs/tests/dbtest_serves_a_name_only_noaccess_field.rs
@@ -1,0 +1,192 @@
+//! **A `dbCommon` `DBF_NOACCESS` internal has an ADDRESS, and every
+//! `dbTest.c` command works from it.**
+//!
+//! C's `dbNameToAddr` resolves any field the `.dbd` declares, so `RSET` — a
+//! `struct typed_rset *` behind `special(SPC_NOMOD)` (`dbCommon.dbd:216-221`)
+//! — comes back with a full `DBADDR` and every command then just reads it.
+//! Measured on `~/work/epics-base/bin/linux-x86_64/softIoc`
+//! (R7.0.10-146-g8f5015b663d764ad75df), `dba T:AI.RSET` prints the descriptor
+//! block and `dbtgf T:AI.RSET` the option block plus thirteen value lines.
+//!
+//! This port resolved the name in one place and then asked a second, narrower
+//! question in each command — `field_desc`, `snapshot_for_field` — which have
+//! no entry for the rows the generator carries by NAME only. `dba T:AI.RSET`
+//! printed nothing at all and `dbtgf T:AI.RSET` printed `PV '…' not found`
+//! for a name it had just resolved.
+//!
+//! Three cells of `dba`'s block have no counterpart here and print `(none)`:
+//! the field address (this port reads a field through `Record::get_field`,
+//! not at a struct offset), and — for these rows only — the descriptor
+//! pointer and the width, because the generator carries a descriptor only for
+//! the `DBF_NOACCESS` rows whose `extra(...)` names a plain scalar. What is
+//! asserted below is everything else, which is C's bytes.
+//!
+//! Unix only: what is asserted is the process console.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+const DB: &str = "\
+record(ai, \"T:AI\") {
+    field(DESC, \"an analog in\")
+    field(EGU, \"V\")
+    field(PREC, \"3\")
+    field(HOPR, \"10\")
+    field(LOPR, \"0\")
+    field(VAL, \"1.5\")
+}
+";
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Load the fixture, run `line`, and give back what it put on stdout after
+/// the shell's own echo of that line.
+fn answer_to(line: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("t.db"), DB).expect("write the .db");
+    let script = dir.path().join("t.cmd");
+    std::fs::write(
+        &script,
+        format!("dbLoadRecords(\"t.db\")\niocInit\n{line}\n"),
+    )
+    .expect("write the script");
+
+    let sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    // SAFETY: the shell writes through fd 1 for the length of one script and
+    // this test is `serial`, so nothing else holds it while it is swapped.
+    let saved = unsafe {
+        std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path());
+        let saved = libc::dup(1);
+        libc::dup2(sink.as_file().as_raw_fd(), 1);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.display().to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    // SAFETY: restoring the descriptor this call replaced.
+    unsafe {
+        libc::dup2(saved, 1);
+        libc::close(saved);
+        std::env::remove_var("EPICS_DB_INCLUDE_PATH");
+    }
+    assert!(ran.is_ok(), "the shell panicked running {line}");
+
+    let text = strip_ansi(&std::fs::read_to_string(sink.path()).expect("stdout capture"));
+    text.split_once(&format!("{line}\n"))
+        .map(|(_, after)| after.to_string())
+        .unwrap_or_else(|| panic!("the shell never echoed {line}; got:\n{text}"))
+}
+
+/// `dba` on a name-only `DBF_NOACCESS` row.
+///
+/// C's block for `dba T:AI.RSET`, with the run-varying pointers elided:
+///
+/// ```text
+/// Record Address: 0x… Field Address: 0x… Field Description: 0x…
+///    No Elements: 1
+///    Record Type: ai
+///     Field Type: 17 = DBF_NOACCESS
+///     Field Size: 8
+///        Special: 1
+/// DBR Field Type: 17 = DBR_NOACCESS
+/// ```
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn dba_prints_the_descriptor_block_for_rset() {
+    let out = answer_to("dba T:AI.RSET");
+    let (head, rest) = out.split_once('\n').expect("dba printed nothing");
+    assert!(
+        head.starts_with("Record Address: 0x")
+            && head.ends_with(" Field Address: (none) Field Description: (none)"),
+        "header was {head:?}"
+    );
+    assert_eq!(
+        rest,
+        "   No Elements: 1\n\
+         \x20  Record Type: ai\n\
+         \x20   Field Type: 17 = DBF_NOACCESS\n\
+         \x20   Field Size: (none)\n\
+         \x20      Special: 1\n\
+         DBR Field Type: 17 = DBR_NOACCESS\n"
+    );
+}
+
+/// `dbtgf` on the same row — `softIoc`'s bytes, with the one substitution
+/// this port makes on purpose.
+///
+/// C's native header reads `DBF_CHAR[0]`, not `DBF_NOACCESS[0]`: `dbr[]` is
+/// declared `[DBR_ENUM+2]` (`dbTest.c:82-85`) while `DBR_NOACCESS` is 17, so
+/// `dbr[17]` reads past the end and R7.0.10 prints the adjacent `dbf[1]`.
+/// The port prints the type C meant.
+///
+/// The option block is C's own, line for line: `getOptions` copies the alarm
+/// off `paddr->precord`, leaves `units` a set-but-empty option for a class
+/// that is neither float nor integer, clears `DBR_PRECISION`, and every limit
+/// falls to `recGblGetGraphicDouble`'s zeros because `aiRecord`'s
+/// `get_graphic_double` answers HOPR/LOPR only for `VAL`.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn dbtgf_prints_the_option_block_and_thirteen_values_for_rset() {
+    assert_eq!(
+        answer_to("dbtgf T:AI.RSET"),
+        "status = 17, severity = 0\n\
+         units = \"\"\n\
+         precision not returned\n\
+         time = <undefined>\n\
+         enum strings not returned\n\
+         grLong: 0 .. 0\n\
+         grDouble: 0 .. 0\n\
+         ctrlLong: 0 .. 0\n\
+         ctrlDouble: 0 .. 0\n\
+         alLong: 0 < 0 .. 0 < 0\n\
+         alDouble: 0 < 0 .. 0 < 0\n\
+         DBF_NOACCESS[0]: (empty)      Bad DBR type 17     \n\
+         DBF_STRING:         failed.   \n\
+         DBF_CHAR:           failed.   \n\
+         DBF_UCHAR:          failed.   \n\
+         DBF_SHORT:          failed.   \n\
+         DBF_USHORT:         failed.   \n\
+         DBF_LONG:           failed.   \n\
+         DBF_ULONG:          failed.   \n\
+         DBF_INT64:          failed.   \n\
+         DBF_UINT64:         failed.   \n\
+         DBF_FLOAT:          failed.   \n\
+         DBF_DOUBLE:         failed.   \n\
+         DBF_ENUM:           failed.   \n"
+    );
+}
+
+/// The control: a readable field still takes the typed path, so the
+/// zero-element native header stays bare — C's `default:` arm is the only one
+/// that speaks under it.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_readable_field_keeps_its_bare_zero_element_header() {
+    let out = answer_to("dbtgf T:AI.VAL");
+    assert!(
+        out.contains("\nDBF_DOUBLE[0]: (empty)        \nDBF_STRING:         \"1.500\"   \n"),
+        "native header was not bare in:\n{out}"
+    );
+}

--- a/crates/epics-base-rs/tests/dbtgf_limits_are_never_nan.rs
+++ b/crates/epics-base-rs/tests/dbtgf_limits_are_never_nan.rs
@@ -1,0 +1,136 @@
+//! **`dbtgf`'s six limit lines are numbers, never `nan`.**
+//!
+//! Each of them is a plain `double` field of the C record — `LOLO`, `LOW`,
+//! `HIGH`, `HIHI`, `LOPR`, `HOPR`, `DRVL`, `DRVH` — read straight into the
+//! option block by `getOptions` (`dbAccess.c:249-311`,
+//! R7.0.10-146-g8f5015b663d764ad75df) and 0.0 until something sets it. There
+//! is no encoding in C for "the record states no limit".
+//!
+//! This port's `Snapshot` has one — NaN — and it was reaching the renderer.
+//! Measured against `~/work/epics-base/bin/linux-x86_64/softIoc` on a record
+//! with no alarm limits, C prints
+//!
+//! ```text
+//! alLong: 0 < 0 .. 0 < 0
+//! alDouble: 0 < 0 .. 0 < 0
+//! ```
+//!
+//! and this port printed `alDouble: nan < nan .. nan < nan`. The long line was
+//! already right only because C's own `finite(x) ? (epicsInt32)x : 0`
+//! (`dbAccess.c:303-310`) had been ported onto it; the rule belongs ahead of
+//! both renderers, not on the arm that happened to be measured.
+//!
+//! Unix only: what is asserted is the process console.
+
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+/// `HOPR`/`LOPR` are set so the graphic and control lines carry real numbers;
+/// no alarm limit is, so those four fields are the ones with no value.
+const DB: &str = "\
+record(ai, \"T:AI\") {
+    field(DESC, \"an analog in\")
+    field(EGU, \"V\")
+    field(PREC, \"3\")
+    field(HOPR, \"10\")
+    field(LOPR, \"0\")
+    field(VAL, \"1.5\")
+}
+";
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+fn answer_to(line: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("t.db"), DB).expect("write the .db");
+    let script = dir.path().join("t.cmd");
+    std::fs::write(
+        &script,
+        format!("dbLoadRecords(\"t.db\")\niocInit\n{line}\n"),
+    )
+    .expect("write the script");
+
+    let sink = tempfile::NamedTempFile::new().expect("stdout capture");
+    // SAFETY: the shell writes through fd 1 for the length of one script and
+    // this test is `serial`, so nothing else holds it while it is swapped.
+    let saved = unsafe {
+        std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path());
+        let saved = libc::dup(1);
+        libc::dup2(sink.as_file().as_raw_fd(), 1);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.display().to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    // SAFETY: restoring the descriptor this call replaced.
+    unsafe {
+        libc::dup2(saved, 1);
+        libc::close(saved);
+        std::env::remove_var("EPICS_DB_INCLUDE_PATH");
+    }
+    assert!(ran.is_ok(), "the shell panicked running {line}");
+
+    let text = strip_ansi(&std::fs::read_to_string(sink.path()).expect("stdout capture"));
+    text.split_once(&format!("{line}\n"))
+        .map(|(_, after)| after.to_string())
+        .unwrap_or_else(|| panic!("the shell never echoed {line}; got:\n{text}"))
+}
+
+/// `DESC` is a `DBF_STRING`, so no limit reaches the block from the record
+/// and all six lines are C's zeros — the whole option block, byte for byte.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn an_unset_limit_prints_zero_on_both_lines() {
+    let out = answer_to("dbtgf T:AI.DESC");
+    assert!(
+        out.starts_with(
+            "status = 17, severity = 0\n\
+             units = \"\"\n\
+             precision not returned\n\
+             time = <undefined>\n\
+             enum strings not returned\n\
+             grLong: 0 .. 0\n\
+             grDouble: 0 .. 0\n\
+             ctrlLong: 0 .. 0\n\
+             ctrlDouble: 0 .. 0\n\
+             alLong: 0 < 0 .. 0 < 0\n\
+             alDouble: 0 < 0 .. 0 < 0\n"
+        ),
+        "option block was:\n{out}"
+    );
+}
+
+/// The control: a limit the record DOES state still prints its own value, so
+/// the rule cannot be read as "zero every double".
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn a_stated_limit_still_prints_itself() {
+    let out = answer_to("dbtgf T:AI.VAL");
+    assert!(
+        out.contains("\ngrDouble: 0 .. 10\nctrlLong: 0 .. 10\nctrlDouble: 0 .. 10\n"),
+        "option block was:\n{out}"
+    );
+    assert!(!out.contains("nan"), "a limit printed nan:\n{out}");
+}

--- a/crates/epics-base-rs/tests/init_record_stops_where_c_has_no_dset.rs
+++ b/crates/epics-base-rs/tests/init_record_stops_where_c_has_no_dset.rs
@@ -1,0 +1,117 @@
+//! Every cell below C's `if (!pdset) return S_dev_noDSET` stays at its `.dbd`
+//! initial for a record whose DTYP names device support nobody registered.
+//!
+//! ```c
+//! if (!(pdset = (aidset *)(prec->dset))) {
+//!     recGblRecordError(S_dev_noDSET, prec, "ai: init_record");
+//!     return(S_dev_noDSET);
+//! }
+//! ...
+//! prec->mlst = prec->val;
+//! prec->alst = prec->val;
+//! prec->lalm = prec->val;
+//! ```
+//! (`aiRecord.c:105-129`; `aoRecord.c:107-160` is the same shape around
+//! `prec->init = TRUE` and `oval = pval = val`.)
+//!
+//! Measured on softIoc R7.0.10 against a dbd declaring `device(ai, CONSTANT,
+//! devAiNoSuch, "Missing Device")` — a menu choice C accepts and a dset C
+//! cannot find, which is the only way to reach a NULL dset from a `.db`.
+//! C reads `ALST 0 LALM 0 MLST 0 INIT 0` on `field(VAL,"1.5")` records of 14
+//! record types; the port read `1.5` in all of them, because it ran the init
+//! passes at record creation and attached device support afterwards, so
+//! `init_record` could not see that it had no dset.
+//!
+//! Boundary cases, not scenarios: dset absent / dset present (soft channel) /
+//! record type that has no dset test at all.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::types::EpicsValue;
+
+async fn ioc(db_text: &str) -> Arc<PvDatabase> {
+    IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+fn f64_of(db: &PvDatabase, pv: &str) -> f64 {
+    db.get_pv(pv)
+        .unwrap_or_else(|e| panic!("{pv}: {e}"))
+        .to_f64()
+        .unwrap_or_else(|| panic!("{pv} is not numeric"))
+}
+
+/// `ai`, the type the whole family was measured on.
+#[epics_macros_rs::epics_test]
+async fn an_ai_with_no_dset_seeds_no_tracker() {
+    let db = ioc("record(ai, \"T:A\") { field(DTYP,\"asynInt32\") field(VAL,\"1.5\") }\n").await;
+
+    assert_eq!(f64_of(&db, "T:A.VAL"), 1.5, "the `.db` field still loaded");
+    for field in ["MLST", "ALST", "LALM"] {
+        assert_eq!(
+            f64_of(&db, &format!("T:A.{field}")),
+            0.0,
+            "`aiRecord.c:127-129` is below the noDSET return; softIoc reads 0"
+        );
+    }
+}
+
+/// The SAME record type with device support present runs the whole tail. This
+/// is the half a per-cell patch gets wrong: the seed is not deleted, it is
+/// conditional on reaching it.
+#[epics_macros_rs::epics_test]
+async fn an_ai_with_a_soft_channel_seeds_its_trackers() {
+    let db = ioc("record(ai, \"T:S\") { field(DTYP,\"Soft Channel\") field(VAL,\"1.5\") }\n").await;
+
+    for field in ["MLST", "ALST", "LALM"] {
+        assert_eq!(
+            f64_of(&db, &format!("T:S.{field}")),
+            1.5,
+            "a dset C always links reaches `aiRecord.c:127-129`"
+        );
+    }
+}
+
+/// `ao`'s cell is a flag, not a tracker: `prec->init = TRUE` (`aoRecord.c:119`)
+/// with `oval = pval = val` at `:155-157`, all below the same return.
+#[epics_macros_rs::epics_test]
+async fn an_ao_with_no_dset_is_not_marked_initialised() {
+    let db = ioc("record(ao, \"T:O\") { field(DTYP,\"asynInt32\") field(VAL,\"1.5\") }\n").await;
+
+    assert_eq!(
+        db.get_pv("T:O.INIT").unwrap(),
+        EpicsValue::Short(0),
+        "`aoRecord.c:119` is below the noDSET return; softIoc reads INIT 0"
+    );
+    for field in ["OVAL", "PVAL", "MLST", "ALST", "LALM"] {
+        assert_eq!(
+            f64_of(&db, &format!("T:O.{field}")),
+            0.0,
+            "`aoRecord.c:155-160`"
+        );
+    }
+}
+
+/// A record type whose C `init_record` has no dset test runs its passes with
+/// any DTYP at all — the gate is the refusal table, not "has a device".
+#[epics_macros_rs::epics_test]
+async fn a_record_type_with_no_dset_test_still_runs_its_passes() {
+    let db = ioc(
+        "record(calc, \"T:C\") { field(DTYP,\"asynInt32\") field(CALC,\"1\") field(VAL,\"1.5\") }\n",
+    )
+    .await;
+
+    assert_eq!(
+        f64_of(&db, "T:C.MLST"),
+        1.5,
+        "calcRecord.c has no `!pdset` branch, so nothing is skipped"
+    );
+}

--- a/crates/epics-base-rs/tests/iocsh_stream_parity.rs
+++ b/crates/epics-base-rs/tests/iocsh_stream_parity.rs
@@ -13,6 +13,12 @@
 //! The port paints the same escapes only when `use_ansi_color` says so,
 //! a deliberate deviation from C painting unconditionally, so this
 //! compares the stripped streams on both sides.
+//!
+//! Unix only: what is captured is the process console, and the only way to
+//! capture it is to point fds 1 and 2 somewhere else and put them back. There
+//! is no fd 2 on Windows, and `libc` is a `cfg(unix)` dependency of this crate.
+
+#![cfg(unix)]
 
 use std::io::Write;
 use std::os::fd::AsRawFd;

--- a/crates/epics-base-rs/tests/iocsh_stream_parity.rs
+++ b/crates/epics-base-rs/tests/iocsh_stream_parity.rs
@@ -1,0 +1,306 @@
+//! What the two shells put on stdout and stderr for the same malformed
+//! and edge-case input.
+//!
+//! Every expectation here is MEASURED, not derived: each script was run
+//! through `~/work/epics-base/bin/linux-x86_64/softIoc`
+//! (R7.0.10-146-g8f5015b663d764ad75df) with stdin on `/dev/null`, and the
+//! bytes below are that run's two streams with the ANSI colour stripped
+//! and `softMain`'s trailing interactive prompt removed — `softMain.cpp`
+//! enters `iocsh(NULL)` after every script (`:247-253`), so C's stdout
+//! always ends with one `epics> ` that belongs to the shell C is about to
+//! start rather than to the script it just ran.
+//!
+//! The port paints the same escapes only when `use_ansi_color` says so,
+//! a deliberate deviation from C painting unconditionally, so this
+//! compares the stripped streams on both sides.
+
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::iocsh::IocShell;
+
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Run one script through a fresh shell with fds 1 and 2 pointed at
+/// files, because the echo C compares against is written with `printf`
+/// and never passes through the command context.
+fn run(script: &str) -> (String, String) {
+    let out_file = tempfile::NamedTempFile::new().expect("stdout capture");
+    let err_file = tempfile::NamedTempFile::new().expect("stderr capture");
+    // SAFETY: the shell writes through fds 1 and 2 for the length of one
+    // script and this test is `serial`, so no other thread is holding
+    // either while they are swapped.
+    let (saved_out, saved_err) = unsafe {
+        let saved = (libc::dup(1), libc::dup(2));
+        libc::dup2(out_file.as_file().as_raw_fd(), 1);
+        libc::dup2(err_file.as_file().as_raw_fd(), 2);
+        saved
+    };
+
+    let db = Arc::new(PvDatabase::new());
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let path = script.to_string();
+    // The shell blocks, so it runs off the reactor thread the way an IOC
+    // startup script does.
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_script(&path)).join();
+
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    // SAFETY: restoring the two descriptors this call replaced.
+    unsafe {
+        libc::dup2(saved_out, 1);
+        libc::dup2(saved_err, 2);
+        libc::close(saved_out);
+        libc::close(saved_err);
+    }
+    assert!(ran.is_ok(), "the shell panicked running {script}");
+
+    (
+        strip_ansi(&std::fs::read_to_string(out_file.path()).expect("stdout capture")),
+        strip_ansi(&std::fs::read_to_string(err_file.path()).expect("stderr capture")),
+    )
+}
+
+/// `(script name, contents, C's stdout, C's stderr)`.
+///
+/// A case whose scripts include a second file writes it as its own row
+/// with no expectation of its own — the row that includes it carries the
+/// measurement.
+type Case = (&'static str, &'static str, &'static str, &'static str);
+
+const CASES: &[Case] = &[
+    // --- an unknown command ---
+    (
+        "k01.cmd",
+        "nosuchcommand\n",
+        "nosuchcommand\n",
+        "ERROR k01.cmd line 1: Command 'nosuchcommand' not registered.\n",
+    ),
+    // --- too few arguments, both shapes: the shell runs the line and
+    // the body refuses, unframed (`libComRegister.c:142-151`) ---
+    (
+        "k02.cmd",
+        "epicsEnvSet ONLYONE\n",
+        "epicsEnvSet ONLYONE\n",
+        "Missing environment variable value argument.\n",
+    ),
+    (
+        "k03.cmd",
+        "epicsEnvSet\n",
+        "epicsEnvSet\n",
+        "Missing environment variable name argument.\n",
+    ),
+    // --- too many arguments: C reads the ones it declared and drops the
+    // rest without a word (`iocsh.cpp:1288-1296`) ---
+    (
+        "k04.cmd",
+        "dbl a b c d\n",
+        "dbl a b c d\nNo record type\n",
+        "",
+    ),
+    // --- a bad numeric argument, all three of C's sentences ---
+    (
+        "k06.cmd",
+        "dbpr A1 notanumber\n",
+        "dbpr A1 notanumber\n",
+        "ERROR k06.cmd line 1: Invalid integer 'notanumber'.\n",
+    ),
+    (
+        "k07.cmd",
+        "dbpr A1 99999999999999999999\n",
+        "dbpr A1 99999999999999999999\n",
+        "ERROR k07.cmd line 1: Integer '99999999999999999999' out of range.\n",
+    ),
+    (
+        "k08.cmd",
+        "epicsThreadSleep notanumber\n",
+        "epicsThreadSleep notanumber\n",
+        "ERROR k08.cmd line 1: Invalid double 'notanumber'.\n",
+    ),
+    // --- an unterminated quote (`iocsh.cpp:362-366`) ---
+    (
+        "k09.cmd",
+        "dbl \"abc\n",
+        "dbl \"abc\n",
+        "ERROR k09.cmd line 1: Unbalanced quote.\n",
+    ),
+    // --- unmatched parens and stray commas: C's separator set is
+    // uniform, so all three of these run `dbl` and say nothing ---
+    ("k10.cmd", "dbl(\n", "dbl(\n", ""),
+    ("k11.cmd", "dbl)\n", "dbl)\n", ""),
+    // `zzz` and not a real record type on purpose: the point is that
+    // the comma separated and the word behind it reached `dbl` as its
+    // argument, which "No record type" proves and an empty listing would
+    // not.
+    ("k12.cmd", "dbl , zzz\n", "dbl , zzz\nNo record type\n", ""),
+    ("k13.cmd", "echo(hello)\n", "echo(hello)\nhello\n", ""),
+    // A quote is removed wherever it sits, not stripped off the ends.
+    ("k14.cmd", "echo(a\"b\"c)\n", "echo(a\"b\"c)\nabc\n", ""),
+    // --- comments, empty and blank lines (`iocsh.cpp:1196-1204`) ---
+    ("k15.cmd", "# a comment\n", "# a comment\n", ""),
+    ("k16.cmd", "#- silent\n", "", ""),
+    ("k17.cmd", "\n", "", ""),
+    // The blank line IS echoed, with its whitespace intact.
+    ("k18.cmd", "   \t  \n", "   \t  \n", ""),
+    // --- `<` to a file that will not open: reported by `iocshBody`
+    // itself (`iocsh.cpp:1053-1058`), so unframed — there is no line
+    // number yet ---
+    (
+        "k19.cmd",
+        "< nosuch.cmd\n",
+        "< nosuch.cmd\n",
+        "Can't open nosuch.cmd: No such file or directory\n",
+    ),
+    // --- a malformed line inside a redirect: framed with the INNER
+    // file's name, and the outer script runs on ---
+    ("kq.cmd", "echo \"unterminated\n", "", ""),
+    (
+        "k20.cmd",
+        "< kq.cmd\necho \"outer continues\"\n",
+        "< kq.cmd\necho \"unterminated\necho \"outer continues\"\nouter continues\n",
+        "ERROR kq.cmd line 1: Unbalanced quote.\n",
+    ),
+    // --- `exit` inside a redirect ends only the inner body
+    // (`iocsh.cpp:1240`) ---
+    (
+        "ksub.cmd",
+        "echo \"in sub\"\nexit\necho \"never\"\n",
+        "",
+        "",
+    ),
+    (
+        "k21.cmd",
+        "< ksub.cmd\necho \"outer after exit\"\n",
+        "< ksub.cmd\necho \"in sub\"\nin sub\nexit\necho \"outer after exit\"\nouter after exit\n",
+        "",
+    ),
+    // --- a failure inside a redirect: the inner file's name again, and
+    // the outer script still runs on ---
+    ("kbad.cmd", "nosuchcmd\n", "", ""),
+    (
+        "k27.cmd",
+        "< kbad.cmd\necho \"outer after failure\"\n",
+        "< kbad.cmd\nnosuchcmd\necho \"outer after failure\"\nouter after failure\n",
+        "ERROR kbad.cmd line 1: Command 'nosuchcmd' not registered.\n",
+    ),
+    // --- an undefined macro: `macDefExpand` returns NULL, so the line is
+    // never echoed and never looked up, and macLib has raised the only
+    // diagnostic (`iocsh.cpp:1184-1187`) ---
+    (
+        "k22.cmd",
+        "dbl $(UNDEF)\n",
+        "",
+        "macLib: macro UNDEF is undefined (expanding string dbl $(UNDEF))\n",
+    ),
+    // --- a variable set then read back through `var` ---
+    (
+        "k24.cmd",
+        "var dbTemplateMaxVars 200\nvar dbTemplateMaxVars\n",
+        "var dbTemplateMaxVars 200\nvar dbTemplateMaxVars\nint dbTemplateMaxVars = 200\n",
+        "",
+    ),
+    // --- a name no variable matches: written by `varCallFunc` straight
+    // to stderr and failed with a bare `iocshSetError(1)`
+    // (`iocsh.cpp:1460-1464`), so it wears no frame ---
+    (
+        "k25.cmd",
+        "var nosuchvar\n",
+        "var nosuchvar\n",
+        "No known vars match 'nosuchvar'.\n",
+    ),
+    // --- `help` for a name nothing registers: silent on both streams ---
+    (
+        "k26.cmd",
+        "help nosuchcommand\n",
+        "help nosuchcommand\n",
+        "",
+    ),
+    // --- `cd` to a directory that is not there: SIX WORDS on stderr and
+    // nothing else. C's `chdirCallFunc` (`libComRegister.c:108-116`) hands
+    // `chdir`'s return to `iocshSetError`, so the line IS errored, but the
+    // sentence it prints is its own and unframed — no file, no line
+    // number, no directory name and no errno. The script runs on because
+    // `onerr` defaults to Continue (`iocsh.cpp:1001`, `:1127-1130`).
+    (
+        "k28.cmd",
+        "cd topbin\necho \"after\"\n",
+        "cd topbin\necho \"after\"\nafter\n",
+        "Invalid directory path, ignored\n",
+    ),
+    // The SAME sentence with no argument at all — and here C's `||`
+    // short-circuits before `iocshSetError`, so this one does not even
+    // error the line.
+    (
+        "k29.cmd",
+        "cd\necho \"after\"\n",
+        "cd\necho \"after\"\nafter\n",
+        "Invalid directory path, ignored\n",
+    ),
+    // --- `iocshLoad`'s pathname up against the separator set: the `,` is
+    // a separator like any other (`iocsh.cpp:271`), so the file opened is
+    // `inner.iocsh` and not `inner.iocsh,`. The inner script's line is
+    // echoed by the inner body, between the outer echo and the output.
+    ("inner.iocsh", "echo \"inner ran\"\n", "", ""),
+    (
+        "k30.cmd",
+        "iocshLoad inner.iocsh, \"P=X\"\n",
+        "iocshLoad inner.iocsh, \"P=X\"\necho \"inner ran\"\ninner ran\n",
+        "",
+    ),
+];
+
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(iocsh_stream_parity)]
+async fn our_streams_match_the_bytes_c_wrote() {
+    let dir = tempfile::tempdir().expect("script root");
+    let saved_cwd = std::env::current_dir().expect("cwd");
+    // A `<` inside a script resolves against the process cwd, as C's
+    // does, so the scripts have to be reached by the names they use for
+    // each other.
+    std::env::set_current_dir(dir.path()).expect("cwd");
+
+    for (name, body, _, _) in CASES {
+        std::fs::write(dir.path().join(name), body).expect("script");
+    }
+
+    let mut wrong = Vec::new();
+    for (name, _, want_out, want_err) in CASES {
+        // The rows that exist only to be included by another carry no
+        // expectation and are not run on their own.
+        if want_out.is_empty() && want_err.is_empty() {
+            continue;
+        }
+        let (got_out, got_err) = run(name);
+        if got_out != *want_out {
+            wrong.push(format!(
+                "{name} stdout\n     C: {want_out:?}\n  ours: {got_out:?}"
+            ));
+        }
+        if got_err != *want_err {
+            wrong.push(format!(
+                "{name} stderr\n     C: {want_err:?}\n  ours: {got_err:?}"
+            ));
+        }
+    }
+
+    std::env::set_current_dir(saved_cwd).expect("cwd");
+    assert!(
+        wrong.is_empty(),
+        "the two shells wrote different bytes:\n{}",
+        wrong.join("\n")
+    );
+}

--- a/crates/epics-base-rs/tests/maclib_expands_the_table_before_the_string.rs
+++ b/crates/epics-base-rs/tests/maclib_expands_the_table_before_the_string.rs
@@ -1,0 +1,341 @@
+//! **C expands the macro TABLE into cached values before it looks at the
+//! caller's string, and a reference COPIES that value.**
+//!
+//! `macExpandString` calls `expand( handle )` first (`macCore.c:203-204`).
+//! That pass walks every `MAC_ENTRY` in the table, clears its `error`, and
+//! translates its raw value at level 1 under THAT entry (`:645-679`); only
+//! then is the caller's string translated, under a stack entry typed
+//! `"string"` whose name is the string itself (`:206-209`). A reference
+//! that resolves while the table is clean copies `refentry->value` and
+//! merges `refentry->error` without re-scanning anything (`:882-886`).
+//!
+//! Three things follow, and none of them are wording:
+//!
+//!   * a macro whose own value is faulty is announced ONCE, seated on the
+//!     macro and not on the string, however many times the string refers
+//!     to it;
+//!   * the value a cycle leaves behind is the one the TABLE pass built,
+//!     which is the other member of the pair — not the reference a lazy
+//!     expander happens to refuse first;
+//!   * anything that changes a raw value — a scoped definition, the scope
+//!     pop that follows it, an environment name materialising as an entry
+//!     — raises `handle->dirty` (`rawval`, `:610-619`; `delete`,
+//!     `:625-643`), and every reference after it in the same string
+//!     translates the raw value again, under the STRING's seat.
+//!
+//! Every expected byte below was captured from `softIoc` built from
+//! `~/work/epics-base` (`R7.0.10`), loading a `.substitutions` that carries
+//! the macro definitions raw into `dbLoadRecords` and a `.db` whose
+//! `field(DESC, …)` is split across lines so the loader echoes back what it
+//! refused to set. The strings passed here are those `.db` lines verbatim,
+//! newline included, because that is what `macLib` quotes.
+//!
+//! Unix only: what is captured is the process console, and the only way to
+//! capture it is to point fd 2 somewhere else and put it back.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+
+use epics_base_rs::server::db_loader::{MacroExpandOptions, MacroTable, expand_macros};
+
+/// Expand `src` against `macros` with fd 2 pointed at a file, and give
+/// back both the text and everything `macLib` wrote.
+fn expand_and_notices(src: &str, macros: &HashMap<String, String>) -> (String, String) {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let expanded =
+        std::panic::catch_unwind(|| expand_macros(src, macros, MacroExpandOptions::default()).text);
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+
+    let notices = strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"));
+    (expanded.expect("the expansion"), notices)
+}
+
+/// C's SGR sequences, dropped — `errlog` strips its own the same way when
+/// the console is not a terminal (`errlog.c:672-681`).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+fn macros(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+/// **Boundary: a value whose expansion is consumed twice.**
+///
+/// One notice, two placeholders. The notice comes from the table pass and
+/// is seated on `A`; both references copy the value that pass cached, and
+/// neither translates `A`'s raw value again. A lazy expander answers with
+/// two notices, one per reference, and seats both on the string.
+///
+/// Measured with `A="$(NOPE)"` and the line `"q[$(A)-$(A)]"`:
+///
+/// ```text
+/// macLib: macro NOPE is undefined (expanding macro A)
+/// ERROR: Can't set 'R1.DESC' to 'q[$(NOPE,undefined)-$(NOPE,undefined)]'  : Bad Field value
+/// ```
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_faulty_value_is_announced_once_per_table_not_once_per_reference() {
+    let (text, notices) = expand_and_notices("\"q[$(A)-$(A)]\"\n", &macros(&[("A", "$(NOPE)")]));
+    assert_eq!(text, "\"q[$(NOPE,undefined)-$(NOPE,undefined)]\"\n");
+    assert_eq!(
+        notices,
+        "macLib: macro NOPE is undefined (expanding macro A)\n"
+    );
+}
+
+/// **Boundary: a clean table versus a dirty one, inside one string.**
+///
+/// `$(Z,K=1)` pushes a scope, defines `K` in it and pops it again, and
+/// both ends of that raise `handle->dirty`. So the first `$(A)` copies the
+/// cached value in silence while the second, three characters later,
+/// re-translates `A`'s raw value — and it does that under the STRING's
+/// seat, because `refer` hands the raw translation `entry` and not
+/// `refentry` (`macCore.c:888-892`). The same fault therefore reports
+/// twice under two different names, which is the discriminator no
+/// single-phase expander can produce.
+///
+/// Measured with `A="$(NOPE)", Z="z"` and the line
+/// `"q[$(A)|$(Z,K=1)|$(A)]"`:
+///
+/// ```text
+/// macLib: macro NOPE is undefined (expanding macro A)
+/// macLib: macro NOPE is undefined (expanding string "q[$(A)|$(Z,K=1)|$(A)]"
+/// )
+/// ERROR: Can't set 'R1.DESC' to 'q[$(NOPE,undefined)|z|$(NOPE,undefined)]'  : Bad Field value
+/// ```
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_scope_pop_sends_the_next_reference_back_to_the_raw_value() {
+    let src = "\"q[$(A)|$(Z,K=1)|$(A)]\"\n";
+    let (text, notices) = expand_and_notices(src, &macros(&[("A", "$(NOPE)"), ("Z", "z")]));
+    assert_eq!(text, "\"q[$(NOPE,undefined)|z|$(NOPE,undefined)]\"\n");
+    assert_eq!(
+        notices,
+        format!(
+            "macLib: macro NOPE is undefined (expanding macro A)\n\
+             macLib: macro NOPE is undefined (expanding string {src})\n"
+        )
+    );
+}
+
+/// **Boundary: a redefinition reached after a completed expansion.**
+///
+/// `Z="$(A)"` is resolved by the table pass, so the pass reports `A`'s
+/// fault twice — once seated on `A` and once on `Z`, which had to follow
+/// it. Then the string redefines `A` inside `$(Z,A=one)`: the scoped
+/// definition is visible to `Z`'s raw value, so `Z` comes out `one` and
+/// not the cached `$(NOPE,undefined)`, and the pop leaves the table dirty
+/// for the `$(A)` after it.
+///
+/// Measured with `A="$(NOPE)", Z="$(A)"` and the line
+/// `"q[$(Z,A=one)|$(A)]"`:
+///
+/// ```text
+/// macLib: macro NOPE is undefined (expanding macro A)
+/// macLib: macro NOPE is undefined (expanding macro Z)
+/// macLib: macro NOPE is undefined (expanding string "q[$(Z,A=one)|$(A)]"
+/// )
+/// ERROR: Can't set 'R1.DESC' to 'q[one|$(NOPE,undefined)]'  : Bad Field value
+/// ```
+///
+/// The order of the first two lines is the table's order. C's is the order
+/// `macPutValue` was called in; this port is handed a `HashMap` and sorts
+/// by name, which agrees here and is the only thing that keeps the stream
+/// reproducible at all.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_scoped_redefinition_beats_the_value_the_table_pass_cached() {
+    let src = "\"q[$(Z,A=one)|$(A)]\"\n";
+    let (text, notices) = expand_and_notices(src, &macros(&[("A", "$(NOPE)"), ("Z", "$(A)")]));
+    assert_eq!(text, "\"q[one|$(NOPE,undefined)]\"\n");
+    assert_eq!(
+        notices,
+        format!(
+            "macLib: macro NOPE is undefined (expanding macro A)\n\
+             macLib: macro NOPE is undefined (expanding macro Z)\n\
+             macLib: macro NOPE is undefined (expanding string {src})\n"
+        )
+    );
+}
+
+/// **Boundary: a self-cycle versus a mutual one.**
+///
+/// Both are refused at C's per-entry `visited` guard, and the difference
+/// is which entry the refusal lands in. `A="$(A)"` closes on itself, so one notice
+/// and `$(A,recursive)`. `A="$(B)", B="$(A)"` closes one step further out:
+/// the pass expanding `A` follows `$(B)` and refuses the `$(A)` inside it,
+/// so `A`'s cached value — and therefore the loaded value — names B, and
+/// the pass then expands `B` and reports the mirror image.
+///
+/// Measured, one `softIoc` run each:
+///
+/// ```text
+/// macLib: macro A is recursive (expanding macro A)
+/// ERROR: Can't set 'R1.DESC' to 'q[$(A,recursive)]'  : Bad Field value
+///
+/// macLib: macro A is recursive (expanding macro B)
+/// macLib: macro B is recursive (expanding macro A)
+/// ERROR: Can't set 'R1.DESC' to 'q[$(B,recursive)]'  : Bad Field value
+/// ```
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_cycle_leaves_behind_the_entry_the_table_pass_refused() {
+    let (text, notices) = expand_and_notices("\"q[$(A)]\"\n", &macros(&[("A", "$(A)")]));
+    assert_eq!(text, "\"q[$(A,recursive)]\"\n");
+    assert_eq!(
+        notices,
+        "macLib: macro A is recursive (expanding macro A)\n"
+    );
+
+    let (text, notices) =
+        expand_and_notices("\"q[$(A)]\"\n", &macros(&[("A", "$(B)"), ("B", "$(A)")]));
+    assert_eq!(text, "\"q[$(B,recursive)]\"\n");
+    assert_eq!(
+        notices,
+        "macLib: macro A is recursive (expanding macro B)\n\
+         macLib: macro B is recursive (expanding macro A)\n"
+    );
+}
+
+/// **Boundary: an undefined name reached through a macro value versus one
+/// written in the string.**
+///
+/// Same fault, same placeholder, different seat — and the seat is the
+/// whole of what tells an operator which of the two it is. Measured, one
+/// `softIoc` run each:
+///
+/// ```text
+/// macLib: macro NOPE is undefined (expanding macro A)
+/// macLib: macro NOPE is undefined (expanding string "q[$(NOPE)]"
+/// )
+/// ```
+///
+/// Both loads refuse the same `q[$(NOPE,undefined)]`.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn an_undefined_name_names_the_entry_it_was_reached_through() {
+    let (text, notices) = expand_and_notices("\"q[$(A)]\"\n", &macros(&[("A", "$(NOPE)")]));
+    assert_eq!(text, "\"q[$(NOPE,undefined)]\"\n");
+    assert_eq!(
+        notices,
+        "macLib: macro NOPE is undefined (expanding macro A)\n"
+    );
+
+    let src = "\"q[$(NOPE)]\"\n";
+    let (text, notices) = expand_and_notices(src, &macros(&[("Z", "z")]));
+    assert_eq!(text, "\"q[$(NOPE,undefined)]\"\n");
+    assert_eq!(
+        notices,
+        format!("macLib: macro NOPE is undefined (expanding string {src})\n")
+    );
+}
+
+/// **Boundary: an unterminated reference in a macro value versus one in
+/// the string.**
+///
+/// The arm copies from the `$` to the end of whatever it was translating
+/// and writes no placeholder (`macCore.c:862-875`), so in a macro value it
+/// consumes the rest of THAT value and in a string the rest of the line.
+///
+/// Measured with `A="$(P "` and the line `"q$(A)"`:
+///
+/// ```text
+/// macLib: unterminated macro reference in macro A
+///  3 | "q$(P ""
+/// ```
+///
+/// which is also the sharpest confirmation that the copy runs to the end
+/// and stops nowhere else: `macParseDefns` had already translated the
+/// substitution's own quoting at level 1 and left `A`'s raw value as
+/// `$(P "`, trailing quote and all, and every byte of it came through.
+/// The raw value is set directly here, so the expected text is that same
+/// copy without the quote `macParseDefns` contributed.
+///
+/// In the string, measured on the line `"q[$(P ]"`:
+///
+/// ```text
+/// macLib: unterminated macro reference in string "q[$(P ]"
+///
+/// ERROR: Can't set 'R1.DESC' to 'q[$(P ]'  : Bad Field value
+/// ```
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn an_unterminated_reference_names_the_entry_it_was_reached_through() {
+    let (text, notices) = expand_and_notices("\"q$(A)\"\n", &macros(&[("A", "$(P ")]));
+    assert_eq!(text, "\"q$(P \"\n");
+    assert_eq!(notices, "macLib: unterminated macro reference in macro A\n");
+
+    let src = "\"q[$(P ]\"\n";
+    let (text, notices) = expand_and_notices(src, &macros(&[("Z", "z")]));
+    assert_eq!(text, src);
+    assert_eq!(
+        notices,
+        format!("macLib: unterminated macro reference in string {src}\n")
+    );
+}
+
+/// **Boundary: one table across many strings.**
+///
+/// C creates one `MAC_HANDLE` per file and expands it on first use, so a
+/// macro whose value is faulty is announced once for the whole file — not
+/// once per line that mentions it. [`MacroTable`] is that handle; the
+/// per-call [`expand_macros`] above is the same engine for callers that
+/// have one string.
+///
+/// Measured on a two-line `.db` under one `dbLoadRecords`: the notice
+/// appears once, ahead of both `WARNING:` lines.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn one_table_announces_a_faulty_value_once_however_many_strings_read_it() {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let mut table = MacroTable::new(&macros(&[("A", "$(NOPE)")]), MacroExpandOptions::default());
+    let first = table.expand("\"q[$(A)]\"\n");
+    let second = table.expand("\"r[$(A)]\"\n");
+
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+
+    assert_eq!(first.text, "\"q[$(NOPE,undefined)]\"\n");
+    assert_eq!(second.text, "\"r[$(NOPE,undefined)]\"\n");
+    assert!(first.errored() && second.errored(), "both must report it");
+    let notices = strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"));
+    assert_eq!(
+        notices,
+        "macLib: macro NOPE is undefined (expanding macro A)\n"
+    );
+}

--- a/crates/epics-base-rs/tests/maclib_keeps_the_definition_order.rs
+++ b/crates/epics-base-rs/tests/maclib_keeps_the_definition_order.rs
@@ -1,0 +1,155 @@
+//! **The macro table's notice order is the order the definitions were
+//! made in, and nothing else.**
+//!
+//! C builds its table one `macPutValue` at a time: `macInstallMacros`
+//! walks the `pairs` array `macParseDefns` produced, in the order the
+//! operator wrote them (`macUtil.c:250-275`), and `expand` then walks the
+//! table in that same order (`macCore.c:655`). So the sequence a load's
+//! `macLib:` notices come out in is the sequence of the definitions, and
+//! a redefinition does not move its entry — `rawval` writes through the
+//! entry `lookup` found (`macCore.c:610-619`).
+//!
+//! Measured on `softIoc` built from `~/work/epics-base` (`R7.0.10`), with
+//! the two definitions delivered raw through a `.substitutions` row so
+//! they reach `macLib` unexpanded, and with the alphabetical order and
+//! the definition order deliberately opposed:
+//!
+//! ```text
+//! $ cat ordB.sub                     $ cat ordA.sub
+//! file ord.db {                      file ord.db {
+//! { B="$(NOPEB)", A="$(NOPEA)" }     { A="$(NOPEA)", B="$(NOPEB)" }
+//! }                                  }
+//!
+//! macLib: macro NOPEB is undefined   macLib: macro NOPEA is undefined
+//!         (expanding macro B)                (expanding macro A)
+//! macLib: macro NOPEA is undefined   macLib: macro NOPEB is undefined
+//!         (expanding macro A)                (expanding macro B)
+//! ```
+//!
+//! This port sorted the names instead, which agreed with C on every shape
+//! measured so far only because those shapes were already alphabetical.
+//! [`MacroDefs`] carries the order, and the sort survives in exactly one
+//! place — the conversion from a [`HashMap`], where there is no order to
+//! carry and the only thing left to promise is that two runs agree.
+//!
+//! Unix only: what is captured is the process console, and the only way to
+//! capture it is to point fd 2 somewhere else and put it back.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+
+use epics_base_rs::server::db_loader::{MacroDefs, MacroExpandOptions, expand_macros};
+
+/// Expand `src` against `defs` with fd 2 pointed at a file, and give back
+/// everything `macLib` wrote.
+fn notices(src: &str, defs: impl Into<MacroDefs>) -> String {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let defs = defs.into();
+    let ran =
+        std::panic::catch_unwind(|| expand_macros(src, &defs, MacroExpandOptions::default()).text);
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+    ran.expect("the expansion");
+
+    strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"))
+}
+
+/// C's SGR sequences, dropped — `errlog` strips its own the same way when
+/// the console is not a terminal (`errlog.c:672-681`).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The `.db` line the two shapes above load. It mentions neither macro:
+/// the notices under test are the TABLE pass's, raised before the string
+/// is looked at, which is why C prints them for a line that refers to
+/// nothing.
+const LINE: &str = "#ord\n";
+
+const B_THEN_A: &str = "\
+macLib: macro NOPEB is undefined (expanding macro B)
+macLib: macro NOPEA is undefined (expanding macro A)
+";
+
+const A_THEN_B: &str = "\
+macLib: macro NOPEA is undefined (expanding macro A)
+macLib: macro NOPEB is undefined (expanding macro B)
+";
+
+/// **Boundary: definition order against alphabetical order.**
+///
+/// Both directions, because a port that sorts passes one of them. `B`
+/// first is the row a sort gets wrong.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn the_notice_order_is_the_definition_order() {
+    let mut b_first = MacroDefs::new();
+    b_first.put("B", "$(NOPEB)");
+    b_first.put("A", "$(NOPEA)");
+    assert_eq!(notices(LINE, &b_first), B_THEN_A);
+
+    let mut a_first = MacroDefs::new();
+    a_first.put("A", "$(NOPEA)");
+    a_first.put("B", "$(NOPEB)");
+    assert_eq!(notices(LINE, &a_first), A_THEN_B);
+}
+
+/// **Boundary: a redefinition of a name already in the table.**
+///
+/// C `macPutValue` looks the name up and writes through the entry it
+/// finds, so the entry keeps its place and the second definition of `B`
+/// does not move it behind `A`. A port that appended would report `A`
+/// first here.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_redefinition_keeps_the_entry_where_it_was() {
+    let mut defs = MacroDefs::new();
+    defs.put("B", "unset");
+    defs.put("A", "$(NOPEA)");
+    defs.put("B", "$(NOPEB)");
+    assert_eq!(defs.len(), 2, "a redefinition adds no entry");
+    assert_eq!(notices(LINE, &defs), B_THEN_A);
+}
+
+/// **Boundary: the input that has no order to carry.**
+///
+/// A [`HashMap`] iterates in whatever order its hasher gives, so the
+/// conversion sorts by name — the one surviving sort, and the only thing
+/// it promises is that two runs of the same load agree. Both maps below
+/// hold the same two definitions and are built in opposite orders.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_hash_map_falls_back_to_name_order_whichever_way_it_was_built() {
+    let mut b_first: HashMap<String, String> = HashMap::new();
+    b_first.insert("B".into(), "$(NOPEB)".into());
+    b_first.insert("A".into(), "$(NOPEA)".into());
+
+    let mut a_first: HashMap<String, String> = HashMap::new();
+    a_first.insert("A".into(), "$(NOPEA)".into());
+    a_first.insert("B".into(), "$(NOPEB)".into());
+
+    assert_eq!(notices(LINE, &b_first), A_THEN_B);
+    assert_eq!(notices(LINE, &a_first), A_THEN_B);
+}

--- a/crates/epics-base-rs/tests/maclib_quiets_the_regions_c_quiets.rs
+++ b/crates/epics-base-rs/tests/maclib_quiets_the_regions_c_quiets.rs
@@ -1,0 +1,166 @@
+//! **`FLAG_SUPPRESS_WARNINGS` is a region in C `refer`, not a caller's knob.**
+//!
+//! C `refer` raises and lowers `handle->flags & FLAG_SUPPRESS_WARNINGS` three
+//! times inside one reference, and swaps the `MAC_ENTRY` under one of them:
+//!
+//!   * the reference NAME is translated quiet, through the caller's own `entry`
+//!     (`macCore.c:795-800`) — so a fault inside the name still fails the
+//!     expansion, but writes no notice and leaves the SHORT `$(X)` placeholder;
+//!   * the default's discarding first pass is quiet, through a throwaway
+//!     `MAC_ENTRY dflt` (`:805-816`) — this port has no first pass, it slices
+//!     the default out instead, so there is nothing to quiet;
+//!   * the scoped definitions are translated quiet AND through a separate
+//!     `MAC_ENTRY subs` whose `error` starts `FALSE` and is never merged back
+//!     (`:820-860`) — so a fault in `,K=$(UNDEF)` neither warns nor fails.
+//!
+//! Everything else — the used default, a resolved value's re-scan — runs at the
+//! caller's own setting through the caller's own `entry`.
+//!
+//! This port had one flag read straight off [`MacroExpandOptions`], so all three
+//! regions were loud and all three merged their faults. Measured against
+//! `softIoc` built from `~/work/epics-base` (`R7.0.10`) on the file below, with
+//! `P=pval`:
+//!
+//! | line | C stderr | this port, before |
+//! |---|---|---|
+//! | `#a$(P,K=$(UNDEF))b` | nothing, and no error | one notice, expansion FAILED |
+//! | `#c$(K,K=$(UNDEF))d` | one notice | two notices |
+//! | `#g$($(NAMEREF))h` | one notice, names `$(NAMEREF)` | two, names `NAMEREF` then `$(NAMEREF,undefined)` |
+//!
+//! The first row is the one that matters beyond wording: a scoped definition
+//! that mentions an undefined macro made the whole line fail, and every consumer
+//! reading [`MacroExpansion::errored`] — the `.db` reader's per-line `WARNING:`,
+//! `expand_includes`, iocsh, autosave's hard error — acted on a failure C does
+//! not have.
+//!
+//! ANSI is stripped before comparing; whether the escapes are emitted has its
+//! own gate. Unix only: what is captured is the process console.
+//!
+//! [`MacroExpandOptions`]: epics_base_rs::server::db_loader::MacroExpandOptions
+//! [`MacroExpansion::errored`]: epics_base_rs::server::db_loader::MacroExpansion::errored
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::db_loader::{MacroExpandOptions, expand_macros};
+use epics_base_rs::server::iocsh::IocShell;
+
+/// One line per region, each on a `#` comment so the only thing the load can
+/// produce is the diagnostics. `P` is defined; `UNDEF`, `UNDEF3`, `NAMEREF` and
+/// `NOPE` are not.
+///
+///   * line 2 — a scoped definition that is never looked up: silent in C;
+///   * line 3 — the same definition, looked up. The stored value is the quiet
+///     `$(UNDEF)`, and it is the OUTER lookup re-scanning it that warns once;
+///   * line 4 — a USED default, which C translates loud through the outer
+///     entry, so this one was never in question;
+///   * line 5 — a reference name that is itself an unresolved reference;
+///   * line 6 — two scoped definitions, to show the quiet is the region and not
+///     the first entry in it.
+const REGIONS_DB: &str = "record(ai, \"T1\") {}\n\
+                          #a$(P,K=$(UNDEF))b\n\
+                          #c$(K,K=$(UNDEF))d\n\
+                          #e$(NOPE=$(UNDEF3))f\n\
+                          #g$($(NAMEREF))h\n\
+                          #i$(P,K=$(UNDEF),L=2)j\n";
+
+/// Run one iocsh line with fd 2 pointed at a file, and give back what it wrote.
+fn stderr_of(line: &str, db: Arc<PvDatabase>) -> String {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let bridge = epics_base_rs::runtime::task::BlockingBridge::capture();
+    let owned = line.to_string();
+    let ran = std::thread::spawn(move || IocShell::new(db, bridge).execute_line(&owned)).join();
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+    ran.expect("the shell thread").ok();
+
+    strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"))
+}
+
+/// C's SGR sequences, dropped — `errlog` strips its own the same way when the
+/// console is not a terminal (`errlog.c:672-681`).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+/// C's whole answer for the five lines, byte for byte. Two of them say nothing
+/// at all, and that silence is the assertion.
+#[epics_macros_rs::epics_test]
+#[serial_test::serial(db_load_stderr)]
+async fn only_the_regions_c_quiets_are_quiet() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("regions.db"), REGIONS_DB).expect("write the .db");
+    // SAFETY: the process-global env is why this test is `serial`.
+    unsafe { std::env::set_var("EPICS_DB_INCLUDE_PATH", dir.path().display().to_string()) };
+    let got = stderr_of(
+        "dbLoadRecords(\"regions.db\",\"P=pval\")",
+        Arc::new(PvDatabase::new()),
+    );
+    unsafe { std::env::remove_var("EPICS_DB_INCLUDE_PATH") };
+
+    let want = "\
+macLib: macro UNDEF is undefined (expanding string #c$(K,K=$(UNDEF))d
+)
+WARNING: 'regions.db' line 3 has undefined macros
+macLib: macro UNDEF3 is undefined (expanding string #e$(NOPE=$(UNDEF3))f
+)
+WARNING: 'regions.db' line 4 has undefined macros
+macLib: macro $(NAMEREF) is undefined (expanding string #g$($(NAMEREF))h
+)
+WARNING: 'regions.db' line 5 has undefined macros
+";
+    assert_eq!(got, want, "\n--- got ---\n{got}\n--- want ---\n{want}");
+}
+
+/// The half the stderr cannot show: which expansions C calls failures, and what
+/// text the quiet placeholder leaves behind.
+///
+/// `$(P,K=$(UNDEF))` is the row that changes a decision rather than a message.
+/// C loads it — `V1.DESC` is set to `apvalb` with no complaint — where this
+/// port reported a fault and every `errored()` consumer refused the line.
+#[test]
+fn a_fault_inside_a_scoped_definition_does_not_fail_the_expansion() {
+    let macros = HashMap::from([("P".to_string(), "pval".to_string())]);
+    for (raw, text, errored) in [
+        // Region: scoped definition, never looked up. C: silent, loads.
+        ("a$(P,K=$(UNDEF))b", "apvalb", false),
+        // Two definitions — the quiet covers the region, not just the first.
+        ("i$(P,K=$(UNDEF),L=2)j", "ipvalj", false),
+        // Looked up: the stored value is the QUIET `$(UNDEF)`, and the outer
+        // re-scan of it is what fails, with the loud placeholder.
+        ("c$(K,K=$(UNDEF))d", "c$(UNDEF,undefined)d", true),
+        // A used default is translated through the outer entry, loud.
+        ("e$(NOPE=$(UNDEF3))f", "e$(UNDEF3,undefined)f", true),
+        // A name that is itself unresolved: the inner placeholder is the SHORT
+        // form, because the name translation is the quiet region.
+        ("g$($(NAMEREF))h", "g$($(NAMEREF),undefined)h", true),
+    ] {
+        let got = expand_macros(raw, &macros, MacroExpandOptions::default());
+        assert_eq!(got.text, text, "text of {raw:?}");
+        assert_eq!(got.errored(), errored, "errored() of {raw:?}");
+    }
+}

--- a/crates/epics-base-rs/tests/maclib_scoped_defs_see_the_ones_before_them.rs
+++ b/crates/epics-base-rs/tests/maclib_scoped_defs_see_the_ones_before_them.rs
@@ -1,0 +1,77 @@
+//! **C pushes the scope BEFORE it parses the definition list, so a scoped
+//! definition can reference the ones before it.**
+//!
+//! `macCore.c:827-850` interleaves the push with the parse: `macPushScope`
+//! runs first, then the `while (*r == ',')` loop translates each definition's
+//! value and `macPutValue`s it into the scope that is already on the stack. So
+//! definition N sees definitions 1..N-1 and nothing after them, and each value
+//! is resolved once, where it is written — not re-resolved at reference time.
+//!
+//! This port staged the definitions in a `Vec` and pushed the whole frame
+//! afterwards, which cannot express any of that: every definition saw the same
+//! enclosing scope, so a forward reference silently read the OUTER value.
+//!
+//! Measured on `softIoc` built from `~/work/epics-base` (`R7.0.10`), with an
+//! outer `A=outer` supplied to `dbLoadRecords`. The value is read back out of a
+//! numeric field, because a `.db` that loads cleanly prints nothing at all:
+//!
+//! ```text
+//! ERROR: Can't set 'Q1.PREC' to 'q[plain]'    : No digits to convert
+//! ERROR: Can't set 'Q2.PREC' to 'q[2]'        : No digits to convert
+//! ERROR: Can't set 'Q3.PREC' to 'q[1]'        : No digits to convert
+//! ERROR: Can't set 'Q4.PREC' to 'q[1-tail]'   : No digits to convert
+//! ERROR: Can't set 'Q5.PREC' to 'q[outer]'    : No digits to convert
+//! ERROR: Can't set 'Q6.PREC' to 'q[outer]'    : No digits to convert
+//! ```
+//!
+//! Rows 3 and 4 are the ones this port got wrong: it wrote `outer` and
+//! `outer-tail`.
+
+use std::collections::HashMap;
+
+use epics_base_rs::server::db_loader::{MacroExpandOptions, expand_macros};
+
+/// One case per boundary of "which definitions are visible from a definition",
+/// not one per story.
+#[test]
+fn a_scoped_definition_sees_the_ones_declared_before_it() {
+    let macros = HashMap::from([("A".to_string(), "outer".to_string())]);
+    for (raw, want) in [
+        // No forward reference at all — the baseline the old staging got right.
+        ("$(B,B=plain)", "plain"),
+        ("$(B,A=1,B=2)", "2"),
+        // FORWARD: `B` is declared after `A`, so `A` is already in the scope
+        // C pushed, and `$(A)` is the scoped `1` — not the outer `outer`.
+        ("$(B,A=1,B=$(A))", "1"),
+        // Same, with the reference embedded rather than the whole value, so a
+        // fix that special-cased a bare `$(A)` cannot pass.
+        ("$(B,A=1,B=$(A)-tail)", "1-tail"),
+        // REVERSE: `B` is declared FIRST, so `A` is not in the scope yet and
+        // the outer one wins. This is also what proves the value is resolved
+        // where it is written: if it were kept raw and re-resolved at
+        // reference time, the later `A=1` would have won and this would read
+        // `1`.
+        ("$(B,B=$(A),A=1)", "outer"),
+        // SELF: the outer `A` is visible from inside `A`'s own definition,
+        // because `macPutValue` has not run for it yet.
+        ("$(A,A=$(A))", "outer"),
+    ] {
+        let got = expand_macros(raw, &macros, MacroExpandOptions::default());
+        assert_eq!(got.text, want, "expanding {raw:?}");
+        assert!(!got.errored(), "{raw:?} must not report a fault");
+    }
+}
+
+/// The scope is popped on the way out — a definition must not leak past the
+/// reference that declared it, in either direction.
+#[test]
+fn a_scoped_definition_does_not_outlive_its_reference() {
+    let macros = HashMap::from([("A".to_string(), "outer".to_string())]);
+    let got = expand_macros(
+        "$(B,A=1,B=$(A))|$(A)",
+        &macros,
+        MacroExpandOptions::default(),
+    );
+    assert_eq!(got.text, "1|outer", "the scoped A must not survive the `)`");
+    assert!(!got.errored());
+}

--- a/crates/epics-base-rs/tests/nomod_put_refusal_speaks.rs
+++ b/crates/epics-base-rs/tests/nomod_put_refusal_speaks.rs
@@ -1,0 +1,144 @@
+//! A `dbPut` refused for `SPC_NOMOD` REPORTS — `dbpf` prints nothing itself,
+//! so this line is the whole diagnostic.
+//!
+//! ```c
+//! /* dbAccess.c:122-127, reached from dbPut via dbPutSpecial(paddr, 0) */
+//! if ((special == SPC_NOMOD) && (pass == 0)) {
+//!     status = S_db_noMod;
+//!     recGblDbaddrError(status, paddr, "dbPut");
+//!     return status;
+//! }
+//! ```
+//!
+//! softIoc @`R7.0.10`, with `record(sub,"T:SUB"){field(INAM,"initSub")}` and
+//! `record(sel,"T:SEL"){}` — stdout carries the unchanged read-back, stderr
+//! carries the refusal:
+//!
+//! ```text
+//! epics> dbpf T:SUB.INAM zzz
+//! DBF_STRING:         "initSub"
+//! epics> dbpf T:SEL.VAL 3
+//! DBF_DOUBLE:         0
+//! ...
+//! recGblDbaddrError: dbPut Attempt to modify noMod field PV: T:SUB.INAM
+//! recGblDbaddrError: dbPut Attempt to modify noMod field PV: T:SEL.VAL
+//! ```
+//!
+//! The port returned `S_db_noMod` and said nothing at all, so a refused put was
+//! indistinguishable from an accepted one on the console.
+
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::record::Record;
+use epics_base_rs::types::EpicsValue;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+const DB: &str = r#"
+record(sub, "T:SUB") { field(INAM, "initSub") }
+record(sel, "T:SEL") { }
+"#;
+
+async fn build() -> Arc<epics_base_rs::server::database::PvDatabase> {
+    IocBuilder::new()
+        .register_subroutine("initSub", |_: &mut dyn Record| Ok(0))
+        .db_string(DB, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("")
+}
+
+fn forget(sink: &Arc<Mutex<Vec<String>>>) {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").clear();
+}
+
+/// The CA / `dbpf` route: `dbPutField` → `dbPut` → `dbPutSpecial(paddr, 0)`.
+/// The line names the record AND the field, and the value does not change.
+#[epics_macros_rs::epics_test]
+async fn a_refused_ca_put_writes_the_line_dbpf_relies_on() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    let err = db
+        .put_record_field_from_ca("T:SUB", "INAM", EpicsValue::String("zzz".into()))
+        .await
+        .expect_err("INAM is special(SPC_NOMOD)");
+    assert!(
+        matches!(err, epics_base_rs::error::CaError::ReadOnlyField(ref f) if f == "INAM"),
+        "expected S_db_noMod, got {err:?}"
+    );
+    assert_eq!(
+        heard(&sink),
+        "recGblDbaddrError: dbPut Attempt to modify noMod field PV: T:SUB.INAM\n",
+        "dbAccess.c:125 through recGbl.c:87-90, verbatim and once"
+    );
+    assert_eq!(
+        db.get_pv("T:SUB.INAM").unwrap(),
+        EpicsValue::String("initSub".into())
+    );
+}
+
+/// The internal route: `put_pv` is the port's `dbPut` analogue and C's
+/// `dbPutLink` reaches the same `dbPutSpecial`, so it speaks too. `sel.VAL` is
+/// the `SPC_NOMOD` the oracle's monitor phase already excludes.
+#[epics_macros_rs::epics_test]
+async fn a_refused_internal_put_speaks_from_the_same_gate() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    db.put_pv("T:SEL.VAL", EpicsValue::Double(3.0))
+        .await
+        .expect_err("sel.VAL is special(SPC_NOMOD)");
+    assert_eq!(
+        heard(&sink),
+        "recGblDbaddrError: dbPut Attempt to modify noMod field PV: T:SEL.VAL\n"
+    );
+}
+
+/// The boundary the gate must NOT cross: pvxs `doPreProcessing`
+/// (`iocsource.cpp:363-375`) refuses ABOVE `dbPut`, so the QSRV precondition
+/// check reports the same status with no console line — otherwise a QSRV put
+/// would print C's `dbPut` line twice, once before `dbPut` and once inside it.
+#[epics_macros_rs::epics_test]
+async fn the_pre_put_precondition_check_stays_silent() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    db.check_external_put_preconditions("T:SUB", "INAM")
+        .await
+        .expect_err("the precondition check still refuses");
+    assert_eq!(heard(&sink), "", "doPreProcessing writes no errlog line");
+}
+
+/// An accepted put says nothing — the line belongs to the refusal, not to the
+/// route.
+#[epics_macros_rs::epics_test]
+async fn an_accepted_put_writes_no_line() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    db.put_record_field_from_ca("T:SUB", "DESC", EpicsValue::String("ok".into()))
+        .await
+        .unwrap();
+    assert_eq!(heard(&sink), "");
+}

--- a/crates/epics-base-rs/tests/one_macro_table_for_the_whole_include_tree.rs
+++ b/crates/epics-base-rs/tests/one_macro_table_for_the_whole_include_tree.rs
@@ -1,0 +1,252 @@
+//! **One macro table for a whole `.db` read, includes and all — and every
+//! line goes through it before anything reads what the line says.**
+//!
+//! C `dbReadCOM` creates a single `MAC_HANDLE`, installs the caller's
+//! macros into it and reads `dbQuietMacroWarnings` into it once, at open
+//! (`dbLexRoutines.c:256-300`). `dbIncludeNew` pushes the included file
+//! onto `inputFileList` and never touches the handle (`:443-461`), and
+//! `db_yyinput` expands each `fgets` line through it before the lexer
+//! sees a character (`:375-391`). msi is built the same way: one
+//! `macCreateHandle` for the run (`msi.cpp:111`), no scope around an
+//! `include`.
+//!
+//! This port built a `MacroTable` per LINE inside `expand_includes_inner`
+//! and kept a per-file `HashMap` copy of the macros beside it. Four things
+//! followed, all measured against `softIoc`/`msi` built from
+//! `~/work/epics-base` (`R7.0.10`):
+//!
+//! | shape | C | this port, before |
+//! |---|---|---|
+//! | a faulty definition, 3 lines referring to it | one `macLib:` notice | three |
+//! | `substitute` inside an included file | outlives the include | reverted at its end |
+//! | `substitute "X=$(Y)"` then `substitute "Y=2"` | `X` is `2` | `X` is `1` |
+//! | `include "$(NOPE)b.db"` | notice AND `WARNING:` for the line | notice only |
+//!
+//! Unix only for the notice half: what is captured is the process console,
+//! and the only way to capture it is to point fd 2 somewhere else and put
+//! it back.
+
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use epics_base_rs::server::db_loader::{DbFaults, DbLoadConfig, MacroDefs, expand_includes};
+
+/// Expand an include tree with fd 2 pointed at a file, and give back both
+/// the flattened text and everything the read wrote to the console.
+fn expand_and_notices(path: &Path, macros: impl Into<MacroDefs>) -> (String, String) {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let config = DbLoadConfig {
+        include_paths: vec![path.parent().expect("a parent directory").to_path_buf()],
+        ..DbLoadConfig::default()
+    };
+    let macros = macros.into();
+    let ran = std::panic::catch_unwind(move || {
+        expand_includes(path, &macros, &config, &mut DbFaults::default())
+    });
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+
+    let text = ran.expect("the expansion").expect("the flattened text");
+    let notices = strip_ansi(&std::fs::read_to_string(sink.path()).expect("read the capture"));
+    (text, notices)
+}
+
+/// C's SGR sequences, dropped — `errlog` strips its own the same way when
+/// the console is not a terminal (`errlog.c:672-681`).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\x1b') {
+        out.push_str(&rest[..at]);
+        rest = match rest[at..].find('m') {
+            Some(end) => &rest[at + end + 1..],
+            None => "",
+        };
+    }
+    out.push_str(rest);
+    out
+}
+
+fn write(dir: &tempfile::TempDir, name: &str, text: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    std::fs::write(&path, text).expect("write the fixture");
+    path
+}
+
+/// **Boundary: one faulty definition against many lines that read it.**
+///
+/// The notice belongs to the table pass, which runs once; the `WARNING:`
+/// belongs to the line, which is read three times. Measured on `softIoc`
+/// with `A="$(NOPE)"` delivered raw through a `.substitutions` row:
+///
+/// ```text
+/// macLib: macro NOPE is undefined (expanding macro A)
+/// WARNING: 'once.db' line 2 has undefined macros
+/// WARNING: 'once.db' line 3 has undefined macros
+/// WARNING: 'once.db' line 4 has undefined macros
+/// ```
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_faulty_definition_is_announced_once_for_the_file_and_the_lines_warn_each() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let main = write(
+        &dir,
+        "once.db",
+        "record(ai, \"T1\") {}\n#$(A)\n#$(A)\n#$(A)\n",
+    );
+    let mut defs = MacroDefs::new();
+    defs.put("A", "$(NOPE)");
+
+    let (_, notices) = expand_and_notices(&main, &defs);
+    let want = format!(
+        "\
+macLib: macro NOPE is undefined (expanding macro A)
+WARNING: '{f}' line 2 has undefined macros
+WARNING: '{f}' line 3 has undefined macros
+WARNING: '{f}' line 4 has undefined macros
+",
+        f = main.display()
+    );
+    assert_eq!(
+        notices, want,
+        "\n--- got ---\n{notices}\n--- want ---\n{want}"
+    );
+}
+
+/// **Boundary: a `substitute` made inside an included file, after the
+/// include returns.**
+///
+/// One handle means the definition survives. Measured with `msi -M
+/// X=outer -I .` over an outer file that reads `$(X)` before and after
+/// including a file whose only content is `substitute "X=inner"`:
+///
+/// ```text
+/// before:[outer]
+/// in:[inner]
+/// after:[inner]
+/// ```
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_substitute_inside_an_include_outlives_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(&dir, "inner.db", "substitute \"X=inner\"\nin:[$(X)]\n");
+    let main = write(
+        &dir,
+        "outer.db",
+        "before:[$(X)]\ninclude \"inner.db\"\nafter:[$(X)]\n",
+    );
+    let mut defs = MacroDefs::new();
+    defs.put("X", "outer");
+
+    let (text, _) = expand_and_notices(&main, &defs);
+    // The `substitute` line contributes an empty line, which is how this
+    // reader keeps a diagnostic's line number the operator's; the
+    // `include` line contributes the included file instead.
+    assert_eq!(text, "before:[outer]\n\nin:[inner]\nafter:[inner]\n");
+}
+
+/// **Boundary: a `substitute` value that mentions a macro redefined
+/// later.**
+///
+/// msi `addMacroReplacements` installs what `macParseDefns` cut out and
+/// nothing more (`msi.cpp:256-275`), so the value stays RAW and follows
+/// the later definition. Measured with `msi -M Y=1`:
+///
+/// ```text
+/// substitute "X=$(Y)"
+/// substitute "Y=2"
+/// X=[$(X)]        ->   X=[2]
+/// ```
+///
+/// This port expanded the value at the directive, which froze `X` to `1`.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_substitute_value_is_installed_raw_and_stays_live() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let main = write(
+        &dir,
+        "live.db",
+        "substitute \"X=$(Y)\"\nsubstitute \"Y=2\"\nX=[$(X)]\n",
+    );
+    let mut defs = MacroDefs::new();
+    defs.put("Y", "1");
+
+    let (text, _) = expand_and_notices(&main, &defs);
+    assert_eq!(text, "\n\nX=[2]\n");
+}
+
+/// **Boundary: the directive keyword itself comes from a macro.**
+///
+/// C expands the line and hands the result to the lexer, so `include` is
+/// read from the EXPANDED text. Measured on `softIoc` with
+/// `dbLoadRecords("ka.db","INC=include")` over a file whose second line is
+/// `$(INC) "kb.db"`: byte-identical to the same file written with a
+/// literal `include`, down to the diagnostics raised inside `kb.db`.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn the_directive_keyword_is_read_from_the_expanded_line() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write(&dir, "kb.db", "included\n");
+    let from_macro = write(&dir, "ka.db", "record(ai, \"T1\") {}\n$(INC) \"kb.db\"\n");
+    let literal = write(&dir, "kl.db", "record(ai, \"T1\") {}\ninclude \"kb.db\"\n");
+    let mut defs = MacroDefs::new();
+    defs.put("INC", "include");
+
+    let (from_macro, _) = expand_and_notices(&from_macro, &defs);
+    let (literal, _) = expand_and_notices(&literal, &defs);
+    assert_eq!(from_macro, "record(ai, \"T1\") {}\nincluded\n");
+    assert_eq!(from_macro, literal);
+}
+
+/// **Boundary: an `include` line whose own expansion failed.**
+///
+/// It is a line like any other, so it carries both per-line diagnostics.
+/// Measured on `softIoc` with `dbLoadRecords("inca.db")` over a file whose
+/// second line is `include "$(NOPE)b.db"`:
+///
+/// ```text
+/// macLib: macro NOPE is undefined (expanding string include "$(NOPE)b.db"
+/// )
+/// WARNING: 'inca.db' line 2 has undefined macros
+/// ```
+///
+/// This port matched the directive on the raw line and expanded only the
+/// filename, so the notice named the fragment `$(NOPE)b.db` and no
+/// `WARNING:` was raised at all.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn an_include_line_carries_the_per_line_warning() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let main = write(
+        &dir,
+        "inca.db",
+        "record(ai, \"T1\") {}\ninclude \"$(NOPE)b.db\"\n",
+    );
+
+    let (_, notices) = expand_and_notices(&main, &HashMap::new());
+    let head = format!(
+        "\
+macLib: macro NOPE is undefined (expanding string include \"$(NOPE)b.db\"
+)
+WARNING: '{f}' line 2 has undefined macros
+",
+        f = main.display()
+    );
+    assert!(
+        notices.starts_with(&head),
+        "\n--- got ---\n{notices}\n--- want prefix ---\n{head}"
+    );
+}

--- a/crates/epics-base-rs/tests/put_notify_cancel_frees_the_whole_chain.rs
+++ b/crates/epics-base-rs/tests/put_notify_cancel_frees_the_whole_chain.rs
@@ -1,0 +1,135 @@
+//! C `dbNotifyCancel` (`dbNotify.c:385-430`) frees EVERY record a dead
+//! put-notify owns, not just the one it was issued against:
+//!
+//! ```c
+//! case notifyRestartInProgress:
+//! case notifyProcessInProgress:
+//!     { /*Take all records out of wait list */
+//!         while ((ppnrWait = ellFirst(&pnotifyPvt->waitList))) {
+//!             ellSafeDelete(&pnotifyPvt->waitList, &ppnrWait->waitNode);
+//!             restartCheck(ppnrWait);          /* :430 */
+//!         }
+//!     }
+//!     if (precord->ppn == ppn) restartCheck(precord->ppnr);   /* :434 */
+//! ```
+//!
+//! The chain target is the case that matters, because the record whose cycle
+//! never ends is exactly the one that keeps a dead set: a `busy` at VAL=1
+//! withholds `recGblFwdLink` by contract (`busyRecord.c:271`), so its
+//! membership outlives the client that started the chain and nothing else
+//! would ever free it.
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::records::busy::BusyRecord;
+use epics_base_rs::types::EpicsValue;
+
+const DB: &str = r#"
+record(bo, "A") { field(FLNK,"B") }
+record(busy, "B") { field(ZNAM,"Done") field(ONAM,"Busy") }
+"#;
+
+async fn build() -> std::sync::Arc<PvDatabase> {
+    IocBuilder::new()
+        .register_record_type("busy", || Box::new(BusyRecord::default()))
+        .db_string(DB, &std::collections::HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+/// A put-notify on A reaches B through the forward link; B joins the wait-set
+/// (C `dbNotifyAdd`) and then declines its own tail because it is a `busy` at
+/// VAL=1, so it keeps the membership. The client gives up.
+///
+/// The next put addressed to B must land. It did not while the release could
+/// only reach the ENTRY record: B's slot held a set nobody could answer, so
+/// the put queued on B's restart list behind a completion that could never
+/// arrive and wrote nothing.
+#[epics_macros_rs::epics_test]
+async fn a_dead_notify_frees_its_chain_target() {
+    let db = build().await;
+    let b = db.get_record("B").unwrap();
+
+    // Park B at VAL=1 with a plain caput, so it has no notify slot of its own.
+    db.put_record_field_from_ca_no_notify("B", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert_eq!(b.read().record.get_field("VAL"), Some(EpicsValue::Enum(1)));
+
+    let held = db
+        .put_record_field_from_ca("A", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert!(
+        !held.is_sync(),
+        "B withholds recGblFwdLink at VAL=1, so the chain has not settled"
+    );
+    assert!(
+        b.read().has_notify(),
+        "B joined A's wait-set through the forward link"
+    );
+    drop(held); // the client gives up and exits
+
+    db.put_record_field_from_ca("B", "VAL", EpicsValue::Double(0.0))
+        .await
+        .unwrap();
+    assert_eq!(
+        b.read().record.get_field("VAL"),
+        Some(EpicsValue::Enum(0)),
+        "the write to the chain target must land"
+    );
+}
+
+/// The case only a teardown call closes: a SECOND client is already queued on
+/// the record's restart list when the first dies. Nothing then arrives to test
+/// ownership, so a release that runs only at the next arrival never runs at
+/// all and the queued client waits forever.
+///
+/// The cancel here is what `PendingWriteNotify`'s `Drop` performs when a CA
+/// connection with a busy put-callback goes away (C `rsrvFreePutNotify`,
+/// `camessage.c:1630-1638`), and it is C's `restartCheck` that then hands the
+/// record to the queued client.
+#[epics_macros_rs::epics_test]
+async fn a_cancel_hands_the_record_to_the_queued_client() {
+    let db = build().await;
+    let b = db.get_record("B").unwrap();
+
+    // Client 1 leaves B at VAL=1, so its callback is withheld and it owns B.
+    let first = db
+        .put_record_field_from_ca("B", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert!(!first.is_sync(), "VAL=1 withholds the callback");
+    assert!(b.read().has_notify());
+
+    // Client 2 arrives while client 1 still owns the record: C
+    // `processNotifyCommon` tests ownership above `putCallback`
+    // (`dbNotify.c:213-219`), so this writes nothing and queues.
+    let second = db
+        .put_record_field_from_ca("B", "VAL", EpicsValue::Double(0.0))
+        .await
+        .unwrap();
+    assert!(!second.is_sync(), "queued behind client 1");
+    assert_eq!(
+        b.read().record.get_field("VAL"),
+        Some(EpicsValue::Enum(1)),
+        "a queued put-notify writes nothing until it is replayed"
+    );
+
+    drop(first); // the CA connection goes away with its put-callback busy
+    db.cancel_unanswerable_notify("B");
+
+    second
+        .into_handle()
+        .expect("client 2 is still waiting")
+        .await
+        .expect("the cancel must replay the queued put, not drop its sender");
+    assert_eq!(
+        b.read().record.get_field("VAL"),
+        Some(EpicsValue::Enum(0)),
+        "restartCheck hands the record to the queued client"
+    );
+}

--- a/crates/epics-base-rs/tests/put_numeric_into_string_field_uses_prec.rs
+++ b/crates/epics-base-rs/tests/put_numeric_into_string_field_uses_prec.rs
@@ -1,0 +1,115 @@
+//! The `DBF_FLOAT`/`DBF_DOUBLE` → `DBF_STRING` row of C's put table renders
+//! with the record's `get_precision`, seeded 6.
+//!
+//! `putFloatString` / `putDoubleString` (`dbConvert.c:1558`/`:1600`) and the
+//! scalar twins `cvt_f_st` / `cvt_d_st` (`dbFastLinkConv.c:1216`/`:1333`) all
+//! open `long precision = 6;` and overwrite it from `prset->get_precision`
+//! before calling `cvtFloatToString`/`cvtDoubleToString`. Every other numeric
+//! row of that column is precision-free.
+//!
+//! softIoc (EPICS 7.0.10, linux-x86_64), `T:AI` an `ai` with `PREC=3` and
+//! `T:SO` a `stringout`:
+//!
+//! ```text
+//! dbtpf T:AI.DESC 1.0        -> DBF_STRING:         "1.000"
+//! dbtpf T:AI.EGU  1.23456789 -> DBF_STRING:         "1.235"
+//! dbtpf T:SO.VAL  1.0        -> DBF_STRING:         "1.000000"
+//! ```
+//!
+//! Pre-fix the port rendered all three through Rust's `Display` — `"1"`,
+//! `"1.23456789"`, `"1"` — so one field read back differently depending on
+//! whether the value arrived through `dbtgf` (which already consulted PREC)
+//! or through a put.
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::records::ai::AiRecord;
+use epics_base_rs::server::records::histogram::HistogramRecord;
+use epics_base_rs::server::records::stringout::StringoutRecord;
+use epics_base_rs::types::EpicsValue;
+
+async fn read(db: &PvDatabase, record: &str, field: &str) -> String {
+    let r = db.get_record(record).unwrap();
+    let r = r.read();
+    match r.resolve_field_stored(field).unwrap() {
+        EpicsValue::String(s) => s.as_str_lossy().into_owned(),
+        other => panic!("{record}.{field} is not a DBF_STRING: {other:?}"),
+    }
+}
+
+/// `ai` seeds `*precision = prec->prec` before the shared tail
+/// (`aiRecord.c:238-239`), and `recGblGetPrec` has no `DBF_STRING` case, so a
+/// dbCommon string field keeps PREC.
+#[epics_macros_rs::epics_test]
+async fn a_float_put_into_a_string_field_renders_at_the_records_prec() {
+    let db = PvDatabase::new();
+    db.add_record("T:AI", Box::new(AiRecord::new(0.0)))
+        .await
+        .unwrap();
+    db.put_record_field_from_ca_no_notify("T:AI", "PREC", EpicsValue::Short(3))
+        .await
+        .unwrap();
+
+    db.put_record_field_from_ca_no_notify("T:AI", "DESC", EpicsValue::Float(1.0))
+        .await
+        .unwrap();
+    assert_eq!(read(&db, "T:AI", "DESC").await, "1.000");
+
+    db.put_record_field_from_ca_no_notify("T:AI", "EGU", EpicsValue::Double(1.23456789))
+        .await
+        .unwrap();
+    assert_eq!(read(&db, "T:AI", "EGU").await, "1.235");
+}
+
+/// A record type whose rset NULLs `get_precision` never overwrites the seed,
+/// so the put renders at 6 — `stringout` is the measured case.
+#[epics_macros_rs::epics_test]
+async fn a_record_with_no_get_precision_slot_renders_at_the_seeded_six() {
+    let db = PvDatabase::new();
+    db.add_record("T:SO", Box::new(StringoutRecord::new("")))
+        .await
+        .unwrap();
+
+    db.put_record_field_from_ca_no_notify("T:SO", "VAL", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert_eq!(read(&db, "T:SO", "VAL").await, "1.000000");
+}
+
+/// `histogram` supplies the slot but its body is a bare switch with no seed
+/// and no case a dbCommon field reaches (`histogramRecord.c:420-438`), so the
+/// caller's 6 survives even though the record HAS a `PREC` field. The boundary
+/// that separates "has PREC" from "get_precision answers PREC".
+#[epics_macros_rs::epics_test]
+async fn a_records_prec_is_not_used_where_its_get_precision_never_seeds_it() {
+    let db = PvDatabase::new();
+    db.add_record("T:HI", Box::new(HistogramRecord::new(4, 0.0, 4.0)))
+        .await
+        .unwrap();
+    db.put_record_field_from_ca_no_notify("T:HI", "PREC", EpicsValue::Short(3))
+        .await
+        .unwrap();
+
+    db.put_record_field_from_ca_no_notify("T:HI", "DESC", EpicsValue::Double(1.0))
+        .await
+        .unwrap();
+    assert_eq!(read(&db, "T:HI", "DESC").await, "1.000000");
+}
+
+/// The other side of the family boundary: `cvtLongToString` and its siblings
+/// take no precision argument at all, so an integer put keeps the plain
+/// decimal whatever PREC says.
+#[epics_macros_rs::epics_test]
+async fn an_integer_put_into_a_string_field_ignores_prec() {
+    let db = PvDatabase::new();
+    db.add_record("T:AI", Box::new(AiRecord::new(0.0)))
+        .await
+        .unwrap();
+    db.put_record_field_from_ca_no_notify("T:AI", "PREC", EpicsValue::Short(3))
+        .await
+        .unwrap();
+
+    db.put_record_field_from_ca_no_notify("T:AI", "DESC", EpicsValue::Long(1))
+        .await
+        .unwrap();
+    assert_eq!(read(&db, "T:AI", "DESC").await, "1");
+}

--- a/crates/epics-base-rs/tests/scan_add_io_intr_refusal_reaches_the_errlog.rs
+++ b/crates/epics-base-rs/tests/scan_add_io_intr_refusal_reaches_the_errlog.rs
@@ -1,0 +1,80 @@
+//! `scanAdd`'s I/O Intr refusal is a `recGblRecordError`, not a sentence.
+//!
+//! ```c
+//! if (precord->dset == NULL){
+//!     recGblRecordError(-1, precord,
+//!         "scanAdd: I/O Intr not valid (no DSET) ");
+//!     precord->scan = menuScanPassive;
+//!     return;
+//! }
+//! ```
+//! (`dbScan.c:272-277`; `:281-284` is the same shape with
+//! `"(no get_ioint_info)"`.)
+//!
+//! Two things the port's own `eprintln!` did not do. The line went to
+//! `stderr` and not to the errlog, so an IOC forwarding to a log server
+//! reported nothing; and it was worded `scanAdd: I/O Intr not valid (no
+//! DSET), <name> set to Passive`, so a site or a test grepping
+//! `recGblRecordError` — which is how every other record-level refusal is
+//! found — matched nothing.
+//!
+//! `-1` is not a positive status, so C skips `errSymLookup` and the middle
+//! `%s` of `"recGblRecordError: %s %s PV: %s\n"` is empty; with C's own
+//! trailing space in the message that is the three spaces before `PV:`.
+//! Measured on `softIoc` R7.0.10 through `scripts/compat-smoke.sh`:
+//! `recGblRecordError: scanAdd: I/O Intr not valid (no DSET)   PV:
+//! asyndevAiInt32A0`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::types::EpicsValue;
+
+/// The refusal is written during `build()`, so the listener goes on first.
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("\n")
+}
+
+async fn ioc(db_text: &str) -> Arc<PvDatabase> {
+    IocBuilder::new()
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+/// A record asking for I/O Intr with no device support at all: C's first
+/// branch, byte for byte, and the demotion it announces.
+#[epics_macros_rs::epics_test]
+async fn a_record_with_no_dset_is_refused_through_recgbl_record_error() {
+    let sink = listen();
+    let db = ioc("record(ai, \"T:A\") { field(SCAN,\"I/O Intr\") }\n").await;
+
+    let log = heard(&sink);
+    assert!(
+        log.contains("recGblRecordError: scanAdd: I/O Intr not valid (no DSET)   PV: T:A"),
+        "C `dbScan.c:273-275` through `recGbl.c:68-70`, got {log:?}"
+    );
+
+    // C sets `precord->scan = menuScanPassive` on the same path, and says
+    // nothing further about it — the SCAN field is the report.
+    assert_eq!(
+        db.get_pv("T:A.SCAN").expect("SCAN reads back"),
+        EpicsValue::Enum(0),
+        "the refused record is demoted to Passive"
+    );
+}

--- a/crates/epics-base-rs/tests/seed_deadband_tracking_matches_c_init_record.rs
+++ b/crates/epics-base-rs/tests/seed_deadband_tracking_matches_c_init_record.rs
@@ -4,19 +4,22 @@
 //! Most C value records end `init_record` with
 //! `prec->mlst = prec->alst = prec->lalm = prec->val`, but seven of the types
 //! this port implements do not, and nothing in a record's shape predicts which
-//! group it lands in: `sub` seeds and `calc` does not; `calcout` seeds and
-//! `acalcout` does not; `bo` seeds and `busy` does not. Seeding uniformly
-//! suppressed a first-cycle post that C makes whenever such a record is loaded
-//! with a nonzero initial VAL.
+//! group it lands in: `calcout` seeds and `acalcout` does not; `bo` seeds and
+//! `busy` does not. Seeding uniformly suppressed a first-cycle post that C
+//! makes whenever such a record is loaded with a nonzero initial VAL.
 //!
 //! The table below is every record type this port serves MLST, ALST or LALM
-//! for, with the C `init_record` line range behind each verdict.
+//! for, with the C `init_record` line range behind each verdict. The verdict
+//! is about THIS hook, not about C in the abstract: `sub` is a `false` whose C
+//! counterpart does seed, because its seed sits below `init_record`'s early
+//! returns and so belongs to a later owner.
 
 mod module_records;
 
 use epics_base_rs::types::EpicsValue;
 
-/// `(record type, a nonzero VAL in the type's own representation, C seeds?)`
+/// `(record type, a nonzero VAL in the type's own representation, does
+/// `seed_deadband_tracking` seed?)`
 const CASES: &[(&str, EpicsValue, bool)] = &[
     // Seeds — std/rec
     ("ai", EpicsValue::Double(3.0), true), // aiRecord.c:129-131
@@ -32,14 +35,22 @@ const CASES: &[(&str, EpicsValue, bool)] = &[
     ("mbbiDirect", EpicsValue::Long(3), true), // mbbiDirectRecord.c:128
     ("mbbo", EpicsValue::UShort(3), true), // mbboRecord.c:179-180
     ("mbboDirect", EpicsValue::Long(3), true), // mbboDirectRecord.c:160
-    ("sub", EpicsValue::Double(3.0), true), // subRecord.c:130-132
     // Does not seed
+    //
+    // `sub` is the one row whose C counterpart DOES seed: `subRecord.c:130-132`
+    // sits below `init_record`'s empty-SNAM (`:122`) and unregistered-SNAM
+    // (`:128`) early returns, so only a record whose SNAM resolved reaches it.
+    // The generic tail runs before the resolution exists and cannot tell those
+    // apart, so the seed is performed by the resolution owner
+    // (`ioc_app::wire_subroutine`) and this hook is empty. Covered by
+    // `tests/snam_is_resolved_only_where_c_resolves_it.rs`.
+    ("sub", EpicsValue::Double(3.0), false), // subRecord.c:130-132
     ("calc", EpicsValue::Double(3.0), false), // calcRecord.c:90-112
     ("dfanout", EpicsValue::Double(3.0), false), // dfanoutRecord.c:96-109
-    ("sel", EpicsValue::Double(3.0), false),  // selRecord.c:88-108
+    ("sel", EpicsValue::Double(3.0), false), // selRecord.c:88-108
     ("scalcout", EpicsValue::Double(3.0), false), // sCalcoutRecord.c:203-320
     ("acalcout", EpicsValue::Double(3.0), false), // aCalcoutRecord.c:171-277
-    ("busy", EpicsValue::Enum(1), false),     // busyRecord.c:127-181
+    ("busy", EpicsValue::Enum(1), false),    // busyRecord.c:127-181
     ("swait", EpicsValue::Double(3.0), false), // swaitRecord.c:266-
 ];
 
@@ -74,7 +85,8 @@ fn each_type_seeds_its_trackers_exactly_as_its_c_init_record_does() {
                 .unwrap_or_else(|| panic!("{rtype}.{field} is not numeric"));
             if got != want {
                 wrong.push(format!(
-                    "{rtype}.{field}: VAL={val}, C {} seed at init_record, got {got} want {want}",
+                    "{rtype}.{field}: VAL={val}, seed_deadband_tracking {} seed, \
+                     got {got} want {want}",
                     if *seeds { "does" } else { "does not" }
                 ));
             }

--- a/crates/epics-base-rs/tests/snam_is_resolved_only_where_c_resolves_it.rs
+++ b/crates/epics-base-rs/tests/snam_is_resolved_only_where_c_resolves_it.rs
@@ -1,0 +1,240 @@
+//! `SNAM` resolution at init: `sub` always, `aSub` only under `LFLG=IGNORE`.
+//!
+//! ```c
+//! if (prec->lflg == aSubLFLG_IGNORE &&
+//!     prec->snam[0] != 0) {
+//!     pfunc = (GENFUNCPTR)registryFunctionFind(prec->snam);
+//!     ...
+//! }
+//! strcpy(prec->onam, prec->snam);
+//! ```
+//! (`aSubRecord.c:151-162`.) An `LFLG=READ` aSub therefore leaves `sadr`
+//! NULL at init, and `fetch_values` (`:254-275`) re-resolves only when the
+//! name the `SUBL` link delivered DIFFERS from `onam` — which init just made
+//! equal to `snam`. So a READ aSub with no SUBL link never binds a
+//! subroutine at all, and `do_sub` (`:456-463`) takes its null-pointer exit:
+//! `BAD_SUB_ALARM` at `INVALID_ALARM`, returning `S_db_BadSub`.
+//!
+//! The port resolved SNAM at init for both flavours, so that record ran its
+//! subroutine and read back `NO_ALARM`. The rule already had an owner —
+//! `Record::is_subroutine_name_field`, which the put path consults for the
+//! same `LFLG` reason — so init asks it instead of re-deriving the type test.
+//!
+//! Second half: `sub` with an EMPTY SNAM.
+//!
+//! ```c
+//! if (prec->snam[0] == 0) {
+//!     epicsPrintf("%s.SNAM is empty\n", prec->name);
+//!     prec->pact = TRUE;
+//!     return 0;
+//! }
+//! ```
+//! (`subRecord.c:118-122`.) `epicsPrintf` is `errlogPrintf` (`errlog.h:90`),
+//! so the line belongs to the errlog and not to stderr. The PACT half was
+//! already ported (`SubRecord::parks_pact`); only the line was missing.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::ioc_builder::IocBuilder;
+use epics_base_rs::server::recgbl::alarm_status;
+use epics_base_rs::server::record::AlarmSeverity;
+use epics_base_rs::types::EpicsValue;
+
+/// C `S_db_BadSub` (`dbAccessDefs.h:189`), aSub's VAL on the null-`sadr` exit.
+const S_DB_BAD_SUB: i32 = (511 << 16) | 35;
+
+/// The empty-SNAM line is written during `build()`, so the listener goes first.
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("\n")
+}
+
+async fn ioc(db_text: &str) -> Arc<PvDatabase> {
+    IocBuilder::new()
+        // Returns 0, and stamps VAL so a bound subroutine is distinguishable
+        // from an unbound one by more than the alarm.
+        .register_subroutine("theSub", |rec| {
+            let _ = rec.put_field("VALA", EpicsValue::Long(42));
+            Ok(0)
+        })
+        .db_string(db_text, &HashMap::new())
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0
+}
+
+async fn process(db: &PvDatabase, name: &str) {
+    let mut visited = HashSet::new();
+    db.process_record_with_links(name, &mut visited, 0)
+        .await
+        .unwrap();
+}
+
+/// `LFLG=IGNORE` (the default) binds at init and runs; `LFLG=READ` does not
+/// bind, and takes `do_sub`'s null-pointer exit on the very first cycle.
+#[epics_macros_rs::epics_test]
+async fn an_lflg_read_asub_does_not_bind_its_snam_at_init() {
+    let db = ioc(concat!(
+        "record(aSub, \"T:IGN\") { field(SNAM,\"theSub\") field(LFLG,\"IGNORE\")\n",
+        "                          field(FTVA,\"LONG\") field(NOVA,\"1\") }\n",
+        "record(aSub, \"T:RD\")  { field(SNAM,\"theSub\") field(LFLG,\"READ\")\n",
+        "                          field(FTVA,\"LONG\") field(NOVA,\"1\") }\n",
+    ))
+    .await;
+
+    process(&db, "T:IGN").await;
+    process(&db, "T:RD").await;
+
+    let ign = db.get_record("T:IGN").expect("T:IGN");
+    let ign = ign.read();
+    assert_eq!(
+        (ign.common.stat, ign.common.sevr),
+        (0, AlarmSeverity::NoAlarm),
+        "C `aSubRecord.c:151`: LFLG=IGNORE resolves SNAM at init and runs"
+    );
+    assert_eq!(
+        ign.record.get_field("VAL"),
+        Some(EpicsValue::Long(0)),
+        "the subroutine ran and returned 0"
+    );
+    drop(ign);
+
+    let rd = db.get_record("T:RD").expect("T:RD");
+    let rd = rd.read();
+    assert_eq!(
+        (rd.common.stat, rd.common.sevr),
+        (alarm_status::BAD_SUB_ALARM, AlarmSeverity::Invalid),
+        "C `aSubRecord.c:456-463`: LFLG=READ left `sadr` NULL, and `onam == \
+         snam` keeps `fetch_values` from re-resolving it"
+    );
+    assert_eq!(
+        rd.record.get_field("VAL"),
+        Some(EpicsValue::Long(S_DB_BAD_SUB)),
+        "C `process`: prec->val = do_sub() = S_db_BadSub"
+    );
+}
+
+/// C `subRecord.c:118-122` — the report and the PACT park are one branch.
+#[epics_macros_rs::epics_test]
+async fn a_sub_with_an_empty_snam_says_so_on_the_errlog() {
+    let sink = listen();
+    let db = ioc(concat!(
+        "record(sub, \"T:EMPTY\") { }\n",
+        "record(sub, \"T:NAMED\") { field(SNAM,\"theSub\") }\n",
+    ))
+    .await;
+
+    let log = heard(&sink);
+    assert!(
+        log.contains("T:EMPTY.SNAM is empty"),
+        "C `subRecord.c:119` through `epicsPrintf`, got {log:?}"
+    );
+    assert!(
+        !log.contains("T:NAMED.SNAM is empty"),
+        "a named SNAM takes no such branch, got {log:?}"
+    );
+    assert_eq!(
+        db.get_pv("T:EMPTY.PACT").expect("PACT reads back"),
+        EpicsValue::Char(1),
+        "C `subRecord.c:120`: prec->pact = TRUE, and it is never released"
+    );
+}
+
+/// An empty SNAM on an aSub is `aSubRecord.c:152`'s `snam[0] != 0` test,
+/// which says nothing at all — the report belongs to `sub` alone.
+#[epics_macros_rs::epics_test]
+async fn an_empty_snam_on_an_asub_is_silent() {
+    let sink = listen();
+    let db = ioc("record(aSub, \"T:A\") { }\n").await;
+
+    let log = heard(&sink);
+    assert!(
+        !log.contains("T:A.SNAM is empty"),
+        "C reports an empty SNAM only from `subRecord.c:119`, got {log:?}"
+    );
+    process(&db, "T:A").await;
+    let rec = db.get_record("T:A").expect("T:A");
+    let rec = rec.read();
+    assert_eq!(
+        (rec.common.stat, rec.common.sevr),
+        (0, AlarmSeverity::NoAlarm),
+        "C `aSubRecord.c:459`: an empty SNAM returns 0 before the null check"
+    );
+}
+
+/// C `subRecord.c:130-132` is the tail BELOW the two early returns, so a
+/// record whose SNAM is empty (`:122`) or unregistered (`:128`) never seeds
+/// its trackers. Measured on softIoc R7.0.10 with `dbpr REC 4`:
+/// `MLST: 0 ALST: 0 LALM: 0` for both, against `VAL : 5`.
+#[epics_macros_rs::epics_test]
+async fn only_a_resolved_snam_seeds_the_trackers() {
+    let db = ioc(concat!(
+        "record(sub, \"T:OK\")    { field(SNAM,\"theSub\") field(VAL,\"5\") }\n",
+        "record(sub, \"T:MISS\")  { field(SNAM,\"noSuchSub\") field(VAL,\"5\") }\n",
+        "record(sub, \"T:EMPTY\") { field(VAL,\"5\") }\n",
+        "record(sub, \"T:BADIN\") { field(INAM,\"noSuchInit\") field(SNAM,\"theSub\")\n",
+        "                          field(VAL,\"5\") }\n",
+    ))
+    .await;
+
+    let trackers = |name: &str| {
+        let rec = db.get_record(name).expect("record");
+        let rec = rec.read();
+        (
+            rec.record.get_field("MLST"),
+            rec.record.get_field("ALST"),
+            rec.record.get_field("LALM"),
+        )
+    };
+    let seeded = (
+        Some(EpicsValue::Double(5.0)),
+        Some(EpicsValue::Double(5.0)),
+        Some(EpicsValue::Double(5.0)),
+    );
+    let unseeded = (
+        Some(EpicsValue::Double(0.0)),
+        Some(EpicsValue::Double(0.0)),
+        Some(EpicsValue::Double(0.0)),
+    );
+
+    assert_eq!(trackers("T:OK"), seeded, "C `subRecord.c:130-132`");
+    assert_eq!(
+        trackers("T:MISS"),
+        unseeded,
+        "C `subRecord.c:128` returns S_db_BadSub above the tail"
+    );
+    assert_eq!(
+        trackers("T:EMPTY"),
+        unseeded,
+        "C `subRecord.c:122` returns 0 above the tail"
+    );
+    // C `subRecord.c:113` returns S_db_BadSub for an INAM that does not
+    // resolve, which skips the SNAM lookup as well — so a perfectly good SNAM
+    // stays unbound and the tail is never reached.
+    assert_eq!(
+        trackers("T:BADIN"),
+        unseeded,
+        "C `subRecord.c:110-114` returns above both the lookup and the tail"
+    );
+    assert!(
+        db.get_record("T:BADIN")
+            .expect("T:BADIN")
+            .read()
+            .subroutine
+            .is_none(),
+        "the INAM early return skips `prec->sadr = registryFunctionFind(snam)`"
+    );
+}

--- a/crates/epics-base-rs/tests/sub_record_names_that_resolve_to_nothing.rs
+++ b/crates/epics-base-rs/tests/sub_record_names_that_resolve_to_nothing.rs
@@ -1,0 +1,128 @@
+//! A `sub` record whose SNAM names nothing must say so.
+//!
+//! ```c
+//! if (prec->snam[0] == 0) { ... }
+//! prec->sadr = (SUBFUNCPTR)registryFunctionFind(prec->snam);
+//! if (prec->sadr == NULL) {
+//!     fprintf(stderr, "%s.SNAM " ERL_ERROR " function '%s' not found\n",
+//!             prec->name, prec->snam);
+//!     return S_db_BadSub;
+//! }
+//! ```
+//! (`subRecord.c:123-130`; `aSubRecord.c:155-160` is the same, and `:145` /
+//! `subRecord.c:110` are the INAM half.)
+//!
+//! The port resolved SNAM and threw the answer away when it was `None`, so an
+//! IOC booted with a record that would process as a no-op and printed nothing
+//! at all; measured across `scripts/compat-smoke.sh`, C wrote 9 such lines in
+//! 6 cases and the port wrote 0. Two things hid it. The INAM half was worded
+//! `iocInit: <name>.INAM function ... not found`, so it did not read as C's
+//! and could not stand in; and `wire_subroutines` returned early when the
+//! subroutine registry was EMPTY — precisely the IOC whose `.db` names
+//! subroutines that its binary never registered, which is every case above.
+//!
+//! `fprintf(stderr, ...)` and not `errlogPrintf`, so this reads the console
+//! rather than a listener.
+
+use std::collections::HashMap;
+
+use epics_base_rs::server::ioc_builder::IocBuilder;
+
+/// Point fd 2 at a file; the returned guard restores it and reads back what
+/// was written. Not a closure: the body is `async`, and fd 2 is process-wide
+/// so it does not need to be.
+struct Captured {
+    sink: tempfile::NamedTempFile,
+    saved: i32,
+}
+
+impl Captured {
+    fn start() -> Self {
+        let sink = tempfile::NamedTempFile::new().expect("capture file");
+        let saved = unsafe { libc::dup(2) };
+        assert!(saved >= 0, "dup(2) failed");
+        let fd = {
+            use std::os::fd::AsRawFd;
+            sink.as_file().as_raw_fd()
+        };
+        assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+        Self { sink, saved }
+    }
+
+    /// Restore BEFORE anything can panic on an assertion, or the failure
+    /// report has nowhere to go.
+    fn finish(self) -> String {
+        assert!(
+            unsafe { libc::dup2(self.saved, 2) } >= 0,
+            "restore fd 2 failed"
+        );
+        unsafe { libc::close(self.saved) };
+        strip_ansi(&std::fs::read_to_string(self.sink.path()).expect("read the capture"))
+    }
+}
+
+/// `ERL_ERROR` is `ANSI_RED("ERROR")`, so the escapes come off before the
+/// text is compared — the same way `errlog` strips its own.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(at) = rest.find('\u{1b}') {
+        out.push_str(&rest[..at]);
+        rest = &rest[at..];
+        match rest.find('m') {
+            Some(end) => rest = &rest[end + 1..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+const DB: &str = r#"
+record(sub, "T:I") {
+  field(INAM, "noSuchInit")
+}
+record(sub, "T:S") {
+  field(SNAM, "noSuchSub")
+}
+record(sub, "T:B") {
+  field(INAM, "noSuchInit")
+  field(SNAM, "noSuchSub")
+}
+"#;
+
+/// Both halves, with C's wording, from an IOC that registered no subroutines
+/// at all — the state the old early return treated as "nothing to report".
+///
+/// One record each, because C's INAM failure is `return S_db_BadSub`
+/// (`subRecord.c:113`) and everything below it — including the SNAM lookup —
+/// is skipped. Measured on softIoc R7.0.10 with both fields wrong: the INAM
+/// line alone.
+#[epics_macros_rs::epics_test]
+async fn an_unresolved_snam_and_inam_are_both_reported() {
+    let capture = Captured::start();
+    let built = IocBuilder::new()
+        .db_string(DB, &HashMap::new())
+        .unwrap()
+        .build()
+        .await;
+    let out = capture.finish();
+    built.expect("the IOC still builds; an unresolved SNAM is reported, not fatal");
+
+    assert!(
+        out.contains("T:S.SNAM ERROR function 'noSuchSub' not found"),
+        "C `subRecord.c:126`, got {out:?}"
+    );
+    assert!(
+        out.contains("T:I.INAM ERROR function 'noSuchInit' not found"),
+        "C `subRecord.c:110` — and no `iocInit: ` frame of our own, got {out:?}"
+    );
+    assert!(
+        out.contains("T:B.INAM ERROR function 'noSuchInit' not found"),
+        "C `subRecord.c:110`, got {out:?}"
+    );
+    assert!(
+        !out.contains("T:B.SNAM"),
+        "C `subRecord.c:113` returns above the SNAM lookup, got {out:?}"
+    );
+}

--- a/crates/epics-base-rs/tests/sub_record_names_that_resolve_to_nothing.rs
+++ b/crates/epics-base-rs/tests/sub_record_names_that_resolve_to_nothing.rs
@@ -23,6 +23,12 @@
 //!
 //! `fprintf(stderr, ...)` and not `errlogPrintf`, so this reads the console
 //! rather than a listener.
+//!
+//! Unix only: reading that console means pointing fd 2 somewhere else and
+//! putting it back. There is no fd 2 on Windows, and `libc` is a `cfg(unix)`
+//! dependency of this crate.
+
+#![cfg(unix)]
 
 use std::collections::HashMap;
 

--- a/crates/epics-base-rs/tests/sub_snam_put_moves_the_pact_park.rs
+++ b/crates/epics-base-rs/tests/sub_snam_put_moves_the_pact_park.rs
@@ -37,7 +37,7 @@
 use epics_base_rs::server::ioc_builder::IocBuilder;
 use epics_base_rs::types::EpicsValue;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 const DB: &str = r#"
 record(sub, "BARE") { }
@@ -191,4 +191,102 @@ async fn a_put_to_an_unrelated_field_does_not_disturb_the_park() {
         .await
         .unwrap();
     assert_eq!(pact(&db, "BARE"), 1, "DESC is not a park field");
+}
+
+/// `epicsPrintf` is `errlogPrintf` (`errlog.h:90`), so the line lands on the
+/// errlog and not on stderr. Registered before `build()` and drained after it,
+/// so an init-time emitter — the same line from `subRecord.c:120`, which is a
+/// different function on a different branch — cannot be mistaken for the
+/// put-time one these tests are about.
+fn listen() -> Arc<Mutex<Vec<String>>> {
+    let heard = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&heard);
+    epics_base_rs::runtime::log::errlog_add_listener(move |m| {
+        sink.lock().expect("sink").push(m.to_string());
+    });
+    heard
+}
+
+fn heard(sink: &Arc<Mutex<Vec<String>>>) -> String {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").join("")
+}
+
+fn forget(sink: &Arc<Mutex<Vec<String>>>) {
+    epics_base_rs::runtime::log::errlog_flush();
+    sink.lock().expect("sink").clear();
+}
+
+/// Boundary: named -> empty, the arm C prints from. `subRecord.c:182-186` is
+/// one block — `epicsPrintf`, then `pact = TRUE` — so the record that parks is
+/// the record that must say why, with the record's own name and a trailing
+/// newline exactly as `"%s.SNAM is empty\n"` renders it.
+#[epics_macros_rs::epics_test]
+async fn emptying_a_running_subs_snam_says_why_it_parked() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    put_snam(&db, "NAMED", "").await.unwrap();
+
+    assert_eq!(pact(&db, "NAMED"), 1, "the park half");
+    assert_eq!(
+        heard(&sink),
+        "NAMED.SNAM is empty\n",
+        "subRecord.c:183, verbatim and once"
+    );
+}
+
+/// Boundary: empty -> empty. Pass 0 released the park and pass 1 re-took it, so
+/// C runs the whole block again and prints again — a no-op put is not a silent
+/// one.
+#[epics_macros_rs::epics_test]
+async fn re_emptying_an_already_parked_sub_says_it_again() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    put_snam(&db, "BARE", "").await.unwrap();
+
+    assert_eq!(heard(&sink), "BARE.SNAM is empty\n");
+}
+
+/// Boundary: empty -> named, the arm C does NOT print from — it falls through
+/// to `registryFunctionFind` (`subRecord.c:188`).
+#[epics_macros_rs::epics_test]
+async fn naming_a_parked_sub_says_nothing() {
+    let sink = listen();
+    let db = build().await;
+    forget(&sink);
+
+    put_snam(&db, "BARE", "bump").await.unwrap();
+
+    assert_eq!(heard(&sink), "", "a released park has nothing to report");
+}
+
+/// Boundary: the other record whose `special()` reaches an empty subroutine
+/// name. `aSubRecord.c:560-561` sets `pfunc = 0` and returns 0 — no line, no
+/// park — so the line must be the parking record's, not every SNAM's.
+#[epics_macros_rs::epics_test]
+async fn emptying_an_asubs_snam_says_nothing() {
+    let sink = listen();
+    let db = IocBuilder::new()
+        .register_subroutine("bump", step(1.0))
+        .db_string(
+            "record(aSub, \"ASUB\") { field(SNAM, \"bump\") field(LFLG, \"IGNORE\") }",
+            &HashMap::new(),
+        )
+        .unwrap()
+        .build()
+        .await
+        .unwrap()
+        .0;
+    forget(&sink);
+
+    db.put_record_field_from_ca_no_notify("ASUB", "SNAM", EpicsValue::String("".into()))
+        .await
+        .unwrap();
+
+    assert_eq!(pact(&db, "ASUB"), 0, "aSub never parks");
+    assert_eq!(heard(&sink), "", "and never reports");
 }

--- a/crates/epics-base-rs/tests/substitute_installs_what_macparsedefns_installs.rs
+++ b/crates/epics-base-rs/tests/substitute_installs_what_macparsedefns_installs.rs
@@ -1,0 +1,153 @@
+//! **A `substitute` directive makes exactly the `macPutValue` calls C's
+//! `macParseDefns` + `macInstallMacros` make for the same text.**
+//!
+//! The `.db` `substitute` directive is msi's, not dbStatic's — C's `.db`
+//! grammar has no such production — so msi is the reference for the whole
+//! round trip: `makeSubstitutions` cuts the text out between the outer
+//! quotes with `\"` skipped as a pair and without unescaping it
+//! (`msi.cpp:305-358`), `addMacroReplacements` hands that to
+//! `macParseDefns` and its result straight to `macInstallMacros`
+//! (`:256-275`), and `macParseDefns` removes quotes and escapes from
+//! NAMES only, leaving values for `trans` to re-read at level 1
+//! (`macUtil.c:199-227`).
+//!
+//! Four rules of that round trip this port did not have. Measured with
+//! `msi` built from `~/work/epics-base` (`R7.0.10`):
+//!
+//! | `substitute` line | msi | this port, before |
+//! |---|---|---|
+//! | `"'A'=1,B"` with `-M B=preset` | `A=[1] B=[$(B)]` | `A=[$(A)] B=[preset]` |
+//! | `"A=\"1\",B=2"` | `A=["1"] B=[2]` | value truncated at the escape |
+//! | `"=1,B=2"` | `empty:[1] B=[2]` | the empty name dropped |
+//! | `"X=1"` then `"X"` under `-M X=outer` | `after:[$(X)]` | `after:[outer]` |
+//!
+//! msi suppresses macLib's warnings by default (`msi.cpp:154`), which is
+//! why its undefined placeholder is the short `$(X)`; the `.db` reader
+//! runs at `dbQuietMacroWarnings`, which defaults to loud, so the same
+//! reference comes out here as `$(X,undefined)`. `msi -V` prints that
+//! longer form and was used to confirm each row above.
+//!
+//! Unix only: fd 2 is redirected so the notices these loads raise do not
+//! land in the test harness's own output.
+
+#![cfg(unix)]
+
+use std::path::Path;
+
+use epics_base_rs::server::db_loader::{DbFaults, DbLoadConfig, MacroDefs, expand_includes};
+
+/// Flatten a one-file include tree with fd 2 pointed at a temporary file.
+fn expanded(path: &Path, macros: &MacroDefs) -> String {
+    let sink = tempfile::NamedTempFile::new().expect("capture file");
+    let saved = unsafe { libc::dup(2) };
+    assert!(saved >= 0, "dup(2) failed");
+    let fd = {
+        use std::os::fd::AsRawFd;
+        sink.as_file().as_raw_fd()
+    };
+    assert!(unsafe { libc::dup2(fd, 2) } >= 0, "dup2 onto fd 2 failed");
+
+    let config = DbLoadConfig::default();
+    let macros = macros.clone();
+    let ran = std::panic::catch_unwind(move || {
+        expand_includes(path, &macros, &config, &mut DbFaults::default())
+    });
+
+    // Restore BEFORE anything can panic on the assertion, or the failure
+    // report has nowhere to go.
+    assert!(unsafe { libc::dup2(saved, 2) } >= 0, "restore fd 2 failed");
+    unsafe { libc::close(saved) };
+    ran.expect("the expansion").expect("the flattened text")
+}
+
+/// Write `text` as a `.db`, expand it against `macros`, and give back the
+/// flattened result. A directive line contributes an empty line, which is
+/// how this reader keeps a diagnostic's line number the operator's.
+fn through_the_reader(text: &str, macros: &[(&str, &str)]) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("sub.db");
+    std::fs::write(&path, text).expect("write the .db");
+    let mut defs = MacroDefs::new();
+    for (name, value) in macros {
+        defs.put(*name, *value);
+    }
+    expanded(&path, &defs)
+}
+
+/// **Boundary: a quoted name, and a name with no `=` at all.**
+///
+/// One line carries both, because the two rules meet in `macParseDefns`'s
+/// `del[]` array and a port can pass either alone.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn quotes_come_off_a_name_and_a_bare_name_deletes() {
+    let got = through_the_reader(
+        "substitute \"'A'=1,B\"\nA=[$(A)] B=[$(B)]\n",
+        &[("B", "preset")],
+    );
+    assert_eq!(got, "\nA=[1] B=[$(B,undefined)]\n");
+}
+
+/// **Boundary: an escaped quote, which is where the directive scan and
+/// the value both have to leave the text alone.**
+///
+/// msi's closing-quote scan skips `\"` as a pair and copies the escape
+/// through, and the value keeps it until `trans` discards it at level 1 —
+/// so what comes out is a literal `"1"`.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn an_escaped_quote_survives_the_directive_and_the_value() {
+    let got = through_the_reader("substitute \"A=\\\"1\\\",B=2\"\nA=[$(A)] B=[$(B)]\n", &[]);
+    assert_eq!(got, "\nA=[\"1\"] B=[2]\n");
+}
+
+/// **Boundary: an escaped quote in a NAME.**
+///
+/// The same two characters mean the opposite thing here: C's cleanup loop
+/// reaches its escape branch only after the quote branch has declined the
+/// character, so `\"A\"` is a macro whose name is `"A"`, quotes included,
+/// and `$(A)` finds nothing.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn an_escaped_quote_in_a_name_is_a_literal_quote() {
+    let got = through_the_reader("substitute \"\\\"A\\\"=1\"\nA=[$(A)]\n", &[]);
+    assert_eq!(got, "\nA=[$(A,undefined)]\n");
+}
+
+/// **Boundary: the empty name.**
+///
+/// `=1` is a definition, not a syntax error to drop: `msi` on `substitute
+/// "=1,B=2"` resolves `$()` to `1`.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn an_empty_name_is_a_name() {
+    let got = through_the_reader("substitute \"=1,B=2\"\nempty:[$()] B=[$(B)]\n", &[]);
+    assert_eq!(got, "\nempty:[1] B=[2]\n");
+}
+
+/// **Boundary: a deletion of a name the caller defined.**
+///
+/// Both definitions sit at scope level 0, so the deletion removes the
+/// entry outright and leaves nothing behind it. Measured with `msi -V -M
+/// X=outer`: `after:[$(X,undefined)]`.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_deletion_removes_the_callers_definition_too() {
+    let got = through_the_reader(
+        "substitute \"X=1\"\nmid:[$(X)]\nsubstitute \"X\"\nafter:[$(X)]\n",
+        &[("X", "outer")],
+    );
+    assert_eq!(got, "\nmid:[1]\n\nafter:[$(X,undefined)]\n");
+}
+
+/// **Boundary: text after the closing quote.**
+///
+/// msi requires blanks only between the closing quote and the end of the
+/// line; anything else and the line was never a command, so it is
+/// expanded as ordinary text and no macro is defined by it.
+#[test]
+#[serial_test::serial(db_load_stderr)]
+fn a_line_with_trailing_text_is_not_a_directive() {
+    let got = through_the_reader("substitute \"A=1\" junk\nA=[$(A)]\n", &[]);
+    assert_eq!(got, "substitute \"A=1\" junk\nA=[$(A,undefined)]\n");
+}

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -27,7 +27,7 @@ default = ["qsrv", "qsrv-bin", "ca-gateway", "ca-gateway-bin"]
 #
 # It exists because `qsrv = [... "pvalink" ...]` is unsatisfiable on that
 # target: pvalink needs `epics_pva_rs::client_native`, a 23,881-line tree that
-# does not compile for RTEMS (47 errors — doc/qsrv-rtems-design.md §0 probe D).
+# does not compile for RTEMS (47 errors, measured).
 # Deleting the implication instead would silently drop pvalink from every host
 # build that asks for `qsrv`; naming the reduced set keeps `qsrv` a strict
 # superset, so every existing host selection resolves exactly as before.
@@ -38,11 +38,10 @@ default = ["qsrv", "qsrv-bin", "ca-gateway", "ca-gateway-bin"]
 # which is a green that proves nothing.
 qsrv-core = ["dep:epics-pva-rs", "dep:serde", "dep:serde_json"]
 # The RTEMS bring-up measurement rig for `realtime-pva-ioc` (the family twin of
-# `epics-ca-rs/bringup-probes` — doc/calink-rtems-design.md §11.7 item 3): the
-# stage-5 pvalink probe records (doc/pvalink-rtems-design.md §12), the §8 QSRV
-# load-probe group (doc/qsrv-rtems-design.md §9.14: victim `RTEMS:PVA:V0` plus
-# the 20-member `RTEMS:PVA:BIG`), the `stage5-probe` reporter thread and the
-# compiled-in SLIRP name-server default. OFF by default — the default binary
+# `epics-ca-rs/bringup-probes`): the stage-5 pvalink probe records, the QSRV
+# load-probe group (victim `RTEMS:PVA:V0` plus the 20-member `RTEMS:PVA:BIG`),
+# the `stage5-probe` reporter thread and the compiled-in SLIRP name-server
+# default. OFF by default — the default binary
 # is a clean IOC with no probe records, no probe thread and no link fields at
 # all. The bring-up box's build scripts add this flag to get exactly the
 # measured stage-5/§8 image back. NOT forwarded to `epics-ca-rs`: each target
@@ -265,8 +264,8 @@ required-features = ["dual-gateway-bin"]
 # The RTEMS PVA+QSRV IOC entry point — the workspace's one target PVA binary.
 # It lives here rather than in `epics-pva-rs`, where it started, because
 # mounting the QSRV group source needs `epics-bridge-rs` and `epics-pva-rs`
-# cannot depend on the bridge without a cyclic package dependency (measured;
-# doc/qsrv-rtems-design.md §9.7).
+# cannot depend on the bridge without a cyclic package dependency, which cargo
+# rejects outright (measured).
 #
 # `required-features` IS correct here, unlike on `epics-ca-rs`'s `realtime-ca-ioc`
 # — but for a reason worth stating, because the manifest comment this binary

--- a/crates/epics-bridge-rs/src/bin/realtime-pva-ioc.rs
+++ b/crates/epics-bridge-rs/src/bin/realtime-pva-ioc.rs
@@ -592,6 +592,28 @@ mod ioc {
         //     VxWorks' takes this as a no-op.
         epics_rtems_boot::stats::register_task();
 
+        // (0-cmd) The RTEMS operator commands — C `iocshRegisterRTEMS`
+        //     ($EPICS_BASE/modules/libcom/RTEMS/posix/rtems_init.c:692-705 at
+        //     R7.0.10). C registers `netstat`, `heapSpace`, `zoneset`, `rt` and
+        //     `setlogmask` from its RTEMS boot path, so an IOC has them because
+        //     it booted on RTEMS; this is that boot path, so this is where they
+        //     are registered.
+        //
+        //     `cfg!` and not `#[cfg]`: the call compiles on every target this
+        //     binary builds for, and the condition is C's own — `iocshRegisterRTEMS`
+        //     exists only in the RTEMS build of libCom, so a host or VxWorks
+        //     image must not grow the names.
+        //
+        //     KNOWN, and not a defect in the registration: this target has no
+        //     iocsh (`rustyline` does not build for RTEMS, see above), so
+        //     nothing reads the table here yet. The commands are held to C's
+        //     names, arities and output by this workspace's host tests; a shell
+        //     on the target is what turns them into something an operator can
+        //     type.
+        if cfg!(target_os = "rtems") {
+            epics_base_rs::server::iocsh::register_rtems_commands();
+        }
+
         // (0-probe) STAGE-5 PROBE: the target's `EPICS_PVA_NAME_SERVERS`.
         // Set before `install_pvalink_resolver` builds the ONE client, because
         // `PvaClientBuilder`'s default reads the variable once at construction

--- a/crates/epics-bridge-rs/src/pva_gateway/channel_cache.rs
+++ b/crates/epics-bridge-rs/src/pva_gateway/channel_cache.rs
@@ -624,7 +624,7 @@ pub struct ChannelCache {
     /// variant aging out of its channel's nested map via the cleaner).
     max_entries: usize,
     /// Lifetime count of cleanup-tick sweeps (pva2pva `cleanerRuns`,
-    /// `p2pApp/chancache.cpp:230-262`). Surfaced in the control status
+    /// `p2pApp/chancache.cpp:104-130`). Surfaced in the control status
     /// report so an operator can confirm the idle-eviction loop is live.
     cleaner_runs: AtomicU64,
     /// Lifetime count of entries evicted by the cleanup tick (pva2pva
@@ -1380,7 +1380,7 @@ impl ChannelCache {
             !channel.monitors.is_empty() || connection_retained
         });
         // pva2pva bumps `cleanerRuns` every sweep and `cleanerDust` by the
-        // number of evicted CHANNELS (`chancache.cpp:230-262`,
+        // number of evicted CHANNELS (`chancache.cpp:112-124`,
         // `p2pApp/server.cpp:182-198`); both surface in the operator
         // status report.
         // Relaxed is sufficient — these are monotonic diagnostic counters

--- a/crates/epics-bridge-rs/src/pvalink/link.rs
+++ b/crates/epics-bridge-rs/src/pvalink/link.rs
@@ -150,8 +150,8 @@ fn enqueue_scan_trigger(tx: &mpsc::Sender<ScanEvent>, overrun: &ScanOverrun, eve
 /// one observer, so its `catch(client::Disconnect&)` arm clears `connected`
 /// and runs every link's `onDisconnect()` unconditionally
 /// (`pvxs/ioc/pvalink_channel.cpp:360-373`, `pvxs/ioc/pvalink_link.cpp:75-81`); its
-/// `if(!connected)` at `:342` is the value-update path's reconnect arm, not
-/// a disconnect gate.
+/// `if(!connected)` at `pvalink_channel.cpp:342` is the value-update path's
+/// reconnect arm, not a disconnect gate.
 fn inp_disconnect_scan(
     connected: &AtomicBool,
     disconnect_time: &Mutex<Option<(i64, i32)>>,

--- a/crates/epics-bridge-rs/src/qsrv/iocsh.rs
+++ b/crates/epics-bridge-rs/src/qsrv/iocsh.rs
@@ -133,10 +133,11 @@ pub(crate) fn apply_group_file(
         raw
     } else {
         // pvxs expands each group-config line independently through
-        // `macDefExpand` and, when expansion fails (an undefined or recursive
-        // macro makes `macExpandString` return a negative length, so
-        // `macDefExpand` returns `NULL`), logs an error and skips that line —
-        // the failed line never reaches the JSON buffer
+        // `macDefExpand` and, when expansion fails (any of macLib's three
+        // error arms — an undefined name, a recursive reference, or one
+        // never closed — makes `macExpandString` return a negative length,
+        // so `macDefExpand` returns `NULL`), logs an error and skips that
+        // line — the failed line never reaches the JSON buffer
         // (groupconfigprocessor.cpp:88-106). Expanding line-by-line, rather
         // than the whole file at once, is what stops an undefined reference
         // inside a quoted string (`"+channel": "$(MISSING)"`) or a group name
@@ -150,11 +151,21 @@ pub(crate) fn apply_group_file(
                     buffer.push('\n');
                 }
                 None => {
+                    // The cause is already on the operator's console and is
+                    // not this line's to restate: the expansion runs with
+                    // `suppress_warnings` off, so macLib itself wrote
+                    // `macLib: macro … is undefined` / `… is recursive` /
+                    // `macLib: unterminated macro reference in string …`
+                    // for this very line, naming the macro, before it
+                    // returned. A cause list here is a second copy of that
+                    // knowledge with no way to stay in step with it — it
+                    // already said "undefined or recursive macro" after the
+                    // unterminated arm began reaching this branch. What only
+                    // this layer knows is WHICH line was dropped.
                     tracing::error!(
                         file = %filename,
                         line = idx + 1,
-                        "dbLoadGroup: macro expansion failed (undefined or \
-                         recursive macro); skipping line"
+                        "dbLoadGroup: macro expansion failed; skipping line"
                     );
                 }
             }
@@ -229,379 +240,60 @@ fn parse_macros(s: &str) -> std::collections::HashMap<String, String> {
 ///   - a resolved (macro or env) value is re-scanned for further
 ///     references (chained expansion); a self-referential macro is a
 ///     recursive reference and fails the expansion (`refentry->visited`).
-///   - an undefined name with no default, or a recursive reference, is an
-///     expansion *error* (`refer` sets `entry->error`, errval
-///     `,undefined)`/`,recursive)`). `macExpandString` then returns a
+///   - three arms set `entry->error`: an undefined name with no default
+///     and a recursive reference, which leave the errval placeholders
+///     `,undefined)` / `,recursive)`, and a reference whose closing
+///     delimiter never matched its opener, which writes no placeholder at
+///     all and copies itself and the whole rest of the string through
+///     verbatim (`macCore.c:862-875`). `macExpandString` then returns a
 ///     negative length and `macDefExpand` returns `NULL`
 ///     (macCore.c:210,220,895-896,881-882), so this function returns `None`
 ///     instead of a string. pvxs's group loader skips the whole line on
 ///     `NULL`, so a placeholder can never register as a literal channel or
 ///     group name (groupconfigprocessor.cpp:91-103).
+///   - a fault inside a scoped DEFINITION is the exception that sets no
+///     error: C translates the `,k=v` list through a separate `MAC_ENTRY
+///     subs` whose flag is never merged back (`macCore.c:820-826`), so
+///     `$(P,K=$(UNDEF))` with `P` defined expands to `P`'s value and
+///     succeeds.
 ///
 /// Returns `None` exactly when C `macDefExpand()` would return `NULL` for the
 /// same input + macro set; `Some(expanded)` otherwise.
 fn expand_macros(s: &str, macros: &std::collections::HashMap<String, String>) -> Option<String> {
-    let chars: Vec<char> = s.chars().collect();
-    let mut out = String::with_capacity(s.len());
-    // `error` mirrors C `entry.error`: any undefined or recursive reference
-    // anywhere in the (possibly nested) expansion sets it. The reference name
-    // and an actually-used default value are translated through this same flag
-    // (C uses the outer `entry`, macCore.c:798,890-894), so their errors
-    // propagate; scoped-definition names/values are NOT (separate `subs`,
-    // macCore.c:821-826), handled inside `mac_parse_scoped`.
-    let mut error = false;
-    // The user's source string is translated at level 0 (`discard = false`):
-    // its own quote delimiters and escape backslashes are preserved
-    // (`macExpandString` → `trans(handle, &entry, 0, ...)`, macCore.c:216).
-    // Substituted macro values/names/defaults/scopes are translated at
-    // level+1 inside `mac_refer`, where `discard = true` strips them
-    // (matching C `expand`/`refer`, macCore.c:669-673,798,892).
-    mac_trans(
-        &chars,
+    // The engine is `epics-base-rs`'s, not a copy of it. This used to be a
+    // private fork — `mac_trans`/`mac_refer`/`mac_parse_scoped` plus two
+    // byte-identical `top_level_*` helpers — and the fork is what let C
+    // `refer`'s unterminated arm (`macCore.c:862-875`) stay open here after it
+    // was closed in base: a `$(` with no `)` returned `None`, the caller
+    // emitted a bare `$`, the shared `error` was never set, and pvxs's
+    // skip-the-line path never fired. One owner, one arm.
+    //
+    // The three options are pvxs's, not base's `.db` defaults:
+    //
+    //   * `env_fallback` — pvxs builds the handle with the `{"", "environ"}`
+    //     pair, so an unset name falls through to the process environment
+    //     (`groupsourcehooks.cpp:155-158`, C `lookup` + `FLAG_USE_ENVIRONMENT`);
+    //   * `dollar_escape` off — `$$` is not macLib syntax, it is an autosave
+    //     `.req` convenience;
+    //   * `suppress_warnings` off — `macDefExpand` never calls
+    //     `macSuppressWarning` (`macEnv.c:27-79`) and pvxs does not either, so
+    //     C writes the `macLib:` notice for every bad reference in a group
+    //     file.
+    let expanded = epics_base_rs::server::db_loader::expand_macros(
+        s,
         macros,
-        &mut Vec::new(),
-        &mut Vec::new(),
-        false,
-        &mut error,
-        &mut out,
-    );
-    // macExpandString returns the destination text even on error, but
-    // macDefExpand discards it and returns NULL when the length is negative
-    // (macCore.c:220). Mirror that: a failed expansion yields no string.
-    if error { None } else { Some(out) }
-}
-
-/// Translate `chars` into `out`, expanding macro references.
-///
-/// `scopes` is the stack of scoped-macro frames pushed by enclosing
-/// `$(name,key=val)` references; lookup walks it innermost-first, then
-/// `macros`, then the environment. `visiting` is the stack of macro
-/// names currently being expanded — it guards a self-referential macro
-/// (`A=$(A)`) against infinite recursion, mirroring C `macCore.c`'s
-/// per-entry `visited` flag.
-fn mac_trans(
-    chars: &[char],
-    macros: &std::collections::HashMap<String, String>,
-    scopes: &mut Vec<std::collections::HashMap<String, String>>,
-    visiting: &mut Vec<String>,
-    discard: bool,
-    error: &mut bool,
-    out: &mut String,
-) {
-    let mut quote: Option<char> = None;
-    let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-
-        // Track single/double quote state (C `trans` `quote` var). At a
-        // discard level (`level > 0` — i.e. these are NOT the user's quotes
-        // but a substituted macro value/name/default/scope) the quote
-        // DELIMITERS are dropped: C `continue`s past the opening and the
-        // closing quote without copying them (macCore.c:717-726). The
-        // characters between the quotes are still emitted.
-        if let Some(q) = quote {
-            if c == q {
-                quote = None;
-                if discard {
-                    i += 1;
-                    continue;
-                }
-            }
-        } else if c == '"' || c == '\'' {
-            quote = Some(c);
-            if discard {
-                i += 1;
-                continue;
-            }
-        }
-
-        // `\<char>`: copy the escaped character; the backslash itself is
-        // kept only at level 0 (the user's escape) and dropped at a discard
-        // level (C `if (v < valend && !discard) *v++ = '\\'`,
-        // macCore.c:741-744). Either way the macro detector does not see the
-        // escaped byte.
-        if c == '\\' && i + 1 < chars.len() {
-            if !discard {
-                out.push('\\');
-            }
-            out.push(chars[i + 1]);
-            i += 2;
-            continue;
-        }
-
-        // Macro reference: `$` followed by `(` or `{`, NOT inside single
-        // quotes (C `macRef && quote != '\''`).
-        let mac_ref =
-            c == '$' && i + 1 < chars.len() && (chars[i + 1] == '(' || chars[i + 1] == '{');
-        if mac_ref && quote != Some('\'') {
-            if let Some(next) = mac_refer(chars, i, macros, scopes, visiting, error, out) {
-                i = next;
-                continue;
-            }
-        }
-
-        out.push(c);
-        i += 1;
-    }
-}
-
-/// Expand one macro reference starting at `chars[start]` (`$`). Returns
-/// the index just past the closing bracket, or `None` if the reference
-/// is unterminated (caller then copies `$` raw).
-fn mac_refer(
-    chars: &[char],
-    start: usize,
-    macros: &std::collections::HashMap<String, String>,
-    scopes: &mut Vec<std::collections::HashMap<String, String>>,
-    visiting: &mut Vec<String>,
-    error: &mut bool,
-    out: &mut String,
-) -> Option<usize> {
-    let close = if chars[start + 1] == '(' { ')' } else { '}' };
-    // Find the matching close bracket, honoring nested `$(`/`${`.
-    let body_start = start + 2;
-    let mut depth = 1usize;
-    let mut j = body_start;
-    while j < chars.len() && depth > 0 {
-        if j + 1 < chars.len() && chars[j] == '$' && (chars[j + 1] == '(' || chars[j + 1] == '{') {
-            depth += 1;
-            j += 2;
-            continue;
-        }
-        if depth == 1 && chars[j] == close || depth > 1 && (chars[j] == ')' || chars[j] == '}') {
-            depth -= 1;
-            if depth == 0 {
-                break;
-            }
-        }
-        j += 1;
-    }
-    if depth != 0 {
-        return None; // unterminated — caller emits '$' literally
-    }
-    let body = &chars[body_start..j];
-    let after = j + 1;
-
-    // Split the body at the first top-level `=` or `,` (the C `macEnd`
-    // terminator set). Nested `$(...)` brackets are skipped so a `=`/`,`
-    // inside an inner reference does not terminate.
-    let (name_chars, rest) = match mac_top_level_terminator(body) {
-        Some(k) => (&body[..k], &body[k..]),
-        None => (body, &body[body.len()..]),
-    };
-
-    // the name itself may contain macro references — expand it. The name
-    // is a substituted (level+1) value, so its quotes/escapes are discarded
-    // (C `trans(handle, entry, level+1, macEnd, ...)`, macCore.c:798). C
-    // translates the name through the *outer* `entry`, so an undefined or
-    // recursive reference inside the name fails the whole expansion — pass the
-    // shared `error`.
-    let mut name = String::new();
-    mac_trans(name_chars, macros, scopes, visiting, true, error, &mut name);
-
-    // Default value (`=...`) and scoped definitions (`,k=v`).
-    let mut default: Option<&[char]> = None;
-    let mut scoped: Vec<(String, String)> = Vec::new();
-    if let Some(first) = rest.first() {
-        if *first == '=' {
-            let dflt = &rest[1..];
-            match mac_top_level_comma(dflt) {
-                Some(k) => {
-                    default = Some(&dflt[..k]);
-                    mac_parse_scoped(&dflt[k..], macros, scopes, visiting, &mut scoped);
-                }
-                None => default = Some(dflt),
-            }
-        } else if *first == ',' {
-            mac_parse_scoped(rest, macros, scopes, visiting, &mut scoped);
-        }
-    }
-
-    // Push the scoped frame (visible only inside this expansion).
-    let mut frame: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    for (k, v) in scoped {
-        frame.insert(k, v);
-    }
-    scopes.push(frame);
-
-    // Look up: innermost scope first, then base macros, then the
-    // environment (pvxs's `{"","environ"}` handle / FLAG_USE_ENVIRONMENT).
-    let resolved = scopes
-        .iter()
-        .rev()
-        .find_map(|s| s.get(&name).cloned())
-        .or_else(|| macros.get(&name).cloned())
-        .or_else(|| {
-            if name.is_empty() {
-                None
-            } else {
-                std::env::var(&name).ok()
-            }
-        });
-
-    match resolved {
-        Some(val) => {
-            if visiting.contains(&name) {
-                // Recursive reference: C `refer` finds `refentry->visited`
-                // already set, sets `entry->error = TRUE`, and writes the
-                // `$(name,recursive)` placeholder (macCore.c:881-882,904-912).
-                // `macExpandString` then reports a negative length so
-                // `macDefExpand` returns `NULL`. Flag the error; the
-                // placeholder text is discarded by `expand_macros` on error,
-                // exactly as `macDefExpand` discards the destination buffer.
-                *error = true;
-                out.push_str("$(");
-                out.push_str(&name);
-                out.push_str(",recursive)");
-            } else {
-                visiting.push(name.clone());
-                let val_chars: Vec<char> = val.chars().collect();
-                // A resolved macro value is a substituted (level+1) value:
-                // its quote delimiters and escape backslashes are stripped
-                // (C `trans(handle, entry, level+1, "", &rv, ...)` /
-                // pre-`expand` at level 1, macCore.c:669-673,875). Errors in
-                // the value (e.g. a chained reference to an undefined macro)
-                // propagate through the shared `entry` (macCore.c:870,875).
-                mac_trans(&val_chars, macros, scopes, visiting, true, error, out);
-                visiting.pop();
-            }
-        }
-        None => match default {
-            Some(def_chars) => {
-                // The default value is also substituted at level+1, so its
-                // quotes/escapes are discarded by the translation itself —
-                // C `trans(handle, entry, level+1, macEnd+1, &defval, ...)`
-                // (macCore.c:892). It is translated through the outer `entry`,
-                // so a default that itself resolves to an undefined/recursive
-                // reference still fails the expansion — pass the shared
-                // `error`. A present, resolvable default is NOT an error.
-                mac_trans(def_chars, macros, scopes, visiting, true, error, out);
-            }
-            None => {
-                // Undefined reference with no default: C `refer` sets
-                // `entry->error = TRUE` and writes the `$(name,undefined)`
-                // placeholder (macCore.c:895-896,904-912), so
-                // `macExpandString` returns a negative length and
-                // `macDefExpand` returns `NULL`. Flag the error; the
-                // placeholder is discarded by `expand_macros` on error.
-                *error = true;
-                out.push_str("$(");
-                out.push_str(&name);
-                out.push_str(",undefined)");
-            }
+        epics_base_rs::server::db_loader::MacroExpandOptions {
+            env_fallback: true,
+            dollar_escape: false,
+            suppress_warnings: false,
         },
-    }
-
-    scopes.pop();
-    Some(after)
-}
-
-/// Parse a `,key=val,key2=val2,...` scoped-definition tail. A bare
-/// `,key` with no `=` defines nothing (C silently skips it).
-fn mac_parse_scoped(
-    rest: &[char],
-    macros: &std::collections::HashMap<String, String>,
-    scopes: &mut Vec<std::collections::HashMap<String, String>>,
-    visiting: &mut Vec<String>,
-    out: &mut Vec<(String, String)>,
-) {
-    // C translates scoped-definition names and values through a SEPARATE
-    // `MAC_ENTRY subs` whose `error` flag is initialized fresh and never
-    // merged back into the enclosing `entry` (macCore.c:821-826,841,849). So
-    // an undefined or recursive reference inside a scoped definition does NOT
-    // fail the surrounding expansion. Route these translations through a
-    // throwaway sink rather than the caller's `error` to match.
-    let mut scoped_err = false;
-    let mut k = 0;
-    while k < rest.len() {
-        if rest[k] != ',' {
-            break;
-        }
-        k += 1; // step over ','
-        let seg = &rest[k..];
-        let (name_part, tail) = match mac_top_level_terminator(seg) {
-            Some(t) => (&seg[..t], &seg[t..]),
-            None => (seg, &seg[seg.len()..]),
-        };
-        let mut sname = String::new();
-        // Scoped macro names/values are substituted at level+1, so their
-        // quotes/escapes are discarded (C `trans(handle, &subs, level+1,
-        // ...)`, macCore.c:841,849).
-        mac_trans(
-            name_part,
-            macros,
-            scopes,
-            visiting,
-            true,
-            &mut scoped_err,
-            &mut sname,
-        );
-        k += name_part.len();
-        if let Some('=') = tail.first() {
-            let valseg = &tail[1..];
-            let (val_part, _) = match mac_top_level_comma(valseg) {
-                Some(t) => (&valseg[..t], &valseg[t..]),
-                None => (valseg, &valseg[valseg.len()..]),
-            };
-            let mut sval = String::new();
-            mac_trans(
-                val_part,
-                macros,
-                scopes,
-                visiting,
-                true,
-                &mut scoped_err,
-                &mut sval,
-            );
-            out.push((sname, sval));
-            k += 1 + val_part.len();
-        }
-        // else: bare `,name` — no value, defines nothing.
-    }
-}
-
-/// Index of the first top-level `=` or `,` in `body`, skipping any
-/// nested `$(...)` / `${...}` reference.
-fn mac_top_level_terminator(body: &[char]) -> Option<usize> {
-    let mut depth = 0usize;
-    let mut i = 0;
-    while i < body.len() {
-        let c = body[i];
-        if c == '$' && i + 1 < body.len() && (body[i + 1] == '(' || body[i + 1] == '{') {
-            depth += 1;
-            i += 2;
-            continue;
-        }
-        if (c == ')' || c == '}') && depth > 0 {
-            depth -= 1;
-        } else if depth == 0 && (c == '=' || c == ',') {
-            return Some(i);
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Index of the first top-level `,` in `body` (splits a default value
-/// from trailing scoped definitions).
-fn mac_top_level_comma(body: &[char]) -> Option<usize> {
-    let mut depth = 0usize;
-    let mut i = 0;
-    while i < body.len() {
-        let c = body[i];
-        if c == '$' && i + 1 < body.len() && (body[i + 1] == '(' || body[i + 1] == '{') {
-            depth += 1;
-            i += 2;
-            continue;
-        }
-        if (c == ')' || c == '}') && depth > 0 {
-            depth -= 1;
-        } else if depth == 0 && c == ',' {
-            return Some(i);
-        }
-        i += 1;
-    }
-    None
+    );
+    // C `macExpandString` returns the destination text even on error, but
+    // `macDefExpand` discards it and returns NULL when the length is negative
+    // (macCore.c:216-224, macEnv.c:58-61). `errored()` is that negative
+    // length: it covers the undefined, recursive AND unterminated arms alike,
+    // which is precisely what the fork could not do.
+    (!expanded.errored()).then_some(expanded.text)
 }
 
 /// `processGroups` — finalize group config after `dbLoadGroup` calls
@@ -1380,14 +1072,84 @@ mod tests {
         assert_eq!(m.len(), 2);
     }
 
+    /// C `refer`'s unterminated arm (`macCore.c:862-875`), which this file
+    /// carried open for as long as it had its own copy of the expander.
+    ///
+    /// A `$(`/`${` whose closing delimiter never arrives is not a reference:
+    /// C copies it and the whole rest of the string through verbatim, sets
+    /// `entry->error`, and writes `macLib: unterminated macro reference in
+    /// string …`. `macExpandString` then returns a negative length, so
+    /// `macDefExpand` returns `NULL` and pvxs skips the line
+    /// (groupconfigprocessor.cpp:91-103). The fork returned `Some` with the
+    /// `$` copied through and the shared `error` untouched, so the line
+    /// survived into the JSON buffer carrying a literal `$(`.
+    ///
+    /// All four shapes, measured against `softIoc R7.0.10`: a plain `$(`, the
+    /// `${` opener, a MISMATCHED `$(A}`, and two openers with no closer. The
+    /// third and fourth matter because the tail after the opener is text — the
+    /// `$(P)` in them is consumed as part of the unterminated reference's name
+    /// and is never expanded, so a fork that rescanned the tail resolved a
+    /// macro C leaves alone.
+    #[test]
+    fn an_unterminated_reference_fails_the_expansion() {
+        let m = std::collections::HashMap::from([("P".to_string(), "IOC:".to_string())]);
+        for s in [
+            r#"  "$(P:grp": {"#,
+            r#"  "${P:grp": {"#,
+            r#"  "x$(A} $(P) y""#,
+            r#"  "$(A$(B z""#,
+        ] {
+            assert_eq!(expand_macros(s, &m), None, "expanding {s:?}");
+        }
+        // The guard: a reference that IS closed still resolves, and the tail
+        // after it is still scanned.
+        assert_eq!(
+            expand_macros(r#"  "$(P)grp": {"#, &m).as_deref(),
+            Some(r#"  "IOC:grp": {"#)
+        );
+    }
+
+    /// End to end: a group whose NAME carries an unterminated `$(` must never
+    /// reach the provider.
+    ///
+    /// This is the hazard the line-by-line expansion exists to prevent, spelled
+    /// out in [`apply_group_file`]'s own comment — pvxs drops the line rather
+    /// than let a half-expanded name register as a real group. With the fork,
+    /// `  "$(P:grp": {` expanded to itself with no error reported, the JSON
+    /// stayed well-formed, and a group literally named `$(P:grp` was created.
+    #[test]
+    fn a_group_name_with_an_unterminated_reference_is_not_created() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("unterm-groups.json");
+        std::fs::write(
+            &path,
+            "{\n  \"$(P:grp\": {\n    \"+id\": \"epics:nt/NTGroup:1.0\"\n  }\n}\n",
+        )
+        .expect("write the group file");
+
+        let db = std::sync::Arc::new(epics_base_rs::server::database::PvDatabase::new());
+        let provider = BridgeProvider::new(db);
+        let loaded = apply_group_file(&provider, path.to_str().expect("utf-8 path"), "P=IOC:");
+
+        assert!(
+            loaded.is_err(),
+            "the skipped line leaves malformed JSON, so the load must fail; got {loaded:?}"
+        );
+        let names: Vec<String> = provider.groups().into_keys().collect();
+        assert!(
+            !names.iter().any(|n| n.contains("$(")),
+            "no group may be created from a half-expanded name: {names:?}"
+        );
+    }
+
     /// libCom `macParseDefns` (macUtil.c:74-196): a comma inside quotes or
     /// backslash-escaped is a literal, not a pair separator. A raw
     /// `split(',')` truncated `DESC="a,b"` to `DESC="a` and dropped `b"`;
     /// the quote-aware splitter keeps `a,b` as one value. The quotes and
     /// escapes themselves stay in the parsed value — macParseDefns removes
-    /// them from names only (macUtil.c:198-200) — and [`mac_trans`]'s
-    /// `discard` takes them off when the macro is substituted, so both
-    /// halves are asserted here.
+    /// them from names only (macUtil.c:198-200) — and the expander's
+    /// `discard` level takes them off when the macro is substituted, so
+    /// both halves are asserted here.
     #[test]
     fn parse_macros_keeps_quoted_or_escaped_comma_in_one_value() {
         let m = parse_macros(r#"DESC="a,b",P=IOC:"#);

--- a/crates/epics-bridge-rs/tests/testqsingle.rs
+++ b/crates/epics-bridge-rs/tests/testqsingle.rs
@@ -877,7 +877,7 @@ async fn common_field_descriptor_matches_value_type() {
 
     // (field, expected descriptor scalar type)
     //
-    // `.PROC` is `DBF_UCHAR` (`dbCommon.dbd:110`), not `DBF_CHAR`, and pvxs
+    // `.PROC` is `DBF_UCHAR` (`dbCommon.dbd.pod:241`), not `DBF_CHAR`, and pvxs
     // serves `DBR_UCHAR` as `TypeCode::UInt8` (`ioc/typeutils.cpp`). The
     // `Byte` this case used to expect was the port's signed storage variant
     // showing through — the descriptor was derived from the stored value

--- a/crates/epics-ca-rs/Cargo.toml
+++ b/crates/epics-ca-rs/Cargo.toml
@@ -113,9 +113,8 @@ windows-sys = { version = "0.59", features = [
 # build passes, and it is the configuration that gets to state its own
 # selection (`scripts/rtems-check.sh`'s `CRATE_FEATURES`).
 default = ["client"]
-# The CA client a *record link* needs, and nothing else
-# (`doc/calink-rtems-design.md` §2.1, §6 stage C2): `client`, `channel` and
-# `calink` — search (UDP where it exists, `EPICS_CA_NAME_SERVERS` where it
+# The CA client a *record link* needs, and nothing else: `client`, `channel`
+# and `calink` — search (UDP where it exists, `EPICS_CA_NAME_SERVERS` where it
 # does not), the virtual circuit, subscriptions, and the `ca://` link
 # resolver over them.
 #
@@ -134,13 +133,13 @@ client-core = []
 # a dependency that does not build for `armv7-rtems-eabihf`; none of them is
 # reachable from a record link.
 client = ["client-core"]
-# The RTEMS bring-up measurement rig (doc/calink-rtems-design.md §6 stage C6,
-# gated by §11.7 item 3): the 14 C6 probe records in `realtime-ca-ioc`'s built-in
-# database, its two probe threads (the tick task and the `c6-probe` reporter),
-# and the compiled-in SLIRP search topology. OFF by default — the default
-# binary is a clean IOC with no probe records, no probe threads and no link
-# fields at all (the link-free image §11.7 item 4 needs). The bring-up box's
-# build scripts add this flag to get exactly the measured C6 image back.
+# The RTEMS bring-up measurement rig: the 14 C6 probe records in
+# `realtime-ca-ioc`'s built-in database, its two probe threads (the tick task
+# and the `c6-probe` reporter), and the compiled-in SLIRP search topology. OFF
+# by default — the default binary is a clean IOC with no probe records, no
+# probe threads and no link fields at all, which is the link-free image the
+# bring-up measurements also need. The bring-up box's build scripts add this
+# flag to get exactly the measured C6 image back.
 bringup-probes = []
 # Bundled Prometheus exporter + tracing-subscriber init helpers.
 # Without this feature consumers wire up their own observability

--- a/crates/epics-ca-rs/doc/01-overview.md
+++ b/crates/epics-ca-rs/doc/01-overview.md
@@ -205,8 +205,8 @@ ring buffer.
 
 ## Where libca-parity is enforced
 
-`09-libca-parity.md` lists the cases where we deliberately mirror libca
-behaviour. The most important examples:
+The port deliberately mirrors libca behaviour rather than tidying it up.
+The cases that matter most:
 
 - **Search response parsing**: accept `cid == 0` and `cid == ~0u32` as
   "use UDP source address" (`client/search.rs::handle_udp_response`).
@@ -216,8 +216,11 @@ behaviour. The most important examples:
   `osiSockDiscoverBroadcastAddresses`.
 - **DBR_PUT_ACKT/ACKS** route to record `ACKT`/`ACKS` fields, never to
   the channel's normal write path.
-- **`CAS_USE_HOST_NAMES=NO` (default)** → server uses peer IP, ignores
-  client-supplied hostname.
+- **Client host name**: under C's default (`asCheckClientIP == 0`) the
+  server stores the name the client sent in `CA_PROTO_HOST_NAME` and does
+  not verify it; only `asCheckClientIP = 1` pins the peer's dotted-quad IP
+  instead. There is no `EPICS_CAS_USE_HOST_NAMES` variable, here or in
+  epics-base — see `08-environment.md`.
 
 ## Performance notes
 

--- a/crates/epics-ca-rs/doc/08-environment.md
+++ b/crates/epics-ca-rs/doc/08-environment.md
@@ -166,9 +166,9 @@ Used by some `softIoc` configurations. `epics-ca-rs` itself uses
 ### `asCheckClientIP` — an iocsh knob, not an environment variable
 
 There is **no** `EPICS_CAS_USE_HOST_NAMES` variable. Earlier revisions of
-this document, `04-server.md` and `09-libca-parity.md` described one and
-claimed it matched C's default; it exists nowhere in epics-base and the
-port no longer reads it (R7-16).
+this document and `04-server.md` described one and claimed it matched C's
+default; it exists nowhere in epics-base and the port no longer reads it
+(R7-16).
 
 What C actually has is the global `asCheckClientIP`
 (`asLibRoutines.c:34`), default `0`, set from the shell:

--- a/crates/epics-ca-rs/doc/README.md
+++ b/crates/epics-ca-rs/doc/README.md
@@ -21,7 +21,6 @@ the crate or trying to understand a runtime issue. End-user usage
 | [`06-dbr-types.md`](06-dbr-types.md) | DBR type families and encoding |
 | [`07-flow-control.md`](07-flow-control.md) | Backpressure: client queue, server flow control gate, coalescing |
 | [`08-environment.md`](08-environment.md) | All `EPICS_CA_*` / `EPICS_CAS_*` variables and their effect |
-| [`09-libca-parity.md`](09-libca-parity.md) | Parity matrix vs `epics-base` libca / rsrv |
 | [`functional-review-2026-05-20.md`](functional-review-2026-05-20.md) | Functional-review findings (with resolution status) vs `epics-base` C implementation |
 | [`10-observability.md`](10-observability.md) | tracing events, metrics schema, exporter integrations |
 | [`11-tls-design.md`](11-tls-design.md) | CA over TLS (encryption + mTLS auth), design and migration plan |

--- a/crates/epics-ca-rs/doc/functional-review-2026-05-20.md
+++ b/crates/epics-ca-rs/doc/functional-review-2026-05-20.md
@@ -151,8 +151,9 @@ The Rust client exposes `CaClient::create_channel(&str)` with no priority
 argument, and the transport key is `SocketAddr`, so all channels to a server
 share one virtual circuit. libca treats priority as part of channel creation
 and creates independent virtual circuits for different priorities to the same
-server. Rust also lacks the C API shape where a thread can attach to an existing
-CA context.
+server, and gives each priority its own OS thread priority; the Rust side has
+no equivalent, since the tokio runtime is pool-shared. Rust also lacks the C
+API shape where a thread can attach to an existing CA context.
 
 Rust evidence:
 
@@ -160,9 +161,6 @@ Rust evidence:
   without priority and immediately allocates only a `cid`.
 - `crates/epics-ca-rs/src/client/transport.rs:246-314` queues and connects by
   `server_addr`.
-- `crates/epics-ca-rs/crates/epics-ca-rs/doc/09-libca-parity.md:111-119` records the missing
-  priority, per-priority virtual circuit, OS-thread priority, and attachable
-  context behavior.
 
 C reference:
 

--- a/crates/epics-ca-rs/src/bin/ca-repeater-rs.rs
+++ b/crates/epics-ca-rs/src/bin/ca-repeater-rs.rs
@@ -83,7 +83,7 @@ fn main() {
         if let Err(e) = run_repeater_with_debug(debug).await {
             // A socket the daemon could not make or bind never reaches here:
             // C `ca_repeater` names both outcomes at the bind and returns
-            // from its void function either way (`repeater.cpp:513-531`), and
+            // from its void function either way (`repeater.cpp:501-519`), and
             // `run_repeater_with_debug` does the same, printing "CA Repeater:
             // Exiting, a repeater is already running" or the fatal stderr
             // line and answering `Ok(())`. Anything left is a failure C's

--- a/crates/epics-ca-rs/src/bin/caget-rs.rs
+++ b/crates/epics-ca-rs/src/bin/caget-rs.rs
@@ -26,6 +26,71 @@ const TERMINALS: &[(&str, copt::Terminal)] = &[
     ("version", copt::Terminal::Version),
 ];
 
+/// C `caget.c:56-105` `usage()`, byte for byte. C substitutes two
+/// COMPILE-TIME constants, not the running configuration: `%f` of
+/// `DEFAULT_TIMEOUT` and `%u` of `CA_PRIORITY_MAX`, so `caget -w 5 -h` still
+/// advertises the 1.000000 s default. Written to stderr by
+/// `copt::Scan::finish` on the `Terminal::Usage` arm (`caget.c:400-402`).
+fn usage() -> String {
+    format!(
+        r#"
+Usage: caget [options] <PV name> ...
+
+  -h: Help: Print this message
+  -V: Version: Show EPICS and CA versions
+Channel Access options:
+  -w <sec>: Wait time, specifies CA timeout, default is {timeout:.6} second(s)
+  -c: Asynchronous get (use ca_get_callback and wait for completion)
+  -p <prio>: CA priority (0-{max}, default 0=lowest)
+Format options:
+      Default output format is "name value"
+  -t: Terse mode - print only value, without name
+  -a: Wide mode "name timestamp value stat sevr" (read PVs as DBR_TIME_xxx)
+  -d <type>: Request specific dbr type; use string (DBR_ prefix may be omitted)
+      or number of one of the following types:
+ DBR_STRING     0  DBR_STS_FLOAT    9  DBR_TIME_LONG   19  DBR_CTRL_SHORT    29
+ DBR_INT        1  DBR_STS_ENUM    10  DBR_TIME_DOUBLE 20  DBR_CTRL_INT      29
+ DBR_SHORT      1  DBR_STS_CHAR    11  DBR_GR_STRING   21  DBR_CTRL_FLOAT    30
+ DBR_FLOAT      2  DBR_STS_LONG    12  DBR_GR_SHORT    22  DBR_CTRL_ENUM     31
+ DBR_ENUM       3  DBR_STS_DOUBLE  13  DBR_GR_INT      22  DBR_CTRL_CHAR     32
+ DBR_CHAR       4  DBR_TIME_STRING 14  DBR_GR_FLOAT    23  DBR_CTRL_LONG     33
+ DBR_LONG       5  DBR_TIME_INT    15  DBR_GR_ENUM     24  DBR_CTRL_DOUBLE   34
+ DBR_DOUBLE     6  DBR_TIME_SHORT  15  DBR_GR_CHAR     25  DBR_STSACK_STRING 37
+ DBR_STS_STRING 7  DBR_TIME_FLOAT  16  DBR_GR_LONG     26  DBR_CLASS_NAME    38
+ DBR_STS_SHORT  8  DBR_TIME_ENUM   17  DBR_GR_DOUBLE   27
+ DBR_STS_INT    8  DBR_TIME_CHAR   18  DBR_CTRL_STRING 28
+Enum format:
+  -n: Print DBF_ENUM value as number (default is enum string)
+Arrays: Value format: print number of requested values, then list of values
+  Default:    Print all values
+  -# <count>: Print first <count> elements of an array
+  -S:         Print array of char as a string (long string)
+Floating point type format:
+  Default: Use %g format
+  -e <nr>: Use %e format, with a precision of <nr> digits
+  -f <nr>: Use %f format, with a precision of <nr> digits
+  -g <nr>: Use %g format, with a precision of <nr> digits
+  -s:      Get value as string (honors server-side precision)
+  -lx:     Round to long integer and print as hex number
+  -lo:     Round to long integer and print as octal number
+  -lb:     Round to long integer and print as binary number
+Integer number format:
+  Default: Print as decimal number
+  -0x: Print as hex number
+  -0o: Print as octal number
+  -0b: Print as binary number
+Alternate output field separator:
+  -F <ofs>: Use <ofs> as an alternate output field separator
+
+Example: caget -a -f8 my_channel another_channel
+  (uses wide output format, doubles are printed as %f with precision of 8)
+
+"#,
+        timeout = epics_ca_rs::cli::DEFAULT_CLI_TIMEOUT_SECS,
+        max = epics_ca_rs::copt::CA_PRIORITY_MAX,
+    )
+}
+
 /// C `caget` output format (`caget.c:45`, `typedef enum { plain, terse,
 /// all, specifiedDbr }`). The request DBR type and the output format are
 /// independent: only `specifiedDbr` carries the `-d` type to the wire;
@@ -749,8 +814,7 @@ async fn main() {
     // Parse via ArgMatches (not the plain derive) so the command-line
     // order of `-t`/`-a`/`-d` is recoverable for the C mutual-exclusion
     // rule (`resolve_format`).
-    let cmd = Args::command();
-    let parsed = TOOL.get_matches(cmd.clone());
+    let parsed = TOOL.get_matches(Args::command());
     let matches = parsed.matches();
     let args = Args::from_arg_matches(matches).expect("clap validated the arguments");
 
@@ -786,7 +850,7 @@ async fn main() {
     // End of C's getopt loop: the warnings above go to stderr in command-line
     // order, and `-h` / `-V` — which C's loop `return`s from where it meets
     // them — run here, AFTER those warnings and never before (R13-26).
-    scan.finish(&cmd, &epics_ca_rs::protocol::version_info(), TERMINALS);
+    scan.finish(&usage(), &epics_ca_rs::protocol::version_info(), TERMINALS);
 
     // C `caget.c:527-531`: the missing-PV check runs after the getopt loop,
     // so `-V` above still wins and a bad option argument has already warned.
@@ -1137,6 +1201,21 @@ fn parse_dbr_type(s: &str) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Measured against `caget -h` from EPICS 7.0.10.1-DEV: 2606 bytes on
+    /// stderr, byte for byte. The length is pinned because the failure this
+    /// guards against — rendering the block through clap instead — changes
+    /// every line of it.
+    #[test]
+    fn the_usage_block_is_cs_text_not_claps() {
+        let u = super::usage();
+        assert!(u.starts_with("\nUsage: caget [options] <PV name> ...\n"));
+        // C prints the COMPILE-TIME constants, not the running configuration.
+        assert!(u.contains("default is 1.000000 second(s)"));
+        assert!(u.contains("(0-99, default 0=lowest)"));
+        assert!(u.ends_with("\n\n"), "C's block closes with a blank line");
+        assert_eq!(u.len(), 2606);
+    }
     use super::{
         Args, GetResult, OutputMode, PvRead, ReadError, ReqCount, TOOL, caget_req_count,
         dbr_extended_str, dbr_text, parse_dbr_type, read_error, read_timeout, resolve_dbr_type,

--- a/crates/epics-ca-rs/src/bin/cainfo-rs.rs
+++ b/crates/epics-ca-rs/src/bin/cainfo-rs.rs
@@ -22,6 +22,36 @@ const TERMINALS: &[(&str, copt::Terminal)] = &[
     ("dead_n", copt::Terminal::Usage(1)),
 ];
 
+/// C `cainfo.c:37-49` `usage()`, byte for byte. C substitutes two
+/// COMPILE-TIME constants, not the running configuration: `%f` of
+/// `DEFAULT_TIMEOUT` and `%u` of `CA_PRIORITY_MAX`, so `cainfo -w 5 -h` still
+/// advertises the 1.000000 s default. Written to stderr by
+/// `copt::Scan::finish` on the `Terminal::Usage` arm (`cainfo.c:148-150`).
+fn usage() -> String {
+    let mut block = format!(
+        r#"
+Usage: cainfo [options] <PV name> ...
+
+  -h: Help: Print this message
+  -V: Version: Show EPICS and CA versions
+Channel Access options:
+  -w <sec>:   Wait time, specifies CA timeout, default is {timeout:.6} second(s)
+  -s <level>: Call ca_client_status with the specified interest level
+  -p <prio>:  CA priority (0-{max}, default 0=lowest)
+
+Example: cainfo my_channel another_channel
+
+"#,
+        timeout = epics_ca_rs::cli::DEFAULT_CLI_TIMEOUT_SECS,
+        max = epics_ca_rs::copt::CA_PRIORITY_MAX,
+    );
+    // C's SECOND `fprintf` in `usage()` (`cainfo.c:49`): the same banner
+    // `-V` prints, but on stderr and appended to the block.
+    block.push_str(&epics_ca_rs::protocol::version_info());
+    block.push('\n');
+    block
+}
+
 #[derive(Parser)]
 #[command(
     name = "cainfo-rs",
@@ -90,8 +120,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
-    let cmd = Args::command();
-    let parsed = TOOL.get_matches(cmd.clone());
+    let parsed = TOOL.get_matches(Args::command());
     let matches = parsed.matches();
     let args = Args::from_arg_matches(matches).expect("clap validated the arguments");
 
@@ -113,7 +142,7 @@ async fn main() {
     let priority = scan.priority("priority");
     // End of C's getopt loop: warnings out in command-line order, then `-h` /
     // `-V` if the loop reached one (R13-26).
-    scan.finish(&cmd, &epics_ca_rs::protocol::version_info(), TERMINALS);
+    scan.finish(&usage(), &epics_ca_rs::protocol::version_info(), TERMINALS);
 
     // C `cainfo.c:202-205`: a missing PV list is an error unless a
     // non-zero `-s` level was selected. `--diag` (Rust-only) is an
@@ -246,6 +275,22 @@ fn dbr_name(t: DbFieldType) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+
+    /// Measured against `cainfo -h` from EPICS 7.0.10.1-DEV: 440 bytes on
+    /// stderr, of which the block is 380 and the rest is the version
+    /// banner C appends with a second `fprintf`. The banner carries the
+    /// build's own version string, so only the block's length is pinned.
+    #[test]
+    fn the_usage_block_is_cs_text_not_claps() {
+        let u = super::usage();
+        assert!(u.starts_with("\nUsage: cainfo [options] <PV name> ...\n\n"));
+        // C prints the COMPILE-TIME constants, not the running configuration.
+        assert!(u.contains("default is 1.000000 second(s)"));
+        assert!(u.contains("(0-99, default 0=lowest)"));
+        let banner = format!("{}\n", epics_ca_rs::protocol::version_info());
+        assert!(u.ends_with(&banner), "C appends the -V banner to the block");
+        assert_eq!(u.len() - banner.len(), 380);
+    }
     use super::*;
 
     /// `cainfo -s <arg>`, resolved the way `main` resolves it — through the

--- a/crates/epics-ca-rs/src/bin/camonitor-rs.rs
+++ b/crates/epics-ca-rs/src/bin/camonitor-rs.rs
@@ -23,6 +23,66 @@ const TERMINALS: &[(&str, copt::Terminal)] = &[
     ("version", copt::Terminal::Version),
 ];
 
+/// C `camonitor.c:45-92` `usage()`, byte for byte. C substitutes two
+/// COMPILE-TIME constants, not the running configuration: `%f` of
+/// `DEFAULT_TIMEOUT` and `%u` of `CA_PRIORITY_MAX`, so `camonitor -w 5 -h` still
+/// advertises the 1.000000 s default. Written to stderr by
+/// `copt::Scan::finish` on the `Terminal::Usage` arm (`camonitor.c:226-228`).
+fn usage() -> String {
+    format!(
+        r#"
+Usage: camonitor [options] <PV name> ...
+
+  -h:       Help: Print this message
+  -V:       Version: Show EPICS and CA versions
+Channel Access options:
+  -w <sec>: Wait time, specifies CA timeout, default is {timeout:.6} second(s)
+  -m <msk>: Specify CA event mask to use.  <msk> is any combination of
+            'v' (value), 'a' (alarm), 'l' (log/archive), 'p' (property).
+            Default event mask is 'va'
+  -p <pri>: CA priority (0-{max}, default 0=lowest)
+Timestamps:
+  Default:  Print absolute timestamps (as reported by CA server)
+  -t <key>: Specify timestamp source(s) and type, with <key> containing
+            's' = CA server (remote) timestamps
+            'c' = CA client (local) timestamps (shown in '()'s)
+            'n' = no timestamps
+            'r' = relative timestamps (time elapsed since start of program)
+            'i' = incremental timestamps (time elapsed since last update)
+            'I' = incremental timestamps (time since last update, by channel)
+            'r', 'i' or 'I' require 's' or 'c' to select the time source
+Enum format:
+  -n:       Print DBF_ENUM values as number (default is enum string)
+Array values: Print number of elements, then list of values
+  Default:  Request and print all elements (dynamic arrays supported)
+  -# <num>: Request and print up to <num> elements
+  -S:       Print arrays of char as a string (long string)
+Floating point format:
+  Default:  Use %g format
+  -e <num>: Use %e format, with a precision of <num> digits
+  -f <num>: Use %f format, with a precision of <num> digits
+  -g <num>: Use %g format, with a precision of <num> digits
+  -s:       Get value as string (honors server-side precision)
+  -lx:      Round to long integer and print as hex number
+  -lo:      Round to long integer and print as octal number
+  -lb:      Round to long integer and print as binary number
+Integer number format:
+  Default:  Print as decimal number
+  -0x:      Print as hex number
+  -0o:      Print as octal number
+  -0b:      Print as binary number
+Alternate output field separator:
+  -F <ofs>: Use <ofs> to separate fields in output
+
+Example: camonitor -f8 my_channel another_channel
+  (doubles are printed as %f with precision of 8)
+
+"#,
+        timeout = epics_ca_rs::cli::DEFAULT_CLI_TIMEOUT_SECS,
+        max = epics_ca_rs::copt::CA_PRIORITY_MAX,
+    )
+}
+
 /// Mirror of C `camonitor` flags. The flag set is mostly the same as
 /// `caget` minus `-t`/`-a`/`-d` and plus `-m`/`-t<key>`. We model the
 /// CLI to match — including the parity-only flags so existing scripts
@@ -220,8 +280,7 @@ impl Args {
 async fn main() {
     // Parse via ArgMatches (not the plain derive) so the command-line order of
     // `-e`/`-f`/`-g` is recoverable for C's last-valid-wins rule (W10-B2).
-    let cmd = Args::command();
-    let parsed = TOOL.get_matches(cmd.clone());
+    let parsed = TOOL.get_matches(Args::command());
     let matches = parsed.matches();
     let args = Args::from_arg_matches(matches).expect("clap validated the arguments");
 
@@ -242,7 +301,7 @@ async fn main() {
     let spec = parse_timestamp_spec(&mut scan, "timestamp_key");
     // End of C's getopt loop: warnings out in command-line order, then `-h` /
     // `-V` if the loop reached one (R13-26).
-    scan.finish(&cmd, &epics_ca_rs::protocol::version_info(), TERMINALS);
+    scan.finish(&usage(), &epics_ca_rs::protocol::version_info(), TERMINALS);
 
     if args.pv_names.is_empty() {
         TOOL.no_pv_name();
@@ -280,9 +339,20 @@ async fn main() {
     let prev_all_server = Arc::new(std::sync::Mutex::new(None::<SystemTime>));
     let prev_all_client = Arc::new(std::sync::Mutex::new(None::<SystemTime>));
 
+    // C `camonitor.c:392-395` calls `create_pvs` itself — not the
+    // `connect_pvs` barrier, because camonitor has no all-channels wait —
+    // and returns its code before the event loop starts. The name gate is
+    // the same one, so it lives in the same owner.
+    let channels = match epics_ca_rs::cli::create_pvs(&client, &args.pv_names, priority) {
+        Ok(channels) => channels,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    };
+
     let mut handles = Vec::new();
-    for (i, pv_name) in args.pv_names.iter().enumerate() {
-        let channel = client.create_channel_with_priority(pv_name, priority);
+    for (i, (pv_name, channel)) in args.pv_names.iter().zip(channels).enumerate() {
         let pv = pv_name.clone();
         let flag = connected_flags[i].clone();
         let fmt = fmt.clone();
@@ -760,6 +830,21 @@ fn render_timestamp(
 
 #[cfg(test)]
 mod tests {
+
+    /// Measured against `camonitor -h` from EPICS 7.0.10.1-DEV: 2193 bytes on
+    /// stderr, byte for byte. The length is pinned because the failure this
+    /// guards against — rendering the block through clap instead — changes
+    /// every line of it.
+    #[test]
+    fn the_usage_block_is_cs_text_not_claps() {
+        let u = super::usage();
+        assert!(u.starts_with("\nUsage: camonitor [options] <PV name> ...\n"));
+        // C prints the COMPILE-TIME constants, not the running configuration.
+        assert!(u.contains("default is 1.000000 second(s)"));
+        assert!(u.contains("(0-99, default 0=lowest)"));
+        assert!(u.ends_with("\n\n"), "C's block closes with a blank line");
+        assert_eq!(u.len(), 2193);
+    }
     use super::{
         Args, TOOL, TimestampKind, TimestampSpec, TimestampState, parse_event_mask,
         parse_timestamp_spec, render_timestamp,

--- a/crates/epics-ca-rs/src/bin/caput-rs.rs
+++ b/crates/epics-ca-rs/src/bin/caput-rs.rs
@@ -135,6 +135,48 @@ const TERMINALS: &[(&str, copt::Terminal)] = &[
     ("version", copt::Terminal::Version),
 ];
 
+/// C `caput.c:60-87` `usage()`, byte for byte. C substitutes two
+/// COMPILE-TIME constants, not the running configuration: `%f` of
+/// `DEFAULT_TIMEOUT` and `%u` of `CA_PRIORITY_MAX`, so `caput -w 5 -h` still
+/// advertises the 1.000000 s default. Written to stderr by
+/// `copt::Scan::finish` on the `Terminal::Usage` arm (`caput.c:292-294`).
+fn usage() -> String {
+    format!(
+        r#"
+Usage: caput [options] <PV name> <PV value> ...
+       caput -a [options] <PV name> <no of values> <PV value> ...
+
+  -h: Help: Print this message
+  -V: Version: Show EPICS and CA versions
+Channel Access options:
+  -w <sec>:  Wait time, specifies CA timeout, default is {timeout:.6} second(s)
+  -c: Asynchronous put (use ca_put_callback and wait for completion)
+  -p <prio>: CA priority (0-{max}, default 0=lowest)
+Format options:
+  -t: Terse mode - print only successfully written value, without name
+  -l: Long mode "name timestamp value stat sevr" (read PVs as DBR_TIME_xxx)
+Enum format:
+  Default: Auto - try value as ENUM string, then as index number
+  -n: Force interpretation of values as numbers
+  -s: Force interpretation of values as strings
+Arrays:
+  Default: Put scalar
+      Value format: all value arguments concatenated with spaces
+  -S: Put string as an array of chars (long string)
+  -a: Put array
+      Value format: number of values, then list of values
+Alternate output field separator:
+  -F <ofs>: Use <ofs> as an alternate output field separator
+
+Example: caput my_channel 1.2
+  (puts 1.2 to my_channel)
+
+"#,
+        timeout = epics_ca_rs::cli::DEFAULT_CLI_TIMEOUT_SECS,
+        max = epics_ca_rs::copt::CA_PRIORITY_MAX,
+    )
+}
+
 /// Mirror of C `caput` flag set.
 ///
 /// Note: positional grammar differs in array mode (`-a`):
@@ -306,8 +348,7 @@ fn last_of_pair(matches: &clap::ArgMatches, this_id: &str, that_id: &str) -> (bo
 
 #[tokio::main]
 async fn main() {
-    let cmd = Args::command();
-    let parsed = TOOL.get_matches(cmd.clone());
+    let parsed = TOOL.get_matches(Args::command());
     let matches = parsed.matches();
     let args = Args::from_arg_matches(matches).expect("clap validated the arguments");
 
@@ -327,7 +368,7 @@ async fn main() {
     let field_separator = scan.field_separator("field_separator");
     // End of C's getopt loop: warnings out in command-line order, then `-h` /
     // `-V` if the loop reached one (R13-26).
-    scan.finish(&cmd, &epics_ca_rs::protocol::version_info(), TERMINALS);
+    scan.finish(&usage(), &epics_ca_rs::protocol::version_info(), TERMINALS);
 
     // -n / -s steer ENUM scalar handling below (force_numeric =
     // interpret as index; force_string = always send DBR_STRING for
@@ -1053,6 +1094,21 @@ fn build_enum_array(
 
 #[cfg(test)]
 mod tests {
+
+    /// Measured against `caput -h` from EPICS 7.0.10.1-DEV: 1120 bytes on
+    /// stderr, byte for byte. The length is pinned because the failure this
+    /// guards against — rendering the block through clap instead — changes
+    /// every line of it.
+    #[test]
+    fn the_usage_block_is_cs_text_not_claps() {
+        let u = super::usage();
+        assert!(u.starts_with("\nUsage: caput [options] <PV name> <PV value> ...\n"));
+        // C prints the COMPILE-TIME constants, not the running configuration.
+        assert!(u.contains("default is 1.000000 second(s)"));
+        assert!(u.contains("(0-99, default 0=lowest)"));
+        assert!(u.ends_with("\n\n"), "C's block closes with a blank line");
+        assert_eq!(u.len(), 1120);
+    }
     use super::{
         Args, Readback, ValueFormat, WriteValue, build_write_value, classify_readback,
         last_of_pair, raw_from_escaped, raw_from_escaped_string, readback_line, readback_stderr,

--- a/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
+++ b/crates/epics-ca-rs/src/bin/realtime-ca-ioc.rs
@@ -1031,6 +1031,28 @@ mod ioc {
         //     VxWorks' takes this as a no-op.
         epics_rtems_boot::stats::register_task();
 
+        // (0-cmd) The RTEMS operator commands — C `iocshRegisterRTEMS`
+        //     ($EPICS_BASE/modules/libcom/RTEMS/posix/rtems_init.c:692-705 at
+        //     R7.0.10). C registers `netstat`, `heapSpace`, `zoneset`, `rt` and
+        //     `setlogmask` from its RTEMS boot path, so an IOC has them because
+        //     it booted on RTEMS; this is that boot path, so this is where they
+        //     are registered.
+        //
+        //     `cfg!` and not `#[cfg]`: the call compiles on every target this
+        //     binary builds for, and the condition is C's own — `iocshRegisterRTEMS`
+        //     exists only in the RTEMS build of libCom, so a host or VxWorks
+        //     image must not grow the names.
+        //
+        //     KNOWN, and not a defect in the registration: this target has no
+        //     iocsh (`rustyline` does not build for RTEMS, see above), so
+        //     nothing reads the table here yet. The commands are held to C's
+        //     names, arities and output by this workspace's host tests; a shell
+        //     on the target is what turns them into something an operator can
+        //     type.
+        if cfg!(target_os = "rtems") {
+            epics_base_rs::server::iocsh::register_rtems_commands();
+        }
+
         // (0-iface) PROBE: what the OS's interface enumeration returns, before
         //     anything in this image decides what to do with it.
         #[cfg(feature = "bringup-probes")]

--- a/crates/epics-ca-rs/src/cli.rs
+++ b/crates/epics-ca-rs/src/cli.rs
@@ -148,20 +148,26 @@ pub fn connect_timeout_message(names: &[String]) -> String {
     }
 }
 
-/// A failed [`connect_pvs`] barrier: carries the exact C diagnostic to
-/// print on stderr before the tool exits 1.
+/// A failed [`connect_pvs`] / [`create_pvs`] barrier: carries the exact C
+/// diagnostic to print on stderr before the tool exits 1.
+///
+/// One type for both failures because C ends them the same way — every
+/// caller does `fprintf(stderr, ...)`-then-`return 1` — and because they are
+/// mutually exclusive: `connect_pvs` reaches its `ca_pend_io` only when
+/// `create_pvs` returned 0 (`tool_lib.c:625-626`), so a run never has both a
+/// rejected name and a connect timeout to report.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConnectPvsTimeout {
+pub struct ConnectPvsFailure {
     message: String,
 }
 
-impl std::fmt::Display for ConnectPvsTimeout {
+impl std::fmt::Display for ConnectPvsFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.message)
     }
 }
 
-impl std::error::Error for ConnectPvsTimeout {}
+impl std::error::Error for ConnectPvsFailure {}
 
 /// C `tool_lib.c::connect_pvs` (`:623-641`) — the single all-channels
 /// barrier the synchronous CA tools put between channel creation and
@@ -179,20 +185,18 @@ impl std::error::Error for ConnectPvsTimeout {}
 ///
 /// The connect wait runs concurrently across channels, so the whole
 /// barrier fits in one `timeout` window, exactly like C's single
-/// `ca_pend_io`. C's other failure mode — `ca_create_channel` itself
-/// rejecting a name (`create_pvs`, `tool_lib.c:588-594`) — has no port
-/// analogue: [`CaClient::create_channel_with_priority`] is infallible and
-/// defers every failure to the connect wait.
+/// `ca_pend_io`. C's other failure mode — [`create_pvs`] rejecting a name —
+/// comes first and, when it fires, the wait never runs.
 pub async fn connect_pvs(
     client: &CaClient,
     names: &[String],
     priority: u8,
     timeout: std::time::Duration,
-) -> Result<Vec<CaChannel>, ConnectPvsTimeout> {
-    let channels: Vec<CaChannel> = names
-        .iter()
-        .map(|name| client.create_channel_with_priority(name, priority))
-        .collect();
+) -> Result<Vec<CaChannel>, ConnectPvsFailure> {
+    // C `connect_pvs:625-626`: `create_pvs` first, and its non-zero return
+    // is returned WITHOUT entering `ca_pend_io` — so a rejected name costs
+    // no timeout and emits no "Channel connect timed out" line.
+    let channels = create_pvs(client, names, priority)?;
     let all_connected =
         futures_util::future::join_all(channels.iter().map(|ch| ch.wait_connected(timeout)))
             .await
@@ -202,10 +206,70 @@ pub async fn connect_pvs(
     if all_connected {
         Ok(channels)
     } else {
-        Err(ConnectPvsTimeout {
+        Err(ConnectPvsFailure {
             message: connect_timeout_message(names),
         })
     }
+}
+
+/// C `ca_create_channel`'s name gate (`cac.cpp:522-524` plus
+/// `nciu.cpp:53-58`), reported the way C `tool_lib.c::create_pvs`
+/// (`:588-599`) reports it.
+///
+/// # Invariant (CONTRACT)
+///
+/// A channel name that `ca_create_channel` would refuse MUST be refused
+/// here, before any search goes out. **This is the single owner of that
+/// gate** — every CA tool creates its channels through it, so none of them
+/// can spend a timeout window searching for a name the protocol cannot
+/// carry, nor report such a name as "not found".
+///
+/// The rule is C's, in two clauses, and both are measured against C `caget`:
+/// a name that is empty (`pName[0] == '\0'`), or whose length plus its NUL
+/// exceeds the search datagram's room for it (`MAX_UDP_SEND - sizeof(caHdr)`
+/// = 1008, so 1007 characters connect and 1008 are refused). C raises
+/// `badString` for both, `ca_create_channel` maps it to `ECA_BADSTR`, and
+/// `create_pvs` prints `ca_message(ECA_BADSTR)` — "Invalid string".
+///
+/// Every rejected name gets its own line, in argv order, because C's loop
+/// reports each one and only then returns 1.
+pub fn create_pvs(
+    client: &CaClient,
+    names: &[String],
+    priority: u8,
+) -> Result<Vec<CaChannel>, ConnectPvsFailure> {
+    if let Some(message) = uncreatable_names_message(names) {
+        return Err(ConnectPvsFailure { message });
+    }
+    Ok(names
+        .iter()
+        .map(|name| client.create_channel_with_priority(name, priority))
+        .collect())
+}
+
+/// The diagnostic [`create_pvs`] fails with, or `None` when every name is
+/// creatable. Split out so the gate is testable without a live client — it
+/// is pure text over the names, exactly as C's loop is.
+fn uncreatable_names_message(names: &[String]) -> Option<String> {
+    let rejected: Vec<String> = names
+        .iter()
+        .filter(|name| !channel_name_is_creatable(name))
+        .map(|name| {
+            format!("CA error Invalid string occurred while trying to create channel '{name}'.")
+        })
+        .collect();
+    (!rejected.is_empty()).then(|| rejected.join("\n"))
+}
+
+/// C `MAX_UDP_SEND - sizeof(caHdr)` (`caProto.h:66` = 1024, minus the
+/// 16-byte header): the largest `strlen(name) + 1` a search datagram can
+/// carry, and the bound `nciu`'s constructor tests (`nciu.cpp:56`).
+const MAX_CHANNEL_NAME_BYTES: usize = 1024 - 16;
+
+fn channel_name_is_creatable(name: &str) -> bool {
+    // C tests `strlen(name) + 1 > bound` because the NUL travels on the
+    // wire with the name; the same bound without the NUL is `len < bound`.
+    !name.is_empty() && name.len() < MAX_CHANNEL_NAME_BYTES
 }
 
 /// Field width the C tools (`caget` / `camonitor` / `caput -l`) use
@@ -806,16 +870,37 @@ fn join_elements<I: Iterator<Item = String>>(iter: I, total: usize, fmt: &ValueF
         .join(&fmt.field_separator.to_string())
 }
 
+/// C `MAX_ENUM_STATES` (`db_access.h:32`) — the number of string slots a
+/// GR/CTRL enum reply carries on the wire, whatever `no_str` claims.
+const MAX_ENUM_STATES: i64 = 16;
+
+/// C `val2str`'s `DBR_ENUM` arm (`tool_lib.c:169-188`).
+///
+/// `enum_strings` is `Some` exactly when the reply carried a string table,
+/// which is C's `dbr_type_is_GR(type)` / `dbr_type_is_CTRL(type)` test: those
+/// two flavours resolve the index, every other ENUM request (plain, STS,
+/// TIME) prints the raw number, and so does `-n` on any of them.
+///
+/// Resolving is not just a table lookup — C reports the two out-of-range
+/// cases apart, and a `-d DBR_GR_ENUM` against a numeric PV lands on them
+/// immediately, because such a channel answers with `no_str = 0` and the
+/// value cast to an index. Past `MAX_ENUM_STATES` the index cannot name a
+/// state at all (`Illegal Value`); inside it, it names one the server did
+/// not fill in (`Enum Index Overflow`). Falling through both to the bare
+/// number, as this did, made `caget -d 24` on a DOUBLE record print the
+/// index where C prints its diagnosis.
 fn format_enum(idx: i64, fmt: &ValueFormat, enum_strings: Option<&[PvString]>) -> String {
-    if !fmt.enum_as_number
-        && let Some(strs) = enum_strings
-        && idx >= 0
-        && (idx as usize) < strs.len()
-    {
+    if let Some(strs) = enum_strings.filter(|_| !fmt.enum_as_number) {
+        if !(0..MAX_ENUM_STATES).contains(&idx) {
+            return format!("Illegal Value ({idx})");
+        }
+        let Some(label) = strs.get(idx as usize) else {
+            return format!("Enum Index Overflow ({idx})");
+        };
         // Escape the label bytes exactly like a DBR_STRING (line 166):
         // enum choice labels are raw, not-guaranteed-UTF-8 bytes, so a
         // byte-wise escaper renders them faithfully on the CLI.
-        return escape_from_raw(strs[idx as usize].as_bytes());
+        return escape_from_raw(label.as_bytes());
     }
     // C `val2str`'s DBR_ENUM arm prints a bare index with `sprintf("%d")`
     // (`tool_lib.c:187`) — the `-0x`/`-0o`/`-0b` base (`outTypeI`) is
@@ -1255,6 +1340,64 @@ mod tests {
         fmt.enum_as_number = true;
         let s = fv(&v, &fmt, Some(&strs), false);
         assert_eq!(s, "1");
+    }
+
+    /// The two out-of-range arms C keeps apart (`tool_lib.c:172-186`),
+    /// measured against C `caget` on a `softIoc` DOUBLE record read as
+    /// `-d DBR_GR_ENUM`: such a channel answers `no_str = 0` and casts the
+    /// value to an index, so every value lands out of range.
+    ///
+    /// | VAL   | index | C prints                  |
+    /// |-------|-------|---------------------------|
+    /// | 0     | 0     | `Enum Index Overflow (0)` |
+    /// | 1.5   | 1     | `Enum Index Overflow (1)` |
+    /// | 20    | 20    | `Illegal Value (20)`      |
+    /// | 70000 | 4464  | `Illegal Value (4464)`    |
+    #[test]
+    fn an_index_past_the_string_table_is_an_overflow() {
+        let strs: Vec<PvString> = vec!["off".into(), "on".into()];
+        for (idx, want) in [
+            (2, "Enum Index Overflow (2)"),
+            (15, "Enum Index Overflow (15)"),
+            (16, "Illegal Value (16)"),
+            (4464, "Illegal Value (4464)"),
+        ] {
+            assert_eq!(
+                fv(&EpicsValue::Enum(idx), &fmt_default(), Some(&strs), false),
+                want,
+                "index {idx}"
+            );
+        }
+    }
+
+    /// `no_str = 0` is the shape a numeric PV answers a GR/CTRL enum request
+    /// with, and it has no in-range index at all.
+    #[test]
+    fn an_empty_string_table_overflows_at_zero() {
+        let none: Vec<PvString> = vec![];
+        assert_eq!(
+            fv(&EpicsValue::Enum(0), &fmt_default(), Some(&none), false),
+            "Enum Index Overflow (0)"
+        );
+    }
+
+    /// `-n` keeps the bare index on every arm — C tests `!enumAsNr` before
+    /// it looks at the table at all, so neither diagnosis can appear.
+    #[test]
+    fn the_n_flag_suppresses_both_diagnoses() {
+        let strs: Vec<PvString> = vec!["off".into(), "on".into()];
+        let mut fmt = fmt_default();
+        fmt.enum_as_number = true;
+        assert_eq!(fv(&EpicsValue::Enum(2), &fmt, Some(&strs), false), "2");
+        assert_eq!(fv(&EpicsValue::Enum(20), &fmt, Some(&strs), false), "20");
+    }
+
+    /// A request that carries NO string table — plain / STS / TIME `DBR_ENUM`
+    /// — prints the raw number however far out of range it is. C reaches its
+    /// `sprintf("%d")` fall-through without consulting a table it was not sent.
+    #[test]
+    fn an_enum_without_a_string_table_stays_numeric() {
+        assert_eq!(fv(&EpicsValue::Enum(20), &fmt_default(), None, false), "20");
     }
 
     #[test]
@@ -1822,5 +1965,54 @@ mod tests {
         // DBR_CTRL_DOUBLE`), which C prints with its own literal `%g`.
         assert_eq!(format_c_g(f64::NAN), "nan");
         assert_eq!(format_c_g(f64::NEG_INFINITY), "-inf");
+    }
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Measured against C `caget ''` (rc=1, this exact stderr line, no
+    /// search sent and no timeout spent) — `cac::createChannel` refuses an
+    /// empty name at `cac.cpp:522-524`.
+    #[test]
+    fn an_empty_name_is_refused_before_any_search() {
+        assert_eq!(
+            uncreatable_names_message(&names(&[""])).as_deref(),
+            Some("CA error Invalid string occurred while trying to create channel ''.")
+        );
+    }
+
+    /// The boundary `nciu.cpp:56` tests is `strlen(name) + 1 >
+    /// MAX_UDP_SEND - sizeof(caHdr)`, i.e. 1007 characters fit and 1008 do
+    /// not. Measured: C `caget` spends its full connect timeout on the
+    /// 1007-char name and refuses the 1008-char one instantly.
+    #[test]
+    fn the_name_length_bound_is_the_search_datagrams_room() {
+        assert!(channel_name_is_creatable(&"X".repeat(1007)));
+        assert!(!channel_name_is_creatable(&"X".repeat(1008)));
+    }
+
+    /// C's loop reports EVERY rejected name and only then returns 1, so a
+    /// creatable name beside an uncreatable one does not suppress the line
+    /// — and does not earn a connect wait either.
+    #[test]
+    fn every_rejected_name_gets_its_own_line_in_argv_order() {
+        let msg = uncreatable_names_message(&names(&["", "T:ai", &"X".repeat(1008)]));
+        let long = "X".repeat(1008);
+        assert_eq!(
+            msg.as_deref(),
+            Some(
+                format!(
+                    "CA error Invalid string occurred while trying to create channel ''.\n\
+                     CA error Invalid string occurred while trying to create channel '{long}'."
+                )
+                .as_str()
+            )
+        );
+    }
+
+    #[test]
+    fn creatable_names_produce_no_diagnostic() {
+        assert_eq!(uncreatable_names_message(&names(&["T:ai", "T:ao"])), None);
     }
 }

--- a/crates/epics-ca-rs/src/copt.rs
+++ b/crates/epics-ca-rs/src/copt.rs
@@ -32,6 +32,24 @@
 //! family; and the resolvers here take the whole occurrence list, so
 //! "last wins" is the only shape a caller can express.
 //!
+//! # Long options are a port EXTENSION, and that is a deviation not a defect
+//!
+//! The goal is broad compatibility plus features that are reasonably needed,
+//! not parity: a strict superset keeps everything a site script written for C
+//! depends on, and a script written against our long forms failing on C is
+//! not our compatibility to keep.
+//!
+//! `getopt(3)` (not `getopt_long`) means C has no long options at all: every
+//! `--name` form ends the loop at `case '?'` with `Unrecognized option:
+//! '--'. ('caget -h' for help.)` on stderr and exit 1 — measured for
+//! `--help`, `--version`, `caget --wait`, `caput --timeout`,
+//! `cainfo --wait` and `camonitor --num-enum`. The port declares a long
+//! alias beside every short option and accepts all of them, and the superset
+//! is strict: every argv C accepts behaves identically (the differential
+//! harness is byte-clean on 115 cases against both a C `softIoc` and
+//! `softioc-rs`, `--` and a bare `-` included), so the only divergence is
+//! argv C REFUSES.
+//!
 //! # Order (R13-26)
 //!
 //! getopt processes options STRICTLY in command-line order, and `case 'h'` /
@@ -279,9 +297,10 @@ pub enum Terminal {
     /// `caput.c:60-62`, `cainfo.c:37-39`), and the `-h` case just calls that
     /// same function. One block, one stream, both statuses — the port used to
     /// split it, sending the exit-0 half to stdout because that is where clap
-    /// puts help. The block's WORDING is still clap's, not C's — a standing,
-    /// separate divergence. `-V` keeps stdout: C prints the version banner with
-    /// `printf` (`caget.c:404`).
+    /// puts help. The WORDING is the tool's own `usage()` text, handed to
+    /// [`Scan::finish`]; clap's renderer never reaches a user's terminal.
+    /// `-V` keeps stdout: C prints the version banner with `printf`
+    /// (`caget.c:404`).
     Usage(i32),
     /// C `case 'V'`: the version banner on stdout, `return 0`.
     Version,
@@ -402,8 +421,11 @@ impl<'m> Scan<'m> {
     /// precedes the offending token still wins, because C's loop reaches it
     /// first and `return`s 0 (R14-18).
     ///
-    /// `cmd` renders the usage block; `version_info` is the tool's `-V` banner.
-    pub fn finish(self, cmd: &clap::Command, version_info: &str, terminals: &[(&str, Terminal)]) {
+    /// `usage` is the tool's `usage()` block, byte for byte as its C
+    /// counterpart writes it; `version_info` is the tool's `-V` banner. Both
+    /// are text, not a `clap::Command`, so no help renderer can substitute
+    /// its own wording for C's on the way out.
+    pub fn finish(self, usage: &str, version_info: &str, terminals: &[(&str, Terminal)]) {
         let terminal = self.terminal(terminals);
         // The error sits at the offending token, which is past every option in
         // `matches` — [`Parsed`] parsed only the argv PREFIX before it — so any
@@ -440,7 +462,7 @@ impl<'m> Scan<'m> {
             Some((_, Terminal::Usage(status))) => {
                 // C's `usage()` writes to stderr whatever brought it here —
                 // `-h`, or the `default:` arm's exit-1 path.
-                let _ = cmd.clone().write_help(&mut std::io::stderr());
+                let _ = std::io::stderr().write_all(usage.as_bytes());
                 std::process::exit(status)
             }
         }

--- a/crates/epics-ca-rs/src/lib.rs
+++ b/crates/epics-ca-rs/src/lib.rs
@@ -33,6 +33,8 @@
 //! | `epics-base` | `R7.0.10` |
 //! | `pvxs` | `1.5.1-42-gb568e93` |
 //! | `ca-gateway` | `R2-1-3-0-54-g0666f21` |
+//! | `asyn` | `R4-45-19-ge2a281e2` |
+//! | `iocStats` | `4.0.1` |
 //!
 //! **Resolve by symbol at the pin; the line is a hint.** Find the named
 //! function, struct, macro or field first, and treat the line number as a hint

--- a/crates/epics-ca-rs/src/repeater.rs
+++ b/crates/epics-ca-rs/src/repeater.rs
@@ -16,16 +16,21 @@ pub async fn run_repeater() -> io::Result<()> {
 
 /// Run the CA repeater daemon with an explicit debug level.
 ///
-/// Mirrors epics-base PR #831 (commit `e2717521` "Added -d option
-/// to caRepeater, sets debug level"), i.e. C `ca_repeater(setDebug)`
-/// assigning the file-static `debug` (`repeater.cpp:493-502`):
-/// - level 0: the four `debugPrintf` sites C leaves unguarded still
-///   print — `CA Repeater: Attached and initialized` among them.
-/// - level 1: also "New client", "Verified N active clients",
-///   "Client on port N refused message", "Deleted client on port N" —
-///   high-level client lifecycle.
+/// C `ca_repeater` takes no argument at the R7.0.10 pin; the level is
+/// `e271752158dd` ("Added -d option to caRepeater, sets debug level"),
+/// which gives it a `setDebug` parameter assigning a file-static
+/// `debug`:
+/// - level 0: nothing. Every `debugPrintf` in `repeater.cpp` is silent
+///   in a stock C repeater — compiled out at the pin, and post-tag
+///   sent to `/dev/null` by `caRepeater.cpp` unless `-d`/`-v` — so
+///   `DebugGate` has no variant for it.
+/// - level 1: "CA Repeater: Attached and initialized", "New client",
+///   "Verified N active clients", "Client on port N refused message",
+///   "Deleted client on port N" — the sites C guards with `if (debug)`
+///   plus the four it leaves unguarded, which reach a terminal only
+///   with `-d` anyway.
 /// - level 2: also per-beacon "Sent to port N" and per-client
-///   "Client on port N is alive" verification.
+///   "Client on port N is alive" verification, C `if (debug > 1)`.
 ///
 /// Which stream a line takes is `Diag`'s business, not this level's:
 /// `debugPrintf` is stdout, `fprintf(stderr, …)` is stderr, and
@@ -42,7 +47,7 @@ pub async fn run_repeater_with_debug(debug: u8) -> io::Result<()> {
     use socket2::{Domain, Protocol, Socket, Type};
     let diag = Diag::new(debug);
     // C folds socket creation and bind into one `makeSocket` errno
-    // (`repeater.cpp:94-129`), so a failure at either step reaches the same
+    // (`repeater.cpp:91-126`), so a failure at either step reaches the same
     // pair of diagnostics at `:513-531`.
     let sock = match Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)) {
         Ok(s) => s,
@@ -82,7 +87,7 @@ pub async fn run_repeater_with_debug(debug: u8) -> io::Result<()> {
     // multiple IOCs share the CA port; the repeater daemon port does not.
     //
     // C `ca_repeater` decides what a bind failure MEANS right here and
-    // returns from its void function either way (`repeater.cpp:513-531`):
+    // returns from its void function either way (`repeater.cpp:501-519`):
     // EADDRINUSE is the ordinary "someone else got there first" and prints
     // on stdout, anything else is fatal and prints on stderr. Handing the
     // bare `io::Error` up made the caller re-derive that — and `caget-rs`,
@@ -92,7 +97,7 @@ pub async fn run_repeater_with_debug(debug: u8) -> io::Result<()> {
     if let Err(e) = sock.bind(&bind_sa) {
         if e.kind() == io::ErrorKind::AddrInUse {
             diag.printf(
-                0,
+                DebugGate::Debug,
                 format_args!("CA Repeater: Exiting, a repeater is already running"),
             );
         } else {
@@ -130,13 +135,17 @@ pub async fn run_repeater_with_debug(debug: u8) -> io::Result<()> {
         );
     }
 
-    // C `repeater.cpp:583`. `debugPrintf` is `::printf` here (`:73`
-    // `#define DEBUG`), so this is stdout and UNGUARDED — a stock C
-    // `caget` whose `caStartRepeaterIfNotInstalled` fell back to the
-    // in-process `caRepeaterThread` prints it on its own stdout. The port
-    // gated it behind `debug > 0` and sent it to stderr, which is the
-    // whole of the observed client-side A/B difference.
-    diag.printf(0, format_args!("CA Repeater: Attached and initialized"));
+    // C `repeater.cpp:571`, a `debugPrintf` inside no `if (debug)`.
+    // Unguarded is not the same as printed: at the pin `repeater.cpp`
+    // defines no `DEBUG`, so the macro expands to nothing, and after
+    // `e271752158dd` adds `#define DEBUG` the line still goes to
+    // `caRepeater.cpp`'s `/dev/null` unless `-d`/`-v`. This port ran it
+    // in-process on a CA client's own stdout, so it needs the gate more
+    // than C does, not less.
+    diag.printf(
+        DebugGate::Debug,
+        format_args!("CA Repeater: Attached and initialized"),
+    );
 
     let mut clients: HashMap<u16, RepeaterClient> = HashMap::new();
     let mut buf = [0u8; 4096];
@@ -156,7 +165,7 @@ pub async fn run_repeater_with_debug(debug: u8) -> io::Result<()> {
                         e.kind(),
                         std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::ConnectionReset
                     ) {
-                        // C `repeater.cpp:602` is `fprintf(stderr, …)`, and
+                        // C `repeater.cpp:590` is `fprintf(stderr, …)`, and
                         // stderr is where `caRepeater -v` leaves it. A
                         // `tracing::warn!` reached nobody in a daemon that
                         // installs no subscriber.
@@ -413,7 +422,7 @@ fn spawn_repeater() {
 }
 
 /// C reports a bind-test socket it cannot create exactly once
-/// (`repeater.cpp:382-398`, the `static bool init`), so an exhausted fd
+/// (`repeater.cpp:372-388`, the `static bool init`), so an exhausted fd
 /// table gives one line rather than one per registration datagram.
 static BIND_TEST_SOCKET_REPORTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
@@ -491,10 +500,12 @@ mod tests {
         /// received.
         ///
         /// WHICH stream a `repeater.cpp` diagnostic takes is half of what this
-        /// module got wrong: `debugPrintf` is `::printf` (stdout) because
-        /// `repeater.cpp:73` `#define DEBUG`s before including `iocinf.h`, while
-        /// the port emitted every line on stderr. Asserting the bytes alone
-        /// would not have caught that, so the tests assert the stream too.
+        /// module got wrong: `debugPrintf` is `::printf` (stdout) wherever the
+        /// facility is compiled in — `#define DEBUG` before `iocinf.h`, added
+        /// post-R7.0.10 in `e271752158dd` — while the port emitted every line
+        /// on stderr. Asserting the bytes alone would not have caught that, so
+        /// the tests assert the stream too. The other half was WHETHER it takes
+        /// one at all; `repeater_is_silent_at_debug_zero` covers that.
         pub(crate) fn capture_streams<F: FnOnce() -> R, R>(f: F) -> (R, String, String) {
             use std::io::{Read, Write};
             use std::os::fd::FromRawFd;
@@ -545,11 +556,12 @@ mod tests {
         }
     }
 
-    /// C `repeater.cpp:515-521`: a repeater that loses the race for the
-    /// port says so with a `debugPrintf` — stdout, and inside no
-    /// `if (debug)`, so it prints at the stock level 0 — and then returns.
-    /// The port propagated a bare `AddrInUse` instead, which `caget-rs`'s
-    /// in-process fallback discards with `let _ =`.
+    /// C `repeater.cpp:505-510`: a repeater that loses the race for the
+    /// port says so with a `debugPrintf` — stdout — and then returns. The
+    /// port propagated a bare `AddrInUse` instead, which `caget-rs`'s
+    /// in-process fallback discards with `let _ =`. The line needs `-d`:
+    /// C leaves this site outside any `if (debug)`, but the facility is
+    /// shut at level 0 either way, so the test asserts both halves.
     // RTEMS-EXEC-MODEL-ALLOW(1): builds and enters its own current-thread
     // runtime rather than taking an ambient one; green on the exec
     // backend.
@@ -567,8 +579,18 @@ mod tests {
             .build()
             .expect("test runtime");
 
-        let (result, out, err) =
+        let (quiet, quiet_out, _) =
             stream_capture::capture_streams(|| rt.block_on(run_repeater_with_debug(0)));
+        assert!(quiet.is_ok(), "a lost bind race is not an error: {quiet:?}");
+        assert!(
+            quiet_out.is_empty(),
+            "the `debugPrintf` facility is shut at debug 0 — a CA client tool \
+             runs this repeater in-process, so its stdout must stay clean; \
+             got {quiet_out:?}"
+        );
+
+        let (result, out, err) =
+            stream_capture::capture_streams(|| rt.block_on(run_repeater_with_debug(1)));
 
         assert!(
             result.is_ok(),
@@ -587,22 +609,103 @@ mod tests {
         drop(held);
     }
 
-    /// The bytes and the stream of three `repeater.cpp` diagnostics, taken
-    /// off a live `run_repeater_with_debug`.
+    /// The `debugPrintf` facility is shut at debug 0, on the path where
+    /// that matters: a full registration, which fires the banner, `New
+    /// client on port %u` and `Verified %u active clients` — the three
+    /// lines the sibling test reads at `-d 1`.
     ///
-    /// * `CA Repeater: Attached and initialized` — `repeater.cpp:583`, a
-    ///   `debugPrintf` inside NO `if (debug)`, so it prints at the stock
-    ///   level 0. Captured from the C build for comparison: with the
-    ///   `caRepeater` executable off `PATH` (so
-    ///   `caStartRepeaterIfNotInstalled` falls back to the in-process
-    ///   `caRepeaterThread`), `caget NOSUCH:PV` writes exactly this line to
-    ///   its own **stdout** while `Channel connect timed out` goes to
-    ///   stderr. The port gated it behind `debug > 0` and put it on stderr.
-    /// * `New client on port %u` — `repeater.cpp:136`, the `repeaterClient`
-    ///   constructor, inside `if (debug)`.
-    /// * `Verified %u active clients` — `repeater.cpp:332`, and this is the
-    ///   only function in the file that prints it; the port also printed it
-    ///   from `fanOut` and from a registration wrapper.
+    /// `ensure_repeater` runs this daemon on a background thread inside
+    /// whichever CA client tool could not find a `caRepeater` binary, so
+    /// anything it writes to stdout is written into that tool's data
+    /// channel. C never does: at R7.0.10 `repeater.cpp` defines no
+    /// `DEBUG` and the macro expands to nothing, and after
+    /// `e271752158dd` `caRepeater.cpp` `dup2`s stdout to `/dev/null`
+    /// unless `-d`/`-v`. C's `fprintf(stderr, …)` sites are ungated and
+    /// stay ungated here, so only stdout is asserted.
+    // RTEMS-EXEC-MODEL-ALLOW(1): builds and enters its own multi-thread
+    // runtime rather than taking an ambient one; green on the exec
+    // backend.
+    #[cfg(unix)]
+    #[test]
+    fn repeater_is_silent_at_debug_zero() {
+        use std::time::{Duration, Instant};
+
+        let free_port = StdUdpSocket::bind("127.0.0.1:0")
+            .expect("probe bind")
+            .local_addr()
+            .expect("probe addr")
+            .port();
+        // SAFETY: nextest runs each test in its own process.
+        unsafe { std::env::set_var("EPICS_CA_REPEATER_PORT", free_port.to_string()) };
+
+        let client = std::sync::Arc::new(StdUdpSocket::bind("127.0.0.1:0").expect("client bind"));
+        client
+            .set_read_timeout(Some(Duration::from_millis(200)))
+            .expect("client read timeout");
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("test runtime");
+
+        let (confirmed, out, err) = stream_capture::capture_streams(|| {
+            let held = std::sync::Arc::clone(&client);
+            rt.block_on(async move {
+                let repeater = tokio::spawn(run_repeater_with_debug(0));
+                let confirmed = tokio::task::spawn_blocking(move || {
+                    let register = CaHeader::new(CA_PROTO_REPEATER_REGISTER).to_bytes();
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    let mut buf = [0u8; 64];
+                    while Instant::now() < deadline {
+                        let _ = client.send_to(&register, ("127.0.0.1", free_port));
+                        if let Ok((n, _)) = client.recv_from(&mut buf) {
+                            if n >= CaHeader::SIZE {
+                                if let Ok(h) = CaHeader::from_bytes(&buf[..n]) {
+                                    if h.cmmd == CA_PROTO_REPEATER_CONFIRM {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    false
+                })
+                .await
+                .unwrap_or(false);
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                repeater.abort();
+                drop(held);
+                confirmed
+            })
+        });
+
+        assert!(
+            confirmed,
+            "the repeater never confirmed the registration; captured stdout \
+             {out:?} stderr {err:?}"
+        );
+        assert!(
+            out.is_empty(),
+            "a repeater at debug 0 must write nothing to stdout — it shares \
+             one with the CA client tool that started it; got {out:?}"
+        );
+    }
+
+    /// The bytes and the stream of three `repeater.cpp` diagnostics, taken
+    /// off a live `run_repeater_with_debug` at `-d 1` — at level 0 the
+    /// facility is shut, which `repeater_is_silent_at_debug_zero` covers.
+    ///
+    /// * `CA Repeater: Attached and initialized` — `repeater.cpp:571`, a
+    ///   `debugPrintf` inside no `if (debug)`. The port put it on stderr.
+    /// * `New client on port %u` — `repeater.cpp:133`, the `repeaterClient`
+    ///   constructor, `#ifdef DEBUG` at the pin and `if (debug)` after
+    ///   `e271752158dd`.
+    /// * `Verified %u active clients` — post-pin, added by `e271752158dd`
+    ///   at the tail of `verifyClients` (`repeater.cpp:310-325` at
+    ///   R7.0.10), and that is the only function in the file that prints
+    ///   it; the port also printed it from `fanOut` and from a
+    ///   registration wrapper.
     // RTEMS-EXEC-MODEL-ALLOW(1): builds and enters its own multi-thread
     // runtime rather than taking an ambient one; green on the exec
     // backend.
@@ -624,7 +727,7 @@ mod tests {
         unsafe { std::env::set_var("EPICS_CA_REPEATER_PORT", free_port.to_string()) };
 
         // `verifyClients` bind-tests the client's own address, and C's
-        // order is confirm-then-sweep (`repeater.cpp:453-486`) — so the
+        // order is confirm-then-sweep (`repeater.cpp:443-476`) — so the
         // socket has to stay open past the CONFIRM or the sweep correctly
         // reaps it. Share it rather than moving it into the blocking task,
         // whose return would close it.

--- a/crates/epics-ca-rs/src/repeater_clients.rs
+++ b/crates/epics-ca-rs/src/repeater_clients.rs
@@ -47,36 +47,60 @@ use std::net::{Ipv4Addr, SocketAddr, UdpSocket as StdUdpSocket};
 use crate::protocol::*;
 
 /// C `__FILE__` for `repeater.cpp` as the base build compiles it — the
-/// literal the `fprintf(stderr, "%s: …", __FILE__, …)` sites at `:148`,
-/// `:158` and `:526` put on the terminal. Verified in the built artifact:
+/// literal the `fprintf(stderr, "%s: …", __FILE__, …)` sites at `:145`,
+/// `:155` and `:514` put on the terminal. Verified in the built artifact:
 /// `strings lib/linux-x86_64/libca.so` carries `../repeater.cpp`.
 pub(crate) const C_FILE: &str = "../repeater.cpp";
 
-/// The three diagnostic facilities `repeater.cpp` uses, and the debug
-/// threshold each of its call sites carries.
+/// The three diagnostic facilities `repeater.cpp` uses.
 ///
-/// `repeater.cpp:73` does `#define DEBUG` *before* `#include "iocinf.h"`,
-/// so `debugPrintf` (`iocinf.h:28-32`) expands to `::printf` — **stdout,
-/// and compiled in, in every stock build**. It is not a debug-only macro
-/// in this translation unit: a `debugPrintf` is silent only where the C
-/// call site itself sits inside `if (debug)` / `if (debug > 1)`. Four of
-/// the eleven (`:187`, `:216`, `:519`, `:583`) sit inside nothing and
-/// print always — `CA Repeater: Attached and initialized` among them,
-/// which is why a C `caget` prints it on stdout and this port's did not.
+/// A stock C repeater prints none of the nine `debugPrintf` lines, at
+/// either revision this port has been read against. At R7.0.10 — the pin
+/// — `repeater.cpp` never defines `DEBUG`, so `debugPrintf`
+/// (`iocinf.h:28-32`) expands to nothing and all nine compile out; five
+/// of them are additionally inside `#ifdef DEBUG`. The runtime facility
+/// arrives after the tag, in `e271752158dd` ("Added -d option to
+/// caRepeater, sets debug level"), which adds `#define DEBUG`, a
+/// file-static `int debug`, `ca_repeater(int setDebug)` and an
+/// `if (debug)` / `if (debug > 1)` around most sites — and even there
+/// `caRepeater.cpp` `dup2`s stdout to `/dev/null` unless `-d` or `-v`
+/// was given. The facility is closed at level 0 both ways.
 ///
-/// The port had a bare `eprintln!` per site behind a single `debug > 0`
-/// gate, so `debug` meant two different things — "C gated this site" and
-/// "C did not gate it, we do" — and every line landed on stderr whatever
-/// facility C used. `Diag` removes that dual meaning: a site names the
-/// facility C uses, and [`Diag::printf`] takes the threshold C wrote at
-/// that site, `0` for the unguarded ones. The three facilities are not
-/// interchangeable — `debugPrintf` is stdout, `fprintf(stderr, …)` is
-/// stderr, and `errlogPrintf` is the errlog queue with its listeners.
+/// The port had it open. A threshold of `0` meant two things at once —
+/// "C wrote no `if (debug)` here" and "the facility is compiled in" —
+/// and `0 >= 0` holds, so four lines printed unasked. That is not a
+/// cosmetic difference: [`crate::repeater::ensure_repeater`]
+/// runs the repeater in-process on a background thread when the
+/// `caRepeater` binary is absent, so those lines came out of a CA client
+/// tool's own stdout, its data channel. [`DebugGate`] removes the dual
+/// meaning by having no variant for `0`; the facility opens only at a
+/// level the operator asked for, and `-d` keeps its meaning.
+///
+/// The three facilities are not interchangeable — `debugPrintf` is
+/// stdout, `fprintf(stderr, …)` is stderr, and `errlogPrintf` is the
+/// errlog queue with its listeners.
 #[derive(Clone, Copy)]
 pub(crate) struct Diag {
-    /// C `repeater.cpp:89` `static int debug`, assigned once from
-    /// `ca_repeater`'s `setDebug` argument (`:502`).
+    /// C's file-static `int debug` and the `setDebug` argument that
+    /// assigns it, both from `e271752158dd`; at the R7.0.10 pin
+    /// `ca_repeater` takes no argument and there is no such variable.
     debug: u8,
+}
+
+/// The `if ( debug… )` a C `debugPrintf` site sits inside, and the only
+/// thing that can open the facility.
+///
+/// There is deliberately no variant for `0`. No `debugPrintf` in
+/// `repeater.cpp` reaches a terminal at debug 0 — see [`Diag`] — so a
+/// `0` threshold describes no C site that exists, and it was the value
+/// that put this port's diagnostics on a CA client's stdout.
+#[derive(Clone, Copy)]
+pub(crate) enum DebugGate {
+    /// C `if ( debug )`, and the four sites C leaves unguarded: both are
+    /// silent until `-d 1`.
+    Debug = 1,
+    /// C `if ( debug > 1 )` — the per-datagram and per-client chatter.
+    Verbose = 2,
 }
 
 impl Diag {
@@ -84,12 +108,12 @@ impl Diag {
         Self { debug }
     }
 
-    /// C `debugPrintf` — `::printf`, i.e. **stdout**. `min_debug` is the
-    /// threshold of the `if (debug…)` the C call site sits inside: `0`
-    /// when it sits inside nothing, `1` for `if (debug)`, `2` for
-    /// `if (debug > 1)`.
-    pub(crate) fn printf(self, min_debug: u8, args: fmt::Arguments<'_>) {
-        if self.debug >= min_debug {
+    /// C `debugPrintf` — `::printf`, i.e. **stdout** — once the facility
+    /// is open. `gate` is the `if (debug…)` the C site sits inside;
+    /// the sites C leaves unguarded take [`DebugGate::Debug`], because
+    /// unguarded in C still means "not without `-d`".
+    pub(crate) fn printf(self, gate: DebugGate, args: fmt::Arguments<'_>) {
+        if self.debug >= gate as u8 {
             println!("{args}");
         }
     }
@@ -139,7 +163,7 @@ pub(crate) struct RepeaterClient {
 
 impl RepeaterClient {
     /// C `repeaterClient::repeaterClient` + `repeaterClient::connect`
-    /// (`repeater.cpp:131-164`). The two fallible steps are C's two, and
+    /// (`repeater.cpp:137-161`). The two fallible steps are C's two, and
     /// each has its own stderr diagnostic: a socket that cannot be made,
     /// and a socket that cannot be connected to the client. Collapsing
     /// them into one `io::Result` the caller answered with `Err(_) =>
@@ -147,7 +171,10 @@ impl RepeaterClient {
     pub(crate) fn new(addr: SocketAddr, diag: Diag) -> Option<Self> {
         // The constructor announces the client BEFORE `connect` runs, so
         // the line appears even for a client whose socket then fails.
-        diag.printf(1, format_args!("New client on port {}", addr.port()));
+        diag.printf(
+            DebugGate::Debug,
+            format_args!("New client on port {}", addr.port()),
+        );
         let sock = match StdUdpSocket::bind("0.0.0.0:0") {
             Ok(s) => s,
             Err(e) => {
@@ -171,7 +198,7 @@ impl RepeaterClient {
         Some(Self { sock, addr, diag })
     }
 
-    /// C `repeaterClient::sendConfirm` (`repeater.cpp:166-190`): a refused
+    /// C `repeaterClient::sendConfirm` (`repeater.cpp:163-187`): a refused
     /// confirm is the ordinary "client went away" answer and stays silent;
     /// any other send error is reported. The port's `.is_ok()` reported
     /// neither.
@@ -185,7 +212,7 @@ impl RepeaterClient {
             Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => false,
             Err(e) => {
                 self.diag.printf(
-                    0,
+                    DebugGate::Debug,
                     format_args!(
                         "CA Repeater: confirm req err was \"{}\"",
                         sock_err_string(&e)
@@ -205,29 +232,32 @@ impl RepeaterClient {
         // EHOSTUNREACH as "client gone".
         //
         // The diagnostics are C `repeaterClient::sendMessage`'s own
-        // (`repeater.cpp:192-220`) and belong here, not in the caller:
+        // (`repeater.cpp:189-217`) and belong here, not in the caller:
         // `fanOut` prints nothing, and only this function knows the errno
         // that decides between the two messages.
         match self.sock.send(data) {
             Ok(_) => {
-                self.diag
-                    .printf(2, format_args!("Sent to port {}", self.addr.port()));
+                self.diag.printf(
+                    DebugGate::Verbose,
+                    format_args!("Sent to port {}", self.addr.port()),
+                );
                 true
             }
             Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
                 self.diag.printf(
-                    1,
+                    DebugGate::Debug,
                     format_args!("Client on port {} refused message", self.addr.port()),
                 );
                 false
             }
             Err(e) => {
-                // C `repeater.cpp:216` — unguarded, so it prints at the
-                // stock debug level. The RETURN value keeps this port's
-                // rule (a transient error must not reap a live client);
-                // only the diagnostic is C's.
+                // C `repeater.cpp:213` — a `debugPrintf` C leaves
+                // outside any `if (debug)`, which still means "not
+                // without `-d`". The RETURN value keeps this port's rule
+                // (a transient error must not reap a live client); only
+                // the diagnostic is C's.
                 self.diag.printf(
-                    0,
+                    DebugGate::Debug,
                     format_args!("CA Repeater: UDP send err was \"{}\"", sock_err_string(&e)),
                 );
                 !matches!(e.kind(), io::ErrorKind::HostUnreachable)
@@ -259,15 +289,15 @@ impl RepeaterClient {
         match StdUdpSocket::bind(bind_addr) {
             Ok(_) => false, // addr free → client gone
             Err(e) if e.kind() == io::ErrorKind::AddrInUse => {
-                // C `repeaterClient::verify` (`repeater.cpp:290-297`).
+                // C `repeaterClient::verify` (`repeater.cpp:282-304`).
                 self.diag.printf(
-                    2,
+                    DebugGate::Verbose,
                     format_args!("Client on port {} is alive", self.addr.port()),
                 );
                 true
             }
             Err(e) => {
-                // C `repeater.cpp:303-309`: a bind test that fails for any
+                // C `repeater.cpp:296-302`: a bind test that fails for any
                 // reason OTHER than EADDRINUSE is neither "alive" nor a
                 // clean departure, and C says so on stderr before
                 // returning false. This port answers `true` instead —
@@ -284,7 +314,7 @@ impl RepeaterClient {
 }
 
 impl Drop for RepeaterClient {
-    /// C `repeaterClient::~repeaterClient` (`repeater.cpp:222-231`) closes
+    /// C `repeaterClient::~repeaterClient` (`repeater.cpp:219-228`) closes
     /// the socket and announces the departure. Putting it in `Drop` is what
     /// makes the line cover EVERY removal path — `fanOut`'s send-failure
     /// reap, `verifyClients`' bind-test sweep, the confirm-failure removal
@@ -292,7 +322,7 @@ impl Drop for RepeaterClient {
     /// print from.
     fn drop(&mut self) {
         self.diag.printf(
-            1,
+            DebugGate::Debug,
             format_args!("Deleted client on port {}", self.addr.port()),
         );
     }
@@ -390,7 +420,7 @@ pub(crate) fn fan_out(clients: &mut HashMap<u16, RepeaterClient>, src: SocketAdd
 /// never aborts: the repeater keeps running for unicast/broadcast beacons.
 ///
 /// `default_port` is the repeater port C passes to
-/// `addAddrToChannelAccessAddressList` (`repeater.cpp:545-546`) and which
+/// `addAddrToChannelAccessAddressList` (`repeater.cpp:533-534`) and which
 /// therefore appears in the failure line, since C renders the address with
 /// `ipAddrToDottedIP` — `a.b.c.d:port` (`osiSock.c:166-169`).
 pub(crate) fn join_beacon_multicast_groups(sock: &socket2::Socket, default_port: u16, diag: Diag) {
@@ -414,7 +444,7 @@ pub(crate) fn join_beacon_multicast_groups(sock: &socket2::Socket, default_port:
             continue;
         }
         if let Err(e) = sock.join_multicast_v4(&addr, &Ipv4Addr::UNSPECIFIED) {
-            // C `repeater.cpp:575` — `errlogPrintf`, not a stream: the
+            // C `repeater.cpp:563` — `errlogPrintf`, not a stream: the
             // line has to reach `errlogAddListener` consumers (the IOC log
             // client among them), which a `tracing::warn!` with different
             // wording never did.
@@ -435,20 +465,22 @@ pub(crate) fn join_beacon_multicast_groups(sock: &socket2::Socket, default_port:
 /// abused. C `caRepeater.c` has no cap; we choose to be stricter.
 pub(crate) const MAX_REPEATER_CLIENTS: usize = 1024;
 
-/// C `verifyClients` (`repeater.cpp:317-335`) — bind-test EVERY registered
+/// C `verifyClients` (`repeater.cpp:310-325`) — bind-test EVERY registered
 /// client and reap the ones whose port is now free.
 ///
 /// This is unconditional: it does NOT wait for a send to fail. C's own
-/// comment at the call site (`repeater.cpp:473-484`) gives the reason —
+/// comment at the call site (`repeater.cpp:463-474`) gives the reason —
 /// "an ICMP error return does not get through to send(), which returns no
 /// error code" on some platforms — so send-failure reaping alone leaks stale
 /// clients there.
 ///
 /// C closes with `debugPrintf("Verified %u active clients\n",
-/// theClients.count())` (`:331-333`) — the SURVIVOR count, and this is the
-/// only function in `repeater.cpp` that prints it. The port used to print it
-/// from `fanOut` and from the registration wrapper, and to print an invented
-/// "Reaped N departed client(s)" here instead.
+/// theClients.count())` — the SURVIVOR count, and this is the only function
+/// in `repeater.cpp` that prints it. The port used to print it from `fanOut`
+/// and from the registration wrapper, and to print an invented "Reaped N
+/// departed client(s)" here instead. That line is post-pin: it and its
+/// `if (debug)` arrive in `e271752158dd`, so R7.0.10's `verifyClients`
+/// (`:310-325`) prints nothing at all.
 pub(crate) fn verify_clients(clients: &mut HashMap<u16, RepeaterClient>, diag: Diag) {
     let dead: Vec<u16> = clients
         .iter()
@@ -458,7 +490,10 @@ pub(crate) fn verify_clients(clients: &mut HashMap<u16, RepeaterClient>, diag: D
     for p in dead {
         clients.remove(&p);
     }
-    diag.printf(1, format_args!("Verified {} active clients", clients.len()));
+    diag.printf(
+        DebugGate::Debug,
+        format_args!("Verified {} active clients", clients.len()),
+    );
 }
 
 /// C `register_new_client` (`repeater.cpp:358-477`), in C's order:
@@ -502,7 +537,7 @@ pub(crate) fn register_client(
     if !confirmed {
         clients.remove(&port);
         diag.printf(
-            1,
+            DebugGate::Debug,
             format_args!("Deleted repeater client on port {port}, error sending ack"),
         );
     }
@@ -515,7 +550,7 @@ pub(crate) fn register_client(
     let noop = CaHeader::new(CA_PROTO_VERSION);
     fan_out(clients, src, &noop.to_bytes());
 
-    // C `repeater.cpp:473-486`: the bind-test sweep, run whenever a
+    // C `repeater.cpp:463-476`: the bind-test sweep, run whenever a
     // registration created a client, and deliberately AFTER the confirm above
     // so the new client is never reaped before it is acknowledged. It carries
     // its own `Verified %u active clients` line.
@@ -843,7 +878,7 @@ mod tests {
         );
     }
 
-    /// C `repeater.cpp:575` reports a failed `IP_ADD_MEMBERSHIP` through
+    /// C `repeater.cpp:563` reports a failed `IP_ADD_MEMBERSHIP` through
     /// `errlogPrintf` — the message queue with its listeners, not a stream —
     /// and renders the group with `ipAddrToDottedIP`, i.e. `a.b.c.d:port`
     /// (`osiSock.c:166-169`). The port used a `tracing::warn!` carrying

--- a/crates/epics-ca-rs/src/server/ca_server.rs
+++ b/crates/epics-ca-rs/src/server/ca_server.rs
@@ -1281,10 +1281,14 @@ impl CaServer {
         let tcp_abort = tcp_handle.abort_handle();
 
         let udp_cfg = addr_list::from_env()?;
-        eprintln!(
-            "CA server: UDP search on port {port}, TCP on port {tcp_port}, beacons → {} address(es)",
+        // C's RSRV announces nothing here, so this line is the port's own —
+        // and it goes through the errlog for the same reason every C boot
+        // line does: `eltc 0` must be able to silence the console. As a raw
+        // `eprintln!` it survived `eltc 0` where every C line vanished.
+        epics_base_rs::runtime::log::errlog_printf(&format!(
+            "CA server: UDP search on port {port}, TCP on port {tcp_port}, beacons → {} address(es)\n",
             udp_cfg.beacon_addrs.len()
-        );
+        ));
 
         // mDNS announce: held for the lifetime of run(). Drops when
         // the function returns, deregistering us from the network.

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -4421,6 +4421,15 @@ pub(crate) async fn serve_write_head(
             format!("{}.{}", record.read().name, field)
         }
     };
+    // The record a deferred put-callback parks a notify on, captured under the
+    // same `entry` borrow as `audit_pv`. C keeps it as `pciu->pPutNotify`'s
+    // `dbChannel` for exactly one purpose: `rsrvFreePutNotify` needs something
+    // to hand `dbNotifyCancel` when the client dies still busy
+    // (`camessage.c:1630-1638`). See [`PendingWriteNotify`]'s `Drop`.
+    let notify_record = match &entry.target {
+        ChannelTarget::SimplePv(_) => None,
+        ChannelTarget::RecordField { record, .. } => Some(record.read().name.clone()),
+    };
 
     // Post-#934 (epics-base 4128a7c07) BOTH opcodes gate the TYPE first,
     // then clamp `m_count` to `dbChannelFinalElements`, then cross-check
@@ -4895,6 +4904,7 @@ pub(crate) async fn serve_write_head(
                 reply,
                 completion,
                 sid,
+                cancel: notify_record.map(|record| (db.clone(), record)),
             }));
         }
         // Synchronous completion — respond immediately. Same echoed type as
@@ -4988,6 +4998,40 @@ pub(crate) struct PendingWriteNotify {
     pub reply: WriteNotifyReply,
     completion: Arc<PutNotifyCompletion>,
     pub sid: u32,
+    /// What the `Drop` below needs to cancel this notify: the database and the
+    /// record it parked on. `None` for a simple PV, which has no `dbCommon`
+    /// and so no `ppn` slot to release. C carries the equivalent as
+    /// `pciu->pPutNotify`'s `dbChannel`.
+    cancel: Option<(Arc<PvDatabase>, String)>,
+}
+
+/// C `rsrvFreePutNotify` (`rsrv/camessage.c:1630-1638`): a client torn down
+/// with `pNotify->busy` still set has its put-callback cancelled, which frees
+/// every record the notify owns and hands each one to its restart-list head.
+///
+/// A `Drop`, not a call at the teardown site, because this is a strong state
+/// transition — the record's slot is claimed on the client's behalf the moment
+/// the notify installs — and every exit path after it must release: a closed
+/// socket, a read error, a cancelled task, an unwind. One finalizer covers them
+/// all, and the alternative is a release that holds only on the paths someone
+/// remembered.
+///
+/// Ordering matters: `rx.close()` FIRST, because
+/// `PvDatabase::cancel_unanswerable_notify` recognises a dead notify by the
+/// sender having no receiver left, and `Drop::drop` runs before the struct's
+/// own fields are dropped. Without the close, the receiver is still alive at
+/// the moment the database is asked, and the cancel finds nothing to do.
+///
+/// A completion that already `settle`d is a no-op here: its wait-set fired, so
+/// the sender is spent and the record's slot is long since empty.
+impl Drop for PendingWriteNotify {
+    fn drop(&mut self) {
+        let Some((db, record)) = self.cancel.as_ref() else {
+            return;
+        };
+        self.rx.close();
+        db.cancel_unanswerable_notify(record);
+    }
 }
 
 impl PendingWriteNotify {
@@ -7506,6 +7550,8 @@ mod write_notify_queue_tests {
             },
             completion: PutNotifyCompletion::new(None),
             sid,
+            // A simple-PV put: nothing parks a notify, so nothing to cancel.
+            cancel: None,
         };
         (p, tx)
     }

--- a/crates/epics-ca-rs/tests/put_notify_cancel_on_client_teardown.rs
+++ b/crates/epics-ca-rs/tests/put_notify_cancel_on_client_teardown.rs
@@ -1,0 +1,269 @@
+//! **A client that dies with its put-callback still busy hands the record to
+//! whoever is queued behind it.**
+//!
+//! C does this from the teardown itself: `rsrvFreePutNotify` sees
+//! `pNotify->busy` and calls `dbNotifyCancel` (`rsrv/camessage.c:1630-1638`),
+//! whose `notifyProcessInProgress` arm runs `restartCheck` on every record the
+//! notify owned (`dbNotify.c:428-434`) — and `restartCheck` pops the record's
+//! restart list and gives the record to its head (`:156-168`).
+//!
+//! The queued client is what makes the teardown call load-bearing rather than
+//! merely tidy. Releasing the slot lazily, at the next put that tests
+//! ownership, cannot reach this case: the second client is ALREADY queued when
+//! the first dies, so nothing further arrives and nothing tests anything. It
+//! waits forever.
+//!
+//! `busy` is the record type that reaches the case without any device
+//! simulation. It withholds `recGblFwdLink` — and so the put-callback — for as
+//! long as VAL is non-zero (`busyRecord.c:271`), which is the contract, not a
+//! stall: the client is expected to wait for the operation the record
+//! represents. A client that gives up instead is exactly the teardown here.
+//!
+//! Both receive loops are driven, because each hands the completion to a
+//! different owner — the async loop to the circuit's write-notify queue, the
+//! blocking driver to its event thread — and the release rides on that owner
+//! dropping the pending. One loop passing says nothing about the other.
+//!
+//! Ports are always ephemeral (`:0`) — never the real 5064, per the
+//! `build() ⟹ listening` port-ownership rule.
+
+// RTEMS-EXEC-MODEL-ALLOW(1): measured, not argued — the 1 ungated case here
+// (the blocking driver's) runs and passes under
+// `EPICS_RS_BUILD_EXEC_BACKEND=thread`.
+
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use epics_base_rs::server::database::PvDatabase;
+use epics_base_rs::server::records::busy::BusyRecord;
+use epics_base_rs::types::EpicsValue;
+use epics_ca_rs::protocol::{
+    CA_MINOR_VERSION, CA_PROTO_CREATE_CHAN, CA_PROTO_ECHO, CA_PROTO_VERSION, CA_PROTO_WRITE_NOTIFY,
+    CaHeader,
+};
+#[cfg(tokio_backend)]
+use epics_ca_rs::server::CaServer;
+use epics_ca_rs::server::blocking::BlockingCaServer;
+
+const PV: &str = "CANCEL:BUSY";
+const DBR_DOUBLE: u16 = 6;
+const IOID_A: u32 = 0x0000_1111;
+const IOID_B: u32 = 0x0000_2222;
+/// Long enough that a completion which is coming at all has landed; the
+/// failing shape never completes, so this is the whole cost of a red run.
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct Raw {
+    sock: TcpStream,
+    pending: VecDeque<Vec<u8>>,
+}
+
+impl Raw {
+    fn connect(addr: SocketAddr) -> Self {
+        let sock = TcpStream::connect(addr).expect("connect");
+        sock.set_read_timeout(Some(READ_TIMEOUT)).expect("timeout");
+        Self {
+            sock,
+            pending: VecDeque::new(),
+        }
+    }
+
+    fn send(&mut self, frame: &[u8]) {
+        self.sock.write_all(frame).expect("write frame");
+    }
+
+    fn next_frame(&mut self) -> Option<Vec<u8>> {
+        if let Some(f) = self.pending.pop_front() {
+            return Some(f);
+        }
+        let mut hdr = [0u8; CaHeader::SIZE];
+        self.sock.read_exact(&mut hdr).ok()?;
+        let mut frame = hdr.to_vec();
+        let mut body = u16::from_be_bytes([hdr[2], hdr[3]]) as usize;
+        if body == 0xFFFF {
+            let mut annex = [0u8; 8];
+            self.sock.read_exact(&mut annex).expect("extended annex");
+            frame.extend_from_slice(&annex);
+            body = u32::from_be_bytes([annex[0], annex[1], annex[2], annex[3]]) as usize;
+        }
+        if body > 0 {
+            let mut rest = vec![0u8; body];
+            self.sock.read_exact(&mut rest).expect("frame body");
+            frame.extend_from_slice(&rest);
+        }
+        Some(frame)
+    }
+
+    fn wait_for(&mut self, cmmd: u16) -> Vec<u8> {
+        let mut held = VecDeque::new();
+        let found = loop {
+            match self.next_frame() {
+                Some(f) if u16::from_be_bytes([f[0], f[1]]) == cmmd => break f,
+                Some(f) => held.push_back(f),
+                None => panic!("circuit fell silent before 0x{cmmd:04x}"),
+            }
+        };
+        held.append(&mut self.pending);
+        self.pending = held;
+        found
+    }
+
+    /// Open a channel on [`PV`] and return its sid.
+    fn open(addr: SocketAddr, cid: u32) -> (Self, u32) {
+        let mut c = Self::connect(addr);
+        c.send(&version_frame());
+        c.send(&create_chan_frame(cid, PV));
+        let cc = c.wait_for(CA_PROTO_CREATE_CHAN);
+        let sid = u32::from_be_bytes([cc[12], cc[13], cc[14], cc[15]]);
+        (c, sid)
+    }
+
+    /// Put with callback, then round-trip an echo so the reply proves the
+    /// receive loop has already run the write head for it.
+    fn put_notify(&mut self, sid: u32, ioid: u32, value: f64) {
+        self.send(&write_notify_frame(sid, ioid, value));
+        self.send(CaHeader::new(CA_PROTO_ECHO).to_bytes().as_ref());
+        self.wait_for(CA_PROTO_ECHO);
+    }
+}
+
+fn version_frame() -> Vec<u8> {
+    let mut h = CaHeader::new(CA_PROTO_VERSION);
+    h.count = CA_MINOR_VERSION;
+    h.available = 0;
+    h.to_bytes().to_vec()
+}
+
+fn create_chan_frame(cid: u32, pv: &str) -> Vec<u8> {
+    let name = epics_ca_rs::protocol::pad_string(pv);
+    let mut h = CaHeader::new(CA_PROTO_CREATE_CHAN);
+    h.postsize = name.len() as u16;
+    h.cid = cid;
+    h.available = CA_MINOR_VERSION as u32;
+    let mut f = h.to_bytes().to_vec();
+    f.extend_from_slice(&name);
+    f
+}
+
+fn write_notify_frame(sid: u32, ioid: u32, value: f64) -> Vec<u8> {
+    let mut h = CaHeader::new(CA_PROTO_WRITE_NOTIFY);
+    h.data_type = DBR_DOUBLE;
+    h.count = 1;
+    h.postsize = 8;
+    h.cid = sid;
+    h.available = ioid;
+    let mut f = h.to_bytes().to_vec();
+    f.extend_from_slice(&value.to_be_bytes());
+    f
+}
+
+fn val(db: &PvDatabase) -> Option<EpicsValue> {
+    db.get_record(PV)?.read().record.get_field("VAL")
+}
+
+/// The async server's completions live in the circuit's write-notify queue
+/// task, so the release rides on that task's `Vec` dropping when the circuit
+/// ends.
+#[cfg(tokio_backend)]
+#[test]
+fn the_async_loop_hands_the_record_to_the_queued_put_callback() {
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<(u16, Arc<PvDatabase>)>();
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+    let server_thread = thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        rt.block_on(async move {
+            let server = CaServer::builder()
+                .port(0)
+                .tcp_port(0)
+                .record(PV, BusyRecord::default())
+                .build()
+                .await
+                .expect("build CA server");
+            ready_tx
+                .send((server.tcp_port(), server.database().clone()))
+                .expect("report tcp port");
+            tokio::select! {
+                _ = server.run() => {}
+                _ = tokio::task::spawn_blocking(move || { let _ = stop_rx.recv(); }) => {}
+            }
+        });
+    });
+
+    let (port, db) = ready_rx.recv().expect("server reports its port");
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    assert_queued_client_is_answered(addr, &db);
+
+    let _ = stop_tx.send(());
+    let _ = server_thread.join();
+}
+
+/// The blocking driver hands the completion to its event thread instead, so
+/// the release rides on that thread's queue dropping. This is also the
+/// embedded path, and the only one an exec-backend run can see.
+#[test]
+fn the_blocking_loop_hands_the_record_to_the_queued_put_callback() {
+    let db = Arc::new(PvDatabase::new());
+    epics_base_rs::runtime::task::block_on_sync(db.add_record(PV, Box::new(BusyRecord::default())))
+        .expect("no async runtime on this thread")
+        .expect("add_record");
+    let server = Arc::new(
+        BlockingCaServer::bind(
+            "127.0.0.1:0",
+            db.clone(),
+            epics_base_rs::server::access_security::new_acf_cell(None),
+        )
+        .expect("bind ephemeral port"),
+    );
+    let addr = server.local_addr().expect("local_addr");
+    let srv = server.clone();
+    let accept = thread::spawn(move || srv.serve());
+
+    assert_queued_client_is_answered(addr, &db);
+
+    server.shutdown();
+    let _ = accept.join();
+}
+
+/// Two clients, one record: the second is queued when the first dies, and C
+/// hands it the record from the teardown itself.
+fn assert_queued_client_is_answered(addr: SocketAddr, db: &PvDatabase) {
+    // Client A takes the record to BUSY. Its callback is withheld by contract,
+    // so A owns the record's notify slot from here on.
+    let (mut a, sid_a) = Raw::open(addr, 0x1111);
+    a.put_notify(sid_a, IOID_A, 1.0);
+    assert_eq!(val(db), Some(EpicsValue::Enum(1)), "A's write landed");
+
+    // Client B arrives while A still owns it. C `processNotifyCommon` tests
+    // ownership above `putCallback` (`dbNotify.c:213-219`), so B writes nothing
+    // and parks on the record's restart list.
+    let (mut b, sid_b) = Raw::open(addr, 0x2222);
+    b.put_notify(sid_b, IOID_B, 0.0);
+    assert_eq!(
+        val(db),
+        Some(EpicsValue::Enum(1)),
+        "a queued put-callback must write nothing until it is replayed"
+    );
+
+    // A gives up and its circuit goes away with the put-callback still busy.
+    drop(a);
+
+    let reply = b.wait_for(CA_PROTO_WRITE_NOTIFY);
+    assert_eq!(
+        u32::from_be_bytes([reply[12], reply[13], reply[14], reply[15]]),
+        IOID_B,
+        "the completion must be B's"
+    );
+    assert_eq!(
+        val(db),
+        Some(EpicsValue::Enum(0)),
+        "restartCheck hands the record to the queued client, which then writes"
+    );
+}

--- a/crates/epics-libcom-rs/src/runtime/log.rs
+++ b/crates/epics-libcom-rs/src/runtime/log.rs
@@ -75,8 +75,14 @@ fn console_subscriber_is_current() -> bool {
 /// subscriber is also what keeps `errlogPrintfNoConsole` off the console and
 /// makes `eltc(0)` mean what C means by it: both are decisions about *these*
 /// bytes, and a `tracing` event carries neither.
-fn console_fallback(line: &str) {
-    if (nothing_is_listening() || console_subscriber_is_current()) && errlog_to_console() {
+///
+/// `local_echo` is C's `msgbufCommit` argument, decided once per message by
+/// [`errlog_post`] under the queue lock. It is a parameter rather than another
+/// [`errlog_to_console`] call because the same answer also decides whether the
+/// producer waits for the drain: two reads of `eltc` would let one message
+/// print without back-pressure, or take back-pressure without printing.
+fn console_fallback(line: &str, local_echo: bool) {
+    if local_echo && (nothing_is_listening() || console_subscriber_is_current()) {
         write_console(&mut std::io::stderr().lock(), line);
     }
 }
@@ -555,8 +561,7 @@ pub fn errlog_sev_printf(severity: ErrlogSevEnum, message: &str) {
             tracing::error!(target: "epics_base_rs::errlog", "{record}")
         }
     }
-    errlog_enqueue(&line);
-    console_fallback(&line);
+    errlog_post(&line, ConsoleEcho::Yes);
 }
 
 /// Emit a pre-formatted message through the errlog facility
@@ -571,8 +576,7 @@ pub fn errlog_sev_printf(severity: ErrlogSevEnum, message: &str) {
 /// for the `"errlog"` output stream (`devStdio.c` `logPrintf`).
 pub fn errlog_printf(message: &str) {
     tracing::info!(target: "epics_base_rs::errlog", "{}", as_record(message));
-    errlog_enqueue(message);
-    console_fallback(message);
+    errlog_post(message, ConsoleEcho::Yes);
 }
 
 /// C `errlogPrintfNoConsole` (`errlog.c:343-364`): the same message queue,
@@ -580,7 +584,7 @@ pub fn errlog_printf(message: &str) {
 /// Listeners — the IOC log client among them — still receive it.
 pub fn errlog_printf_no_console(message: &str) {
     tracing::info!(target: "epics_base_rs::errlog", "{}", as_record(message));
-    errlog_enqueue(message);
+    errlog_post(message, ConsoleEcho::No);
 }
 
 /// C `errlogMessage` (`errlog.c:337-341`) — `errlogPrintf("%s", message)`.
@@ -685,6 +689,15 @@ struct Errlog {
     seq: std::sync::Condvar,
     listeners: std::sync::Mutex<Vec<(ErrlogListenerId, ErrlogListenerFn)>>,
     next_id: std::sync::atomic::AtomicU64,
+    /// Set once, after the worker thread is known to exist.
+    ///
+    /// C has no equivalent because C has no such state: `errlogInit2` calls
+    /// `cantProceed` when the thread will not start (`errlog.c:604-606`), so
+    /// every later line runs in a process that has a drainer. This port keeps
+    /// the IOC alive instead, which makes "no drainer" reachable — and a
+    /// producer that waits for a drain that can never happen would hang the
+    /// IOC on its first log line, turning a degraded log sink into a dead IOC.
+    worker_running: std::sync::atomic::AtomicBool,
 }
 
 static ERRLOG: std::sync::OnceLock<&'static Errlog> = std::sync::OnceLock::new();
@@ -729,6 +742,7 @@ fn errlog_pvt2(bufsize: usize, max_msg_size: usize) -> &'static Errlog {
             seq: std::sync::Condvar::new(),
             listeners: std::sync::Mutex::new(Vec::new()),
             next_id: std::sync::atomic::AtomicU64::new(1),
+            worker_running: std::sync::atomic::AtomicBool::new(false),
         }));
         // C `epicsThreadCreateOpt("errlog", …)` at `epicsThreadPriorityLow`
         // with `epicsThreadStackSmall` (`errlog.c:568-574`).
@@ -738,7 +752,11 @@ fn errlog_pvt2(bufsize: usize, max_msg_size: usize) -> &'static Errlog {
             crate::runtime::task::StackSizeClass::Small,
             move || errlog_worker(errlog),
         );
-        if spawned.is_err() {
+        if spawned.is_ok() {
+            errlog
+                .worker_running
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        } else {
             // C exits the process when the thread cannot be created
             // (`errlog.c:604-606`). Here the queue still accepts and still
             // accounts; only delivery stops, so say so rather than kill an
@@ -806,21 +824,76 @@ fn errlog_worker(errlog: &'static Errlog) {
     }
 }
 
-/// C `msgbufAlloc`/`msgbufCommit` (`errlog.c:113-180`) as one step.
+/// Whether this call site puts the message on the console at all — C's
+/// `localEcho` argument to `msgbufCommit`, which is `pvt.toConsole` for
+/// `errlogVprintf`/`errlogSevVprintf` and a hard `0` for the `NoConsole` pair
+/// (`errlog.c:334`, `:365`, `:388`).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConsoleEcho {
+    Yes,
+    No,
+}
+
+/// C `msgbufAlloc`/`msgbufCommit` (`errlog.c:113-188`) as one step: admit the
+/// message, wake the worker, echo it, and — the part that makes the arena a
+/// bound on *latency* rather than on messages — wait for the drain.
 ///
-/// The admission rule is C's and is what makes the buffer a bound rather than
-/// a `Vec` that grows: a message is accepted only when the WORST CASE still
-/// fits — `bufSize - pos >= 1 + maxMsgSize` — so a burst is dropped and
+/// The admission rule is C's: a message is accepted only when the WORST CASE
+/// still fits — `bufSize - pos >= 1 + maxMsgSize` — so a burst is dropped and
 /// counted instead of consuming memory, and the count reaches the console as
 /// `errlog: lost N messages`.
-fn errlog_enqueue(message: &str) {
+///
+/// # Why the flush is not optional
+///
+/// C pairs that refusal with back-pressure in the same function: after a
+/// message that echoes to the console, logged from a thread that may block and
+/// outside shutdown, `msgbufCommit` runs `errlogFlush()` (`errlog.c:186-187`).
+/// The producer therefore cannot get ahead of the drainer by more than one
+/// message, and `pos` is back at 0 before the next call — which is why a C IOC
+/// boots a 400-line script through a 1280-byte arena and loses nothing.
+///
+/// Porting the arena without the flush turned a bound on memory into silent
+/// loss of listener copies: a boot burst filled `pos` and every further line
+/// was refused until the worker happened to run. The fix belongs here and not
+/// in [`MIN_BUFFER_SIZE`], because no buffer size is large enough — the rule C
+/// relies on is that the producer waits, not that the arena is big.
+///
+/// The three gates are C's and each closes a real path: `ok_to_block` keeps a
+/// scan or serving thread off the drain and, because
+/// [`enter_ioc_thread`](crate::runtime::task::enter_ioc_thread) clears it, also
+/// stops the errlog worker from flushing into itself when a listener logs;
+/// `at_exit` matches C's `!atExit`, the worker having stopped; `local_echo`
+/// matches C's argument, so `errlogPrintfNoConsole` and `eltc(0)` cost no wait.
+fn errlog_post(message: &str, echo: ConsoleEcho) {
     let errlog = errlog_pvt();
+    // C reads it before the lock (`errlog.c:147`); it is this thread's own.
+    let ok_to_block = crate::runtime::task::thread_is_ok_to_block();
+
     let mut q = errlog.queue.lock().expect("errlog queue");
     let was_empty = q.log.pos == 0;
+    let at_exit = q.at_exit;
+    // One read of `eltc` per message, under the same lock that admits it.
+    let local_echo = echo == ConsoleEcho::Yes && q.to_console;
     let accepted = q.accept(message);
     drop(q);
+
     if accepted && was_empty {
         errlog.work.notify_all();
+    }
+    console_fallback(message, local_echo);
+
+    // C `msgbufCommit`'s tail (`errlog.c:186-187`). `accepted` stands for C's
+    // `msgbufAlloc` having returned a buffer at all: a refused message never
+    // reaches `msgbufCommit` and so never flushes there either.
+    if accepted
+        && local_echo
+        && ok_to_block
+        && !at_exit
+        && errlog
+            .worker_running
+            .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        errlog_flush();
     }
 }
 
@@ -1446,6 +1519,182 @@ mod tests {
         q.log.pos = q.buf_size - q.max_msg_size;
         assert!(!q.accept("x"), "one byte past it is not");
         assert_eq!(q.n_lost, 1);
+    }
+
+    /// The defect this arena had without C's back-pressure: a boot burst.
+    ///
+    /// 200 console-echoed messages is what a real `iocBoot` script produces,
+    /// and 1280/256 admits 86 of them at a time. C loses none of it because
+    /// `msgbufCommit` flushes after every echoed message (`errlog.c:186-187`),
+    /// so `pos` is 0 again before the next call. The observable is both halves
+    /// of "nothing was lost": the refusal counter, and the listener copies —
+    /// the console copy is written by the producer here and would survive the
+    /// loss, which is exactly why the counter alone would have looked fine.
+    ///
+    /// Deterministic, not a race: the last message's flush cannot return until
+    /// the worker has completed a pass with it in hand.
+    #[test]
+    #[serial(errlog_listeners)]
+    fn a_boot_sized_burst_of_console_messages_loses_none() {
+        let seen = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let sink = std::sync::Arc::clone(&seen);
+        let id = errlog_add_listener(move |_| {
+            sink.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        const BURST: usize = 200;
+        for i in 0..BURST {
+            errlog_printf(&format!("burst line {i}\n"));
+        }
+
+        let lost = errlog_messages_lost();
+        let heard = seen.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(errlog_remove_listener(id));
+        assert_eq!(lost, 0, "the arena refused {lost} of {BURST}");
+        assert_eq!(heard, BURST, "every message reached the listeners");
+    }
+
+    /// The invariant the previous test rests on, stated directly and in both
+    /// directions: **a producer that echoes to the console and may block does
+    /// not return until the worker has drained its message; one that may not
+    /// block returns straight away.**
+    ///
+    /// C `msgbufCommit` (`errlog.c:186-187`). Holding the worker inside a
+    /// listener makes both halves decidable rather than timed: while the gate
+    /// is shut the drain cannot complete, so a producer that waits for it
+    /// cannot return, and a producer that does not wait must already have.
+    #[test]
+    #[serial(errlog_listeners)]
+    fn only_a_blocking_producer_waits_for_the_drain() {
+        for prologue in [false, true] {
+            let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+            let (entered_tx, entered_rx) = std::sync::mpsc::channel::<()>();
+            let release_rx = std::sync::Mutex::new(release_rx);
+            let holding = std::sync::atomic::AtomicBool::new(false);
+            let id = errlog_add_listener(move |_| {
+                if !holding.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                    let _ = entered_tx.send(());
+                    let _ = release_rx.lock().expect("gate").recv();
+                }
+            });
+
+            // Shuts the gate, and is itself a producer of the kind under test
+            // only in the `false` pass — so the gate is entered from a message
+            // whose own wait has already been satisfied or never taken.
+            let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+            let producer = std::thread::spawn(move || {
+                if prologue {
+                    let _ = crate::runtime::task::enter_ioc_thread(
+                        crate::runtime::task::ThreadPriority::ScanLow,
+                    );
+                }
+                errlog_printf("gated\n");
+                let _ = done_tx.send(());
+            });
+            entered_rx
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .expect("the worker reaches the listener");
+
+            let returned_while_gated = done_rx
+                .recv_timeout(std::time::Duration::from_millis(300))
+                .is_ok();
+            let _ = release_tx.send(());
+            if !returned_while_gated {
+                done_rx
+                    .recv_timeout(std::time::Duration::from_secs(10))
+                    .expect("the producer returns once the drain completes");
+            }
+            producer.join().expect("the producer thread");
+            errlog_flush();
+            assert!(errlog_remove_listener(id));
+
+            assert_eq!(
+                returned_while_gated, prologue,
+                "prologue={prologue}: C waits exactly when `epicsThreadIsOkToBlock`"
+            );
+        }
+    }
+
+    /// The same burst with the console off, which is C's other answer and the
+    /// proof that the burst really does overflow.
+    ///
+    /// `eltc(0)` makes `localEcho` 0, so `msgbufCommit` takes no back-pressure
+    /// and the arena behaves as a pure bound: the messages past 86 are refused
+    /// and counted. Holding the worker inside a listener makes that the only
+    /// possible outcome rather than a race with the drain — and it is the same
+    /// hold that shows the previous test is measuring something, since without
+    /// the flush that burst is this one.
+    #[test]
+    #[serial(errlog_listeners)]
+    fn the_same_burst_with_the_console_off_overflows_and_is_counted() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel::<()>();
+        let release_rx = std::sync::Mutex::new(release_rx);
+        let holding = std::sync::atomic::AtomicBool::new(false);
+        let id = errlog_add_listener(move |_| {
+            if !holding.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                let _ = entered_tx.send(());
+                let _ = release_rx.lock().expect("gate").recv();
+            }
+        });
+
+        let was = eltc(false);
+        errlog_printf("prime\n");
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("the worker reaches the listener");
+
+        for i in 0..200 {
+            errlog_printf(&format!("burst line {i}\n"));
+        }
+        let lost = errlog_messages_lost();
+
+        let _ = release_tx.send(());
+        errlog_flush();
+        eltc(was);
+        assert!(errlog_remove_listener(id));
+        assert!(
+            lost > 0,
+            "a stalled drain plus 200 messages must overflow a 1280-byte arena"
+        );
+    }
+
+    /// The gate that makes the flush safe: the errlog worker must never wait
+    /// for its own next pass.
+    ///
+    /// A listener runs on the worker thread, and a listener that logs is
+    /// ordinary — the IOC log client does it on a reconnect. C is protected by
+    /// `isOkToBlock`, which is 0 for every `epicsThreadCreate` thread; here
+    /// `enter_ioc_thread` clears the same flag for the worker. Without it this
+    /// test does not fail, it hangs, so the wait is bounded and the failure is
+    /// a timeout rather than a wedged process.
+    #[test]
+    #[serial(errlog_listeners)]
+    fn a_listener_that_logs_does_not_wait_for_its_own_drain() {
+        let logged = std::sync::atomic::AtomicBool::new(false);
+        let id = errlog_add_listener(move |_| {
+            if !logged.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                errlog_printf("from inside the listener\n");
+            }
+        });
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let worker = std::thread::spawn(move || {
+            errlog_printf("trigger\n");
+            errlog_flush();
+            let _ = done_tx.send(());
+        });
+        let finished = done_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .is_ok();
+        if finished {
+            worker.join().expect("the logging thread");
+        }
+        assert!(errlog_remove_listener(id));
+        assert!(
+            finished,
+            "the worker flushed into itself and the producer never returned"
+        );
     }
 
     /// Boundary: a message at `maxMsgSize`. C cuts it to `maxMsgSize - 1`

--- a/crates/epics-libcom-rs/src/runtime/task.rs
+++ b/crates/epics-libcom-rs/src/runtime/task.rs
@@ -1410,6 +1410,40 @@ pub fn apply_to_current_thread_under(
     }
 }
 
+thread_local! {
+    /// C `epicsThreadOSD::isOkToBlock` (`osdThread.c`).
+    ///
+    /// `true` here and `false` set by [`enter_ioc_thread`] reproduces C's two
+    /// defaults without a second registry: `create_threadInfo` `calloc`s the
+    /// field to 0 for every `epicsThreadCreate` thread, and `createImplicit`
+    /// (`osdThread.c:710`) sets it to 1 for every thread that reaches the
+    /// epicsThread API without having been created by it. Our EPICS threads are
+    /// exactly the ones that pass the prologue.
+    static OK_TO_BLOCK: std::cell::Cell<bool> = const { std::cell::Cell::new(true) };
+}
+
+/// C `epicsThreadIsOkToBlock` (`osdThread.c:1145-1150`).
+///
+/// "May this thread wait on something that is not bounded by its own work?" —
+/// asked by facilities that would otherwise stall a scan or a serving loop to
+/// keep themselves in step. `runtime::log`'s errlog is the caller C has
+/// (`errlog.c:186`); the answer is what stops a real-time thread from waiting
+/// on the log drain and what stops the log's own worker from waiting on itself.
+pub fn thread_is_ok_to_block() -> bool {
+    OK_TO_BLOCK.with(std::cell::Cell::get)
+}
+
+/// C `epicsThreadSetOkToBlock` (`osdThread.c:1152-1157`).
+///
+/// C's callers are `iocsh` around a script (`iocsh.cpp:1122`, restored at
+/// `:1327`) and `iocInit` (`iocInit.c:126`): both raise a thread that WAS
+/// created by `epicsThreadCreate` back to blocking for the duration of a boot,
+/// because a boot is not real-time work. A thread that never passed
+/// [`enter_ioc_thread`] is already blocking and needs no call.
+pub fn set_thread_ok_to_block(ok: bool) {
+    OK_TO_BLOCK.with(|c| c.set(ok));
+}
+
 /// The prologue an IOC thread runs as its first statement, when it takes on
 /// its role: publish its name to the OS, then request its scheduling band.
 ///
@@ -1444,6 +1478,17 @@ pub fn apply_to_current_thread_under(
 /// invisible to that census, and the census output says so in its own header.
 pub fn enter_ioc_thread(priority: ThreadPriority) -> PriorityApplied {
     name_current_thread();
+    // C `create_threadInfo` leaves `isOkToBlock` at 0 for every thread
+    // `epicsThreadCreate` makes, and `iocsh` raises it back to 1 for the
+    // thread running a shell (`iocsh.cpp:1122`, restored at `:1327`) — as
+    // does `iocInit` for the thread that boots (`iocInit.c:126`), which here
+    // is that same thread running the script's `iocInit` line. The band is
+    // the identity: `ThreadPriority::Iocsh` is taken by the three iocsh
+    // threads and by nothing else, which `ioc_app.rs`'s
+    // `iocsh_threads_take_the_iocsh_band` pins. Deciding it here rather than
+    // at those three spawns keeps one owner for the flag, so a fourth shell
+    // cannot start without it.
+    set_thread_ok_to_block(priority == ThreadPriority::Iocsh);
     #[cfg(target_os = "vxworks")]
     epics_rtems_boot::stats::register_task();
     let applied = apply_to_current_thread(priority);
@@ -4149,6 +4194,48 @@ mod tests {
             "`epicsThreadShowAll` prints exactly what the prologue registered; \
              a registration outside the prologue is a thread that can start \
              without one"
+        );
+    }
+
+    /// Both of C's `isOkToBlock` defaults, and they differ by exactly one
+    /// thing: whether the thread passed the prologue.
+    ///
+    /// C sets 1 in `createImplicit` (`osdThread.c:710`) for a thread that
+    /// reaches the epicsThread API without having been created by it, and
+    /// leaves the `calloc`ed 0 for every `epicsThreadCreate` thread. A test
+    /// thread is the first kind; anything spawned through this module is the
+    /// second. `runtime::log`'s errlog reads it to decide whether a producer
+    /// may wait for the log drain, so getting this backwards either stalls a
+    /// scan thread on the log or lets the log's own worker wait for itself.
+    #[test]
+    fn only_a_thread_that_ran_the_prologue_is_not_ok_to_block() {
+        assert!(
+            thread_is_ok_to_block(),
+            "a thread this module did not create is C's implicit context"
+        );
+        let banded = std::thread::spawn(|| {
+            let _ = enter_ioc_thread(ThreadPriority::ScanLow);
+            let after_prologue = thread_is_ok_to_block();
+            set_thread_ok_to_block(true);
+            (after_prologue, thread_is_ok_to_block())
+        })
+        .join()
+        .expect("the banded thread");
+        assert_eq!(banded, (false, true));
+
+        // The one band that is a shell, so the prologue does what C's
+        // `iocsh`/`iocInit` do to their own thread rather than leaving it at
+        // the `epicsThreadCreate` default.
+        let shell = std::thread::spawn(|| {
+            let _ = enter_ioc_thread(ThreadPriority::Iocsh);
+            thread_is_ok_to_block()
+        })
+        .join()
+        .expect("the shell thread");
+        assert!(shell, "an iocsh thread boots a database and may block");
+        assert!(
+            thread_is_ok_to_block(),
+            "the flag is per-thread: the child's prologue must not clear ours"
         );
     }
 

--- a/crates/epics-macros-rs/src/lib.rs
+++ b/crates/epics-macros-rs/src/lib.rs
@@ -7,6 +7,7 @@
 //! | tree | pinned revision |
 //! | --- | --- |
 //! | `pvxs` | `1.5.1-42-gb568e93` |
+//! | `epics-base` | `R7.0.10` |
 //!
 //! **Resolve by symbol at the pin; the line is a hint.** Find the named
 //! function, struct, macro or field first, and treat the line number as a hint

--- a/crates/epics-oracle-rs/FINDINGS.md
+++ b/crates/epics-oracle-rs/FINDINGS.md
@@ -32,10 +32,14 @@ caput -c -t -w 2 T:CALC.INPM 1
 # ~/work/oracle-ioc/bin/linux-x86_64/softIoc   -> Channel write request failed
 ```
 
-So the default run diffs against **pre-`2ab1bb14c` C** and CBUG-F6 still fires,
-exactly as this document's put phase recorded. `EPICS_ORACLE_DBD` changes the
-denominator only; the IOC binary is `EPICS_ORACLE_IOC_BIN`, and a run that does
-not pin both has not pinned its ground truth.
+`EPICS_ORACLE_DBD` changes the denominator only; the IOC binary is
+`EPICS_ORACLE_IOC_BIN`, and a run that does not pin both has not pinned its
+ground truth.
+
+**Superseded 2026-08-30.** The fat tree has since been rebuilt past
+`2ab1bb14c`: the same eighteen `calc`/`calcout` `INPM`..`INPU` put cases now
+report `{"outcome": "completed"}` on BOTH sides. The two binaries no longer
+differ here, and CBUG-F6's allowlist row was retired for that reason.
 
 ## The denominator
 
@@ -187,17 +191,26 @@ so the zero is measured, not inherited.
 
 **CBUG-F6 fires as an EXPECTED DEVIATION on exactly the nine fields it names**
 (`calc.INPM`..`INPU`): C's `special()` rejects the `SPC_MOD` put, the port
-accepts it. That is the allowlist working as designed — the difference is
-justified by `doc/upstream-c-bugs.md` and is not counted as a defect.
+accepts it. That is the allowlist working as designed: `calcRecord.dbd` declares
+a `special` that `calcRecord.c`'s `special()` never implements, so it falls
+through to `S_db_badChoice` and nine documented link fields cannot be written
+over CA at all. The port declines to reproduce that, so the difference is
+justified and is not counted as a defect.
 
 It still does — but only against the ground truth the harness actually uses.
 Base `2ab1bb14c` (2026-07-21) dropped `special(SPC_MOD)` from `calcRecord.dbd`'s
-`INPM`..`INPU`, and a **stock** `softIoc` built from that tree accepts the nine
-puts, which would make the row STALE and fail the run. The default
-`EPICS_ORACLE_IOC_BIN` is the fat `softIoc`, built before that commit, and it
-still refuses them — measured 2026-08-25, see the ground-truth section above. So
-CBUG-F6 fires on 9 of 842, exactly as recorded here, and it will go STALE the
-moment the fat tree is rebuilt.
+`INPM`..`INPU`, and a `softIoc` built from that tree accepts the nine puts,
+which makes the row STALE and fails the run. The default `EPICS_ORACLE_IOC_BIN`
+was the fat `softIoc`, built before that commit, and it still refused them when
+this was written — measured 2026-08-25, see the ground-truth section above. So
+CBUG-F6 fired on 9 of 842, exactly as recorded here, and it would go STALE the
+moment the fat tree was rebuilt.
+
+**That happened.** A `--phase all` run on 2026-08-30 reported CBUG-F6 STALE:
+C now completes all eighteen `calc`/`calcout` `INPM`..`INPU` puts, the port
+always did, and the two agree. The row is retired. Nothing in the port moved —
+the same run at the preceding commit reports it identically, and the row was
+byte-identical to its state at `24756f664`.
 
 ### The dominant put defect: an empty CALC expression alarms on the port
 
@@ -284,6 +297,18 @@ and there is nothing to compare. They reproduce on every run.
 left both traces empty and `compare` called that agreement. Three cases the
 harness cannot drive is a coverage gap in the monitor probe, and it is named
 here rather than counted as a pass.
+
+SUPERSEDED 2026-08-30 — the gap is closed, and the three rows split two ways.
+`sel.VAL` was never a measurement failure: the `.dbd` declares it
+`special(SPC_NOMOD)`, so no client can drive it and it leaves the drive
+denominator, which is what the PVA monitor phase had always done and the CA
+probe had not (`surface::val_status` now owns the rule for both). The other two
+were the harness calling a reading an absence: a `caput -c` that times out on
+the *callback* over a connected channel and a landed write is the server
+declining to finish, not a write that did not happen, so it is now
+`PutOutcome::NeverCompleted` and the drive counts as a stimulus. Re-measured on
+`--phase all`: `sub.VAL` and `busy.VAL` monitor cases both AGREE (identical
+event streams on both sides), and the monitor phase reports 0 ERROR.
 
 The three original DEFECTs, kept as the record of what was fixed:
 
@@ -397,6 +422,31 @@ out the write callback on a PACT-latched record gets its own bucket with this
 citation attached. Neither is taken here.
 
 The remaining 5: 4 `busy` and 1 `sel`, also identical across both runs.
+
+SUPERSEDED 2026-08-30 — all 5 are closed, and none of them was a flake or an
+instrument failure. `sel.VAL` left the monitor drive denominator (above). The 4
+`busy` were C's `busy` record doing the one thing it exists to do: it declines
+`recGblFwdLink()` while `VAL` is non-zero (busy `docs/busyRecord.md`), and
+`recGblFwdLink()` is the only caller of `dbNotifyCompletion()`, so a `caput -c`
+that leaves the record Busy is *meant* never to complete. Measured at the same
+commit: the three put cases drove `VAL` to `1`, `2` and `-1` and timed out; the
+`0` case completed normally. With the non-completion carried as a reading, the
+monitor case AGREES and the three put cases become DEFECTs on `put_accepted` —
+C answers "accepted, never completed", the port answers "completed". That is a
+port divergence, not a C bug and not a harness failure. Re-measured
+`--phase all`: `ran 23935 = agreed 23448 + expected-deviation 20 + DEFECT 3 +
+no-completion 464 + ERROR 0`.
+
+FIXED 2026-08-30 in the port, and the divergence was structural rather than
+busy's own. `recGblFwdLink` is where `dbNotifyCompletion` lives, so a record
+type that gates the forward link gates the put-callback with it; the port had
+split that into two trait methods and honoured only one at the cycle tail. With
+both read in `complete_put_notify`, the three cases agree on
+"accepted, never completed" with identical readbacks (`Busy`,
+`Illegal_Value`, `Illegal_Value`) and no differences at all:
+`ran 23935 = agreed 23448 + expected-deviation 20 + DEFECT 0 +
+no-completion 467 + ERROR 0`. `--phase pva-monitor` unchanged: 57 ran, 0 DEFECT,
+0 ERROR.
 
 ## Reproducing
 

--- a/crates/epics-oracle-rs/README.md
+++ b/crates/epics-oracle-rs/README.md
@@ -9,10 +9,14 @@ Ground truth is the **fat** C IOC built under `oracle-ioc/`, not base's stock
 denominator. There are two lanes — CA against `softIoc`, and PVA against pvxs
 QSRV2 in `softIocPVX`.
 
-It exists to make "clean" a measurement instead of an opinion. See
-`doc/strategy-2026-07-13.md` §3.2 for the rationale: nineteen audit rounds of
-reading C and Rust side by side never converged, because there was no
-denominator and "verified clean" verdicts kept turning out false.
+It exists to make "clean" a measurement instead of an opinion. It replaced
+reading C and Rust side by side, which ran nineteen rounds without converging:
+the per-round finding count stayed flat in the 22–54 band and then rose to 114
+once the auditor pool widened — the signature of a process bounded by how much
+surface it had looked at, not by how many defects were left — and Round 18
+reopened three entries previously recorded as *verified clean*. More rounds
+answer neither symptom, because reading has no denominator. The `.dbd` is one,
+which is why coverage below is a percentage rather than an impression.
 
 ## Shape
 
@@ -49,7 +53,7 @@ honest experiment puts a real C client in front of both.
 | verdict | meaning |
 |---|---|
 | **AGREED** | both sides produced a reading, and they match |
-| **EXPECTED DEVIATION** | they differ, and an enabled allowlist row justifies it. Four buckets, three justification bases: `NOT-REPRODUCED` and `REPRODUCED` must cite a `CBUG-…` id in `doc/upstream-c-bugs.md`; `DESIGN-DIVERGENCE` and `INSTRUMENT-SUPERSET` are justified by their own `why` and are exempt from that citation rule. All four match, fire and go stale identically |
+| **EXPECTED DEVIATION** | they differ, and an enabled allowlist row justifies it. Four buckets, three justification bases: `NOT-REPRODUCED` and `REPRODUCED` must name the `CBUG-…` id of the upstream C defect they refuse to reproduce, and say in their own `why` what C does and why it is wrong; `DESIGN-DIVERGENCE` and `INSTRUMENT-SUPERSET` are justified by their own `why` and are exempt from that citation rule. All four match, fire and go stale identically |
 | **DEFECT** | they differ and nothing justifies it |
 | **ERROR** | no reading was obtained — IOC would not boot, PV never connected, tool timed out. **Never scored as agreement.** |
 
@@ -143,8 +147,8 @@ was built to end.
   (`--phase pva-read`, `--phase pva-monitor`) are real and measured, but sit
   outside `--phase all` on purpose: different ground truth (`softIocPVX`), a
   different instrument (`pvxget`/`pvxinfo`/`pvxmonitor`), and no CA allowlist,
-  since `doc/upstream-c-bugs.md` is about C's CA behaviour and justifies nothing
-  about QSRV2. Folding them into `all` would merge two populations whose
+  since every `CBUG-…` row records C `softIoc`'s CA-side behaviour and justifies
+  nothing about QSRV2. Folding them into `all` would merge two populations whose
   verdicts are not comparable into one set of counts.
 
 ## What the first run measured

--- a/crates/epics-oracle-rs/allowlist/expected-deviations.toml
+++ b/crates/epics-oracle-rs/allowlist/expected-deviations.toml
@@ -1,21 +1,30 @@
 # Expected-deviation allowlist for the differential oracle.
 #
 # WHAT THIS IS
-# Under the product policy adopted 2026-07-13 (doc/strategy-2026-07-13.md §2),
-# "C's bugs are not the contract. Clean is the goal." So a difference between
-# the C softIoc and the Rust port is NOT automatically a port bug. It is one of
-# these things:
+# Under the product policy adopted 2026-07-13 -- "C's bugs are not the contract.
+# Clean is the goal." -- a difference between the C softIoc and the Rust port is
+# NOT automatically a port bug. It is one of these things:
 #
 #   * a deliberate refusal to reproduce a C defect     -> EXPECTED DEVIATION
 #   * an intentional port DESIGN divergence            -> EXPECTED DEVIATION
 #   * a ground-truth INSTRUMENT superset artifact      -> EXPECTED DEVIATION
 #   * anything else                                     -> PORT DEFECT
 #
+# That policy has three tiers. Interoperability -- the CA and PVA wire protocols,
+# DBR/DBF type codes, opcode framing, the .db/.dbd grammar -- admits no deviation
+# at all; a C client must not be able to tell the difference. Semantics (record
+# processing, alarms, monitor posting, link behaviour) match C where C is right
+# and fix C where C is wrong, documenting the deviation and reporting it
+# upstream: that second half is what this file records. Drivers and applications
+# are held to correctness against hardware and simulators, never to parity with
+# C source.
+#
 # THREE JUSTIFICATION BASES, FOUR BUCKETS
-# Most rows are C-bug refusals: for these the allowlist IS doc/upstream-c-bugs.md.
-# Each NOT-REPRODUCED (or, disabled, REPRODUCED) row transcribes an entry from
-# that catalogue and MUST cite the CBUG id that justifies it; if such a row is
-# not backed by an entry there, the row is wrong.
+# Most rows are C-bug refusals. Each NOT-REPRODUCED (or, disabled, REPRODUCED)
+# row MUST cite the CBUG id of the upstream defect it refuses to reproduce, and
+# -- because this file is the record, not a pointer to one -- its `why` MUST
+# itself name the C symbol, state what C does, why that is wrong, and what the
+# port does instead. A row whose `why` does not stand up without the id is wrong.
 #
 # A DESIGN-DIVERGENCE row is different in kind: it records an INTENTIONAL port
 # design choice that is neither a C-bug refusal nor a defect (e.g. lifting a
@@ -65,23 +74,6 @@ schema = 1
 # --------------------------------------------------------------------------
 # Reachable today: base record/field CA surface.
 # --------------------------------------------------------------------------
-
-[[deviation]]
-id = "CBUG-F6"
-bucket = "NOT-REPRODUCED"
-upstream = "epics-base / calc"
-record_types = ["calc", "calcout"]
-fields = ["INPM", "INPN", "INPO", "INPP", "INPQ", "INPR", "INPS", "INPT", "INPU"]
-surface = ["put_accepted"]
-why = """
-C's calcRecord.dbd declares special(SPC_MOD) on the nine link fields INPM..INPU,
-but calcRecord.c's special() implements only SPC_CALC and falls through to
-S_db_badChoice. So on a C IOC every dbPutField to these nine documented fields is
-REJECTED -- they are unwritable over CA. The port implements them as ordinary
-writable links, so the put is ACCEPTED. The deviation is the port refusing to
-reproduce an upstream defect that makes documented fields unusable.
-Expect: C rejects the put, port accepts it.
-"""
 
 [[deviation]]
 id = "CBUG-E1"
@@ -310,9 +302,11 @@ port serves the same menu minus that one instrument-only choice.
 # Entries that were REPRODUCED and have since been re-adjudicated.
 #
 # A REPRODUCED entry is not a deviation: the port deliberately carries C's bug,
-# so the oracle must see AGREEMENT, and the row sits here disabled while
-# doc/strategy-2026-07-13.md §4 schedules it for re-adjudication under the clean
-# policy. When the port STOPS reproducing the bug the row is flipped to
+# so the oracle must see AGREEMENT, and the row sits here disabled until it is
+# re-adjudicated. Adopting the clean policy left the then-18 REPRODUCED entries
+# as exactly that backlog, with a default disposition: implement the intended
+# behaviour, document the deviation, keep the upstream report.
+# When the port STOPS reproducing the bug the row is flipped to
 # NOT-REPRODUCED and enabled, and the diff it then produces is EXPECTED rather
 # than a defect.
 #
@@ -334,7 +328,7 @@ An INVERTED-limits histogram (LLIM > ULIM) cannot bin anything, so the record is
 genuinely misconfigured. C's add_count tries to raise SOFT/INVALID but writes
 stat/sevr DIRECTLY instead of nsta/nsev, so recGblResetAlarms erases it on the
 process path (dead code -> NO_ALARM) while it sticks on the .SGNL special path.
-Per strategy-2026-07-13 §2 (clean is the goal) the port now REFUSES this: it raises
+Per the clean policy -- C's bugs are not the contract -- the port REFUSES this: it raises
 the alarm through the single nsta/nsev owner (recGblSetSevr), so a misconfigured
 histogram reports SOFT/INVALID CONSISTENTLY on both the process and the .SGNL
 special paths (port fix landed 2026-07-20, CBUG-F12 REPRODUCED -> NOT-REPRODUCED;

--- a/crates/epics-oracle-rs/src/bin/oracle.rs
+++ b/crates/epics-oracle-rs/src/bin/oracle.rs
@@ -15,7 +15,9 @@ use epics_oracle_rs::allowlist::Allowlist;
 use epics_oracle_rs::dbd::Dbd;
 use epics_oracle_rs::ioc::{CTools, PvxTools};
 use epics_oracle_rs::report::CaseResult;
-use epics_oracle_rs::report::{Counts, Denominator, Report, StaleRow, exit_status, run_failures};
+use epics_oracle_rs::report::{
+    Counts, Denominator, Report, StaleRow, UndrivableVal, exit_status, run_failures,
+};
 use epics_oracle_rs::runner::{Runner, select_types, workdir};
 use epics_oracle_rs::surface::{Surface, probe_supported_record_types};
 use epics_oracle_rs::{pvamonitor, pvaread};
@@ -141,6 +143,12 @@ async fn run() -> Result<ExitCode, String> {
     let runner = Runner::new(tools, dbd, workdir(None)?);
     let mut cases: Vec<CaseResult> = Vec::new();
     let drives_puts = matches!(args.phase, Phase::Put | Phase::Monitor | Phase::All);
+    let runs_monitor = matches!(args.phase, Phase::Monitor | Phase::All);
+    // Record types the monitor phase cannot stimulate at all, because the .dbd
+    // says no client may write their VAL. Collected here so the report states
+    // the exclusion; `Runner::probe_monitor` enforces it, and both read the
+    // same owner (`surface::val_status`) as the PVA monitor phase.
+    let mut monitor_undrivable: Vec<UndrivableVal> = Vec::new();
 
     for (i, rt) in types.iter().enumerate() {
         eprintln!("[{}/{}] {rt}", i + 1, types.len());
@@ -165,8 +173,18 @@ async fn run() -> Result<ExitCode, String> {
         if matches!(args.phase, Phase::Put | Phase::All) && drivable {
             cases.extend(runner.probe_puts(rt, &surface, &mut allowlist, args.max_put_cases));
         }
-        if matches!(args.phase, Phase::Monitor | Phase::All) && drivable {
-            cases.extend(runner.probe_monitor(rt, &surface, &mut allowlist));
+        if runs_monitor {
+            // Loud, and it names the rule: a shrunken drive denominator must
+            // never read as a measured-clean one.
+            if let Some(why) = epics_oracle_rs::surface::val_status(&surface, rt).why() {
+                eprintln!("    monitor phase excluded for {rt}: {why}");
+                monitor_undrivable.push(UndrivableVal {
+                    record_type: rt.to_string(),
+                    why: why.to_string(),
+                });
+            } else if drivable {
+                cases.extend(runner.probe_monitor(rt, &surface, &mut allowlist));
+            }
         }
         if matches!(args.phase, Phase::Array | Phase::All) {
             cases.extend(runner.probe_array(rt, &mut allowlist));
@@ -201,6 +219,7 @@ async fn run() -> Result<ExitCode, String> {
             record_types_unimplemented: surface.unimplemented_types.clone(),
             observable_fields: surface.denominator(),
             excluded_noaccess_fields: surface.excluded_noaccess,
+            excluded_undrivable_val: monitor_undrivable,
         },
         field_coverage,
         counts,

--- a/crates/epics-oracle-rs/src/catool.rs
+++ b/crates/epics-oracle-rs/src/catool.rs
@@ -343,33 +343,33 @@ impl CaTools {
         self.put(&args)
     }
 
-    /// The single classifier for every `caput` invocation: did the server
-    /// answer, or did the measurement not happen?
+    /// The single classifier for every `caput` invocation: what did the server
+    /// do, or did the measurement not happen at all?
     ///
-    /// Both spellings used to collapse every `Err` into
-    /// `PutOutcome { accepted: false, … }`, so a spawn failure, the 8 s
-    /// [`TOOL_TIMEOUT`] kill and the `-w` CA timeout were the same value as a
-    /// `SPC_NOMOD` refusal. Both sides then "agreed" that the write was refused
-    /// and the case scored AGREED on an experiment that never ran — which is
-    /// why the put phase could report `ERROR 0` across a whole sweep.
+    /// Both spellings used to collapse every `Err` into a not-accepted outcome,
+    /// so a spawn failure, the 8 s [`TOOL_TIMEOUT`] kill and the `-w` CA timeout
+    /// were the same value as a `SPC_NOMOD` refusal. Both sides then "agreed"
+    /// that the write was refused and the case scored AGREED on an experiment
+    /// that never ran — which is why the put phase could report `ERROR 0` across
+    /// a whole sweep.
     ///
-    /// The two meanings are now different types, so no caller can conflate
+    /// Reading and absence are now different types, so no caller can conflate
     /// them by accident. Which failures are absences is decided by
     /// [`is_measurement_failure`] against the C tools' own strings, because
-    /// `caput` exits 1 for a refusal and for a timeout alike.
+    /// `caput` exits 1 for a refusal, a non-completion and a timeout alike; the
+    /// non-completion is pulled out first, because it is the one string of the
+    /// set that describes the *server* rather than the road to it.
     fn put(&self, args: &[String]) -> Result<PutOutcome, ToolError> {
         match self.run_with_stderr("caput", args) {
+            Ok((_, stderr)) if is_no_completion(&stderr) => Ok(PutOutcome::NeverCompleted),
             Ok((_, stderr)) if is_measurement_failure(&stderr) => {
                 Err(self.err("caput", normalize_ca_error(&stderr)))
             }
-            Ok(_) => Ok(PutOutcome {
-                accepted: true,
-                error: None,
-            }),
+            Ok(_) => Ok(PutOutcome::Completed),
+            Err(e) if is_no_completion(&e.message) => Ok(PutOutcome::NeverCompleted),
             Err(e) if is_measurement_failure(&e.message) => Err(e),
-            Err(e) => Ok(PutOutcome {
-                accepted: false,
-                error: Some(normalize_ca_error(&e.message)),
+            Err(e) => Ok(PutOutcome::Refused {
+                error: normalize_ca_error(&e.message),
             }),
         }
     }
@@ -385,18 +385,21 @@ impl CaTools {
     /// PVA. The put phase keeps the opposite rule, because there the refusal
     /// *is* the observable.
     pub fn caput_drive(&self, pv: &str, value: &str) -> Result<(), ToolError> {
-        let out = self.caput(pv, value)?;
-        if out.accepted {
-            return Ok(());
+        match self.caput(pv, value)? {
+            // A write the server took is a stimulus, whether or not it chose to
+            // report the put complete: the value landed and the record
+            // processed. Withholding the completion is C's `busy` record doing
+            // its job, and erroring on it would throw away the very trace the
+            // case exists to compare.
+            PutOutcome::Completed | PutOutcome::NeverCompleted => Ok(()),
+            PutOutcome::Refused { error } => Err(self.err(
+                "caput",
+                format!(
+                    "drive refused: {pv} <- {value}: {error} — nothing was stimulated, \
+                     so the trace proves nothing"
+                ),
+            )),
         }
-        Err(self.err(
-            "caput",
-            format!(
-                "drive refused: {pv} <- {value}: {} — nothing was stimulated, \
-                 so the trace proves nothing",
-                out.error.unwrap_or_default()
-            ),
-        ))
     }
 
     /// `cainfo` — native DBF type, element count, and access rights.
@@ -618,13 +621,44 @@ fn parse_monitor_line(line: &str) -> Option<MonitorEvent> {
     Some(MonitorEvent { pv, value, alarm })
 }
 
-/// Did the server accept the write, and if not, what did it say?
+/// What the server did with a write.
+///
+/// Three outcomes, not two. "Accepted and never finished" is a third thing a
+/// server can do, and it used to have nowhere to live: it was smuggled out
+/// through the `Err` channel, where it meant "no reading" — so a case where one
+/// server finished the put and the other did not could only score ERROR, and
+/// the divergence this harness exists to find was reported as a failure to
+/// look. C's `busy` record makes that outcome its whole purpose: it declines
+/// `recGblFwdLink()` while `VAL` is non-zero (busy `docs/busyRecord.md`), so the
+/// `ca_put_callback` deliberately never completes, and `caput -c` prints
+/// "Write callback operation timed out" over a channel that connected, a write
+/// that landed and a readback that agrees.
+///
+/// Each variant now means exactly one thing on every path, so no caller can
+/// conflate a refusal, a non-completion and an absence by accident.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub struct PutOutcome {
-    pub accepted: bool,
-    /// The server's rejection, normalized so that host/port/timing noise does
-    /// not masquerade as a behavioral difference.
-    pub error: Option<String>,
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum PutOutcome {
+    /// The server accepted the write and reported the put complete.
+    Completed,
+    /// The server refused the write. The message is normalized so that
+    /// host/port/timing noise does not masquerade as a behavioral difference.
+    Refused { error: String },
+    /// The server accepted the write and never reported completion. A reading
+    /// of the server, not the absence of one: see [`is_no_completion`].
+    NeverCompleted,
+}
+
+impl PutOutcome {
+    /// The [`crate::diff::Surface::PutAccepted`] rendering — what the two sides
+    /// are compared on.
+    pub fn as_surface(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Refused { .. } => "refused",
+            Self::NeverCompleted => "accepted, never completed",
+        }
+    }
 }
 
 /// What `cainfo` reports about a channel — the type/shape/rights surface.
@@ -709,22 +743,25 @@ fn is_measurement_failure(msg: &str) -> bool {
         "timed out after",
         "wait:",
     ];
-    MARKERS.iter().any(|m| msg.contains(m)) || is_no_completion(msg)
+    MARKERS.iter().any(|m| msg.contains(m))
 }
 
 /// `caput.c:567` — the write was accepted and the completion never came.
 ///
-/// The one marker in `is_measurement_failure`'s list that describes the
-/// SERVER rather than the road to it. The other five say we never got to ask:
-/// the channel never connected, the child never spawned, the tool was killed at
-/// `TOOL_TIMEOUT`. This one says both ends of the conversation worked and the
-/// IOC chose never to finish — C's `subRecord.c:119-122` latches `pact = TRUE`
-/// on an empty `SNAM`, `dbProcess` (`dbAccess.c:537`) then returns early for
-/// every later cycle, and no `ca_put_callback` can ever complete.
+/// The one `caput` failure string that describes the SERVER rather than the
+/// road to it, which is why it is NOT in `is_measurement_failure`'s list. The
+/// five markers there say we never got to ask: the channel never connected, the
+/// child never spawned, the tool was killed at `TOOL_TIMEOUT`. This one says
+/// both ends of the conversation worked and the IOC chose never to finish — so
+/// it is a reading, [`PutOutcome::NeverCompleted`], and the case is compared
+/// like any other.
 ///
-/// That distinction is what [`crate::diff::Verdict::NeitherCompleted`] rests
-/// on, so the marker is named once and both readers share it: a bucket that
-/// admitted "spawn:" would be scoring the harness's own crash as a reading.
+/// Two servers do it on purpose. C's `subRecord.c:119-122` latches
+/// `pact = TRUE` on an empty `SNAM` and `dbProcess` (`dbAccess.c:537`) then
+/// returns early for every later cycle; C's `busy` record declines
+/// `recGblFwdLink()` while `VAL` is non-zero, which is the record type's entire
+/// contract (busy `docs/busyRecord.md`) — the caller's `ca_put_callback` is
+/// meant to stay open until something writes "Done".
 pub fn is_no_completion(msg: &str) -> bool {
     msg.contains("Write callback operation timed out")
 }
@@ -865,7 +902,6 @@ mod tests {
         assert!(is_measurement_failure(
             "Write operation timed out: Data was not written."
         ));
-        assert!(is_measurement_failure("Write callback operation timed out"));
         // This harness's own failures.
         assert!(is_measurement_failure("spawn: No such file or directory"));
         assert!(is_measurement_failure("timed out after 8s"));
@@ -877,6 +913,12 @@ mod tests {
         assert!(!is_measurement_failure(
             "ERROR from put operation: Invalid record modification"
         ));
+        // caput.c:567 — the server took the write and declined to finish it.
+        // Also a reading, and the one the `busy` record exists to produce.
+        assert!(!is_measurement_failure(
+            "Write callback operation timed out"
+        ));
+        assert!(is_no_completion("Write callback operation timed out"));
     }
 
     fn sh(script: &str) -> std::process::Child {

--- a/crates/epics-oracle-rs/src/diff.rs
+++ b/crates/epics-oracle-rs/src/diff.rs
@@ -172,18 +172,14 @@ pub fn compare(c: &Observation, rust: &Observation) -> Comparison {
     if let (Some(a), Some(b)) = (&c.put, &rust.put) {
         push(
             Surface::PutAccepted,
-            a.accepted.to_string(),
-            b.accepted.to_string(),
+            a.as_surface().to_string(),
+            b.as_surface().to_string(),
         );
-        // Only compare the *reason* when both refused. If one accepted and the
-        // other refused, PutAccepted already says so and a second finding on
+        // Only compare the *reason* when both refused. If the two outcomes
+        // differ at all, PutAccepted already says so and a second finding on
         // the error text would be double-counting the same divergence.
-        if !a.accepted && !b.accepted {
-            push(
-                Surface::PutError,
-                a.error.clone().unwrap_or_default(),
-                b.error.clone().unwrap_or_default(),
-            );
+        if let (PutOutcome::Refused { error: ea }, PutOutcome::Refused { error: eb }) = (a, b) {
+            push(Surface::PutError, ea.clone(), eb.clone());
         }
     }
     if let (Some(a), Some(b)) = (&c.monitor, &rust.monitor) {
@@ -223,12 +219,12 @@ pub enum Verdict {
     /// behaved alike" and "the operation finished" are two different facts and
     /// a run that folded them together would report a completion it never saw.
     ///
-    /// Not [`Self::Errored`]: the crate already rules that a refusal issued by
-    /// the server is a reading and not a measurement failure
-    /// (`tests/oracle.rs:250-258`), and a completion that never comes from
-    /// EITHER side is the same kind of reading — the two IOCs did the same
-    /// observable thing. A one-sided no-completion is the opposite: it is the
-    /// difference this harness exists to find, so it stays `Errored`.
+    /// Not [`Self::Errored`]: a completion that never comes is a reading of the
+    /// server, [`crate::catool::PutOutcome::NeverCompleted`], exactly as a
+    /// refusal it issued is. A one-sided no-completion is therefore not an
+    /// absence either — it is a difference on
+    /// [`Surface::PutAccepted`], and it scores [`Self::Defect`] unless the
+    /// allowlist justifies it.
     NeitherCompleted,
     Errored,
 }
@@ -317,40 +313,63 @@ mod tests {
         assert!(!r.is_readable(), "...it is an ERROR");
     }
 
+    fn put_obs(o: PutOutcome) -> Observation {
+        Observation {
+            put: Some(o),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn put_rejection_reason_is_only_compared_when_both_sides_refused() {
-        // One accepted, one refused: exactly one finding (PutAccepted).
-        let c = Observation {
-            put: Some(PutOutcome {
-                accepted: false,
-                error: Some("Invalid value".into()),
+        // One completed, one refused: exactly one finding (PutAccepted).
+        let d = compare(
+            &put_obs(PutOutcome::Refused {
+                error: "Invalid value".into(),
             }),
-            ..Default::default()
-        };
-        let r = Observation {
-            put: Some(PutOutcome {
-                accepted: true,
-                error: None,
-            }),
-            ..Default::default()
-        };
-        let d = compare(&c, &r).differences;
+            &put_obs(PutOutcome::Completed),
+        )
+        .differences;
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].surface, Surface::PutAccepted);
     }
 
     #[test]
     fn both_refusing_for_different_reasons_is_a_difference() {
-        let mk = |e: &str| Observation {
-            put: Some(PutOutcome {
-                accepted: false,
-                error: Some(e.into()),
-            }),
-            ..Default::default()
-        };
+        let mk = |e: &str| put_obs(PutOutcome::Refused { error: e.into() });
         let d = compare(&mk("Invalid value"), &mk("Write access denied")).differences;
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].surface, Surface::PutError);
+    }
+
+    /// The three outcomes are three readings, and every pair of unequal ones is
+    /// a difference on one surface.
+    ///
+    /// A one-sided non-completion is the case this exists for: C's `busy` record
+    /// declines to finish the put while `VAL` is non-zero, a port that finishes
+    /// it diverges, and that used to be unreportable because the non-completion
+    /// left the harness as an absence rather than a reading.
+    #[test]
+    fn a_one_sided_non_completion_is_a_difference_not_an_absence() {
+        let d = compare(
+            &put_obs(PutOutcome::NeverCompleted),
+            &put_obs(PutOutcome::Completed),
+        )
+        .differences;
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].surface, Surface::PutAccepted);
+        assert_eq!(d[0].c, "accepted, never completed");
+        assert_eq!(d[0].rust, "completed");
+
+        // Both declining is agreement on the surface, not a difference.
+        assert!(
+            compare(
+                &put_obs(PutOutcome::NeverCompleted),
+                &put_obs(PutOutcome::NeverCompleted),
+            )
+            .differences
+            .is_empty()
+        );
     }
 
     fn trace(vals: &[&str]) -> MonitorTrace {

--- a/crates/epics-oracle-rs/src/pvamonitor.rs
+++ b/crates/epics-oracle-rs/src/pvamonitor.rs
@@ -126,7 +126,7 @@ use crate::ioc::{Ioc, PvaPair, PvxTools, Side};
 use crate::ntshape::{NT_ENUM, NtShape};
 use crate::pvatool::{PvaEvent, PvaTools};
 use crate::report::{Counts, StaleRow};
-use crate::surface::{Coverage, Surface, is_put_candidate};
+use crate::surface::{Coverage, Surface, ValStatus, drives_val, val_status};
 
 /// The scan rate of the [`Drive::Scanned`] reproducer.
 ///
@@ -560,14 +560,7 @@ pub fn probe(
     for (i, rt) in record_types.iter().enumerate() {
         // A skip is loud and says WHICH rule excluded the type, so a shrunken
         // denominator can never be mistaken for a measured-clean one.
-        let status = val_status(surface, rt);
-        if status != ValStatus::Drivable {
-            let why = match status {
-                ValStatus::NoChannel => "VAL is DBF_NOACCESS — pvxs serves no channel for it",
-                ValStatus::NoMod => "VAL is special(SPC_NOMOD) — the .dbd forbids writing it",
-                ValStatus::NotWritable => "VAL is not a client-writable scalar",
-                ValStatus::Drivable => unreachable!(),
-            };
+        if let Some(why) = val_status(surface, rt).why() {
             eprintln!(
                 "[{}/{}] pva monitor: {rt} — EXCLUDED: {why}",
                 i + 1,
@@ -593,66 +586,6 @@ pub fn probe(
         cases.extend(probe_type(tools, workdir, rt, val_dbf, allowlist));
     }
     cases
-}
-
-/// Why a record type's `VAL` channel is, or is not, in this phase's denominator.
-///
-/// The single owner of that question, so the report's exclusion lines and the
-/// probe's skips cannot drift into disagreeing about why a type is absent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ValStatus {
-    /// A channel exists and the `.dbd` does not forbid writing it.
-    Drivable,
-    /// `VAL` is `DBF_NOACCESS`: pvxs refuses an NT of `Null`, so no channel
-    /// exists to subscribe to and the read phase already excludes it.
-    NoChannel,
-    /// `VAL` is `special(SPC_NOMOD)`: the `.dbd` states the field cannot be
-    /// written, so no client can ever drive it.
-    NoMod,
-    /// `VAL` is a link or otherwise not a client-writable scalar.
-    NotWritable,
-}
-
-/// Why this record type's `VAL` is or is not measurable here.
-///
-/// The `.dbd` answers two of these *statically*, and both are exclusions rather
-/// than errors — the same rule the read phase applies to `DBF_NOACCESS`: a
-/// channel the spec says cannot be measured is outside the denominator, not a
-/// failure inside it.
-///
-/// [`ValStatus::NoMod`] is the one worth naming. `sel.VAL` is
-/// `special(SPC_NOMOD)`, so **both** sides refuse the drive and **both** post
-/// nothing — identical traces, on an experiment that never ran. Erroring it
-/// every run said "we could not measure this" about a field the `.dbd` already
-/// said could never be measured, and it dragged in nondeterminism through the
-/// back door: the port self-posts on every scan of an undriven `sel`, so the
-/// ERRORED case's diagnostic trace carried 28 events one run and 29 the next.
-///
-/// This does **not** replace the runtime rule that a refused drive is an ERROR
-/// (see the module docs). The two have different jobs and different owners: this
-/// removes what the `.dbd` *proves* undrivable, and the drive check catches
-/// everything the `.dbd` does not know about. A port can never shrink the
-/// denominator by misbehaving, because every exclusion here is derived from the
-/// spec, never from what a side did.
-pub fn val_status(surface: &Surface, record_type: &str) -> ValStatus {
-    let Some(v) = surface
-        .fields_of(record_type)
-        .find(|f| f.field.name == "VAL")
-    else {
-        return ValStatus::NoChannel;
-    };
-    if v.field.is_nomod() {
-        return ValStatus::NoMod;
-    }
-    if !is_put_candidate(&v.field) || v.field.dbf.is_link() {
-        return ValStatus::NotWritable;
-    }
-    ValStatus::Drivable
-}
-
-/// Does this record type have a `VAL` channel this phase can drive?
-fn drives_val(surface: &Surface, record_type: &str) -> bool {
-    val_status(surface, record_type) == ValStatus::Drivable
 }
 
 /// The reproducers this record type gets.
@@ -1332,40 +1265,5 @@ mod tests {
             PUT_SPACING >= Duration::from_millis(300),
             "a put must not race the next scan: {PUT_SPACING:?}"
         );
-    }
-
-    /// The `.dbd` proves `sel.VAL` undrivable (`special(SPC_NOMOD)`), so it is
-    /// excluded before a case exists rather than erroring every run — the same
-    /// rule the read phase applies to `DBF_NOACCESS`. Driven through a real
-    /// parse and a real [`Surface`], so a regression that dropped `special` on
-    /// the way through would fail here rather than silently re-admit `sel`.
-    ///
-    /// `sel`'s and `aai`'s declarations are the real ones from base's `.dbd`.
-    #[test]
-    fn the_dbd_names_which_vals_no_client_can_drive() {
-        const DBD: &str = r#"
-recordtype(sel) {
-    field(VAL, DBF_DOUBLE) { prompt("Result") special(SPC_NOMOD) }
-}
-recordtype(ai) {
-    field(VAL, DBF_DOUBLE) { pp(TRUE) }
-}
-recordtype(aai) {
-    field(VAL, DBF_NOACCESS) { extra("void *val") }
-}
-"#;
-        let dbd = crate::Dbd::parse(DBD).unwrap();
-        let types: std::collections::BTreeSet<String> =
-            ["sel", "ai", "aai"].iter().map(|s| s.to_string()).collect();
-        let s = Surface::build(&dbd, &types);
-
-        assert_eq!(val_status(&s, "sel"), ValStatus::NoMod);
-        assert_eq!(val_status(&s, "ai"), ValStatus::Drivable);
-        // The surface already drops a DBF_NOACCESS VAL, so no channel survives
-        // for this phase to subscribe to.
-        assert_eq!(val_status(&s, "aai"), ValStatus::NoChannel);
-
-        assert!(!drives_val(&s, "sel"));
-        assert!(drives_val(&s, "ai"));
     }
 }

--- a/crates/epics-oracle-rs/src/pvaread.rs
+++ b/crates/epics-oracle-rs/src/pvaread.rs
@@ -494,6 +494,9 @@ pub fn report(
             record_types_unimplemented: surface.unimplemented_types.clone(),
             observable_fields: surface.denominator(),
             excluded_noaccess_fields: surface.excluded_noaccess,
+            // The read phase drives nothing, so it excludes nothing on that
+            // account; the drive denominator is the monitor phases' to state.
+            excluded_undrivable_val: Vec::new(),
         },
         channel_coverage: Coverage {
             enumerated: surface.denominator(),

--- a/crates/epics-oracle-rs/src/report.rs
+++ b/crates/epics-oracle-rs/src/report.rs
@@ -368,6 +368,25 @@ pub struct Denominator {
     pub observable_fields: usize,
     /// DBF_NOACCESS declarations excluded (no client can reach them).
     pub excluded_noaccess_fields: usize,
+    /// Record types the **monitor** phase left out of its drive denominator,
+    /// each with the `.dbd` rule that removed it
+    /// ([`crate::surface::val_status`]). Empty when this run drove no monitor
+    /// phase — an exclusion that was never in scope is not an exclusion.
+    #[serde(default)]
+    pub excluded_undrivable_val: Vec<UndrivableVal>,
+}
+
+/// One record type the monitor phase could not stimulate, and the rule that
+/// says so.
+///
+/// Named rather than counted: a drive denominator that reports only "10
+/// excluded" cannot be audited back against the `.dbd`, which is the failure
+/// this report exists to prevent.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UndrivableVal {
+    pub record_type: String,
+    /// The rule, from [`crate::surface::ValStatus::why`].
+    pub why: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -436,9 +455,21 @@ impl Report {
             d.observable_fields
         ));
         s.push_str(&format!(
-            "  excluded (DBF_NOACCESS): {} (no CA client can reach these)\n\n",
+            "  excluded (DBF_NOACCESS): {} (no CA client can reach these)\n",
             d.excluded_noaccess_fields
         ));
+        if !d.excluded_undrivable_val.is_empty() {
+            s.push_str(&format!(
+                "  monitor drive excluded : {}  (the drive is the stimulus, not the reading, so a\n\
+                 {:26}VAL the .dbd says no client may write leaves that denominator)\n",
+                d.excluded_undrivable_val.len(),
+                ""
+            ));
+            for u in &d.excluded_undrivable_val {
+                s.push_str(&format!("      {:14} {}\n", u.record_type, u.why));
+            }
+        }
+        s.push('\n');
 
         let fc = &self.field_coverage;
         s.push_str("COVERAGE\n");
@@ -719,6 +750,7 @@ mod tests {
                 record_types_unimplemented: vec![],
                 observable_fields: 1,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: field_coverage(&cases, 1),
             counts: Counts::tally(&cases),
@@ -843,6 +875,7 @@ mod tests {
                 record_types_unimplemented: vec![],
                 observable_fields: 2,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: field_coverage(&cases, 2),
             counts: Counts::tally(&cases),
@@ -898,6 +931,7 @@ mod tests {
                 record_types_unimplemented: vec![],
                 observable_fields: 1,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: field_coverage(&cases, 1),
             counts: Counts::tally(&cases),
@@ -955,6 +989,7 @@ mod tests {
                 record_types_unimplemented: vec!["aai".into()],
                 observable_fields: 100,
                 excluded_noaccess_fields: 20,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: Coverage {
                 enumerated: 100,
@@ -998,6 +1033,7 @@ mod tests {
                 record_types_unimplemented: vec!["calc".into()],
                 observable_fields: 100,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: Coverage {
                 enumerated: 100,
@@ -1043,6 +1079,7 @@ mod tests {
                 record_types_unimplemented: vec![],
                 observable_fields: 1,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: Coverage::default(),
             counts: Counts::tally(std::slice::from_ref(&c)),
@@ -1139,6 +1176,7 @@ why = "C's special() rejects SPC_MOD; port accepts."
                 record_types_unimplemented: vec![],
                 observable_fields: 10,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: Coverage {
                 enumerated: 10,
@@ -1230,6 +1268,7 @@ why = "One row, both lanes."
                 record_types_unimplemented: vec![],
                 observable_fields: 1,
                 excluded_noaccess_fields: 0,
+                excluded_undrivable_val: Vec::new(),
             },
             field_coverage: Coverage {
                 enumerated: 1,

--- a/crates/epics-oracle-rs/src/runner.rs
+++ b/crates/epics-oracle-rs/src/runner.rs
@@ -34,7 +34,7 @@ use crate::dbd::{Dbd, DbfType};
 use crate::diff::{Comparison, Observation, Verdict, compare};
 use crate::ioc::{CTools, Ioc, Pair, Side};
 use crate::report::{CasePhase, CaseResult, Reproducer};
-use crate::surface::{FieldRef, Surface, is_put_candidate};
+use crate::surface::{FieldRef, Surface, ValStatus, is_put_candidate};
 
 /// How long to let monitor updates settle after driving the puts. A port that
 /// posts *extra* events must be caught, so we cannot stop listening the moment
@@ -274,20 +274,32 @@ impl Runner {
     /// MDEL/ADEL), so a faithful port posts three updates, not four. "Posts an
     /// event per put regardless of change" is exactly the kind of divergence
     /// that a value-only diff cannot see — the final value agrees either way.
+    /// # What the `.dbd` removes before a case exists
+    ///
+    /// The drive here is a *stimulus*, not the observation, so a record type
+    /// whose `VAL` no client may write has nothing to measure: both sides
+    /// refuse, both post nothing, and the identical traces describe an
+    /// experiment that never ran. [`crate::surface::val_status`] is the single
+    /// owner of that question for both protocols, so `sel` leaves the CA drive
+    /// denominator for exactly the reason it already left the PVA one — rather
+    /// than erroring here and being excluded there.
     pub fn probe_monitor(
         &self,
         record_type: &str,
         surface: &Surface,
         allowlist: &mut Allowlist,
     ) -> Option<CaseResult> {
-        // Only meaningful where VAL is a writable scalar the client can drive.
-        let val = surface
-            .fields_of(record_type)
-            .find(|f| f.field.name == "VAL")?;
-        if !is_put_candidate(&val.field) || val.field.dbf.is_link() {
+        // Only meaningful where the .dbd leaves VAL drivable by some client.
+        if crate::surface::val_status(surface, record_type) != ValStatus::Drivable {
             return None;
         }
-        let val_dbf = val.field.dbf;
+        // `Drivable` was just proven, so VAL exists in the surface.
+        let val_dbf = surface
+            .fields_of(record_type)
+            .find(|f| f.field.name == "VAL")
+            .expect("val_status returned Drivable, so VAL is in the surface")
+            .field
+            .dbf;
 
         let rec = format!("ORACLE:MON:{}", record_type.to_uppercase());
         let db_text = crate::record_stmt(record_type, &rec);
@@ -863,28 +875,14 @@ fn adjudicate(
         rust_side: r.clone(),
     };
 
-    // The one place a case may leave the ERROR bucket while carrying errors.
-    //
-    // A completion that never came from EITHER side is a reading: the two IOCs
-    // did the same observable thing, and the rest of the case — native type,
-    // element count, access, stored value, STAT, SEVR — was still read back
-    // from both and is compared below exactly as any other case is. So this
-    // does not suppress a difference; it only stops the shared non-answer from
-    // masking a case the harness fully measured.
-    //
-    // The discriminator, and the whole honesty of the bucket: BOTH sides must
-    // have produced an error, and EVERY error on the case must be the
-    // no-completion marker (`catool::is_no_completion`). A one-sided
-    // no-completion is a divergence between the two servers, which is the
-    // finding this harness exists to make, and it stays ERROR. So does any case
-    // that mixes in a connect failure or one of the harness's own — those say
-    // the measurement never happened, not that the server declined to finish.
-    let both_sides_declined = !c.errors.is_empty()
-        && !r.errors.is_empty()
-        && errors
-            .iter()
-            .all(|e| crate::catool::is_no_completion(&e.message));
-    if !errors.is_empty() && !both_sides_declined {
+    // An error is an absence, with no exceptions left to carve out. A put the
+    // server took and never finished is no longer one: it arrives as
+    // `PutOutcome::NeverCompleted`, a reading, and is compared below like any
+    // other outcome. That is what removed the special case that used to sit
+    // here — an error list that had to be re-read to decide whether the case
+    // was really unmeasured, which could only ever answer for the ONE shape of
+    // non-answer it knew how to spell.
+    if !errors.is_empty() {
         return base;
     }
 
@@ -905,8 +903,19 @@ fn adjudicate(
     allowlist.note_compared(&ctx, &compared);
 
     if differences.is_empty() {
+        // Agreement, sub-classified. Two servers that agreed by both declining
+        // to finish the put agreed about less than two that both finished it,
+        // and the report has always said so rather than folding the two into
+        // one number.
+        let both_declined = matches!(
+            (&c.put, &r.put),
+            (
+                Some(PutOutcome::NeverCompleted),
+                Some(PutOutcome::NeverCompleted)
+            )
+        );
         return CaseResult {
-            verdict: if both_sides_declined {
+            verdict: if both_declined {
                 Verdict::NeitherCompleted
             } else {
                 Verdict::Agreed
@@ -1357,15 +1366,17 @@ mod adjudicate_tests {
         }
     }
 
-    const NO_COMPLETION: &str = "Write callback operation timed out";
+    /// An `Observation` that read back cleanly and carries a put outcome.
+    fn value_with_put(v: &str, put: PutOutcome) -> Observation {
+        Observation {
+            value_string: Some(v.to_string()),
+            put: Some(put),
+            ..Default::default()
+        }
+    }
 
-    /// The bucket. Both IOCs took the write, neither ever said it finished, and
-    /// every other surface agreed — measured on `sub`, whose empty `SNAM`
-    /// latches `pact = TRUE` (`subRecord.c:119-122`) on the C side and whose
-    /// 464 put cases are all of this shape.
-    #[test]
-    fn a_no_completion_from_both_sides_is_a_reading_not_a_measurement_failure() {
-        let case = adjudicate(
+    fn put_case(c: &Observation, r: &Observation) -> CaseResult {
+        adjudicate(
             CaseRef {
                 record_type: "sub",
                 phase: CasePhase::Put,
@@ -1374,44 +1385,63 @@ mod adjudicate_tests {
                 class: Some("zero"),
             },
             repro(),
-            &value_with_error("0", Side::C, NO_COMPLETION),
-            &value_with_error("0", Side::Rust, NO_COMPLETION),
+            c,
+            r,
             &mut shipped(),
+        )
+    }
+
+    /// The bucket. Both IOCs took the write, neither ever said it finished, and
+    /// every other surface agreed — measured on `sub`, whose empty `SNAM`
+    /// latches `pact = TRUE` (`subRecord.c:119-122`) on the C side and whose
+    /// 464 put cases are all of this shape.
+    #[test]
+    fn a_no_completion_from_both_sides_is_a_reading_not_a_measurement_failure() {
+        let case = put_case(
+            &value_with_put("0", PutOutcome::NeverCompleted),
+            &value_with_put("0", PutOutcome::NeverCompleted),
         );
         assert_eq!(case.verdict, Verdict::NeitherCompleted);
-        assert_eq!(
-            case.errors.len(),
-            2,
-            "the bucket must keep both sides' evidence, not swallow it"
+        assert!(
+            case.errors.is_empty(),
+            "a server that declined to finish answered; that is not an error"
         );
     }
 
     /// The discriminator. One side finishing and the other not is a difference
-    /// between the two servers — the finding this harness exists to make — so
-    /// it must not reach the bucket from either direction.
+    /// between the two servers — the finding this harness exists to make — and
+    /// it is now reported as one, from either direction.
+    ///
+    /// It used to score ERROR, because a non-completion could only reach
+    /// `adjudicate` as a `ToolError` and an error meant "no reading". C's `busy`
+    /// record is the case that proves it wrong: it withholds the completion by
+    /// design while `VAL` is non-zero, so a port that completes the put diverges
+    /// on a surface both sides actually reported.
     #[test]
-    fn a_one_sided_no_completion_stays_an_error() {
+    fn a_one_sided_no_completion_is_a_defect_not_an_error() {
         for (c, r) in [
-            (value_with_error("0", Side::C, NO_COMPLETION), value("0")),
-            (value("0"), value_with_error("0", Side::Rust, NO_COMPLETION)),
+            (
+                value_with_put("0", PutOutcome::NeverCompleted),
+                value_with_put("0", PutOutcome::Completed),
+            ),
+            (
+                value_with_put("0", PutOutcome::Completed),
+                value_with_put("0", PutOutcome::NeverCompleted),
+            ),
         ] {
-            let case = adjudicate(
-                CaseRef {
-                    record_type: "sub",
-                    phase: CasePhase::Put,
-                    field: "VAL",
-                    dbf: DbfType::Double,
-                    class: Some("zero"),
-                },
-                repro(),
-                &c,
-                &r,
-                &mut shipped(),
-            );
+            let case = put_case(&c, &r);
             assert_eq!(
                 case.verdict,
-                Verdict::Errored,
+                Verdict::Defect,
                 "a one-sided no-completion is a divergence, not a shared reading"
+            );
+            assert_eq!(
+                case.differences
+                    .iter()
+                    .map(|d| d.surface)
+                    .collect::<Vec<_>>(),
+                [crate::diff::Surface::PutAccepted],
+                "and it lands on the put surface, once"
             );
         }
     }
@@ -1449,18 +1479,9 @@ mod adjudicate_tests {
     /// still a DEFECT.
     #[test]
     fn a_difference_under_a_shared_no_completion_is_still_a_defect() {
-        let case = adjudicate(
-            CaseRef {
-                record_type: "sub",
-                phase: CasePhase::Put,
-                field: "VAL",
-                dbf: DbfType::Double,
-                class: Some("zero"),
-            },
-            repro(),
-            &value_with_error("0", Side::C, NO_COMPLETION),
-            &value_with_error("7", Side::Rust, NO_COMPLETION),
-            &mut shipped(),
+        let case = put_case(
+            &value_with_put("0", PutOutcome::NeverCompleted),
+            &value_with_put("7", PutOutcome::NeverCompleted),
         );
         assert_eq!(case.verdict, Verdict::Defect);
     }
@@ -1524,7 +1545,7 @@ mod adjudicate_tests {
     ///
     /// The measurement failure is planted for real: both `CaTools` are aimed at
     /// a port nothing is listening on, so `caput` cannot connect. Before this,
-    /// every `Err` from the tool became `PutOutcome { accepted: false, … }`, the
+    /// every `Err` from the tool became a not-accepted `PutOutcome`, the
     /// two sides "agreed" the write had been refused, and the case was scored
     /// AGREED and counted as put coverage — an agreement claim about a write
     /// neither IOC ever saw.
@@ -1666,18 +1687,7 @@ mod adjudicate_tests {
             "ORACLE:RB:0.SEVR".to_string(),
             "ORACLE:RB:1.SEVR".to_string(),
         ];
-        let accepted = || {
-            vec![
-                Ok(PutOutcome {
-                    accepted: true,
-                    error: None,
-                }),
-                Ok(PutOutcome {
-                    accepted: true,
-                    error: None,
-                }),
-            ]
-        };
+        let accepted = || vec![Ok(PutOutcome::Completed), Ok(PutOutcome::Completed)];
 
         let side = |port: u16, s: Side| {
             let t = CaTools::new(&tools, port, s);
@@ -1724,6 +1734,45 @@ mod adjudicate_tests {
         assert_eq!(
             crate::report::exit_status(&crate::report::run_failures(&counts, &[], &[])),
             1,
+        );
+    }
+
+    /// The CA monitor probe reads the same drive rule as the PVA one.
+    ///
+    /// `sel.VAL` is `special(SPC_NOMOD)`, so no client can stimulate it and the
+    /// case never existed on the PVA side — while the CA side built it, drove
+    /// it, watched both servers refuse, and scored ERROR every run. The rule now
+    /// has one owner ([`crate::surface::val_status`]); this fails if a second
+    /// predicate is ever inlined here.
+    ///
+    /// No IOC is booted: the exclusion is decided from the `.dbd` before any
+    /// `.db` is written, which is the point of it being static.
+    #[cfg(tokio_backend)]
+    #[test]
+    fn the_monitor_probe_builds_no_case_for_a_val_the_dbd_forbids_writing() {
+        const DBD: &str = r#"
+recordtype(sel) {
+    field(VAL, DBF_DOUBLE) { prompt("Result") special(SPC_NOMOD) }
+}
+recordtype(ai) {
+    field(VAL, DBF_DOUBLE) { pp(TRUE) }
+}
+"#;
+        let dbd = Dbd::parse(DBD).expect("parse");
+        let types: std::collections::BTreeSet<String> =
+            ["sel", "ai"].iter().map(|s| s.to_string()).collect();
+        let surface = Surface::build(&dbd, &types);
+        let tools = CTools::discover().expect(
+            "the C EPICS tree must be built for the oracle to have ground truth; \
+             set EPICS_BASE_BIN if it is not at the default path",
+        );
+        let runner = Runner::new(tools, dbd, workdir(None).expect("workdir"));
+
+        assert!(
+            runner
+                .probe_monitor("sel", &surface, &mut shipped())
+                .is_none(),
+            "the .dbd forbids writing sel.VAL, so there is nothing to stimulate"
         );
     }
 

--- a/crates/epics-oracle-rs/src/surface.rs
+++ b/crates/epics-oracle-rs/src/surface.rs
@@ -212,6 +212,90 @@ pub fn is_put_candidate(f: &FieldDef) -> bool {
     f.dbf.is_ca_observable()
 }
 
+/// Why a record type's `VAL` channel is, or is not, in a phase's **drive**
+/// denominator.
+///
+/// The single owner of that question for every phase that *drives* — CA's
+/// monitor probe and the PVA monitor phase alike — so the two protocols cannot
+/// drift into disagreeing about which record types no client can stimulate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValStatus {
+    /// A channel exists and the `.dbd` does not forbid writing it.
+    Drivable,
+    /// `VAL` is `DBF_NOACCESS`: it is outside the observable surface
+    /// ([`Surface::build`]), so there is no channel to drive or subscribe to.
+    NoChannel,
+    /// `VAL` is `special(SPC_NOMOD)`: the `.dbd` states the field cannot be
+    /// written, so no client can ever drive it.
+    NoMod,
+    /// `VAL` is a link or otherwise not a client-writable scalar.
+    NotWritable,
+}
+
+impl ValStatus {
+    /// Why this type is outside the drive denominator, or `None` when it is in.
+    ///
+    /// The reason travels with the status so the two phases' skip lines and
+    /// their report's exclusion lines all read from one sentence.
+    pub fn why(self) -> Option<&'static str> {
+        match self {
+            ValStatus::Drivable => None,
+            ValStatus::NoChannel => Some(
+                "VAL is DBF_NOACCESS — no client can reach it, so there is no channel to drive",
+            ),
+            ValStatus::NoMod => Some("VAL is special(SPC_NOMOD) — the .dbd forbids writing it"),
+            ValStatus::NotWritable => Some("VAL is not a client-writable scalar"),
+        }
+    }
+}
+
+/// Can *any* client drive this record type's `VAL`, and if not, why not?
+///
+/// The `.dbd` answers this **statically**, and every answer but
+/// [`ValStatus::Drivable`] is an exclusion rather than an error — the same rule
+/// this module already applies to `DBF_NOACCESS`: a channel the spec says
+/// cannot be stimulated is outside the denominator, not a failure inside it.
+///
+/// [`ValStatus::NoMod`] is the one worth naming. `sel.VAL` is
+/// `special(SPC_NOMOD)`, so **both** sides refuse the drive and **both** post
+/// nothing — identical traces, on an experiment that never ran. Erroring it
+/// every run said "we could not measure this" about a field the `.dbd` already
+/// said could never be measured, and it dragged in nondeterminism through the
+/// back door: the port self-posts on every scan of an undriven `sel`, so the
+/// ERRORED case's diagnostic trace carried 28 events one run and 29 the next.
+///
+/// This does **not** replace the runtime rule that a refused drive is an ERROR.
+/// The two have different jobs and different owners: this removes what the
+/// `.dbd` *proves* undrivable, and the drive check catches everything the
+/// `.dbd` does not know about. A port can never shrink the denominator by
+/// misbehaving, because every exclusion here is derived from the spec, never
+/// from what a side did.
+///
+/// Note what this does **not** govern: the put phase, where a put to a
+/// `SPC_NOMOD` field is the observation rather than a stimulus, and its refusal
+/// on both sides is the reading (see [`is_put_candidate`]). This rule is only
+/// about puts issued to *drive* something else.
+pub fn val_status(surface: &Surface, record_type: &str) -> ValStatus {
+    let Some(v) = surface
+        .fields_of(record_type)
+        .find(|f| f.field.name == "VAL")
+    else {
+        return ValStatus::NoChannel;
+    };
+    if v.field.is_nomod() {
+        return ValStatus::NoMod;
+    }
+    if !is_put_candidate(&v.field) || v.field.dbf.is_link() {
+        return ValStatus::NotWritable;
+    }
+    ValStatus::Drivable
+}
+
+/// Does this record type have a `VAL` channel a client can drive?
+pub fn drives_val(surface: &Surface, record_type: &str) -> bool {
+    val_status(surface, record_type) == ValStatus::Drivable
+}
+
 /// Fields whose type is a plain scalar number — the ones with meaningful
 /// numeric boundaries.
 pub fn is_numeric(t: DbfType) -> bool {
@@ -294,6 +378,41 @@ recordtype(aai) {
     #[test]
     fn empty_surface_reports_zero_not_a_divide_by_zero() {
         assert_eq!(Coverage::default().percent(), 0.0);
+    }
+
+    /// The `.dbd` proves `sel.VAL` undrivable (`special(SPC_NOMOD)`), so it is
+    /// excluded before a case exists rather than erroring every run — the same
+    /// rule the read phase applies to `DBF_NOACCESS`. Driven through a real
+    /// parse and a real [`Surface`], so a regression that dropped `special` on
+    /// the way through would fail here rather than silently re-admit `sel`.
+    ///
+    /// `sel`'s and `aai`'s declarations are the real ones from base's `.dbd`.
+    #[test]
+    fn the_dbd_names_which_vals_no_client_can_drive() {
+        const DBD: &str = r#"
+recordtype(sel) {
+    field(VAL, DBF_DOUBLE) { prompt("Result") special(SPC_NOMOD) }
+}
+recordtype(ai) {
+    field(VAL, DBF_DOUBLE) { pp(TRUE) }
+}
+recordtype(aai) {
+    field(VAL, DBF_NOACCESS) { extra("void *val") }
+}
+"#;
+        let dbd = Dbd::parse(DBD).unwrap();
+        let types: std::collections::BTreeSet<String> =
+            ["sel", "ai", "aai"].iter().map(|s| s.to_string()).collect();
+        let s = Surface::build(&dbd, &types);
+
+        assert_eq!(val_status(&s, "sel"), ValStatus::NoMod);
+        assert_eq!(val_status(&s, "ai"), ValStatus::Drivable);
+        // The surface already drops a DBF_NOACCESS VAL, so no channel survives
+        // for any phase to subscribe to.
+        assert_eq!(val_status(&s, "aai"), ValStatus::NoChannel);
+
+        assert!(!drives_val(&s, "sel"));
+        assert!(drives_val(&s, "ai"));
     }
 
     #[test]

--- a/crates/epics-oracle-rs/tests/oracle.rs
+++ b/crates/epics-oracle-rs/tests/oracle.rs
@@ -38,7 +38,7 @@ use std::collections::BTreeSet;
 
 use epics_oracle_rs::allowlist::Allowlist;
 #[cfg(tokio_backend)]
-use epics_oracle_rs::catool::CaTools;
+use epics_oracle_rs::catool::{CaTools, PutOutcome};
 use epics_oracle_rs::dbd::Dbd;
 use epics_oracle_rs::diff::Verdict;
 use epics_oracle_rs::ioc::CTools;
@@ -295,15 +295,51 @@ fn a_server_issued_refusal_is_a_reading_not_a_measurement_failure() {
             .unwrap_or_else(|e| {
                 panic!("{side}: a refusal by the server must be a reading, got ERROR: {e}")
             });
+        let PutOutcome::Refused { error } = &out else {
+            panic!("{side}: NAME is special(SPC_NOMOD); the write must be refused, got {out:?}");
+        };
         assert!(
-            !out.accepted,
-            "{side}: NAME is special(SPC_NOMOD); the write must be refused"
-        );
-        assert!(
-            out.error.is_some(),
+            !error.is_empty(),
             "{side}: a refusal must carry the server's complaint"
         );
     }
+}
+
+/// A completion the server withholds **on purpose** must stay a reading too.
+///
+/// The third put outcome, planted against the real pair on the record type
+/// whose entire contract is to produce it: C's `busy` declines
+/// `recGblFwdLink()` while `VAL` is non-zero (busy `docs/busyRecord.md`), so
+/// `ca_put_callback` is meant to stay open and `caput -c` prints "Write
+/// callback operation timed out" over a channel that connected and a write that
+/// landed. Classifying that as a measurement failure cost four ERROR cases per
+/// `--phase all` run and hid the divergence underneath them.
+///
+/// The readback is asserted alongside, because it is what proves the write
+/// reached the record: a non-completion is not a put that did not happen.
+#[cfg(tokio_backend)]
+#[test]
+fn a_completion_the_server_withholds_is_a_reading_not_a_measurement_failure() {
+    let t = tools();
+    let dir = workdir(None).unwrap();
+    let db = dir.join("put_busy_nocomplete.db");
+    std::fs::write(&db, "record(busy, \"ORACLE:BUSYNC\") {}\n").unwrap();
+    let pair = Pair::boot(&t, &db, "ORACLE:BUSYNC").expect("both IOCs must boot");
+
+    let c = CaTools::new(&t, pair.c.port(), Side::C);
+    let out = c
+        .caput("ORACLE:BUSYNC", "1")
+        .unwrap_or_else(|e| panic!("a withheld completion must be a reading, got ERROR: {e}"));
+    assert_eq!(
+        out,
+        PutOutcome::NeverCompleted,
+        "busy withholds the put completion while VAL is non-zero"
+    );
+    assert_eq!(
+        c.caget_string("ORACLE:BUSYNC").expect("readback"),
+        "Busy",
+        "the write landed; only the completion callback is outstanding"
+    );
 }
 
 /// The outermost contract: the **binary's own exit code**.

--- a/crates/epics-pva-rs/Cargo.toml
+++ b/crates/epics-pva-rs/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 epics-base-rs = { workspace = true }
 epics-macros-rs = { workspace = true }
 # No `epics-rtems-boot`: this package produces no RTEMS binary. The boot shim
-# is a dependency of whichever package owns one, and `realtime-pva-ioc` moved to
-# `epics-bridge-rs` (doc/qsrv-rtems-design.md §9.7).
+# is a dependency of whichever package owns one, and `realtime-pva-ioc` moved
+# to `epics-bridge-rs`.
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
@@ -102,8 +102,8 @@ client = []
 # of `epics-ca-rs/bringup-probes`, and forwarded from
 # `epics-bridge-rs/bringup-probes` so `realtime-pva-ioc`'s probe image can read
 # it. Compiles a dial-attempt counter and `client_native::dial_pool_probe()`,
-# which is how `doc/pvalink-rtems-design.md` §9.11's `MAX_DIAL_WORKERS` bound
-# is read on a target with no shell and no reachable `caget`. OFF by default:
+# which is how the `MAX_DIAL_WORKERS` bound is read on a target with no shell
+# and no reachable `caget`. OFF by default:
 # a default build compiles neither the counter nor the accessor.
 bringup-probes = []
 # TLS-secured pvAccess (`pvas://`) via rustls. ON by default. Turning it off
@@ -263,5 +263,5 @@ path = "src/bin/mshim-rs.rs"
 
 # `realtime-pva-ioc` used to be declared here. It moved to `epics-bridge-rs` when
 # it grew a QSRV group source: the mount needs the bridge, and this package
-# cannot depend on the bridge without a cyclic package dependency (measured —
-# doc/qsrv-rtems-design.md §9.7). This package now produces no target binary.
+# cannot depend on the bridge without a cyclic package dependency, which cargo
+# rejects outright (measured). This package now produces no target binary.

--- a/crates/epics-pva-rs/src/server/native_source.rs
+++ b/crates/epics-pva-rs/src/server/native_source.rs
@@ -4715,6 +4715,104 @@ ASG(PLAIN) {
         );
     }
 
+    /// Drive `f` in place until it parks — poll it, and keep polling for as
+    /// long as it asks to be woken again.
+    fn drive_until_parked<F: std::future::Future + Unpin>(f: &mut F) -> std::task::Poll<F::Output> {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::task::{Context, Poll, Wake, Waker};
+
+        struct Woken(AtomicBool);
+        impl Wake for Woken {
+            fn wake(self: Arc<Self>) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let woken = Arc::new(Woken(AtomicBool::new(false)));
+        let waker = Waker::from(woken.clone());
+        let mut cx = Context::from_waker(&waker);
+        for _ in 0..64 {
+            woken.0.store(false, Ordering::SeqCst);
+            match std::pin::Pin::new(&mut *f).poll(&mut cx) {
+                Poll::Ready(v) => return Poll::Ready(v),
+                Poll::Pending if !woken.0.load(Ordering::SeqCst) => return Poll::Pending,
+                Poll::Pending => {}
+            }
+        }
+        panic!("the put never parked");
+    }
+
+    async fn busy_db(name: &str) -> Arc<PvDatabase> {
+        use epics_base_rs::server::records::busy::BusyRecord;
+        let db = Arc::new(PvDatabase::new());
+        db.add_record(name, Box::new(BusyRecord::default()))
+            .await
+            .unwrap();
+        db
+    }
+
+    /// `record[block=true]` is the one PVA operation that can outlive the
+    /// client that asked for it, and the transport already knows how to end
+    /// it: the PUT EXEC body is spawned and its abort handle kept on the op
+    /// (`server_native::tcp::finish_exec_data_task`), so DESTROY_CHANNEL and
+    /// connection teardown alike drop `ChannelState::ops`, abort the task and
+    /// drop this future mid-await. Dropping the future here is that abort.
+    ///
+    /// What the drop must do is release the record. `busy` at VAL=1 withholds
+    /// `recGblFwdLink` by contract (`busyRecord.c:271`), so the completion
+    /// never comes on its own, and a SECOND client is already parked on the
+    /// restart list — nothing arrives afterwards to test ownership, so a
+    /// release that ran only at the next put's arrival would never run and
+    /// the queued client would wait forever. C reaches the same release from
+    /// `rsrvFreePutNotify` -> `dbNotifyCancel` (`rsrv/camessage.c:1630-1638`).
+    #[epics_macros_rs::epics_test]
+    async fn an_aborted_blocking_put_hands_the_record_to_the_queued_client() {
+        use epics_base_rs::types::EpicsValue;
+
+        let db = busy_db("BUSY:ABORT").await;
+        let source = PvDatabaseSource::new(db.clone());
+        let block = [("block", PvField::Scalar(ScalarValue::Boolean(true)))];
+        let val = || {
+            db.get_record("BUSY:ABORT")
+                .unwrap()
+                .read()
+                .record
+                .get_field("VAL")
+        };
+
+        let mut first =
+            Box::pin(source.put_value_ctx("BUSY:ABORT", pv_double(1.0), ctx_with_options(&block)));
+        assert!(
+            drive_until_parked(&mut first).is_pending(),
+            "VAL=1 withholds the callback, so the blocking PUT cannot reply"
+        );
+        assert!(
+            db.get_record("BUSY:ABORT").unwrap().read().has_notify(),
+            "the first client owns the record's put-notify slot"
+        );
+
+        let mut second =
+            Box::pin(source.put_value_ctx("BUSY:ABORT", pv_double(0.0), ctx_with_options(&block)));
+        assert!(
+            drive_until_parked(&mut second).is_pending(),
+            "the second client queues behind the first"
+        );
+        assert_eq!(
+            val(),
+            Some(EpicsValue::Enum(1)),
+            "a queued put-notify writes nothing until it is replayed"
+        );
+
+        drop(first); // the op is aborted: DESTROY_CHANNEL or connection teardown
+
+        second.await.expect("the queued PUT must complete");
+        assert_eq!(
+            val(),
+            Some(EpicsValue::Enum(0)),
+            "restartCheck hands the record over, and the queued client then writes"
+        );
+    }
+
     /// pvxs reports an unusable `record._options.process` to the client
     /// (`ioc/iocsource.cpp:446-447` `logRemote(Warn, "Ignoring unsupported
     /// ...")`) and keeps the passive default. The native source emitted no

--- a/crates/epics-pva-rs/src/server_native/blocking.rs
+++ b/crates/epics-pva-rs/src/server_native/blocking.rs
@@ -3195,13 +3195,14 @@ mod tests {
     /// failure is specific to a libbsd socket and is not a general fcntl
     /// gap. The `F_DUPFD_CLOEXEC` variant additionally cannot work on
     /// **RTEMS 6** whatever the file is: `cpukit/libcsupport/src/fcntl.c`
-    /// has no case for it and falls to `default: EINVAL`. That is a
-    /// series-6 statement (`rtems-kernel_6` `51f962fb3`); the series-7
-    /// kernel was not read, and neither tree is checked out here
-    /// (`revisions.py` `ABSENT_HERE`).
+    /// has no case for it (`:146-220`) and falls to `default: EINVAL`.
+    /// That is a series-6 statement (`rtems-kernel_6` `51f962fb3`) and only
+    /// that: the series-7 kernel (`181e86a19`) DOES handle
+    /// `F_DUPFD_CLOEXEC`, at `:173-175`, so the ban rests on the series we
+    /// ship rather than on RTEMS in general.
     ///
     /// **Withdrawn:** this comment used to explain the plain-`F_DUPFD`
-    /// failure by saying `duplicate_iop` (`fcntl.c:47-77`) calls the file's
+    /// failure by saying `duplicate_iop` (`fcntl.c:47-79`) calls the file's
     /// `open_h` and that `rtems_bsd_sysgen_nodeops.open_h` is
     /// `rtems_bsd_sysgen_open_error`. The `duplicate_iop` half is right; the
     /// libbsd half is FALSE at **both** declared pins (`7-freebsd-14`

--- a/crates/epics-pva-rs/src/server_native/tcp.rs
+++ b/crates/epics-pva-rs/src/server_native/tcp.rs
@@ -1070,8 +1070,9 @@ impl MonitorFinishGuard {
         Self { tx, fin: Some(fin) }
     }
 
-    /// Queue this subscriber's removal signal, then hand its terminal frame to
-    /// the writer — the [`ExecFinishGuard::reply`] rule, for the same reason.
+    /// Reserve the writer, then queue this subscriber's removal signal and
+    /// push its terminal frame — the [`ExecFinishGuard::reply`] rule, for the
+    /// same two reasons.
     ///
     /// A client may re-INIT the ioid the instant it sees MONITOR FINISH, and
     /// `handle_op`'s duplicate-INIT check is connection-FATAL, so the op has to
@@ -1080,11 +1081,19 @@ impl MonitorFinishGuard {
     /// client's re-INIT racing the OS scheduler for the few instructions
     /// between the two; `biased` in [`handle_connection_io`] orders the two
     /// queues but cannot order a signal that has not been queued yet.
+    ///
+    /// And [`apply_monitor_finish`] removes the op, dropping the
+    /// `OpState::monitor_abort` that cancels this very task — so an await
+    /// between the signal and the push would let the removal destroy the
+    /// FINISH frame it was sent to announce.
     async fn reply(mut self, tx: &ChannelTx, buf: Vec<u8>) {
+        let permit = tx.reserve(buf.len()).await;
         if let Some(fin) = self.fin.take() {
             let _ = self.tx.send(fin);
         }
-        let _ = tx.send(buf).await;
+        if let Ok(permit) = permit {
+            permit.send(buf);
+        }
     }
 }
 
@@ -1219,8 +1228,9 @@ impl ExecFinishGuard {
         }
     }
 
-    /// Queue this task's completion signal, then hand its terminal frame to
-    /// the writer — in that order, and only in that order.
+    /// Reserve the writer, then queue this task's completion signal and push
+    /// its terminal frame — in that order, with no suspension point between
+    /// the last two.
     ///
     /// pvxs commits the op transition inside `ServerGPR::doReply` —
     /// `state = Idle` / `cleanup()` at `serverget.cpp:112-115` — and enqueues
@@ -1233,19 +1243,33 @@ impl ExecFinishGuard {
     /// on `exec_fin_tx`, so the same order has to be built rather than
     /// inherited: queue the transition first, and let the read loop drain that
     /// queue ahead of the socket (`biased` in [`handle_connection_io`]).
-    /// Signalling from `Drop` instead — after the body is already with the
-    /// writer — leaves the client's answer racing the OS scheduler for the few
-    /// instructions between the two.
+    ///
+    /// The reservation is what makes that safe to do from a *spawned* task.
+    /// [`poll_inline_or_spawn`] promotes this body to a task the moment any
+    /// await inside it returns `Pending` — which tokio's cooperative budget
+    /// makes happen on a wide-open writer queue, not only under real
+    /// backpressure — and parks its `AbortHandle` in `OpState::data_task_abort`.
+    /// The owner drops that handle as soon as it applies the signal
+    /// ([`apply_exec_finish`]), so an await *after* the signal is a
+    /// cancellation point the owner is already racing to fire: the task dies
+    /// mid-`send` and the client waits for a reply that no longer exists.
+    /// Taking both writer bounds first leaves the tail await-free, so
+    /// "the signal is queued" implies "the frame is queued" by construction —
+    /// and a cancellation before the reservation completes loses nothing,
+    /// because no signal has been queued yet.
     ///
     /// Taking `self` by value is what closes the family: a data-phase task
     /// reaches the writer through this method or not at all, so no site can
     /// enqueue a body while its own op is still marked `Executing`.
     async fn reply(mut self, tx: &ChannelTx, buf: Vec<u8>, success: bool) {
+        let permit = tx.reserve(buf.len()).await;
         if let Some(mut fin) = self.fin.take() {
             fin.success = success;
             let _ = self.tx.send(fin);
         }
-        let _ = tx.send(buf).await;
+        if let Ok(permit) = permit {
+            permit.send(buf);
+        }
     }
 
     /// [`Self::reply`] for the error frames a data-phase task emits instead of
@@ -3283,19 +3307,40 @@ impl SrvTx {
         )
     }
 
-    async fn send(&self, buf: Vec<u8>) -> Result<(), tokio::sync::mpsc::error::SendError<Vec<u8>>> {
-        if self.budget.acquire(buf.len()).await.is_err() {
-            return Err(tokio::sync::mpsc::error::SendError(buf));
-        }
-        let len = buf.len();
-        match self.tx.send(buf).await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                // The frame never entered the queue; hand its budget back
+    /// Take both bounds for a frame of `len` bytes up front and hand back
+    /// the reservation, so the push itself is synchronous.
+    ///
+    /// This is what lets a spawned op task pair its completion signal with
+    /// its frame atomically: a task can only be cancelled at an `await`, so
+    /// a producer that has already reserved can queue a signal and push its
+    /// frame with no suspension point in between (see
+    /// [`ExecFinishGuard::reply`]). Awaiting `send` instead puts an await —
+    /// therefore a cancellation point — after the signal, where the owner
+    /// has already dropped the task's `AbortOnDrop`.
+    async fn reserve(&self, len: usize) -> Result<TxPermit<'_>, ()> {
+        self.budget.acquire(len).await?;
+        match self.tx.reserve().await {
+            Ok(permit) => Ok(TxPermit {
+                permit: Some(permit),
+                budget: self.budget.clone(),
+                len,
+            }),
+            Err(_closed) => {
+                // The frame can never enter the queue; hand its budget back
                 // so any producer racing the shutdown is not stuck short.
                 self.budget.release(len);
-                Err(e)
+                Err(())
             }
+        }
+    }
+
+    async fn send(&self, buf: Vec<u8>) -> Result<(), tokio::sync::mpsc::error::SendError<Vec<u8>>> {
+        match self.reserve(buf.len()).await {
+            Ok(permit) => {
+                permit.send(buf);
+                Ok(())
+            }
+            Err(()) => Err(tokio::sync::mpsc::error::SendError(buf)),
         }
     }
 
@@ -3309,6 +3354,35 @@ impl SrvTx {
 
     fn is_closed(&self) -> bool {
         self.tx.is_closed()
+    }
+}
+
+/// Both writer bounds — one queue slot and `len` bytes of [`TxBudget`] —
+/// held for a frame that has not been pushed yet ([`SrvTx::reserve`]).
+///
+/// Consuming it with [`Self::send`] is infallible and synchronous. Dropping
+/// it unused (the producer was cancelled while still holding the
+/// reservation) returns the byte budget; the queue slot is returned by the
+/// inner `Permit`'s own `Drop`.
+struct TxPermit<'a> {
+    permit: Option<tokio::sync::mpsc::Permit<'a, Vec<u8>>>,
+    budget: TxBudget,
+    len: usize,
+}
+
+impl TxPermit<'_> {
+    fn send(mut self, buf: Vec<u8>) {
+        if let Some(permit) = self.permit.take() {
+            permit.send(buf);
+        }
+    }
+}
+
+impl Drop for TxPermit<'_> {
+    fn drop(&mut self) {
+        if self.permit.take().is_some() {
+            self.budget.release(self.len);
+        }
     }
 }
 
@@ -3346,6 +3420,16 @@ impl ChannelTx {
         self.tx.send(buf).await
     }
 
+    /// [`SrvTx::reserve`] for a per-channel frame. The reservation carries
+    /// the channel's stat handle so the `statTx` count is still taken at the
+    /// single owner, at the moment the frame is pushed.
+    async fn reserve(&self, len: usize) -> Result<ChannelTxPermit<'_>, ()> {
+        Ok(ChannelTxPermit {
+            permit: self.tx.reserve(len).await?,
+            stat: self.stat.clone(),
+        })
+    }
+
     /// Current free capacity of the underlying writer channel — used by
     /// the monitor outbound-queue-depth diagnostic. Delegates to the
     /// wrapped `Sender`; carries no byte accounting.
@@ -3357,6 +3441,19 @@ impl ChannelTx {
     /// [`Self::capacity`]).
     fn max_capacity(&self) -> usize {
         self.tx.max_capacity()
+    }
+}
+
+/// [`TxPermit`] plus the channel whose `statTx` the frame counts against.
+struct ChannelTxPermit<'a> {
+    permit: TxPermit<'a>,
+    stat: Arc<crate::server_native::peers::ChannelStat>,
+}
+
+impl ChannelTxPermit<'_> {
+    fn send(self, buf: Vec<u8>) {
+        self.stat.add_tx(buf.len());
+        self.permit.send(buf);
     }
 }
 
@@ -21036,15 +21133,17 @@ mod tests {
     }
 
     /// The removal signal must be QUEUED before the monitor's terminal frame,
-    /// for the same reason [`ExecFinishGuard::reply`] carries: a client may
-    /// re-INIT this ioid the instant it sees MONITOR FINISH, and `handle_op`'s
-    /// duplicate-INIT check is connection-FATAL, so the op has to be gone from
-    /// `channels` before that INIT is dispatched. Park
-    /// [`MonitorFinishGuard::reply`] on a full writer queue: the frame provably
-    /// has not been enqueued, and the signal must already be there. A
-    /// `Drop`-only guard fails this.
+    /// for the reason [`MonitorFinishGuard::reply`] carries — but NOT before
+    /// the frame's writer slot is reserved. Applying that signal removes the
+    /// op, which drops `monitor_abort` and cancels this very task, so any
+    /// suspension point between the signal and the push is a window where the
+    /// FINISH frame is destroyed by the removal it announced.
+    ///
+    /// Boundary: parked on a full writer queue, no signal may be out yet.
+    /// Once the slot frees, both are out. Revert-verify: signal before
+    /// reserving (the pre-fix body) and the first assertion fails.
     #[epics_macros_rs::epics_test]
-    async fn monitor_finish_signal_is_queued_before_its_terminal_frame() {
+    async fn monitor_finish_signal_waits_for_the_writer_reservation() {
         use std::future::Future;
 
         let (srv_tx, mut wire_rx, _budget) = SrvTx::channel(1, 1 << 20);
@@ -21071,14 +21170,19 @@ mod tests {
             reply.as_mut().poll(&mut cx).is_pending(),
             "the writer queue is full, so the frame cannot have been enqueued"
         );
-        let got = rx
-            .try_recv()
-            .expect("the removal signal is queued ahead of the frame");
-        assert_eq!((got.sid, got.ioid, got.op_id), (3, 11, 77));
+        assert!(
+            rx.try_recv().is_err(),
+            "no signal may be queued while the frame is still unreservable — \
+             the owner would answer it by aborting this task mid-send"
+        );
 
-        // Free the slot: the frame still goes out, and the guard signals once.
+        // Free the slot: the signal and the frame both go out, once each.
         assert_eq!(wire_rx.recv().await.as_deref(), Some(&[0u8][..]));
         reply.await;
+        let got = rx
+            .try_recv()
+            .expect("the removal signal rides out with the frame");
+        assert_eq!((got.sid, got.ioid, got.op_id), (3, 11, 77));
         assert_eq!(wire_rx.recv().await.as_deref(), Some(&[1u8][..]));
         assert!(
             rx.try_recv().is_err(),
@@ -23234,12 +23338,16 @@ mod bfr15_tests {
     /// never send a frame the server meets with a still-`Executing` op — and
     /// `begin_exec` answers such a frame by dropping it with no reply at all.
     ///
-    /// Park [`ExecFinishGuard::reply`] on a full writer queue: the frame
-    /// provably has not been enqueued, and the signal must already be there.
-    /// A `Drop`-only guard, which signalled after `tx.send(buf).await`
-    /// returned, fails this.
+    /// It must NOT be queued before the frame's writer slot is reserved,
+    /// though: applying it drops `OpState::data_task_abort`, so a suspension
+    /// point after the signal is a window in which the reply is destroyed
+    /// (see `exec_reply_frame_survives_an_abort_racing_its_signal`).
+    ///
+    /// Boundary: parked on a full writer queue, no signal may be out yet;
+    /// once the slot frees, both are out. Revert-verify: signal before
+    /// reserving (the pre-fix body) and the first assertion fails.
     #[epics_macros_rs::epics_test]
-    async fn exec_finish_signal_is_queued_before_its_reply_frame() {
+    async fn exec_finish_signal_waits_for_the_writer_reservation() {
         use std::future::Future;
 
         let (srv_tx, mut wire_rx, _budget) = SrvTx::channel(1, 1 << 20);
@@ -23268,22 +23376,140 @@ mod bfr15_tests {
             reply.as_mut().poll(&mut cx).is_pending(),
             "the writer queue is full, so the frame cannot have been enqueued"
         );
+        assert!(
+            fin_rx.try_recv().is_err(),
+            "no signal may be queued while the frame is still unreservable — \
+             the owner would answer it by aborting this task mid-send"
+        );
+
+        // Free the slot: the signal and the frame both go out, once each.
+        assert_eq!(wire_rx.recv().await.as_deref(), Some(&[0u8][..]));
+        reply.await;
         let fin = fin_rx
             .try_recv()
-            .expect("the completion signal is queued ahead of the frame");
+            .expect("the completion signal rides out with the frame");
         assert_eq!(
             (fin.sid, fin.ioid, fin.op_id, fin.success),
             (1, 500, 7, true)
         );
-
-        // Free the slot: the frame still goes out, and exactly once.
-        assert_eq!(wire_rx.recv().await.as_deref(), Some(&[0u8][..]));
-        reply.await;
         assert_eq!(wire_rx.recv().await.as_deref(), Some(&[1u8][..]));
         assert!(
             fin_rx.try_recv().is_err(),
             "the guard signals exactly once, not again from Drop"
         );
+    }
+
+    /// The defect this reservation exists to close, end to end: the owner
+    /// applies the completion signal the instant it arrives, and applying it
+    /// drops `OpState::data_task_abort` — aborting the very task that sent it.
+    /// While the reply frame still had to `await` its way into the writer
+    /// after the signal, that abort landed mid-`send` and the frame was
+    /// destroyed; the client then waited out its whole timeout for a reply the
+    /// server believed it had sent.
+    ///
+    /// `poll_inline_or_spawn` makes this reachable on an idle server, not just
+    /// a backpressured one: tokio's cooperative budget returns `Pending` from
+    /// `Semaphore::acquire_many_owned` with the queue wide open, which promotes
+    /// the reply body to a task and installs the abort handle in the first
+    /// place — which is why the loss was load-dependent and hit a different
+    /// channel every run.
+    ///
+    /// Revert-verify: move the signal ahead of `tx.reserve` (the pre-fix body)
+    /// and the frame assertion fails.
+    // A bare `tokio::spawn` handle into `AbortOnDrop`, as in
+    // `cancel_request_returns_non_monitor_exec_to_idle_and_aborts_task`.
+    #[cfg(tokio_backend)]
+    #[epics_macros_rs::epics_test]
+    async fn exec_reply_frame_survives_an_abort_racing_its_signal() {
+        let (sid, ioid) = (5u32, 77u32);
+
+        let (srv_tx, mut wire_rx, _budget) = SrvTx::channel(1, 1 << 20);
+        let chan_tx = ChannelTx::new(
+            srv_tx,
+            crate::server_native::peers::ChannelStat::new(String::new()),
+        );
+        // Hold the only slot so the reply parks in `reserve`, exactly as a
+        // cooperative-budget `Pending` parks it on a live connection.
+        chan_tx.send(vec![0u8]).await.expect("first frame fits");
+
+        let source: DynSource = Arc::new(crate::server_native::SharedSource::new());
+        let mut op = non_monitor_op_state(
+            std::sync::Arc::new(FieldDesc::Variant),
+            OpKind::Get,
+            BitSet::new(),
+        );
+        op.exec_state = ExecState::Executing;
+        let op_id = op.monitor_op_id;
+
+        let (fin_tx, mut fin_rx) = mpsc::unbounded_channel();
+        let guard = ExecFinishGuard::new(
+            fin_tx,
+            ExecFinished {
+                sid,
+                ioid,
+                op_id,
+                success: false,
+                scratch: None,
+            },
+        );
+        let reply_tx = chan_tx.clone();
+        let task = tokio::spawn(async move {
+            guard.reply(&reply_tx, vec![1u8], true).await;
+        });
+        op.data_task_abort = Some(Arc::new(AbortOnDrop(task.abort_handle())));
+
+        let mut channels: HashMap<u32, ChannelState> = HashMap::new();
+        let mut ops = HashMap::new();
+        ops.insert(ioid, op);
+        channels.insert(
+            sid,
+            ChannelState {
+                name: "dut".into(),
+                cid: 0,
+                sid,
+                introspection: Some(std::sync::Arc::new(FieldDesc::Variant)),
+                source,
+                stat: crate::server_native::peers::ChannelStat::new(String::new()),
+                open_cred: Arc::new(ClientCredentials::anonymous(TEST_PEER)),
+                ops,
+                parked: HashMap::new(),
+                put_scratch: None,
+                intro_wire: None,
+            },
+        );
+
+        // The owner does what the read loop's `biased` select does: apply any
+        // completion signal that is available, ahead of anything else. The
+        // reply is still parked on the writer, so a signal here is a signal
+        // sent with the frame not yet queued — and applying it drops the
+        // task's abort guard, cancelling the sender at that parked await.
+        let early = tokio::time::timeout(Duration::from_millis(500), fin_rx.recv()).await;
+        let signalled_before_reserving = matches!(early, Ok(Some(_)));
+        if let Ok(Some(fin)) = early {
+            apply_exec_finish(&mut channels, fin);
+            assert!(
+                channels[&sid]
+                    .ops
+                    .get(&ioid)
+                    .is_none_or(|op| op.data_task_abort.is_none()),
+                "applying the signal must drop the task's abort guard"
+            );
+        }
+
+        // Free the slot. Whatever the owner just did, the client is owed its
+        // reply: pre-fix the task was aborted mid-`send` and this times out.
+        assert_eq!(wire_rx.recv().await.as_deref(), Some(&[0u8][..]));
+        let frame = tokio::time::timeout(Duration::from_secs(5), wire_rx.recv())
+            .await
+            .expect("the reply frame must survive an abort racing its own signal");
+        assert_eq!(frame.as_deref(), Some(&[1u8][..]));
+
+        if !signalled_before_reserving {
+            fin_rx
+                .recv()
+                .await
+                .expect("the completion signal rides out with the frame");
+        }
     }
 
     /// pvxs `ServerGPR::doReply`

--- a/crates/epics-rtems-boot/README.md
+++ b/crates/epics-rtems-boot/README.md
@@ -98,9 +98,8 @@ image).
 ## The target spec (applied automatically)
 
 Every build of the builtin `armv7-rtems-eabihf` triple in this workspace goes
-through the one-key spec deviation `has-thread-local: true`
-(`doc/rtems-tls-spec-deviation.md` — it takes std's per-thread TLS leak on
-RTEMS from 136 B to 0). You do not pass anything: `.cargo/config.toml` wires
+through the one-key spec deviation `has-thread-local: true`, which takes std's
+per-thread TLS leak on RTEMS from 136 B to 0. You do not pass anything: `.cargo/config.toml` wires
 `build.rustc-wrapper = scripts/rtems-rustc-wrapper.sh`, which rewrites the
 triple to a spec generated from the exact rustc in use and leaves every other
 invocation (host builds included) untouched.

--- a/crates/epics-rtems-boot/build.rs
+++ b/crates/epics-rtems-boot/build.rs
@@ -23,6 +23,7 @@ fn main() {
     println!("cargo::rerun-if-changed=csrc/boot_args.h");
     println!("cargo::rerun-if-changed=csrc/rtems_config.c");
     println!("cargo::rerun-if-changed=csrc/rtems_init.c");
+    println!("cargo::rerun-if-changed=csrc/rtems_shell_cmds.c");
     println!("cargo::rerun-if-changed=csrc/rtems_stats.c");
     println!("cargo::rerun-if-changed=src/contract.rs");
     println!("cargo::rerun-if-env-changed={BSP_PREFIX_ENV}");
@@ -60,6 +61,7 @@ fn main() {
         .file("csrc/boot_args.c")
         .file("csrc/rtems_config.c")
         .file("csrc/rtems_init.c")
+        .file("csrc/rtems_shell_cmds.c")
         .file("csrc/rtems_stats.c")
         .include(&include_dir)
         // Base passes -DBSP_$(RTEMS_BSP) (modules/libcom/RTEMS/Makefile:41) so

--- a/crates/epics-rtems-boot/csrc/rtems_config.c
+++ b/crates/epics-rtems-boot/csrc/rtems_config.c
@@ -3,9 +3,9 @@
  *
  * Derived from EPICS base's POSIX arm,
  * `modules/libcom/RTEMS/posix/rtems_config.c` (read in full); every directive
- * below cites the base line it comes from, and `doc/rtems-boot-shim-design.md`
- * §1.1 lists what base configures that we deliberately do not — NFS, TFTP,
- * telnetd, ftpd, libblock/BDBUF, the RTC driver, the ~25-command shell.
+ * below cites the base line it comes from. What base configures and this file
+ * deliberately does not: NFS, TFTP, telnetd, ftpd, libblock/BDBUF, the RTC
+ * driver, the ~25-command shell.
  *
  * This is a *configuration* translation unit: `<rtems/confdefs.h>` at the
  * bottom turns the `CONFIGURE_*` macros above it into the actual RTEMS object
@@ -145,7 +145,7 @@ extern void *POSIX_Init(void *argument);
  * ---------------------------------------------------------------------------
  * THIS IS A DEVIATION: we run base's score-arm 150 on a target where base
  * itself compiles the POSIX arm and runs 64 (see the arm selection above).
- * Full record, with every measurement: `doc/rtems-fd-ceiling-deviation.md`.
+ * Every measurement behind it is below.
  * ---------------------------------------------------------------------------
  *
  * MEASURED on the bring-up box, identical driver (raw CA TCP, version

--- a/crates/epics-rtems-boot/csrc/rtems_init.c
+++ b/crates/epics-rtems-boot/csrc/rtems_init.c
@@ -5,10 +5,9 @@
  * compile-time static address — then calls the Rust `main`. Derived from
  * EPICS base's POSIX arm,
  * `modules/libcom/RTEMS/posix/rtems_init.c`; each step cites the base line it
- * comes from, and `doc/rtems-boot-shim-design.md` §1.1 records what base does
- * here that we deliberately drop (NFS/TFTP mounts, iocsh registration and the
- * startup script, telnetd, NTP, the NVRAM boot path, the i386 QEMU e1000 NVM
- * hack).
+ * comes from. What base does here that this file deliberately drops: NFS/TFTP
+ * mounts, iocsh registration and the startup script, telnetd, NTP, the NVRAM
+ * boot path, the i386 QEMU e1000 NVM hack.
  *
  * The contract with Rust is one line: base's `main(argc, argv)` call at
  * :1184. rustc emits a C `main` that hands argc/argv to the Rust runtime, so

--- a/crates/epics-rtems-boot/csrc/rtems_shell_cmds.c
+++ b/crates/epics-rtems-boot/csrc/rtems_shell_cmds.c
@@ -1,0 +1,213 @@
+/*
+ * rtems_shell_cmds.c — the RTEMS-side half of the operator commands EPICS
+ * base registers from `iocshRegisterRTEMS`
+ * (`modules/libcom/RTEMS/posix/rtems_init.c:692-705` @R7.0.10, and its
+ * `score/` twin at `:523-528`).
+ *
+ * Base registers six there — netstat, heapSpace, nfsMount, zoneset, rt,
+ * setlogmask — and the Rust side of this port registers five of them from
+ * `epics_base_rs::server::iocsh::register_rtems_commands`. This file is only
+ * the part that has to call an RTEMS or libbsd API; everything expressible in
+ * Rust (`zoneset`, the number formatting) stays in Rust, where it is host-
+ * testable.
+ *
+ * Two of base's six are not here and each has its own reason:
+ *
+ *   * `heapSpace` reads the malloc heap, which is `rtems_stats.c`'s job — the
+ *     one file in this crate that already owns `RTEMS_Malloc_Heap`. Its
+ *     `epics_rtems_boot_heap_space` is base's exact three inputs.
+ *   * `nfsMount` cannot be written at all on this stack. Base's own posix arm
+ *     includes `<librtemsNfs.h>` only under `#ifdef RTEMS_LEGACY_STACK`
+ *     (`rtems_init.c:60-62`) while calling `nfsMount()` under
+ *     `#ifndef OMIT_NFS_SUPPORT` (`:593-604`, `:696`), so a base build on the
+ *     libbsd stack that does NOT define `OMIT_NFS_SUPPORT` calls an undeclared
+ *     function. The API itself is gone: rtems-libbsd's `librtemsNfs.h`
+ *     declares `rpcUdpInit`, `nfsInit`, `nfsMountsShow` and
+ *     `rtems_nfs_initialize` and no `nfsMount(char *, char *, char *)` (both
+ *     libbsd pins). NFS on this stack is reached through `mount()` with
+ *     `RTEMS_FILESYSTEM_TYPE_NFS`, which is a different command, and this
+ *     image configures no NFS filesystem. So the command is absent here
+ *     because it is absent on the target, not because it was skipped.
+ *
+ * NOT BUILT FOR THE TARGET ON THIS MACHINE. Like `rtems_init.c` it is
+ * compiled FOR THE HOST on every push against the RTEMS declarations recorded
+ * in tests/rtems-api/, so a name, an arity or a format string that is wrong
+ * here fails CI rather than the board's console. That record's README.md says
+ * what the host compile does and does not prove.
+ */
+
+/* Base does the same, for the same reason: it is what makes <syslog.h> emit
+ * the prioritynames[] table the level listing walks (base :21-22). */
+#define SYSLOG_NAMES
+
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <rtems/bsd/bsd.h>
+#include <rtems/shell.h>
+
+#include <machine/rtems-bsd-commands.h>
+
+/*
+ * `netstat <level>` — base `netStatCallFunc`/`rtems_netstat` (:531-547).
+ *
+ * DELIBERATE DEVIATION, and the only one in this file: base's own body on
+ * this stack is
+ *
+ *     printf("***** Sorry not implemented yet with the new network stack
+ *            (bsdlib)\n");
+ *
+ * because `rtems_netstat` is written against the legacy `rtems_bsdnet_show_*`
+ * calls and everything but the apology is inside `#ifdef RTEMS_LEGACY_STACK`.
+ * An IOC on RTEMS 6/7 therefore has a `netstat` command that reports nothing.
+ *
+ * The readings it wanted are all still available on libbsd, from the same
+ * `netstat` this crate's `POSIX_Init` already runs at boot
+ * (`rtems_init.c:508-516`), so this produces them instead of the apology.
+ * The mapping is base's own level ladder, one flag per legacy call:
+ *
+ *     level >= 0   rtems_bsdnet_show_if_stats     -> netstat -i
+ *                  rtems_bsdnet_show_mbuf_stats   -> netstat -m
+ *     level >= 1   rtems_bsdnet_show_inet_routes  -> netstat -rn
+ *     level >= 2   show_{ip,icmp,udp,tcp}_stats   -> netstat -s
+ *
+ * `-s` is one call where base made four; libbsd's netstat has no per-protocol
+ * flag and prints all four sections, which is the same information in one
+ * pass rather than a subset.
+ *
+ * Void, like base's: `netStatCallFunc` (:548-551) has no failure path and
+ * `rtems_netstat` returns nothing, so a `netstat` line cannot fail a script
+ * here either. libbsd's netstat reports its own errors on the console.
+ */
+void epics_rtems_boot_netstat(int level) {
+  static char netstat[] = "netstat";
+  static char dash_i[] = "-i";
+  static char dash_m[] = "-m";
+  static char dash_rn[] = "-rn";
+  static char dash_s[] = "-s";
+
+  char *if_argv[] = {netstat, dash_i, NULL};
+  char *mbuf_argv[] = {netstat, dash_m, NULL};
+  char *route_argv[] = {netstat, dash_rn, NULL};
+  char *proto_argv[] = {netstat, dash_s, NULL};
+
+  /* Base flushes around every shell hand-off (`rtshellCallFunc`, :512-519)
+   * because the C library's buffer and the command's own output otherwise
+   * interleave on one serial line. */
+  fflush(stdout);
+
+  (void)rtems_bsd_command_netstat(2, if_argv);
+  (void)rtems_bsd_command_netstat(2, mbuf_argv);
+
+  if (level >= 1) {
+    (void)rtems_bsd_command_netstat(2, route_argv);
+  }
+
+  if (level >= 2) {
+    (void)rtems_bsd_command_netstat(2, proto_argv);
+  }
+
+  fflush(stdout);
+}
+
+/*
+ * `rt <cmd> <args...>` — base `rtshellCallFunc` (:506-524).
+ *
+ * `rtems_shell_init_environment` is what links the configured command set
+ * (`rtems_config.c` §L) into the list `rtems_shell_lookup_cmd` walks. Base
+ * calls it once, from `iocshRegisterRTEMS` itself (:704). It is called here
+ * instead, on every lookup, so the ordering invariant holds BY CONSTRUCTION —
+ * there is no way to reach a lookup without it — rather than by remembering
+ * to register in the right order from Rust. It is `pthread_once`-guarded
+ * upstream (`cpukit/libmisc/shell/shell.c:203-206`), so the repeat costs one
+ * atomic.
+ *
+ * Returns 0 with `*status` set when the command ran, -1 when there is no such
+ * command. `*status` is untouched in the second case, so a caller cannot read
+ * a stale exit code as a real one.
+ */
+int epics_rtems_boot_shell_run(const char *cmd, int argc, char **argv,
+                               int *status) {
+  rtems_shell_cmd_t *found;
+
+  if (cmd == NULL || argv == NULL || status == NULL) {
+    return -1;
+  }
+
+  rtems_shell_init_environment();
+
+  found = rtems_shell_lookup_cmd(cmd);
+  if (found == NULL) {
+    return -1;
+  }
+
+  fflush(stdout);
+  fflush(stderr);
+  *status = (*found->command)(argc, argv);
+  fflush(stdout);
+  fflush(stderr);
+  return 0;
+}
+
+/*
+ * `setlogmask <level>` — base `setlogmaskCallFunc` (:660-686).
+ *
+ * Base does two things with the level it matched: `setlogmask(LOG_MASK(val))`
+ * and, on the libbsd stack only, `rtems_bsd_setlogpriority(name)`. Only the
+ * second has an effect here, and that is libbsd's own decision rather than an
+ * inference: its `setlogmask` is a stub that ignores its argument and returns
+ * 0, with the comment that the mask is process-wide, that RTEMS has no
+ * processes, and that "the syslog mask can be set via
+ * rtems_bsd_setlogpriority()" (`rtemsbsd/rtems/syslog.c:92-104`, both libbsd
+ * pins). Calling it as well would be implementation parity with a provably
+ * inert call, so this does not.
+ *
+ * The name lookup stays base's — `strcmp` against `prioritynames`, so an
+ * unknown level is refused here rather than by libbsd, and the case-
+ * insensitive match `rtems_bsd_setlogpriority` would do on its own is not
+ * silently more permissive than a C IOC.
+ *
+ * Note the two spellings differ in reach: base asks for `LOG_MASK(val)` — one
+ * level — while libbsd sets `LOG_UPTO(c_val)`, that level and everything more
+ * severe. That is the behaviour a base IOC on this stack already has, since
+ * `rtems_bsd_setlogpriority` is the call that lands.
+ *
+ * Returns 0 when the level was known and set, -1 otherwise.
+ */
+int epics_rtems_boot_set_log_priority(const char *name) {
+  const CODE *cur;
+
+  if (name == NULL) {
+    return -1;
+  }
+
+  for (cur = prioritynames; cur->c_name; cur++) {
+    if (strcmp(name, cur->c_name) != 0) {
+      continue;
+    }
+    return rtems_bsd_setlogpriority(name) == 0 ? 0 : -1;
+  }
+
+  return -1;
+}
+
+/*
+ * The syslog level names, by index, NULL past the end — base's usage listing
+ * (:665-671) walked from the caller's side.
+ *
+ * An index rather than the table pointer because `prioritynames` is a
+ * definition inside <syslog.h>, so its element type is the C library's, not
+ * one this file could name in a header for Rust to match.
+ */
+const char *epics_rtems_boot_log_priority_name(unsigned index) {
+  unsigned i;
+
+  for (i = 0; prioritynames[i].c_name; i++) {
+    if (i == index) {
+      return prioritynames[i].c_name;
+    }
+  }
+
+  return NULL;
+}

--- a/crates/epics-rtems-boot/csrc/rtems_stats.c
+++ b/crates/epics-rtems-boot/csrc/rtems_stats.c
@@ -54,8 +54,8 @@
  * the most predictive thing the IOC can publish about how close it is to
  * refusing clients — and MEASURED, it is the *only* one that sees this wall:
  * CA_REFUSED_CNT stayed 0 through the whole ramp, because an accept-time
- * ENFILE happens before a client object exists. Cap, walls and the operator
- * consequences: doc/rtems-fd-ceiling-deviation.md.
+ * ENFILE happens before a client object exists. The cap itself, and every
+ * measured wall behind it, is set and recorded in `rtems_config.c`.
  */
 int epics_rtems_boot_fd_usage(uint32_t *used, uint32_t *max) {
   uint32_t i;
@@ -113,10 +113,53 @@ int epics_rtems_boot_mem_usage(uint64_t *free_total, uint64_t *used_total,
 }
 
 /*
- * STAGE-5 PROBE — MEASUREMENT ONLY (doc/pvalink-rtems-design.md §5 stage 5,
- * pass criterion 6). Not merged; see doc/pvalink-stage5-probe.patch.
+ * The three heap numbers the `heapSpace` iocsh command is written against —
+ * EPICS base `heapSpaceCallFunc` (`libcom/RTEMS/posix/rtems_init.c:560-586`
+ * @R7.0.10), whose RTEMS >= 5 arm prints
  *
- * Criterion 6 asks for `rt stackuse` / `rt top` on the guest. This image
+ *     size - (unsigned long)(lifetime_allocated - lifetime_freed)
+ *
+ * These are `Heap_Information_block::Stats`, a different measurement from the
+ * `Free`/`Used` block walk above and NOT a restatement of it: `Stats.size` is
+ * the allocatable area the heap was given (`heap.c:311`) and the lifetime
+ * counters accumulate `_Heap_Block_size` on both sides (`heapallocate.c:303`,
+ * `heapfree.c:230`), so their difference is bytes held in used blocks
+ * INCLUDING per-block overhead. `Free.total` sums free block sizes, which
+ * excludes the overhead the walk skips. The two agree to within block headers
+ * and are not the same number, so the command gets its own reading rather than
+ * a nearby one.
+ *
+ * Base reaches these through `malloc_info()`, whose whole body is
+ * `_Protected_heap_Get_information(RTEMS_Malloc_Heap, the_info)`
+ * (`libcsupport/src/mallocinfo.c:43-51`) — the call above — so this uses that
+ * directly and stays one include shorter, at the same source of truth.
+ *
+ * Same contract as its neighbours: 0 and three values, or -1 and nothing
+ * written.
+ */
+int epics_rtems_boot_heap_space(uint64_t *size, uint64_t *lifetime_allocated,
+                                uint64_t *lifetime_freed) {
+  Heap_Information_block info;
+
+  if (size == NULL || lifetime_allocated == NULL || lifetime_freed == NULL) {
+    return -1;
+  }
+
+  if (!_Protected_heap_Get_information(RTEMS_Malloc_Heap, &info)) {
+    return -1;
+  }
+
+  *size = (uint64_t)info.Stats.size;
+  *lifetime_allocated = (uint64_t)info.Stats.lifetime_allocated;
+  *lifetime_freed = (uint64_t)info.Stats.lifetime_freed;
+  return 0;
+}
+
+/*
+ * STAGE-5 PROBE — MEASUREMENT ONLY. The wiring that calls these two functions
+ * from an image is not merged; only the functions themselves live here.
+ *
+ * The stage-5 pass criterion asks for `rt stackuse` / `rt top` on the guest. This image
  * configures the shell's commands (CONFIGURE_SHELL_COMMAND_STACKUSE,
  * rtems_config.c) but never starts a shell task, and the target has no
  * console input path at all — so the two readings have to be produced from
@@ -129,9 +172,8 @@ int epics_rtems_boot_mem_usage(uint64_t *free_total, uint64_t *used_total,
  *     CONFIGURE_STACK_CHECKER_ENABLED, which csrc/rtems_config.c:223 already sets.
  *   * `epics_rtems_boot_dump_tasks` is the task census (the `rt top` half —
  *     thread count, kernel names, effective priorities). It is verbatim the
- *     probe doc/rtems-priority-probe.patch used for the priority measurement,
- *     reused here rather than re-invented so both measurements are reading
- *     the same listing.
+ *     probe used for the priority measurement, reused here rather than
+ *     re-invented so both measurements are reading the same listing.
  *
  * The visitor only copies ids: `rtems_task_iterate` runs it with the object
  * allocator mutex held, so every query that could block or take another lock

--- a/crates/epics-rtems-boot/csrc/tests/rtems-api/README.md
+++ b/crates/epics-rtems-boot/csrc/tests/rtems-api/README.md
@@ -1,8 +1,8 @@
 # Recorded RTEMS API
 
-The declarations `../../rtems_init.c` names, copied verbatim out of an
-installed RTEMS 6 BSP, so that a CI runner with no cross toolchain can compile
-that file with `-Werror`.
+The declarations `../../rtems_init.c` and `../../rtems_shell_cmds.c` name,
+copied verbatim out of an installed RTEMS 6 BSP, so that a CI runner with no
+cross toolchain can compile those files with `-Werror`.
 
 ## Why this exists
 
@@ -41,6 +41,9 @@ Proved on every push, by `scripts/csrc-check.sh`:
 - `rtems_init.c` compiles under `-Wall -Wextra -Werror`, in all four
   configurations its `#if`s select (DHCP; static address; static address with a
   gateway; `EPICS_RTEMS_BSD_LOG_DEBUG=0`).
+- `rtems_shell_cmds.c` — the RTEMS half of the operator commands base registers
+  from `iocshRegisterRTEMS` — compiles under the same flags. It has no `#if` of
+  its own, so one configuration is all of it.
 - Every RTEMS and libbsd name it uses exists, with the right arity, argument
   types and return type — including the `printf` format checking that
   `RTEMS_PRINTFLIKE` puts on `rtems_panic`.

--- a/crates/epics-rtems-boot/csrc/tests/rtems-api/machine/rtems-bsd-commands.h
+++ b/crates/epics-rtems-boot/csrc/tests/rtems-api/machine/rtems-bsd-commands.h
@@ -1,6 +1,6 @@
 /*
  * Recorded RTEMS 6 / rtems-libbsd declarations — the subset that
- * csrc/rtems_init.c names, and nothing else.
+ * csrc/rtems_init.c and csrc/rtems_shell_cmds.c name, and nothing else.
  *
  * This is NOT a copy of the real header. Every block introduced by an
  * `@rtems-api <header>` marker is verbatim text from that header in an

--- a/crates/epics-rtems-boot/csrc/tests/rtems-api/rtems/bsd/bsd.h
+++ b/crates/epics-rtems-boot/csrc/tests/rtems-api/rtems/bsd/bsd.h
@@ -1,6 +1,6 @@
 /*
  * Recorded RTEMS 6 / rtems-libbsd declarations — the subset that
- * csrc/rtems_init.c names, and nothing else.
+ * csrc/rtems_init.c and csrc/rtems_shell_cmds.c name, and nothing else.
  *
  * This is NOT a copy of the real header. Every block introduced by an
  * `@rtems-api <header>` marker is verbatim text from that header in an

--- a/crates/epics-rtems-boot/csrc/tests/rtems-api/rtems/shell.h
+++ b/crates/epics-rtems-boot/csrc/tests/rtems-api/rtems/shell.h
@@ -1,0 +1,71 @@
+/*
+ * Recorded RTEMS 6 / rtems-libbsd declarations — the subset that
+ * csrc/rtems_shell_cmds.c names, and nothing else.
+ *
+ * This is NOT a copy of the real header. Every block introduced by an
+ * `@rtems-api <header>` marker is verbatim text from that header in an
+ * installed RTEMS 6 BSP, running to its `@rtems-api-end`, and
+ * `scripts/rtems-api-check.sh` proves it line for line against a real
+ * $RTEMS_BSP_PREFIX. Anything introduced by `@rtems-api-local` is ours and
+ * carries its own justification.
+ *
+ * The recorded text stays under its authors' licences: RTEMS (BSD-2-Clause,
+ * (c) OAR Corporation and contributors) and FreeBSD via rtems-libbsd
+ * (BSD-3-Clause, (c) The Regents of the University of California and
+ * contributors).
+ *
+ * Every block below is byte-identical in both series this workspace builds
+ * against — kernel `181e86a199` (series 7) and `51f962fb3f` (series 6),
+ * the pins `scripts/rtems-bsp.sh` installs — so pass 2 holds against either
+ * prefix. That is checked, not assumed: the two headers disagree elsewhere
+ * (the whole file is offset by 18 lines), which is why the record carries
+ * declarations rather than line numbers.
+ *
+ * See tests/rtems-api/README.md for why this exists.
+ */
+
+#ifndef EPICS_RS_RECORDED_RTEMS_SHELL_H
+#define EPICS_RS_RECORDED_RTEMS_SHELL_H
+
+/* @rtems-api-local: the recorded struct names mode_t, uid_t and gid_t, which
+ * the real header gets from its own <sys/types.h> include chain and the host
+ * supplies identically. */
+#include <sys/types.h>
+
+/* @rtems-api rtems/shell.h */
+typedef int (*rtems_shell_command_t)(int argc, char **argv);
+/* @rtems-api-end */
+
+/* @rtems-api rtems/shell.h */
+struct rtems_shell_cmd_tt;
+/* @rtems-api-end */
+
+/* @rtems-api rtems/shell.h */
+typedef struct rtems_shell_cmd_tt rtems_shell_cmd_t;
+/* @rtems-api-end */
+
+/* @rtems-api rtems/shell.h */
+struct rtems_shell_cmd_tt {
+  const char            *name;
+  const char            *usage;
+  const char            *topic;
+  rtems_shell_command_t  command;
+  rtems_shell_cmd_t     *alias;
+  rtems_shell_cmd_t     *next;
+  mode_t                 mode;
+  uid_t                  uid;
+  gid_t                  gid;
+};
+/* @rtems-api-end */
+
+/* @rtems-api rtems/shell.h */
+extern rtems_shell_cmd_t * rtems_shell_lookup_cmd(const char *cmd);
+/* @rtems-api-end */
+
+/* @rtems-api rtems/shell.h */
+extern void rtems_shell_init_environment(
+  void
+);
+/* @rtems-api-end */
+
+#endif /* EPICS_RS_RECORDED_RTEMS_SHELL_H */

--- a/crates/epics-rtems-boot/src/lib.rs
+++ b/crates/epics-rtems-boot/src/lib.rs
@@ -131,6 +131,7 @@
 //! | tree | pinned revision |
 //! | --- | --- |
 //! | `epics-base` | `R7.0.10` |
+//! | `iocStats` | `4.0.1` |
 //!
 //! **Resolve by symbol at the pin; the line is a hint.** Find the named
 //! function, struct, macro or field first, and treat the line number as a hint
@@ -166,6 +167,7 @@
 
 pub mod boot_args;
 pub mod contract;
+pub mod shell;
 pub mod stats;
 
 /// Undefined symbol deliberately left in this crate's object graph when it is

--- a/crates/epics-rtems-boot/src/shell/mod.rs
+++ b/crates/epics-rtems-boot/src/shell/mod.rs
@@ -1,0 +1,388 @@
+//! The RTEMS operator commands EPICS base registers from `iocshRegisterRTEMS`.
+//!
+//! C base registers six iocsh commands from its RTEMS boot path —
+//! `netstat`, `heapSpace`, `nfsMount`, `zoneset`, `rt` and `setlogmask`
+//! (`libcom/RTEMS/posix/rtems_init.c:692-705` @R7.0.10) — and four from its
+//! `score/` twin (`:523-528`, the same set without `rt` and `setlogmask`).
+//! They are registered from the boot path rather than from a `*IocRegister.c`,
+//! which is exactly why they belong to this crate: an IOC gets them because it
+//! booted on RTEMS, not because it loaded a database.
+//!
+//! This module owns their *behaviour*. The iocsh surface — argument
+//! descriptors, usage text, the registry entries — is
+//! `epics_base_rs::server::iocsh::register_rtems_commands`, because a
+//! `CommandDef` is that crate's type and this crate is one of its
+//! dependencies. Nothing here is reachable from the hosted `softioc-rs`.
+//!
+//! # Why this was never caught
+//!
+//! `iocsh/commands.rs`' `ABSENT_DATABASE_COMMANDS` census is measured by
+//! diffing `help` on a C `softIoc` against `softioc-rs`, and a Linux `softIoc`
+//! never reaches `iocshRegisterRTEMS`. The census is true and this gap was
+//! real at the same time; no measurement taken on a host can close it.
+//!
+//! # The five, and the sixth
+//!
+//! | command | where the work happens |
+//! | --- | --- |
+//! | `netstat` | [`netstat`] → libbsd's own `netstat`, see below |
+//! | `heapSpace` | [`crate::stats::heap_space`], base's three `Stats` inputs |
+//! | `zoneset` | [`zoneset`], pure libc, host-tested |
+//! | `rt` | [`run_shell_command`] → `rtems_shell_lookup_cmd` |
+//! | `setlogmask` | [`set_log_priority`], [`log_priority_names`] |
+//!
+//! `nfsMount` is the sixth and is NOT ported, because the API it names does
+//! not exist on this stack. Base's posix arm includes `<librtemsNfs.h>` only
+//! under `#ifdef RTEMS_LEGACY_STACK` (`rtems_init.c:60-62`) while calling
+//! `nfsMount()` under `#ifndef OMIT_NFS_SUPPORT` (`:593-604`, `:696`), so a
+//! base build on the libbsd stack either defines `OMIT_NFS_SUPPORT` — and has
+//! no `nfsMount` command — or calls an undeclared function. And the API is
+//! gone rather than moved: rtems-libbsd's `librtemsNfs.h` declares
+//! `rpcUdpInit`, `nfsInit`, `nfsMountsShow` and `rtems_nfs_initialize`, and no
+//! `nfsMount(char *, char *, char *)`, at both pins this workspace builds
+//! against. Mounting NFS on libbsd goes through `mount()` with
+//! `RTEMS_FILESYSTEM_TYPE_NFS`, which is a different command with a different
+//! argument grammar, and `csrc/rtems_config.c` configures no NFS filesystem
+//! for it to reach. A registered `nfsMount` that could only print a refusal
+//! would be worse than its absence: `help` would list it.
+//!
+//! # `netstat` is the one deliberate behavioural deviation
+//!
+//! Base's `rtems_netstat` (`:531-547`) puts every reading inside
+//! `#ifdef RTEMS_LEGACY_STACK`; on libbsd its whole body is
+//! `printf("***** Sorry not implemented yet with the new network stack
+//! (bsdlib)\n")`. So a C IOC on RTEMS 6/7 has a `netstat` command that reports
+//! nothing at all. `csrc/rtems_shell_cmds.c` produces the readings base wanted
+//! from libbsd's own `netstat`, mapping base's level ladder onto its flags.
+//! See that file for the mapping.
+//!
+//! # The OS fork happens once
+//!
+//! Same shape as [`crate::stats`], for the same reason: one backend module
+//! selected by `#[cfg]` below, and no `#[cfg]` anywhere else in this file —
+//! `the_os_fork_happens_only_at_the_backend_selection` below holds that.
+//! [`zoneset`] is in the funnel rather than in a backend because it calls no
+//! RTEMS API: `setenv`/`unsetenv`/`tzset` is the whole of base's
+//! implementation (`:611-627`), and putting it here is what makes it testable
+//! on a machine that cannot boot the target.
+
+// The one place this module knows what OS it is on — see the module docs.
+#[cfg(all(target_os = "rtems", rtems_boot_linked))]
+#[path = "rtems.rs"]
+mod backend;
+#[cfg(not(all(target_os = "rtems", rtems_boot_linked)))]
+#[path = "unsupported.rs"]
+mod backend;
+
+use std::fmt;
+
+/// Why a command could not do what it was asked.
+///
+/// One type for the module, one meaning per variant: a caller that wants to
+/// print a diagnostic never has to infer which failure it is holding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellError {
+    /// This build has no RTEMS backend — a host build, or a portability build
+    /// where no BSP prefix was set so the C shim was never compiled.
+    ///
+    /// Distinct from every other variant because it is a property of the
+    /// *image*, not of the argument: nothing the operator types can fix it.
+    Unsupported,
+    /// `rtems_shell_lookup_cmd` found no command of that name in the set
+    /// `csrc/rtems_config.c` configured. Base's `rtshellCallFunc` prints
+    /// `ERR: No such command` here (`:511`).
+    NoSuchCommand,
+    /// The syslog level name is not in `prioritynames`. Base prints
+    /// `Error: unknown log level.` here (`:684`).
+    UnknownLevel,
+    /// The argument cannot be handed to a C API — it contains an interior NUL,
+    /// so no NUL-terminated form of it exists.
+    ///
+    /// The iocsh tokeniser cannot produce one, so this is unreachable from a
+    /// typed line; it exists so the conversion has an answer other than a
+    /// panic for a caller that built the string some other way.
+    NotRepresentable,
+}
+
+impl fmt::Display for ShellError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported => f.write_str("not available: this image has no RTEMS boot shim"),
+            Self::NoSuchCommand => f.write_str("No such command"),
+            Self::UnknownLevel => f.write_str("unknown log level."),
+            Self::NotRepresentable => f.write_str("argument contains an embedded NUL"),
+        }
+    }
+}
+
+/// `netstat <level>` — base `netStatCallFunc` (`:548-551`).
+///
+/// Prints; the reading itself goes to the console, as base's does. Base has no
+/// failure path here at all, so the only `Err` is [`ShellError::Unsupported`].
+pub fn netstat(level: i32) -> Result<(), ShellError> {
+    backend::netstat(level)
+}
+
+/// `rt <cmd> <args...>` — base `rtshellCallFunc` (`:506-524`).
+///
+/// `argv` is handed to the RTEMS shell command verbatim, so **`argv[0]` must
+/// be the command name**: base passes `iocshArgArgv` from position 1, whose
+/// `av[0]` is the token that named the command (`iocsh.cpp:1282-1285`), and
+/// every shell command's own `getopt` starts at index 1. A caller that passed
+/// the arguments alone would silently lose the first one.
+///
+/// Returns the command's exit status. A non-zero status is `Ok`, not `Err`:
+/// the command ran and said so, which is a different fact from not being able
+/// to run it.
+pub fn run_shell_command(argv: &[String]) -> Result<i32, ShellError> {
+    let Some(name) = argv.first() else {
+        return Err(ShellError::NoSuchCommand);
+    };
+    backend::run_shell_command(name, argv)
+}
+
+/// `setlogmask <level>` — base `setlogmaskCallFunc` (`:660-686`).
+pub fn set_log_priority(name: &str) -> Result<(), ShellError> {
+    backend::set_log_priority(name)
+}
+
+/// The syslog level names, in the C library's own order — what base's
+/// `setlogmask` with no argument lists (`:665-671`).
+///
+/// Empty on a build with no backend. That is the same claim
+/// [`ShellError::Unsupported`] makes and it cannot be confused with "this
+/// system has no levels", because the command that prints it is not registered
+/// on such a build in the first place.
+pub fn log_priority_names() -> Vec<String> {
+    backend::log_priority_names()
+}
+
+/// `zoneset <zone string>` — base `zoneset` (`:611-637`).
+///
+/// Sets `TZ` and re-reads it, or clears `TZ` when `zone` is `None`. No RTEMS
+/// API is involved: base's own body is `setenv`/`unsetenv` then `tzset`, so
+/// this is the whole command and it runs — and is tested — on the host.
+///
+/// `tzset` is declared directly rather than through the `libc` crate, which
+/// this package takes only on the embedded targets. It is POSIX and is defined
+/// by the C library of every target this workspace builds, so the declaration
+/// leaves no undefined symbol anywhere — unlike an `extern` for an RTEMS
+/// symbol, which is why those live behind the backend.
+///
+/// # Safety
+///
+/// Calls [`std::env::set_var`] / [`std::env::remove_var`], which are unsound
+/// while another thread may be reading the environment. C has the same hazard
+/// and ships it: `zoneset` is an operator command typed into a running IOC.
+/// The caller must be able to say that no other thread is touching the
+/// environment for the duration.
+pub unsafe fn zoneset(zone: Option<&str>) -> Result<(), ShellError> {
+    unsafe extern "C" {
+        fn tzset();
+    }
+
+    match zone {
+        Some(zone) => {
+            // `set_var` panics on an interior NUL rather than returning; C's
+            // `setenv` would return -1. Refuse it with the module's own error
+            // so the two agree that this is a failed command, not a crash.
+            if zone.contains('\0') {
+                return Err(ShellError::NotRepresentable);
+            }
+            // SAFETY: the caller's contract above.
+            unsafe { std::env::set_var("TZ", zone) };
+        }
+        // SAFETY: as above. Base's newlib arm calls `unsetenv` and takes its
+        // return; `remove_var` is that call and cannot report failure, which
+        // matches base's pre-newlib-2.2.0 arm (`:620-625`) exactly.
+        None => unsafe { std::env::remove_var("TZ") },
+    }
+
+    // SAFETY: `tzset` takes no argument and reads only the environment, which
+    // the caller's contract has just made exclusive to this thread.
+    unsafe { tzset() };
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The funnel's own production lines, comments stripped — see
+    /// [`crate::stats`]' twin of this helper for why both halves matter.
+    fn funnel_code() -> impl Iterator<Item = &'static str> {
+        source_guard::production(include_str!("mod.rs"), source_guard::Comments::Strip).lines()
+    }
+
+    /// A host build has no RTEMS shell, and every entry point must say so
+    /// rather than pretend it did the work. A `netstat` that returned `Ok`
+    /// having printed nothing is the shape that makes a boot log read like a
+    /// working IOC.
+    #[test]
+    fn a_host_build_refuses_every_rtems_command_rather_than_faking_it() {
+        assert_eq!(netstat(0), Err(ShellError::Unsupported));
+        assert_eq!(netstat(2), Err(ShellError::Unsupported));
+        assert_eq!(
+            run_shell_command(&["stackuse".to_string()]),
+            Err(ShellError::Unsupported)
+        );
+        assert_eq!(set_log_priority("debug"), Err(ShellError::Unsupported));
+        assert!(log_priority_names().is_empty());
+    }
+
+    /// An empty argv is refused before the backend sees it: there is no name to
+    /// look up, and `NoSuchCommand` is the answer C reaches for the same input
+    /// (`rtems_shell_lookup_cmd(NULL)`'s caller prints `ERR: No such command`).
+    #[test]
+    fn an_empty_command_line_is_no_such_command_not_a_panic() {
+        assert_eq!(run_shell_command(&[]), Err(ShellError::NoSuchCommand));
+    }
+
+    /// `zoneset` is the one command that works off-target, so it is the one
+    /// whose behaviour can be held to base's line by line.
+    ///
+    /// Each assertion is a boundary of base's `zoneset` (`:611-627`): a zone
+    /// sets `TZ`, a second zone replaces it (base passes `overwrite = 1`), and
+    /// no zone unsets it.
+    #[test]
+    fn zoneset_sets_replaces_and_clears_tz() {
+        // SAFETY: nextest runs each test in its own process, so this thread is
+        // the only one that can be touching the environment.
+        unsafe {
+            zoneset(Some("UTC")).expect("a plain zone name is representable");
+            assert_eq!(std::env::var("TZ").as_deref(), Ok("UTC"));
+
+            zoneset(Some("EST5EDT")).expect("the second zone replaces the first");
+            assert_eq!(
+                std::env::var("TZ").as_deref(),
+                Ok("EST5EDT"),
+                "base passes overwrite = 1 to setenv, so a second zoneset wins"
+            );
+
+            zoneset(None).expect("no zone clears TZ");
+            assert!(std::env::var("TZ").is_err(), "TZ is unset, not empty");
+        }
+    }
+
+    /// An empty zone string is a zone, not an absent argument. C stores `""`
+    /// for an empty token and passes it to `setenv`, which sets `TZ` to the
+    /// empty string — UTC — rather than unsetting it. Only a missing argument
+    /// takes the `unsetenv` arm.
+    #[test]
+    fn an_empty_zone_string_sets_tz_rather_than_clearing_it() {
+        // SAFETY: as above.
+        unsafe {
+            zoneset(Some("")).expect("an empty zone is representable");
+            assert_eq!(std::env::var("TZ").as_deref(), Ok(""));
+        }
+    }
+
+    /// A string with an interior NUL has no NUL-terminated form, and
+    /// `std::env::set_var` panics on one. An operator command must not be able
+    /// to abort the IOC.
+    #[test]
+    fn an_embedded_nul_is_refused_rather_than_panicking() {
+        // SAFETY: as above; this call must not reach `set_var` at all.
+        let refused = unsafe { zoneset(Some("UTC\0EST")) };
+        assert_eq!(refused, Err(ShellError::NotRepresentable));
+    }
+
+    /// Every variant prints something an operator can act on, and no two print
+    /// the same thing — a `Display` that collapsed two failures would put the
+    /// port back where a single error string had it.
+    #[test]
+    fn every_failure_has_its_own_message() {
+        let messages: Vec<String> = [
+            ShellError::Unsupported,
+            ShellError::NoSuchCommand,
+            ShellError::UnknownLevel,
+            ShellError::NotRepresentable,
+        ]
+        .iter()
+        .map(|e| e.to_string())
+        .collect();
+        for m in &messages {
+            assert!(!m.is_empty());
+        }
+        let mut unique = messages.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), messages.len(), "two variants print the same");
+    }
+
+    /// The C is compiled on exactly one configuration, and the backend that
+    /// declares its symbols must not outrun it — a declaration on a wider cfg
+    /// leaves an undefined symbol in the toolchain-free portability build.
+    #[test]
+    fn the_rtems_backend_is_scoped_to_the_configuration_that_compiles_the_c() {
+        let src = include_str!("mod.rs");
+        let cfg = concat!("#[cfg(all(target_os = \"rtems\", ", "rtems_boot_linked))]");
+        assert!(
+            src.contains(&format!("{cfg}\n#[path = \"rtems.rs\"]\nmod backend;")),
+            "the RTEMS backend must sit directly under the linked-image cfg"
+        );
+    }
+
+    /// The commands' C must stay in the build script's file list and its change
+    /// list; dropping either leaves the RTEMS backend pointing at nothing, or
+    /// leaves a stale object behind after an edit.
+    #[test]
+    fn the_build_script_compiles_and_watches_the_command_shim() {
+        let build = include_str!("../../build.rs");
+        assert!(build.contains(".file(\"csrc/rtems_shell_cmds.c\")"));
+        assert!(build.contains("cargo::rerun-if-changed=csrc/rtems_shell_cmds.c"));
+    }
+
+    /// The funnel's whole claim is that the OS fork happens once, at the
+    /// `backend` selection. A `#[cfg]` anywhere else is a second fork — see
+    /// [`crate::stats`], where the same guard exists for the same reason.
+    #[test]
+    fn the_os_fork_happens_only_at_the_backend_selection() {
+        assert_eq!(
+            funnel_code().filter(|l| l.contains("#[cfg(")).count(),
+            funnel_code().filter(|l| l.contains("mod backend;")).count(),
+            "every `#[cfg]` in the funnel must be a backend selection"
+        );
+    }
+
+    /// Every backend file, paired with its contents — the census below is only
+    /// as good as this list, so the list is checked against `mod.rs` too.
+    const BACKENDS: &[(&str, &str)] = &[
+        ("rtems.rs", include_str!("rtems.rs")),
+        ("unsupported.rs", include_str!("unsupported.rs")),
+    ];
+
+    /// A `#[cfg]`ed-out backend is not compiled, so nothing about it is checked
+    /// by building — and on this workspace the RTEMS arm builds only on the
+    /// bring-up box. The surface is a census instead, in both directions.
+    #[test]
+    fn every_backend_implements_the_whole_funnel_surface() {
+        let declared: Vec<&str> = funnel_code()
+            .filter_map(|l| l.trim().strip_prefix("#[path = \""))
+            .map(|r| &r[..r.find('"').expect("the path attribute is terminated")])
+            .collect();
+        let listed: Vec<&str> = BACKENDS.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            declared, listed,
+            "every backend `mod.rs` selects must be listed in BACKENDS, in order"
+        );
+
+        let required: Vec<&str> = funnel_code()
+            .filter_map(|l| l.trim().strip_prefix("backend::"))
+            .map(|r| &r[..r.find('(').expect("a backend call is a call")])
+            .collect();
+        assert!(
+            !required.is_empty(),
+            "the funnel must delegate to the backend"
+        );
+
+        for (name, body) in BACKENDS {
+            for f in &required {
+                assert!(
+                    body.contains(&format!("fn {f}(")),
+                    "backend {name} does not implement {f}"
+                );
+            }
+        }
+    }
+}

--- a/crates/epics-rtems-boot/src/shell/mod.rs
+++ b/crates/epics-rtems-boot/src/shell/mod.rs
@@ -164,10 +164,12 @@ pub fn log_priority_names() -> Vec<String> {
 /// this is the whole command and it runs — and is tested — on the host.
 ///
 /// `tzset` is declared directly rather than through the `libc` crate, which
-/// this package takes only on the embedded targets. It is POSIX and is defined
-/// by the C library of every target this workspace builds, so the declaration
-/// leaves no undefined symbol anywhere — unlike an `extern` for an RTEMS
-/// symbol, which is why those live behind the backend.
+/// this package takes only on the embedded targets. Every C library this
+/// workspace builds against defines the function, but the MSVC CRT exports it
+/// as `_tzset`, so the declaration carries that spelling on Windows; without it
+/// the link fails with `LNK2019: unresolved external symbol tzset`. The call
+/// itself is one line on every target — unlike an `extern` for an RTEMS symbol,
+/// which is why those live behind the backend.
 ///
 /// # Safety
 ///
@@ -178,6 +180,7 @@ pub fn log_priority_names() -> Vec<String> {
 /// environment for the duration.
 pub unsafe fn zoneset(zone: Option<&str>) -> Result<(), ShellError> {
     unsafe extern "C" {
+        #[cfg_attr(windows, link_name = "_tzset")]
         fn tzset();
     }
 
@@ -343,6 +346,15 @@ mod tests {
             funnel_code().filter(|l| l.contains("mod backend;")).count(),
             "every `#[cfg]` in the funnel must be a backend selection"
         );
+        // A `cfg_attr` that only spells a C symbol is not a second fork: the
+        // call site stays one line on every target. It is still the one place
+        // the funnel names an OS, so the exception is pinned rather than left
+        // open for the next one to slip in beside it.
+        let named: Vec<&str> = funnel_code()
+            .filter(|l| l.contains("#[cfg_attr("))
+            .map(str::trim)
+            .collect();
+        assert_eq!(named, ["#[cfg_attr(windows, link_name = \"_tzset\")]"]);
     }
 
     /// Every backend file, paired with its contents — the census below is only

--- a/crates/epics-rtems-boot/src/shell/rtems.rs
+++ b/crates/epics-rtems-boot/src/shell/rtems.rs
@@ -1,0 +1,124 @@
+//! The RTEMS backend: `csrc/rtems_shell_cmds.c`, through its four entry points.
+//!
+//! Selected by [`super`] on exactly `all(target_os = "rtems",
+//! rtems_boot_linked)` — the one configuration where this package's build
+//! script compiled the C. The gate is on the `mod` declaration rather than on
+//! each item here, for the same reason `stats/rtems.rs` carries it there: an
+//! `extern` on a wider cfg would leave an undefined symbol in the
+//! toolchain-free portability build that `scripts/rtems-check.sh` keeps
+//! compiling.
+//!
+//! Everything here is a conversion. The decisions — which netstat flags stand
+//! in for base's legacy calls, why `setlogmask` is not called, why the shell
+//! environment is initialised inside the lookup — are all in the C file, next
+//! to the code they govern.
+
+use core::ffi::{c_char, c_int};
+use std::ffi::{CStr, CString};
+
+use super::ShellError;
+
+pub(super) fn netstat(level: i32) -> Result<(), ShellError> {
+    // SAFETY: takes an int by value and reads no memory of ours. It prints,
+    // which is the whole command; base's has no failure path either.
+    unsafe { ffi::epics_rtems_boot_netstat(level as c_int) };
+    Ok(())
+}
+
+/// `argv` is handed to the shell command as a real `char **`, so it must be
+/// writable: `getopt` permutes the array it is given, and several RTEMS shell
+/// commands use it. The buffers are therefore owned `Vec<u8>` rather than
+/// [`CString`] pointers cast to `*mut` — casting away the shared reference and
+/// letting C write through it would be undefined behaviour that no test on
+/// this workspace could observe, because the C never runs here.
+pub(super) fn run_shell_command(name: &str, argv: &[String]) -> Result<i32, ShellError> {
+    let name = CString::new(name).map_err(|_| ShellError::NotRepresentable)?;
+
+    let mut owned: Vec<Vec<u8>> = Vec::with_capacity(argv.len());
+    for arg in argv {
+        if arg.as_bytes().contains(&0) {
+            return Err(ShellError::NotRepresentable);
+        }
+        let mut buf = Vec::with_capacity(arg.len() + 1);
+        buf.extend_from_slice(arg.as_bytes());
+        buf.push(0);
+        owned.push(buf);
+    }
+    // NULL-terminated, as every `main`-shaped C entry point expects even
+    // though it is also handed `argc`.
+    let mut ptrs: Vec<*mut c_char> = owned
+        .iter_mut()
+        .map(|buf| buf.as_mut_ptr().cast::<c_char>())
+        .collect();
+    ptrs.push(core::ptr::null_mut());
+
+    let mut status: c_int = 0;
+    // SAFETY: `name` is NUL-terminated and read-only; `ptrs` is a
+    // NUL-terminated array of `owned.len()` writable NUL-terminated buffers,
+    // all live for the call; `status` points at a live local. The C writes
+    // `status` only on the path where it returns 0.
+    let rc = unsafe {
+        ffi::epics_rtems_boot_shell_run(
+            name.as_ptr(),
+            owned.len() as c_int,
+            ptrs.as_mut_ptr(),
+            &mut status,
+        )
+    };
+    if rc != 0 {
+        return Err(ShellError::NoSuchCommand);
+    }
+    Ok(status as i32)
+}
+
+pub(super) fn set_log_priority(name: &str) -> Result<(), ShellError> {
+    let name = CString::new(name).map_err(|_| ShellError::NotRepresentable)?;
+    // SAFETY: a NUL-terminated string the C only reads.
+    let rc = unsafe { ffi::epics_rtems_boot_set_log_priority(name.as_ptr()) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(ShellError::UnknownLevel)
+    }
+}
+
+/// Walks the C library's `prioritynames` by index until it reports the end.
+///
+/// By index rather than by handing Rust the table pointer: `prioritynames` is
+/// a definition inside `<syslog.h>` whose element type is the C library's, so
+/// the shape this crate would have to declare to walk it itself is exactly the
+/// shape that differs between C libraries.
+pub(super) fn log_priority_names() -> Vec<String> {
+    let mut names = Vec::new();
+    for index in 0u32.. {
+        // SAFETY: takes an index by value; returns either NULL or a pointer to
+        // a string literal in the C library, which outlives the copy below.
+        let name = unsafe { ffi::epics_rtems_boot_log_priority_name(index) };
+        if name.is_null() {
+            break;
+        }
+        // SAFETY: non-NULL and NUL-terminated by construction — it is one of
+        // `prioritynames`' own `c_name` literals.
+        let name = unsafe { CStr::from_ptr(name) };
+        if let Ok(name) = name.to_str() {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
+mod ffi {
+    use core::ffi::{c_char, c_int, c_uint};
+
+    unsafe extern "C" {
+        pub fn epics_rtems_boot_netstat(level: c_int);
+        pub fn epics_rtems_boot_shell_run(
+            cmd: *const c_char,
+            argc: c_int,
+            argv: *mut *mut c_char,
+            status: *mut c_int,
+        ) -> c_int;
+        pub fn epics_rtems_boot_set_log_priority(name: *const c_char) -> c_int;
+        pub fn epics_rtems_boot_log_priority_name(index: c_uint) -> *const c_char;
+    }
+}

--- a/crates/epics-rtems-boot/src/shell/unsupported.rs
+++ b/crates/epics-rtems-boot/src/shell/unsupported.rs
@@ -1,0 +1,34 @@
+//! The backend for every build with no RTEMS shell behind it — a host build,
+//! and the toolchain-free portability build where the C was never compiled.
+//!
+//! Every entry point refuses, and that is the whole point of the file. The
+//! alternative shape — returning `Ok` having printed nothing — is what a stub
+//! would do, and it is worse than the command's absence: an operator reading a
+//! boot log cannot tell a `netstat` that printed nothing from an interface
+//! table that is genuinely empty, and `help` would list a command that does
+//! nothing on a machine where it can never do anything.
+//!
+//! Nothing here is reachable from a hosted IOC in practice: the commands are
+//! registered only from the RTEMS IOC binaries. The refusals exist so that a
+//! host `cargo test` can hold the funnel to its contract without a board.
+
+use super::ShellError;
+
+pub(super) fn netstat(_level: i32) -> Result<(), ShellError> {
+    Err(ShellError::Unsupported)
+}
+
+pub(super) fn run_shell_command(_name: &str, _argv: &[String]) -> Result<i32, ShellError> {
+    Err(ShellError::Unsupported)
+}
+
+pub(super) fn set_log_priority(_name: &str) -> Result<(), ShellError> {
+    Err(ShellError::Unsupported)
+}
+
+/// Empty rather than a guess at the C library's list: the names a target's
+/// `setlogmask` accepts are that target's `prioritynames`, and this build has
+/// none to read.
+pub(super) fn log_priority_names() -> Vec<String> {
+    Vec::new()
+}

--- a/crates/epics-rtems-boot/src/stats/mod.rs
+++ b/crates/epics-rtems-boot/src/stats/mod.rs
@@ -161,6 +161,40 @@ impl MemUsage {
     }
 }
 
+/// The malloc heap's lifetime accounting — the three numbers the `heapSpace`
+/// iocsh command is written against.
+///
+/// A distinct reading from [`MemUsage`], not a restatement of it. [`MemUsage`]
+/// is the free/used *block walk*; this is the allocator's own bookkeeping, and
+/// C base's `heapSpace` (`libcom/RTEMS/posix/rtems_init.c:560-586` @R7.0.10)
+/// derives its number from these rather than from the walk. The two differ by
+/// per-block header bytes, so a command that printed [`MemUsage::free`] would
+/// be printing a nearby number under C's name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeapSpace {
+    /// The allocatable area the heap was given, in bytes.
+    pub size: u64,
+    /// Bytes ever handed out, summed over block sizes.
+    pub lifetime_allocated: u64,
+    /// Bytes ever returned, summed over the same block sizes.
+    pub lifetime_freed: u64,
+}
+
+impl HeapSpace {
+    /// Bytes not currently inside an allocated block — C's
+    /// `size - (lifetime_allocated - lifetime_freed)`.
+    ///
+    /// Saturating where C wraps. C's subtraction is unsigned, so a heap whose
+    /// counters ever disagreed with its size would print a number near 2^32
+    /// rather than a small one; that reads as "plenty free" at exactly the
+    /// moment there is none. Zero is the honest answer to the same input, and
+    /// it is the direction an operator can act on.
+    pub fn free(&self) -> u64 {
+        self.size
+            .saturating_sub(self.lifetime_allocated.saturating_sub(self.lifetime_freed))
+    }
+}
+
 /// Read descriptor usage, or [`None`] on a build whose OS has no backend.
 pub fn fd_usage() -> Option<FdUsage> {
     backend::fd_usage()
@@ -171,6 +205,16 @@ pub fn fd_usage() -> Option<FdUsage> {
 /// them.
 pub fn mem_usage() -> MemUsage {
     backend::mem_usage()
+}
+
+/// Read the heap's lifetime accounting, or [`None`] on a build whose OS has no
+/// backend.
+///
+/// Whole-reading [`Option`] rather than per-field, unlike [`MemUsage`]: the
+/// three come from one structure the allocator fills together, and a partial
+/// one would make [`HeapSpace::free`] a subtraction over an unknown.
+pub fn heap_space() -> Option<HeapSpace> {
+    backend::heap_space()
 }
 
 /// Print the task census — thread count, kernel names, effective priorities —

--- a/crates/epics-rtems-boot/src/stats/rtems.rs
+++ b/crates/epics-rtems-boot/src/stats/rtems.rs
@@ -17,7 +17,7 @@
 use core::ffi::c_char;
 use std::ffi::CString;
 
-use super::{FdUsage, MemUsage};
+use super::{FdUsage, HeapSpace, MemUsage};
 
 pub(super) fn fd_usage() -> Option<FdUsage> {
     let mut used = 0u32;
@@ -45,6 +45,24 @@ pub(super) fn mem_usage() -> MemUsage {
         used: Some(used),
         largest_free: Some(largest_free),
     }
+}
+
+/// The same `_Protected_heap_Get_information` call as [`mem_usage`], reading
+/// the `Stats` half instead of the block walk — see [`HeapSpace`] for why those
+/// are two readings and not one.
+pub(super) fn heap_space() -> Option<HeapSpace> {
+    let mut size = 0u64;
+    let mut lifetime_allocated = 0u64;
+    let mut lifetime_freed = 0u64;
+    // SAFETY: as above — three pointers to live locals of the right type.
+    let rc = unsafe {
+        ffi::epics_rtems_boot_heap_space(&mut size, &mut lifetime_allocated, &mut lifetime_freed)
+    };
+    (rc == 0).then_some(HeapSpace {
+        size,
+        lifetime_allocated,
+        lifetime_freed,
+    })
 }
 
 pub(super) fn dump_tasks(tag: &str) {
@@ -94,6 +112,11 @@ mod ffi {
             free_total: *mut u64,
             used_total: *mut u64,
             free_largest: *mut u64,
+        ) -> c_int;
+        pub fn epics_rtems_boot_heap_space(
+            size: *mut u64,
+            lifetime_allocated: *mut u64,
+            lifetime_freed: *mut u64,
         ) -> c_int;
         pub fn epics_rtems_boot_dump_tasks(tag: *const c_char);
         pub fn epics_rtems_boot_stack_report(tag: *const c_char);

--- a/crates/epics-rtems-boot/src/stats/unsupported.rs
+++ b/crates/epics-rtems-boot/src/stats/unsupported.rs
@@ -11,7 +11,7 @@
 //! support is missing publishes "1000 free" rather than "unknown". An `Option`
 //! says the thing the sentinel cannot.
 
-use super::{FdUsage, MemUsage};
+use super::{FdUsage, HeapSpace, MemUsage};
 
 pub(super) fn fd_usage() -> Option<FdUsage> {
     None
@@ -19,6 +19,10 @@ pub(super) fn fd_usage() -> Option<FdUsage> {
 
 pub(super) fn mem_usage() -> MemUsage {
     MemUsage::default()
+}
+
+pub(super) fn heap_space() -> Option<HeapSpace> {
+    None
 }
 
 /// Silence, not a placeholder line.

--- a/crates/epics-rtems-boot/src/stats/vxworks.rs
+++ b/crates/epics-rtems-boot/src/stats/vxworks.rs
@@ -42,7 +42,7 @@
 use std::io;
 use std::sync::Mutex;
 
-use super::{FdUsage, MemUsage};
+use super::{FdUsage, HeapSpace, MemUsage};
 
 /// Descriptors this RTP holds, and the ceiling it holds them against.
 ///
@@ -150,6 +150,17 @@ pub(super) fn mem_usage() -> MemUsage {
         used: Some(current_commit as u64),
         largest_free: None,
     }
+}
+
+/// No reading. The `heapSpace` command this backs is EPICS base's RTEMS one
+/// (`libcom/RTEMS/posix/rtems_init.c:560-586` @R7.0.10) and its inputs are
+/// `Heap_Information_block::Stats` — an RTEMS allocator's own bookkeeping. An
+/// RTP's heap is mimalloc's, which reports committed bytes and keeps no
+/// lifetime-allocated/freed pair, so there is nothing here to report and a
+/// derived stand-in would be a different measurement wearing this one's name.
+/// Same reason `MemUsage::free` is `None` above.
+pub(super) fn heap_space() -> Option<HeapSpace> {
+    None
 }
 
 /// Note this thread in the census registry. Called once per IOC thread.

--- a/crates/mca-rs/doc/reference-pin.md
+++ b/crates/mca-rs/doc/reference-pin.md
@@ -9,9 +9,8 @@ that revision, not against whatever the local checkout happens to hold.
 | mca | **`687d563`** (tree carries no tags) | `687d563` — same commit | 64 |
 | epics-base | **`R7.0.10`** (tag object `e1c98a45`, commit `bf11a0c3`) | `R7.0.10-146-g8f5015b66` | 10 |
 
-Recorded 2026-08-26. Counted with `doc/parity-instruments/span-census.py`,
-which detects the full `file.ext:payload` form; a bare `:NNN` continuation is
-not counted again. The counts are of the crate **without this file**: the
+Recorded 2026-08-26. Counted by matching the full `file.ext:payload` form; a
+bare `:NNN` continuation is not counted again. The counts are of the crate **without this file**: the
 epics-base list below quotes five of its own citations, so a re-run over
 `crates/mca-rs` now reports 15 rather than 10 for those basenames.
 

--- a/crates/mqtt-rs/src/lib.rs
+++ b/crates/mqtt-rs/src/lib.rs
@@ -9,6 +9,7 @@
 //! | `mqtt` | `278a6a4` (tree carries no tags) |
 //! | `autoparamDriver` | `v2.1.0` |
 //! | `asyn` | `R4-45-19-ge2a281e2` |
+//! | `modbus` | `R3-4-10-gb1009d0` |
 //! | `epics-base` | `R7.0.10` |
 //!
 //! **Resolve by symbol at the pin; the line is a hint.** Find the named

--- a/scripts/csrc-check.sh
+++ b/scripts/csrc-check.sh
@@ -37,6 +37,12 @@
 #   printf format checking RTEMS_PRINTFLIKE puts on rtems_panic. See that
 #   directory's README.md for what this does and does not prove.
 #
+#   `rtems_shell_cmds.c` is the same case as rtems_init.c and is compiled the
+#   same way: it is the RTEMS half of the operator commands base registers from
+#   `iocshRegisterRTEMS`, so every RTEMS and libbsd name it uses — including
+#   `rtems_shell_cmd_t`'s layout, which it dereferences — is checked against the
+#   record here rather than on the board.
+#
 # `rtems_config.c` and `rtems_stats.c` remain outside: the first ends in
 # `<rtems/confdefs.h>`, which generates the configuration table rather than
 # declaring an API, and the second reaches into RTEMS score internals whose
@@ -113,9 +119,16 @@ for config in "${INIT_CONFIGS[@]}"; do
         -c "$CSRC/rtems_init.c" -o "$work/rtems_init.o"
 done
 
+echo "==> compiling rtems_shell_cmds.c against the recorded RTEMS API with $CC_HOST"
+# One configuration: the file has no `#if` of its own, so there is no second
+# arm that could compile for the first time on the board.
+"$CC_HOST" "${INIT_CFLAGS[@]}" -c "$CSRC/rtems_shell_cmds.c" \
+    -o "$work/rtems_shell_cmds.o"
+
 echo "==> csrc-check: boot-argument path compiled and exercised on the host,"
 echo "    rtems_init.c compiled against the recorded RTEMS API in every"
-echo "    configuration it selects."
+echo "    configuration it selects, and rtems_shell_cmds.c against the same"
+echo "    record."
 echo "    NOT covered here: rtems_config.c (generates its table from"
 echo "    <rtems/confdefs.h>) and rtems_stats.c (RTEMS score internals) —" \
      "only an image build compiles them."

--- a/scripts/embedded-image.sh
+++ b/scripts/embedded-image.sh
@@ -21,8 +21,8 @@
 # PROFILE
 #
 # `release-embedded` (root `Cargo.toml`: inherits release, strip=symbols,
-# lto=fat, codegen-units=1) — row 5 of the measured matrix in
-# `doc/vxworks-port.md` §5.5. Override for a comparison build:
+# lto=fat, codegen-units=1) — row 5 of the measured strip/LTO size matrix.
+# Override for a comparison build:
 #
 #   EMBEDDED_PROFILE=release scripts/embedded-image.sh vxworks ca   # row 2
 #

--- a/scripts/rtems-bsp.sh
+++ b/scripts/rtems-bsp.sh
@@ -60,7 +60,7 @@
 # MEASURED PITFALLS THIS SCRIPT ENCODES
 #
 #   * libbsd's `waf install` is not parallel-safe (-j12 dies mid-copy);
-#     install runs -j1. doc/rtems-qemu-bringup-artefacts.md.
+#     install runs -j1.
 #   * RTEMS_POSIX_API defaults to false on both branches; without it libbsd's
 #     openssl apps fail to link (signal/alarm live in cpukit/posix) and an
 #     epics-rs image has no POSIX_Init. It is set in the generated config.ini.

--- a/scripts/rtems-check.sh
+++ b/scripts/rtems-check.sh
@@ -12,9 +12,9 @@
 #
 # WHY THIS FILE EXISTS
 #
-# The invocation used to live only in prose (doc/rtems-runtime-portability-
-# design.md §8.1). Two things followed from that, and the second is why this
-# script is here rather than another paragraph:
+# The invocation used to live only in prose, in a design document. Two things
+# followed from that, and the second is why this script is here rather than
+# another paragraph:
 #
 #   * The written form was `-p <crate> --lib`, and `--lib` never compiles
 #     `src/bin/*.rs`. The one binary anyone boots on the target — realtime-ca-ioc
@@ -78,10 +78,9 @@ cd "$REPO_ROOT"
 # The RTEMS target this gate compiles for.
 #
 # ADOPTED DEVIATION: by default this is the custom spec carrying
-# `has-thread-local: true` (measured to take the per-thread heap leak from
-# 136 B to 0 — `doc/rtems-tls-spec-deviation.md`, evidence in
-# `doc/upstream-rtems-bugs/rust-std-rtems-tls-thread-leak.md`). Every RTEMS
-# image this workspace ships is built with the flip, so the gate compiles the
+# `has-thread-local: true` (measured against stock rust-std to take the
+# per-thread heap leak from 136 B to 0). Every RTEMS image this workspace
+# ships is built with the flip, so the gate compiles the
 # same native-TLS codegen the image uses: `has-thread-local` flips
 # `cfg(target_thread_local)`, which selects a *different* std TLS path, and a
 # gate on the builtin triple would type-check the path the image does not take.
@@ -175,8 +174,8 @@ CRATES=(epics-libcom-rs epics-base-rs epics-ca-rs epics-pva-rs epics-rtems-boot 
 # `SearchUdpSocket` (the ratchet probe below measures zero), and does NOT
 # pull `tls`/`pkcs12` (no `ring`, no `getrandom 0.2`) because the bridge's
 # `epics-pva-rs` dependency is `default-features = false`. Before stage 4 this
-# was `qsrv-core` alone, because `client_native` was 47 errors on this target
-# (doc/qsrv-rtems-design.md §0 probe D); design §5 stage 4 closed them.
+# was `qsrv-core` alone, because `client_native` was 47 errors on this target;
+# the pvalink staging work closed them.
 #
 # `epics-ca-rs` selects `client-core` for the same reason, one protocol over:
 # `realtime-ca-ioc` mounts the `ca://` record-link resolver (design stage C5), and
@@ -205,9 +204,8 @@ BINS=(
     # `realtime-pva-ioc` is an `epics-bridge-rs` binary, not an `epics-pva-rs` one.
     # It moved when it grew a QSRV group source: the mount needs the bridge, and
     # `epics-pva-rs` cannot depend on the bridge without a cyclic package
-    # dependency, which cargo rejects outright (measured — see
-    # doc/qsrv-rtems-design.md §9.7). It is still the only target PVA binary, so
-    # this stays one entry, not two.
+    # dependency, which cargo rejects outright (measured). It is still the
+    # only target PVA binary, so this stays one entry, not two.
     #
     # It carries `required-features = ["qsrv-core", "pvalink"]`, which the loop
     # below supplies from CRATE_FEATURES. That combination is safe here and was
@@ -431,8 +429,8 @@ for config in "${CONFIGS[@]}"; do
         # Each target binary is checked twice: once as shipped by default (a
         # clean IOC — no probe records, no probe threads) and once with
         # `bringup-probes`, the measurement rig the bring-up box's build
-        # scripts select (doc/calink-rtems-design.md §11.7 item 3). Both are
-        # real images someone boots, so both are census, not choice.
+        # scripts select. Both are real images someone boots, so both are
+        # census, not choice.
         for probe in "" bringup-probes; do
             sel="${CRATE_FEATURES[$crate]:-}"
             [[ -n "$probe" ]] && sel="${sel:+$sel,}$probe"
@@ -455,18 +453,18 @@ fi
 # ---------------------------------------------------------------------------
 # The PVA client probe: a RATCHET, not a pass/fail build.
 #
-# `doc/pvalink-rtems-design.md` §5 stage 2 asks for this crate's target
-# selection to be "extended to include `client`". Taken literally — adding
-# `client` to CRATE_FEATURES — the whole gate goes red, because the client's
+# The pvalink staging asks for this crate's target selection to be extended to
+# include `client`. Taken literally — adding `client` to CRATE_FEATURES — the
+# whole gate goes red, because the client's
 # remaining errors are all UDP (newlib has no `recvmsg`/`cmsghdr`/`CMSG_*`, no
-# `IP_PKTINFO` original-destination recovery) and §4.2 stages that work AFTER
+# `IP_PKTINFO` original-destination recovery) and that UDP work is staged AFTER
 # this one, deliberately. A gate that is red for work nobody has started yet
-# reports nothing, and stages 3-5 all extend the green one above.
+# reports nothing, and the later stages all extend the green one above.
 #
 # So the selection is measured rather than built: the count is the artefact.
-# §1.2 could only report "47, and that is a lower bound" because an unresolved
-# import poisons its module and rustc then suppresses downstream errors in code
-# naming its items — so a file reporting zero was ambiguous between "compiles"
+# The first count could only be reported as "47, and that is a lower bound",
+# because an unresolved import poisons its module and rustc then suppresses
+# downstream errors in code naming its items — so a file reporting zero was ambiguous between "compiles"
 # and "hidden". Pinning the number here is what stops that count drifting
 # unobserved in either direction:
 #
@@ -542,9 +540,9 @@ fi
 # ---------------------------------------------------------------------------
 # The CA client had the same RATCHET, and no longer needs one.
 #
-# `doc/calink-rtems-design.md` §6 stage C5 mounts the `ca://` record-link
-# resolver in `realtime-ca-ioc`, which needs `epics-ca-rs`'s CLIENT to compile for
-# the target — `calink` drives a live `CaClient` (§2.1). While that was work in
+# Stage C5 of the calink staging mounts the `ca://` record-link resolver in
+# `realtime-ca-ioc`, which needs `epics-ca-rs`'s CLIENT to compile for the
+# target — `calink` drives a live `CaClient`. While that was work in
 # progress the selection was MEASURED rather than built, exactly as the PVA one
 # above still is, because a gate red for unstarted work reports nothing:
 #
@@ -596,7 +594,7 @@ if [[ "${RTEMS_USE_STOCK_SPEC:-0}" == "1" ]]; then
     log "target binary compiles for armv7-rtems-eabihf, in both the portability"
     log "and the image configuration."
 else
-    log "RTEMS gate (has-thread-local spec, doc/rtems-tls-spec-deviation.md): every"
+    log "RTEMS gate (has-thread-local spec): every"
     log "crate and target binary compiles for the generated native-TLS spec, in"
     log "both the portability and the image configuration."
 fi

--- a/scripts/rtems-rustc-wrapper.sh
+++ b/scripts/rtems-rustc-wrapper.sh
@@ -4,8 +4,8 @@
 # `.cargo/config.toml`) that reroutes any invocation selecting the *builtin*
 # `armv7-rtems-eabihf` triple through the generated has-thread-local spec, so
 # a plain `cargo +nightly build --target armv7-rtems-eabihf` picks up the
-# one-key deviation (`doc/rtems-tls-spec-deviation.md`) without going through
-# `rtems-check.sh` or the box build scripts.
+# one-key deviation without going through `rtems-check.sh` or the box build
+# scripts.
 #
 # Every other invocation — host builds, and the explicit `-tls.json` spec
 # paths the gate and box scripts pass — execs straight through untouched, so

--- a/scripts/rtems-tls-spec.sh
+++ b/scripts/rtems-tls-spec.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # rtems-tls-spec.sh - emit the custom RTEMS target spec that carries
-# `has-thread-local: true`, the one-key deviation documented in
-# `doc/rtems-tls-spec-deviation.md`.
+# `has-thread-local: true`, this workspace's one-key deviation from the builtin
+# `armv7-rtems-eabihf` spec (measured to take std's per-thread TLS leak on
+# RTEMS from 136 B to 0).
 #
 # WHY GENERATE RATHER THAN COMMIT A FROZEN JSON
 #
@@ -59,8 +60,8 @@ fi
 # this script (and the whole wiring) should be retired, not silently no-op.
 if [[ "$(jq -r '."has-thread-local" // "absent"' <<<"$stock")" != "absent" ]]; then
     echo "error: the builtin $STOCK_TARGET spec already sets has-thread-local." >&2
-    echo "The deviation is retired upstream — delete this script, revert the" >&2
-    echo "rtems-check.sh spec wiring, and remove doc/rtems-tls-spec-deviation.md." >&2
+    echo "The deviation is retired upstream — delete this script and revert" >&2
+    echo "the rtems-check.sh spec wiring." >&2
     exit 2
 fi
 

--- a/scripts/vxworks-check.sh
+++ b/scripts/vxworks-check.sh
@@ -127,9 +127,9 @@ TARGET="x86_64-wrs-vxworks"
 #     std.
 #   * `killpg` is referenced by std's own vxworks process code
 #     (`library/std/src/sys/process/unix/vxworks.rs:179`) and is declared for
-#     vxworks nowhere in libc, in any version. CONFIRMED — see
-#     `doc/upstream-rust-targets/` for the trace and the shim-not-extern
-#     conclusion.
+#     vxworks nowhere in libc, in any version. CONFIRMED by tracing std's
+#     imports back to libc: the fix has to be a shim, not an extern
+#     declaration.
 #
 # Which of the two you hit depends on the nightly, since build-std resolves
 # libc from rust-src's own lock: a 2026-07-09 nightly pins 0.2.185 and shows

--- a/tools/dbd-codegen/README.md
+++ b/tools/dbd-codegen/README.md
@@ -12,7 +12,7 @@ cargo run -p dbd-codegen -- --check    # fail if it has drifted (CI)
 The port used to hand-copy the `.dbd` into 1,174 `FieldDesc` literals. A wrong
 `dbf_type` or a missed `special(SPC_NOMOD)` was then a *finding*, discovered by
 eye, one audit round at a time. Deriving the table from the spec makes that
-whole family unrepresentable — see `doc/strategy-2026-07-13.md` §3.1.
+whole family unrepresentable.
 
 ## What is vendored, and why
 


### PR DESCRIPTION
Each of these was measured against base 7's own C — the diagnostic text, the
point of refusal, or the ordering inside `iocInit` — and carries a regression
test that fails at its parent commit. The `iocinit` one is the fix with runtime
consequence: `initDevSup` runs before `initialRecordProcess` in C, so binding
the dset after the init passes left every dset-dependent `init_record` silently
taking the no-dset arm.
