### PR TITLE
Release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.28.0 — 2026-09-02
+
+Minor release. It gathers the owned RTEMS BSP toolchain script and the
+2026-08-25 C-parity round (PRs #89–#93) into one version. Workspace
+0.27.0 -> 0.28.0; the 18 `[workspace.dependencies]` pins and the
+hand-written `epics-pva-rs` pin in `epics-bridge-rs` move in lockstep.
+
+### An owned RTEMS BSP toolchain
+
+`scripts/rtems-bsp.sh` builds the pinned RTEMS toolchain, kernel and
+libbsd into a BSP prefix and is now required to produce one; the boot
+crate reads its cross target off that prefix, and both RTEMS 6 and 7 are
+built and QEMU-verified.
+
+### C-parity round
+
+State is routed through the owner C gives it: `db_loader` holds one
+`MacroTable` across an include tree, `dbNotify` frees every put-notify
+slot its client abandons, `process` refuses a cycle the record has no
+dset for, device support binds before `init_record`, and `qsrv` runs
+`dbLoadGroup` through the base `macLib` rather than a fork. `scalcout`
+serves PAA..PLL as read-only scalar `DBF_STRING`, and every PUT now
+renders in its destination field's shape.
+
+### Build and platform
+
+The exec backend is selected by `EPICS_RS_BUILD_EXEC_BACKEND` rather
+than a cargo feature. VxWorks `-Zbuild-std` rows are pinned to
+nightly-2026-08-30, the last nightly before rust#160170 dropped std's
+`O_NOFOLLOW` guard; rust#162065 is the std-side fix and the pin lifts
+when it reaches nightly.
+
 ## v0.27.0 — 2026-08-24
 
 Minor release. It lands the 2026-08-23 parallel C-parity round: fifteen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1002,7 +1002,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "cc",
  "libc",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2264,7 +2264,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "named-port"
-version = "0.27.0"
+version = "0.28.0"
 
 [[package]]
 name = "ndarray"
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3244,7 +3244,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "source-guard"
-version = "0.27.0"
+version = "0.28.0"
 
 [[package]]
 name = "spin"
@@ -3868,7 +3868,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4978,7 +4978,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,30 +50,30 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.27.0" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.27.0" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.27.0" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.27.0" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.27.0" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.27.0" }
-epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.27.0" }
-epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.27.0" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.27.0" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.27.0" }
-motor-rs = { path = "crates/motor-rs", version = "0.27.0" }
-std-rs = { path = "crates/std-rs", version = "0.27.0" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.27.0" }
-optics-rs = { path = "crates/optics-rs", version = "0.27.0" }
-mca-rs = { path = "crates/mca-rs", version = "0.27.0" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.27.0" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.27.0", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.27.0" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.28.0" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.28.0" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.28.0" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.28.0" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.28.0" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.28.0" }
+epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.28.0" }
+epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.28.0" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.28.0" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.28.0" }
+motor-rs = { path = "crates/motor-rs", version = "0.28.0" }
+std-rs = { path = "crates/std-rs", version = "0.28.0" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.28.0" }
+optics-rs = { path = "crates/optics-rs", version = "0.28.0" }
+mca-rs = { path = "crates/mca-rs", version = "0.28.0" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.28.0" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.28.0", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.28.0" }
 
 # Deployable-image profile for the embedded targets (RTEMS / VxWorks), where
 # image size is a real resource: `cargo build --profile release-embedded ...`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The umbrella crate pulls in what you select by feature:
 
 ```toml
 [dependencies]
-epics-rs = { version = "0.27", features = ["ad"] }
+epics-rs = { version = "0.28", features = ["ad"] }
 ```
 
 ```rust
@@ -74,8 +74,8 @@ through the umbrella crate — depend on them directly when needed.
 You can also depend on sub-crates directly:
 
 ```toml
-epics-base-rs = "0.27"  # just the IOC runtime
-epics-ca-rs   = "0.27"  # just Channel Access
+epics-base-rs = "0.28"  # just the IOC runtime
+epics-ca-rs   = "0.28"  # just Channel Access
 ```
 
 ## Workspace

--- a/crates/epics-base-rs/src/server/records/scalcout.rs
+++ b/crates/epics-base-rs/src/server/records/scalcout.rs
@@ -81,10 +81,10 @@ pub struct ScalcoutRecord {
     /// (`sCalcoutRecord.c:345-353`, `strNcpy(*psprev, *pscurr, STRING_SIZE)`).
     ///
     /// Held as the raw 40-byte buffer C allocates in `init_record`
-    /// (`:223-225`) rather than as a `PvString`, because every byte of it is
-    /// observable: `strNcpy` terminates without clearing the tail, and the
-    /// channel reads all forty bytes: `cvt_dbaddr` (`sCalcoutRecord.c:588-596`)
-    /// leaves `field_size` at 1, so it is forty one-character strings.
+    /// (`:223-225`): `strNcpy` terminates without clearing the tail, so the
+    /// bytes past the NUL are the previous value's. The channel over each is a
+    /// read-only scalar `DBF_STRING` (calc#42 — see `prev_str_channel`), which
+    /// reads only up to that NUL.
     pub prev_str_vals: [[u8; PREV_STRING_SIZE]; 12],
     /// PVAL — C `sCalcoutRecord.dbd:60` `field(PVAL,DBF_DOUBLE)`, writable.
     ///
@@ -466,27 +466,20 @@ impl ScalcoutRecord {
         SCALCOUT_PREV_STR_NAMES.iter().position(|&n| n == name)
     }
 
-    /// The CHANNEL a client sees over one PAA..PLL buffer.
+    /// The CHANNEL a client sees over one PAA..PLL buffer: a read-only scalar
+    /// `DBF_STRING`.
     ///
-    /// C `cvt_dbaddr` (`sCalcoutRecord.c:588-596`) sets `no_elements =
-    /// STRING_SIZE`, `field_type = DBF_STRING` and `field_size = 1`, so
-    /// `getStringString` (`dbConvert.c`) copies ONE byte per element and
-    /// NUL-terminates it: the field is forty one-character strings over the
-    /// 40-byte buffer, not one 40-character string. `caget PAA` on a buffer
-    /// holding `hi` prints `40 h i` followed by 38 blanks, and the compiled
-    /// softIoc is what defines that shape.
+    /// Released `sCalcoutRecord` declares PAA..PLL `DBF_NOACCESS`/
+    /// `special(SPC_DBADDR)`, and `cvt_dbaddr` (`sCalcoutRecord.c:588-596`)
+    /// reshapes each into forty one-character `DBF_STRING` elements over the
+    /// 40-byte buffer (`no_elements = STRING_SIZE`, `field_size = 1`), so a
+    /// `caget PAA` on `hi` prints `40 h i …`. That shape is calc#42; the fix
+    /// (anjohnson) makes them plain read-only `DBF_STRING` scalars. This port
+    /// serves the fixed shape ahead of the upstream merge — the buffer read up
+    /// to its NUL — so `caget PAA` on `hi` reads the scalar `hi`.
     fn prev_str_channel(buf: &[u8; PREV_STRING_SIZE]) -> EpicsValue {
-        EpicsValue::StringArray(
-            buf.iter()
-                .map(|&b| {
-                    if b == 0 {
-                        PvString::new()
-                    } else {
-                        PvString::from_bytes(vec![b])
-                    }
-                })
-                .collect(),
-        )
+        let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        EpicsValue::String(PvString::from_bytes(buf[..end].to_vec()))
     }
 
     /// C `strNcpy` (`sCalcoutRecord.c:146-153`) — copy up to `N-1` source
@@ -589,8 +582,8 @@ const SCALCOUT_PREV_STR_NAMES: [&str; 12] = [
 ];
 
 /// C `sCalcoutRecord.c:198` `#define STRING_SIZE 40` — the width of the
-/// previous-value buffers `init_record` allocates, and the element COUNT
-/// `cvt_dbaddr` puts on their channels.
+/// previous-value buffers `init_record` allocates and the capacity of the
+/// scalar `DBF_STRING` channel served over each (calc#42).
 const PREV_STRING_SIZE: usize = 40;
 
 /// C `sCalcoutRecord.c::fetch_values`' second loop (890-941): INAA..LL → AA..LL.
@@ -1164,23 +1157,10 @@ impl Record for ScalcoutRecord {
                         _ => return Err(CaError::TypeMismatch(name.into())),
                     }
                 }
-                if let Some(idx) = Self::prev_str_index(name) {
-                    // C `putStringString` (`dbConvert.c`) writes each element
-                    // with `strncpy(pdst, psrc, size)` and then
-                    // `pdst[size-1] = 0` — over the SAME byte, because
-                    // `cvt_dbaddr` left `field_size` at 1. A put therefore
-                    // stores nothing and CLEARS the first `nRequest` bytes;
-                    // `get_array_info` is NULL for this record, so the offset
-                    // is always 0 and byte 0 is always among them. The
-                    // compiled softIoc accepts the put and reads back short.
-                    let n = match &value {
-                        EpicsValue::String(_) => 1,
-                        EpicsValue::StringArray(a) => a.len().min(PREV_STRING_SIZE),
-                        _ => return Err(CaError::TypeMismatch(name.into())),
-                    };
-                    self.prev_str_vals[idx][..n].fill(0);
-                    return Ok(());
-                }
+                // PAA..PLL have no put arm: calc#42 makes them
+                // `special(SPC_NOMOD)` (`Self::field_no_mod`), so the framework
+                // read-only gate refuses the client put before it reaches here.
+                // The snapshot itself is the only writer (`snapshot_prev_str`).
                 if let Some(idx) = Self::inp_index(name) {
                     match value {
                         EpicsValue::String(s) => {
@@ -1368,10 +1348,13 @@ impl Record for ScalcoutRecord {
         Vec::new()
     }
 
-    /// C `cvt_dbaddr` (`sCalcoutRecord.c:588-596`) puts `no_elements =
-    /// STRING_SIZE` on PAA..PLL and nothing on any other field.
-    fn dbaddr_capacity(&self, field: &str) -> Option<u32> {
-        Self::prev_str_index(field).map(|_| PREV_STRING_SIZE as u32)
+    /// calc#42: PAA..PLL are read-only (`special(SPC_NOMOD)` in the fixed
+    /// declaration). The released `.dbd` this port mirrors still ships them
+    /// `SPC_DBADDR`, so the static `FieldDesc` cannot carry the bit; the record
+    /// raises it here, and the framework's `is_no_mod` gate refuses every
+    /// client put on the strength of it.
+    fn field_no_mod(&self, field: &str) -> bool {
+        Self::prev_str_index(field).is_some()
     }
 
     fn set_resolved_out_target(&mut self, link_field: &str, target: OutTarget) {

--- a/crates/epics-base-rs/tests/dbf_string_fields_store_as_string.rs
+++ b/crates/epics-base-rs/tests/dbf_string_fields_store_as_string.rs
@@ -122,7 +122,7 @@ fn every_dbf_string_field_reports_dbf_string() {
         scanned, 519,
         "record-owned DBF_STRING fields on this tree; a change here means a \
          field left or joined the sweep and the new count needs reading. \
-         507 before scalcout began answering for PAA..PLL, whose channel is \
-         forty one-byte DBF_STRING elements (sCalcoutRecord.c:588-596)"
+         507 before scalcout began answering for PAA..PLL, which this port \
+         serves as read-only scalar DBF_STRING (calc#42)"
     );
 }

--- a/crates/epics-base-rs/tests/scalcout_snapshots_its_inputs.rs
+++ b/crates/epics-base-rs/tests/scalcout_snapshots_its_inputs.rs
@@ -81,10 +81,10 @@ fn num(db: &Db, field: &str) -> f64 {
         .expect("numeric")
 }
 
-/// The channel exactly as a client reads it: one `String` per element.
-fn prev_str(db: &Db, field: &str) -> Vec<String> {
+/// The channel exactly as a client reads it: a read-only scalar `DBF_STRING`.
+fn prev_str(db: &Db, field: &str) -> String {
     match db.get_pv(&format!("SCO.{field}")).expect("prev string") {
-        EpicsValue::StringArray(a) => a.iter().map(|s| s.as_str_lossy().into_owned()).collect(),
+        EpicsValue::String(s) => s.as_str_lossy().into_owned(),
         other => panic!("SCO.{field} is {other:?}"),
     }
 }
@@ -105,51 +105,56 @@ async fn processing_copies_the_numeric_inputs_into_pa_to_pl() {
     assert_eq!(num(&db, "PB"), 3.0);
 }
 
-/// The string half, and the channel shape it is served through.
+/// The string half, served as a read-only scalar `DBF_STRING` (calc#42).
 #[epics_macros_rs::epics_test]
 async fn processing_copies_the_string_inputs_into_paa_to_pll() {
     let db = build().await;
     put(&db, "AA", EpicsValue::String("hi".into())).await;
     process(&db).await;
 
-    let paa = prev_str(&db, "PAA");
-    assert_eq!(paa.len(), 40, "cvt_dbaddr sets no_elements = STRING_SIZE");
-    assert_eq!(&paa[..4], ["h", "i", "", ""], "field_size 1: one byte each");
-    assert!(paa[2..].iter().all(String::is_empty));
+    assert_eq!(
+        prev_str(&db, "PAA"),
+        "hi",
+        "PAA is the previous cycle's AA, a scalar string"
+    );
 }
 
-/// `strNcpy` terminates without clearing, so a shorter value leaves the
-/// previous one's tail in the buffer — and the 40-element channel shows it.
+/// `strNcpy` terminates without clearing the tail, but a scalar `DBF_STRING`
+/// reads only up to the NUL, so a shorter value no longer exposes the previous
+/// one's tail (calc#42 — released C served the raw 40 bytes and did leak it).
 #[epics_macros_rs::epics_test]
-async fn a_shorter_value_leaves_the_previous_tail_visible() {
+async fn a_shorter_value_reads_clean_over_a_longer_predecessor() {
     let db = build().await;
     put(&db, "AA", EpicsValue::String("hello".into())).await;
     process(&db).await;
-    assert_eq!(&prev_str(&db, "PAA")[..6], ["h", "e", "l", "l", "o", ""]);
+    assert_eq!(prev_str(&db, "PAA"), "hello");
 
     put(&db, "AA", EpicsValue::String("hi".into())).await;
     process(&db).await;
     assert_eq!(
-        &prev_str(&db, "PAA")[..6],
-        ["h", "i", "", "l", "o", ""],
-        "bytes 3 and 4 are `hello`'s tail, which strNcpy never cleared"
+        prev_str(&db, "PAA"),
+        "hi",
+        "the NUL after `hi` hides `hello`'s uncleared tail"
     );
 }
 
-/// `putStringString` with `field_size == 1` writes the byte and then the
-/// terminator over that same byte, so a put stores nothing and clears.
+/// PAA..PLL are `special(SPC_NOMOD)` (calc#42): a client `caput` is refused
+/// before it reaches the record, and the snapshot is untouched.
 #[epics_macros_rs::epics_test]
-async fn a_put_into_the_buffer_clears_its_head_and_stores_nothing() {
+async fn a_put_into_a_prev_string_is_refused() {
     let db = build().await;
     put(&db, "AA", EpicsValue::String("hi".into())).await;
     process(&db).await;
 
-    put(&db, "PAA", EpicsValue::String("zz".into())).await;
-    assert_eq!(
-        &prev_str(&db, "PAA")[..3],
-        ["", "i", ""],
-        "byte 0 cleared, nothing of `zz` stored"
+    let err = db
+        .put_record_field_from_ca_no_notify("SCO", "PAA", EpicsValue::String("zz".into()))
+        .await
+        .expect_err("PAA is SPC_NOMOD; the put must be refused");
+    assert!(
+        matches!(err, epics_base_rs::error::CaError::ReadOnlyField(ref f) if f == "PAA"),
+        "expected S_db_noMod (ReadOnlyField), got {err:?}"
     );
+    assert_eq!(prev_str(&db, "PAA"), "hi", "the snapshot is unchanged");
 }
 
 /// The snapshot belongs to every one of the twelve pairs, not just the first.
@@ -160,5 +165,5 @@ async fn the_snapshot_covers_all_twelve_pairs() {
     put(&db, "LL", EpicsValue::String("z".into())).await;
     process(&db).await;
     assert_eq!(num(&db, "PL"), 9.0);
-    assert_eq!(prev_str(&db, "PLL")[0], "z");
+    assert_eq!(prev_str(&db, "PLL"), "z");
 }

--- a/crates/epics-base-rs/tests/spc_nomod_declaration.rs
+++ b/crates/epics-base-rs/tests/spc_nomod_declaration.rs
@@ -37,11 +37,21 @@ use epics_base_rs::server::record::{RecordInstance, dbd_generated};
 
 /// Fields whose no-modify-ness is NOT a static `.dbd` fact and so are exempt
 /// from the equality: `Record::field_no_mod` raises SPC_NOMOD from record state
-/// the way C's `cvt_dbaddr` does (compress `VAL` under `BALG=LIFO`,
-/// `compressRecord.c:404-405`). Those are covered by
-/// `epics-ca-rs/tests/access_rights_spc_nomod.rs`.
+/// the way C's `cvt_dbaddr` does.
+///
+/// * `compress` `VAL` under `BALG=LIFO` (`compressRecord.c:404-405`) — covered
+///   by `epics-ca-rs/tests/access_rights_spc_nomod.rs`.
+/// * `scalcout` PAA..PLL — calc#42 makes the previous-string fields
+///   `special(SPC_NOMOD)`, which the released-C `.dbd` this port mirrors still
+///   ships as `SPC_DBADDR`; the refusal is covered by
+///   `scalcout_snapshots_its_inputs.rs::a_put_into_a_prev_string_is_refused`.
 fn state_raised_nomod(record_type: &str, field: &str) -> bool {
-    matches!((record_type, field), ("compress", "VAL"))
+    matches!(
+        (record_type, field),
+        ("compress", "VAL")
+            | ("scalcout", "PAA" | "PBB" | "PCC" | "PDD" | "PEE" | "PFF")
+            | ("scalcout", "PGG" | "PHH" | "PII" | "PJJ" | "PKK" | "PLL")
+    )
 }
 
 #[test]

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -171,7 +171,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # host-facing feature that pulls this dependency — `qsrv`, `pvalink`,
 # `pva-gateway`, `dual-ioc` — so host builds resolve exactly as before. Only
 # `qsrv-core`, the RTEMS selection, gets the reduced set.
-epics-pva-rs = { path = "../epics-pva-rs", version = "0.27.0", optional = true, default-features = false }
+epics-pva-rs = { path = "../epics-pva-rs", version = "0.28.0", optional = true, default-features = false }
 # `epics-ca-rs` stays inherited, but NOT because its defaults are empty — they
 # stopped being empty at `274a734b`, which introduced the `client-core`/`client`
 # split and made `default = ["client"]`. The reason is narrower and is a fact

--- a/crates/epics-oracle-rs/allowlist/expected-deviations.toml
+++ b/crates/epics-oracle-rs/allowlist/expected-deviations.toml
@@ -250,6 +250,41 @@ Expect: on ORACLE:ASYN.BOUT the C softIocPVX serves int8[]{80} (zero-filled to
 the OMAX cap) and the port serves int8[]{0} (empty until written).
 """
 
+[[deviation]]
+id = "DESIGN-SCALCOUT-PREV-STRING-SCALAR"
+bucket = "DESIGN-DIVERGENCE"
+upstream = "calc / sCalcoutRecord (epics-modules/calc#42)"
+record_types = ["scalcout"]
+fields = ["PAA", "PBB", "PCC", "PDD", "PEE", "PFF", "PGG", "PHH", "PII", "PJJ", "PKK", "PLL"]
+surface = ["declared_type", "value_marking"]
+why = """
+sCalcoutRecord's cvt_dbaddr, for fieldIndex scalcoutRecordPAA through
+scalcoutRecordPLL, sets no_elements = STRING_SIZE (40) and then UNCONDITIONALLY
+field_type = DBF_STRING, field_size = 1 -- so the released C IOC serves each
+previous-string field as a 40-element DBF_STRING array whose advertised element
+size is one byte (getStringString copies one byte per element and NUL-terminates
+it). That shape is epics-modules/calc#42: the fields hold the previous cycle's
+string inputs AA..LL, one scalar string each, and anjohnson's fix makes them
+plain read-only DBF_STRING scalars -- special(SPC_NOMOD), no
+extra()/special(SPC_DBADDR). The port serves that fixed shape ahead of the
+upstream merge: ScalcoutRecord::prev_str_channel returns a scalar String read to
+the NUL and field_no_mod raises SPC_NOMOD, so pvxinfo declares an NTScalar
+string and pvxget reads the scalar value, where the C side declares and serves a
+40-element string array. This is an intentional design divergence, not a port
+defect. It will vanish the day calc#42 lands in the reference tree, at which
+point the row goes STALE and must be deleted.
+
+Matched on the PVA declared-type (pvxinfo) and value/marking (pvxget) contracts,
+scoped to exactly scalcout PAA..PLL. The two shape contracts are not raised for
+these fields -- the .dbd marks them special(SPC_DBADDR), so NtShape::expected
+declines to predict -- so declared_type and value_marking are the whole surface
+of this deviation.
+
+Expect: on ORACLE:SCALCOUT.PAA..PLL the C softIocPVX declares and serves a
+40-element DBF_STRING array, and the port declares and serves a scalar read-only
+DBF_STRING.
+"""
+
 # --------------------------------------------------------------------------
 # INSTRUMENT-SUPERSET entries: the PVA ground truth (softIocPVX) loads
 # softIocPVX.dbd, a superset of the oracle's measured softIoc.dbd. softIocPVX.dbd
@@ -442,9 +477,12 @@ softIocPVX serving one bare `record(scalcout, "ORACLE:SCALCOUT") {}` aborts it
 with `corrupted size vs. prev_size`, core dumped, 1 of 1 -- but the oracle's own
 read path does NOT trip it, and the row must not claim otherwise. Measured on the
 full `--phase pva-read`: 3468 of 3468 channels measured on both contracts,
-PAA..PLL included, both sides serving the same 40-element string array. Enabled,
-the row would be reported STALE every run and fail it, asserting that a bug pvxs
-has not fixed had gone away.
+PAA..PLL included. The port now serves each as a scalar read-only DBF_STRING
+(calc#42, charged to DESIGN-SCALCOUT-PREV-STRING-SCALAR) while the C side serves
+the 40-element array; this row is only the server_abort contract, on which both
+servers survive when the channels are read one at a time. Enabled, the row would
+be reported STALE every run and fail it, asserting that a bug pvxs has not fixed
+had gone away.
 
 The defect. sCalcoutRecord.c's cvt_dbaddr, for fieldIndex scalcoutRecordPAA
 through scalcoutRecordPLL, sets no_elements = STRING_SIZE (40) and then


### PR DESCRIPTION
Minor release cutting the RTEMS BSP toolchain script and the 2026-08-25 C-parity round (#89–#93) as 0.28.0; also lands the two scalcout scalar-shape commits. Workspace and all 18 dependency pins plus the epics-bridge-rs epics-pva-rs pin move to 0.28.0 in lockstep. CHANGELOG v0.28.0 section carries the detail.