### PR TITLE
ci(vxworks): pin nightly-2026-08-30 until rust#162065 lands

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -265,12 +265,24 @@ jobs:
   # red both when a binary is unclassified and when the closure stops
   # compiling.
   #
-  # `nightly` is unpinned for the same trip-wire reason `rtems-closure` gives
-  # — with one extra tooth here: the std-side patch is a clone of the manifest
-  # pin relabelled to whatever libc version the nightly's rust-src lock
-  # demands (`scripts/libc-std-patch.sh`), so version drift is absorbed by
-  # construction; what still fails loudly is a nightly whose std needs libc
-  # API the pinned content lacks — the signal to rebase the fork branch.
+  # `nightly` was unpinned here for the same trip-wire reason `rtems-closure`
+  # gives — a nightly whose std needs libc API the pinned content lacks fails
+  # loudly, the signal to rebase the fork. It is now PINNED to nightly-2026-08-30,
+  # the last nightly before rust-lang/rust#160170 (merged 2026-08-30, first
+  # shipped in nightly-2026-08-31) dropped the `not(target_os = "vxworks")` guard
+  # around `libc::O_NOFOLLOW` in std's `set_perm_nofollow`. VxWorks libc defines
+  # no `O_NOFOLLOW`, so from nightly-2026-08-31 on `-Zbuild-std` cannot compile
+  # std for x86_64-wrs-vxworks at all. Lift the pin (back to floating `nightly`)
+  # once rust-lang/rust#162065 — the std-side fix that returns `Unsupported` on
+  # VxWorks — merges and reaches nightly.
+  #
+  # Two consequences while pinned: the floating trip-wire above no longer fires
+  # in CI, so until the pin is lifted that check lives in a local
+  # `VXWORKS_TOOLCHAIN=nightly ./scripts/vxworks-check.sh` run; and at the pin
+  # itself the closure compiles against stock rust-src libc (`--locked`, no
+  # derived std patch), so the std graph here no longer leans on the fork.
+  # `VXWORKS_TOOLCHAIN` names the same dated nightly for the script, since a
+  # dated toolchain is not the bare `nightly` its patch-derivation keys on.
   vxworks-census:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -279,13 +291,15 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly
+        toolchain: nightly-2026-08-30
         components: rust-src
     - uses: Swatinem/rust-cache@v2
       with:
         key: vxworks-census
     - name: Census, then type-check the VxWorks closure
       run: ./scripts/vxworks-check.sh
+      env:
+        VXWORKS_TOOLCHAIN: nightly-2026-08-30
 
   # `linux-rt` swaps `PriorityInheritanceMutex` from the parking_lot fallback
   # onto a real `PTHREAD_PRIO_INHERIT` pthread mutex

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -593,6 +593,16 @@ jobs:
       with:
         toolchain: nightly
         components: rust-src
+    # The VxWorks rows below are pinned to nightly-2026-08-30, the last nightly
+    # before rust#160170 (first in nightly-2026-08-31) removed the vxworks guard
+    # around `libc::O_NOFOLLOW` in std's `set_perm_nofollow`; see the
+    # `vxworks-census` header. The RTEMS rows keep the floating `nightly` above —
+    # the break is VxWorks-only. Drop this second toolchain and restore the
+    # VxWorks rows to `+nightly` once rust#162065 (the std-side fix) lands.
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2026-08-30
+        components: rust-src
     - uses: Swatinem/rust-cache@v2
       with:
         key: rustdoc-embedded
@@ -639,7 +649,7 @@ jobs:
         trap 'mv -f Cargo.lock.rustdoc-bak Cargo.lock' EXIT
         cfg=()
         while IFS= read -r line; do cfg+=(--config "$line"); done \
-          < <(./scripts/libc-std-patch.sh nightly)
+          < <(./scripts/libc-std-patch.sh nightly-2026-08-30)
         rc=0
         for crate in epics-libcom-rs epics-base-rs epics-ca-rs epics-pva-rs \
                      epics-rtems-boot epics-bridge-rs asyn-rs; do
@@ -650,7 +660,7 @@ jobs:
             asyn-rs)         feats=(--features epics) ;;
           esac
           echo "::group::$crate --lib (x86_64-wrs-vxworks)"
-          cargo +nightly doc --no-deps --no-default-features --document-private-items \
+          cargo +nightly-2026-08-30 doc --no-deps --no-default-features --document-private-items \
             "${cfg[@]}" -Zbuild-std=std,panic_abort --target x86_64-wrs-vxworks \
             -p "$crate" --lib ${feats[@]+"${feats[@]}"} || rc=1
           echo "::endgroup::"

--- a/scripts/embedded-image.sh
+++ b/scripts/embedded-image.sh
@@ -129,13 +129,21 @@ case "$OS" in
         apply_derived_libc_patch "$TOOLCHAIN"
         ;;
     vxworks)
-        TOOLCHAIN="${VXWORKS_TOOLCHAIN:-nightly}"
+        # Pinned to nightly-2026-08-30, the last nightly before rust#160170
+        # (first in nightly-2026-08-31) dropped the `not(target_os="vxworks")`
+        # guard around `libc::O_NOFOLLOW` in std's `set_perm_nofollow`; VxWorks
+        # libc has no `O_NOFOLLOW`, so `-Zbuild-std` stops compiling std for
+        # x86_64-wrs-vxworks from 08-31 on. Restore the bare `nightly` default
+        # once rust#162065 (the std-side fix) merges and reaches nightly.
+        TOOLCHAIN="${VXWORKS_TOOLCHAIN:-nightly-2026-08-30}"
         TARGET="x86_64-wrs-vxworks"
         if [[ -n "${VXWORKS_CARGO_CONFIG:-}" ]]; then
             ARGS+=(--config "$VXWORKS_CARGO_CONFIG")
-        elif [[ "$TOOLCHAIN" == nightly ]]; then
+        elif [[ "$TOOLCHAIN" == nightly* ]]; then
             # A prepared VXWORKS_TOOLCHAIN bundles its own fixed rust-src and
-            # needs no patch; the stock nightly does.
+            # needs no patch; a stock nightly — bare or a dated
+            # `nightly-YYYY-MM-DD` — does. The glob matches both stock forms
+            # while a prepared toolchain (named otherwise) falls through.
             apply_derived_libc_patch "$TOOLCHAIN"
         fi
         ;;


### PR DESCRIPTION
rust#160170 (first in nightly-2026-08-31) dropped the not(target_os = "vxworks") guard around libc::O_NOFOLLOW in std's set_perm_nofollow, and VxWorks libc has no O_NOFOLLOW, so -Zbuild-std stops compiling std for x86_64-wrs-vxworks. This pins both the vxworks-census gate and embedded-image.sh's default to the last good nightly — verified locally that the whole VxWorks closure type-checks green there against stock rust-src libc (0.2.189, which now carries the fixes) — and widens embedded-image.sh's patch-derivation guard to a nightly* glob so the dated image build still derives the fork libc. Revert both when the std-side fix rust#162065 merges. RTEMS is untouched: the break is VxWorks-only.