### PR TITLE
fix(scalcout): serve PAA..PLL as read-only scalar DBF_STRING

### DIFF
--- a/crates/epics-base-rs/src/server/records/scalcout.rs
+++ b/crates/epics-base-rs/src/server/records/scalcout.rs
@@ -81,10 +81,10 @@ pub struct ScalcoutRecord {
     /// (`sCalcoutRecord.c:345-353`, `strNcpy(*psprev, *pscurr, STRING_SIZE)`).
     ///
     /// Held as the raw 40-byte buffer C allocates in `init_record`
-    /// (`:223-225`) rather than as a `PvString`, because every byte of it is
-    /// observable: `strNcpy` terminates without clearing the tail, and the
-    /// channel reads all forty bytes: `cvt_dbaddr` (`sCalcoutRecord.c:588-596`)
-    /// leaves `field_size` at 1, so it is forty one-character strings.
+    /// (`:223-225`): `strNcpy` terminates without clearing the tail, so the
+    /// bytes past the NUL are the previous value's. The channel over each is a
+    /// read-only scalar `DBF_STRING` (calc#42 — see `prev_str_channel`), which
+    /// reads only up to that NUL.
     pub prev_str_vals: [[u8; PREV_STRING_SIZE]; 12],
     /// PVAL — C `sCalcoutRecord.dbd:60` `field(PVAL,DBF_DOUBLE)`, writable.
     ///
@@ -466,27 +466,20 @@ impl ScalcoutRecord {
         SCALCOUT_PREV_STR_NAMES.iter().position(|&n| n == name)
     }
 
-    /// The CHANNEL a client sees over one PAA..PLL buffer.
+    /// The CHANNEL a client sees over one PAA..PLL buffer: a read-only scalar
+    /// `DBF_STRING`.
     ///
-    /// C `cvt_dbaddr` (`sCalcoutRecord.c:588-596`) sets `no_elements =
-    /// STRING_SIZE`, `field_type = DBF_STRING` and `field_size = 1`, so
-    /// `getStringString` (`dbConvert.c`) copies ONE byte per element and
-    /// NUL-terminates it: the field is forty one-character strings over the
-    /// 40-byte buffer, not one 40-character string. `caget PAA` on a buffer
-    /// holding `hi` prints `40 h i` followed by 38 blanks, and the compiled
-    /// softIoc is what defines that shape.
+    /// Released `sCalcoutRecord` declares PAA..PLL `DBF_NOACCESS`/
+    /// `special(SPC_DBADDR)`, and `cvt_dbaddr` (`sCalcoutRecord.c:588-596`)
+    /// reshapes each into forty one-character `DBF_STRING` elements over the
+    /// 40-byte buffer (`no_elements = STRING_SIZE`, `field_size = 1`), so a
+    /// `caget PAA` on `hi` prints `40 h i …`. That shape is calc#42; the fix
+    /// (anjohnson) makes them plain read-only `DBF_STRING` scalars. This port
+    /// serves the fixed shape ahead of the upstream merge — the buffer read up
+    /// to its NUL — so `caget PAA` on `hi` reads the scalar `hi`.
     fn prev_str_channel(buf: &[u8; PREV_STRING_SIZE]) -> EpicsValue {
-        EpicsValue::StringArray(
-            buf.iter()
-                .map(|&b| {
-                    if b == 0 {
-                        PvString::new()
-                    } else {
-                        PvString::from_bytes(vec![b])
-                    }
-                })
-                .collect(),
-        )
+        let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        EpicsValue::String(PvString::from_bytes(buf[..end].to_vec()))
     }
 
     /// C `strNcpy` (`sCalcoutRecord.c:146-153`) — copy up to `N-1` source
@@ -589,8 +582,8 @@ const SCALCOUT_PREV_STR_NAMES: [&str; 12] = [
 ];
 
 /// C `sCalcoutRecord.c:198` `#define STRING_SIZE 40` — the width of the
-/// previous-value buffers `init_record` allocates, and the element COUNT
-/// `cvt_dbaddr` puts on their channels.
+/// previous-value buffers `init_record` allocates and the capacity of the
+/// scalar `DBF_STRING` channel served over each (calc#42).
 const PREV_STRING_SIZE: usize = 40;
 
 /// C `sCalcoutRecord.c::fetch_values`' second loop (890-941): INAA..LL → AA..LL.
@@ -1164,23 +1157,10 @@ impl Record for ScalcoutRecord {
                         _ => return Err(CaError::TypeMismatch(name.into())),
                     }
                 }
-                if let Some(idx) = Self::prev_str_index(name) {
-                    // C `putStringString` (`dbConvert.c`) writes each element
-                    // with `strncpy(pdst, psrc, size)` and then
-                    // `pdst[size-1] = 0` — over the SAME byte, because
-                    // `cvt_dbaddr` left `field_size` at 1. A put therefore
-                    // stores nothing and CLEARS the first `nRequest` bytes;
-                    // `get_array_info` is NULL for this record, so the offset
-                    // is always 0 and byte 0 is always among them. The
-                    // compiled softIoc accepts the put and reads back short.
-                    let n = match &value {
-                        EpicsValue::String(_) => 1,
-                        EpicsValue::StringArray(a) => a.len().min(PREV_STRING_SIZE),
-                        _ => return Err(CaError::TypeMismatch(name.into())),
-                    };
-                    self.prev_str_vals[idx][..n].fill(0);
-                    return Ok(());
-                }
+                // PAA..PLL have no put arm: calc#42 makes them
+                // `special(SPC_NOMOD)` (`Self::field_no_mod`), so the framework
+                // read-only gate refuses the client put before it reaches here.
+                // The snapshot itself is the only writer (`snapshot_prev_str`).
                 if let Some(idx) = Self::inp_index(name) {
                     match value {
                         EpicsValue::String(s) => {
@@ -1368,10 +1348,13 @@ impl Record for ScalcoutRecord {
         Vec::new()
     }
 
-    /// C `cvt_dbaddr` (`sCalcoutRecord.c:588-596`) puts `no_elements =
-    /// STRING_SIZE` on PAA..PLL and nothing on any other field.
-    fn dbaddr_capacity(&self, field: &str) -> Option<u32> {
-        Self::prev_str_index(field).map(|_| PREV_STRING_SIZE as u32)
+    /// calc#42: PAA..PLL are read-only (`special(SPC_NOMOD)` in the fixed
+    /// declaration). The released `.dbd` this port mirrors still ships them
+    /// `SPC_DBADDR`, so the static `FieldDesc` cannot carry the bit; the record
+    /// raises it here, and the framework's `is_no_mod` gate refuses every
+    /// client put on the strength of it.
+    fn field_no_mod(&self, field: &str) -> bool {
+        Self::prev_str_index(field).is_some()
     }
 
     fn set_resolved_out_target(&mut self, link_field: &str, target: OutTarget) {

--- a/crates/epics-base-rs/tests/dbf_string_fields_store_as_string.rs
+++ b/crates/epics-base-rs/tests/dbf_string_fields_store_as_string.rs
@@ -122,7 +122,7 @@ fn every_dbf_string_field_reports_dbf_string() {
         scanned, 519,
         "record-owned DBF_STRING fields on this tree; a change here means a \
          field left or joined the sweep and the new count needs reading. \
-         507 before scalcout began answering for PAA..PLL, whose channel is \
-         forty one-byte DBF_STRING elements (sCalcoutRecord.c:588-596)"
+         507 before scalcout began answering for PAA..PLL, which this port \
+         serves as read-only scalar DBF_STRING (calc#42)"
     );
 }

--- a/crates/epics-base-rs/tests/scalcout_snapshots_its_inputs.rs
+++ b/crates/epics-base-rs/tests/scalcout_snapshots_its_inputs.rs
@@ -81,10 +81,10 @@ fn num(db: &Db, field: &str) -> f64 {
         .expect("numeric")
 }
 
-/// The channel exactly as a client reads it: one `String` per element.
-fn prev_str(db: &Db, field: &str) -> Vec<String> {
+/// The channel exactly as a client reads it: a read-only scalar `DBF_STRING`.
+fn prev_str(db: &Db, field: &str) -> String {
     match db.get_pv(&format!("SCO.{field}")).expect("prev string") {
-        EpicsValue::StringArray(a) => a.iter().map(|s| s.as_str_lossy().into_owned()).collect(),
+        EpicsValue::String(s) => s.as_str_lossy().into_owned(),
         other => panic!("SCO.{field} is {other:?}"),
     }
 }
@@ -105,51 +105,56 @@ async fn processing_copies_the_numeric_inputs_into_pa_to_pl() {
     assert_eq!(num(&db, "PB"), 3.0);
 }
 
-/// The string half, and the channel shape it is served through.
+/// The string half, served as a read-only scalar `DBF_STRING` (calc#42).
 #[epics_macros_rs::epics_test]
 async fn processing_copies_the_string_inputs_into_paa_to_pll() {
     let db = build().await;
     put(&db, "AA", EpicsValue::String("hi".into())).await;
     process(&db).await;
 
-    let paa = prev_str(&db, "PAA");
-    assert_eq!(paa.len(), 40, "cvt_dbaddr sets no_elements = STRING_SIZE");
-    assert_eq!(&paa[..4], ["h", "i", "", ""], "field_size 1: one byte each");
-    assert!(paa[2..].iter().all(String::is_empty));
+    assert_eq!(
+        prev_str(&db, "PAA"),
+        "hi",
+        "PAA is the previous cycle's AA, a scalar string"
+    );
 }
 
-/// `strNcpy` terminates without clearing, so a shorter value leaves the
-/// previous one's tail in the buffer — and the 40-element channel shows it.
+/// `strNcpy` terminates without clearing the tail, but a scalar `DBF_STRING`
+/// reads only up to the NUL, so a shorter value no longer exposes the previous
+/// one's tail (calc#42 — released C served the raw 40 bytes and did leak it).
 #[epics_macros_rs::epics_test]
-async fn a_shorter_value_leaves_the_previous_tail_visible() {
+async fn a_shorter_value_reads_clean_over_a_longer_predecessor() {
     let db = build().await;
     put(&db, "AA", EpicsValue::String("hello".into())).await;
     process(&db).await;
-    assert_eq!(&prev_str(&db, "PAA")[..6], ["h", "e", "l", "l", "o", ""]);
+    assert_eq!(prev_str(&db, "PAA"), "hello");
 
     put(&db, "AA", EpicsValue::String("hi".into())).await;
     process(&db).await;
     assert_eq!(
-        &prev_str(&db, "PAA")[..6],
-        ["h", "i", "", "l", "o", ""],
-        "bytes 3 and 4 are `hello`'s tail, which strNcpy never cleared"
+        prev_str(&db, "PAA"),
+        "hi",
+        "the NUL after `hi` hides `hello`'s uncleared tail"
     );
 }
 
-/// `putStringString` with `field_size == 1` writes the byte and then the
-/// terminator over that same byte, so a put stores nothing and clears.
+/// PAA..PLL are `special(SPC_NOMOD)` (calc#42): a client `caput` is refused
+/// before it reaches the record, and the snapshot is untouched.
 #[epics_macros_rs::epics_test]
-async fn a_put_into_the_buffer_clears_its_head_and_stores_nothing() {
+async fn a_put_into_a_prev_string_is_refused() {
     let db = build().await;
     put(&db, "AA", EpicsValue::String("hi".into())).await;
     process(&db).await;
 
-    put(&db, "PAA", EpicsValue::String("zz".into())).await;
-    assert_eq!(
-        &prev_str(&db, "PAA")[..3],
-        ["", "i", ""],
-        "byte 0 cleared, nothing of `zz` stored"
+    let err = db
+        .put_record_field_from_ca_no_notify("SCO", "PAA", EpicsValue::String("zz".into()))
+        .await
+        .expect_err("PAA is SPC_NOMOD; the put must be refused");
+    assert!(
+        matches!(err, epics_base_rs::error::CaError::ReadOnlyField(ref f) if f == "PAA"),
+        "expected S_db_noMod (ReadOnlyField), got {err:?}"
     );
+    assert_eq!(prev_str(&db, "PAA"), "hi", "the snapshot is unchanged");
 }
 
 /// The snapshot belongs to every one of the twelve pairs, not just the first.
@@ -160,5 +165,5 @@ async fn the_snapshot_covers_all_twelve_pairs() {
     put(&db, "LL", EpicsValue::String("z".into())).await;
     process(&db).await;
     assert_eq!(num(&db, "PL"), 9.0);
-    assert_eq!(prev_str(&db, "PLL")[0], "z");
+    assert_eq!(prev_str(&db, "PLL"), "z");
 }

--- a/crates/epics-base-rs/tests/spc_nomod_declaration.rs
+++ b/crates/epics-base-rs/tests/spc_nomod_declaration.rs
@@ -37,11 +37,21 @@ use epics_base_rs::server::record::{RecordInstance, dbd_generated};
 
 /// Fields whose no-modify-ness is NOT a static `.dbd` fact and so are exempt
 /// from the equality: `Record::field_no_mod` raises SPC_NOMOD from record state
-/// the way C's `cvt_dbaddr` does (compress `VAL` under `BALG=LIFO`,
-/// `compressRecord.c:404-405`). Those are covered by
-/// `epics-ca-rs/tests/access_rights_spc_nomod.rs`.
+/// the way C's `cvt_dbaddr` does.
+///
+/// * `compress` `VAL` under `BALG=LIFO` (`compressRecord.c:404-405`) — covered
+///   by `epics-ca-rs/tests/access_rights_spc_nomod.rs`.
+/// * `scalcout` PAA..PLL — calc#42 makes the previous-string fields
+///   `special(SPC_NOMOD)`, which the released-C `.dbd` this port mirrors still
+///   ships as `SPC_DBADDR`; the refusal is covered by
+///   `scalcout_snapshots_its_inputs.rs::a_put_into_a_prev_string_is_refused`.
 fn state_raised_nomod(record_type: &str, field: &str) -> bool {
-    matches!((record_type, field), ("compress", "VAL"))
+    matches!(
+        (record_type, field),
+        ("compress", "VAL")
+            | ("scalcout", "PAA" | "PBB" | "PCC" | "PDD" | "PEE" | "PFF")
+            | ("scalcout", "PGG" | "PHH" | "PII" | "PJJ" | "PKK" | "PLL")
+    )
 }
 
 #[test]

--- a/crates/epics-oracle-rs/allowlist/expected-deviations.toml
+++ b/crates/epics-oracle-rs/allowlist/expected-deviations.toml
@@ -250,6 +250,41 @@ Expect: on ORACLE:ASYN.BOUT the C softIocPVX serves int8[]{80} (zero-filled to
 the OMAX cap) and the port serves int8[]{0} (empty until written).
 """
 
+[[deviation]]
+id = "DESIGN-SCALCOUT-PREV-STRING-SCALAR"
+bucket = "DESIGN-DIVERGENCE"
+upstream = "calc / sCalcoutRecord (epics-modules/calc#42)"
+record_types = ["scalcout"]
+fields = ["PAA", "PBB", "PCC", "PDD", "PEE", "PFF", "PGG", "PHH", "PII", "PJJ", "PKK", "PLL"]
+surface = ["declared_type", "value_marking"]
+why = """
+sCalcoutRecord's cvt_dbaddr, for fieldIndex scalcoutRecordPAA through
+scalcoutRecordPLL, sets no_elements = STRING_SIZE (40) and then UNCONDITIONALLY
+field_type = DBF_STRING, field_size = 1 -- so the released C IOC serves each
+previous-string field as a 40-element DBF_STRING array whose advertised element
+size is one byte (getStringString copies one byte per element and NUL-terminates
+it). That shape is epics-modules/calc#42: the fields hold the previous cycle's
+string inputs AA..LL, one scalar string each, and anjohnson's fix makes them
+plain read-only DBF_STRING scalars -- special(SPC_NOMOD), no
+extra()/special(SPC_DBADDR). The port serves that fixed shape ahead of the
+upstream merge: ScalcoutRecord::prev_str_channel returns a scalar String read to
+the NUL and field_no_mod raises SPC_NOMOD, so pvxinfo declares an NTScalar
+string and pvxget reads the scalar value, where the C side declares and serves a
+40-element string array. This is an intentional design divergence, not a port
+defect. It will vanish the day calc#42 lands in the reference tree, at which
+point the row goes STALE and must be deleted.
+
+Matched on the PVA declared-type (pvxinfo) and value/marking (pvxget) contracts,
+scoped to exactly scalcout PAA..PLL. The two shape contracts are not raised for
+these fields -- the .dbd marks them special(SPC_DBADDR), so NtShape::expected
+declines to predict -- so declared_type and value_marking are the whole surface
+of this deviation.
+
+Expect: on ORACLE:SCALCOUT.PAA..PLL the C softIocPVX declares and serves a
+40-element DBF_STRING array, and the port declares and serves a scalar read-only
+DBF_STRING.
+"""
+
 # --------------------------------------------------------------------------
 # INSTRUMENT-SUPERSET entries: the PVA ground truth (softIocPVX) loads
 # softIocPVX.dbd, a superset of the oracle's measured softIoc.dbd. softIocPVX.dbd
@@ -442,9 +477,12 @@ softIocPVX serving one bare `record(scalcout, "ORACLE:SCALCOUT") {}` aborts it
 with `corrupted size vs. prev_size`, core dumped, 1 of 1 -- but the oracle's own
 read path does NOT trip it, and the row must not claim otherwise. Measured on the
 full `--phase pva-read`: 3468 of 3468 channels measured on both contracts,
-PAA..PLL included, both sides serving the same 40-element string array. Enabled,
-the row would be reported STALE every run and fail it, asserting that a bug pvxs
-has not fixed had gone away.
+PAA..PLL included. The port now serves each as a scalar read-only DBF_STRING
+(calc#42, charged to DESIGN-SCALCOUT-PREV-STRING-SCALAR) while the C side serves
+the 40-element array; this row is only the server_abort contract, on which both
+servers survive when the channels are read one at a time. Enabled, the row would
+be reported STALE every run and fail it, asserting that a bug pvxs has not fixed
+had gone away.
 
 The defect. sCalcoutRecord.c's cvt_dbaddr, for fieldIndex scalcoutRecordPAA
 through scalcoutRecordPLL, sets no_elements = STRING_SIZE (40) and then


### PR DESCRIPTION
Fixes calc#42 in the port ahead of the upstream merge: PAA..PLL served as read-only scalar DBF_STRING instead of released C's 40-element one-char-string array (cvt_dbaddr field_size 1). Because this diverges from the C reference until calc#42 lands, the second commit registers the resulting pva-read difference (declared_type + value_marking) as an expected DESIGN-DIVERGENCE in the oracle allowlist — that row goes STALE and must be deleted the day calc#42 merges into the reference tree.