### PR TITLE
fix(asyn): gate call_param_callbacks on interruptAccept so boot seeds survive iocInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.28.1 — 2026-09-03
+
+Patch release. areaDetector read-only RBVs (`MaxSizeX`/`MaxSizeY`,
+`Manufacturer`, `Model`) now reach CA clients: `call_param_callbacks`
+is gated on `interruptAccept`, so the changed-flags a driver sets
+before `iocInit` are held rather than cleared, and the scan facility's
+false->true edge flushes every port once records are wired. Record
+init likewise defers to the `iocInit` barrier, and the busy/sseq
+plugins register through `register_all_plugins`. The `coreRelease`
+banner is branded epics-rs without the base-version line, and the
+modbus example loads `modbus.db` via `$(MODBUS_IOC)` so `st.cmd` no
+longer depends on the launch directory.
+
 ## v0.28.0 — 2026-09-02
 
 Minor release. It gathers the owned RTEMS BSP toolchain script and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ad-core-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "ad-plugins-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ad-core-rs",
  "asyn-rs",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "asyn-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1002,7 +1002,7 @@ version = "0.0.0"
 
 [[package]]
 name = "epics-base-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "epics-bridge-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "epics-ca-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "epics-libcom-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "epics-macros-rs",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "epics-macros-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "epics-base-rs",
  "proc-macro-crate",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "epics-modbus-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "epics-oracle-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "clap",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "epics-pva-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "epics-rtems-boot"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "cc",
  "libc",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "epics-tools-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "mca-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "epics-base-rs",
@@ -2264,7 +2264,7 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-beamline"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-ioc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "motor-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "bitflags",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-ioc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "named-port"
-version = "0.28.0"
+version = "0.28.1"
 
 [[package]]
 name = "ndarray"
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "ophyd-test-ioc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "optics-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "qsrv-ioc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "epics-base-rs",
  "epics-bridge-rs",
@@ -3244,7 +3244,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regression-ioc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "rt-probe"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "clap",
  "epics-base-rs",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "scaler-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "scope-ioc"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "epics-base-rs",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "sim-detector"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "source-guard"
-version = "0.28.0"
+version = "0.28.1"
 
 [[package]]
 name = "spin"
@@ -3868,7 +3868,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-rs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "asyn-rs",
  "chrono",
@@ -4978,7 +4978,7 @@ dependencies = [
 
 [[package]]
 name = "xrt-beamline"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ad-core-rs",
  "ad-plugins-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,30 +50,30 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["Sang Woo Kim <sngwkim915@gmail.com>"]
 license = "EPICS"
 repository = "https://github.com/epics-rs/epics-rs"
 
 [workspace.dependencies]
-ad-core-rs = { path = "crates/ad-core-rs", version = "0.28.0" }
-ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.28.0" }
-asyn-rs = { path = "crates/asyn-rs", version = "0.28.0" }
-epics-base-rs = { path = "crates/epics-base-rs", version = "0.28.0" }
-epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.28.0" }
-epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.28.0" }
-epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.28.0" }
-epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.28.0" }
-epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.28.0" }
-epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.28.0" }
-motor-rs = { path = "crates/motor-rs", version = "0.28.0" }
-std-rs = { path = "crates/std-rs", version = "0.28.0" }
-scaler-rs = { path = "crates/scaler-rs", version = "0.28.0" }
-optics-rs = { path = "crates/optics-rs", version = "0.28.0" }
-mca-rs = { path = "crates/mca-rs", version = "0.28.0" }
-mqtt-rs = { path = "crates/mqtt-rs", version = "0.28.0" }
-modbus-rs = { path = "crates/modbus-rs", version = "0.28.0", package = "epics-modbus-rs" }
-epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.28.0" }
+ad-core-rs = { path = "crates/ad-core-rs", version = "0.28.1" }
+ad-plugins-rs = { path = "crates/ad-plugins-rs", version = "0.28.1" }
+asyn-rs = { path = "crates/asyn-rs", version = "0.28.1" }
+epics-base-rs = { path = "crates/epics-base-rs", version = "0.28.1" }
+epics-ca-rs = { path = "crates/epics-ca-rs", version = "0.28.1" }
+epics-macros-rs = { path = "crates/epics-macros-rs", version = "0.28.1" }
+epics-rtems-boot = { path = "crates/epics-rtems-boot", version = "0.28.1" }
+epics-libcom-rs = { path = "crates/epics-libcom-rs", version = "0.28.1" }
+epics-pva-rs = { path = "crates/epics-pva-rs", version = "0.28.1" }
+epics-bridge-rs = { path = "crates/epics-bridge-rs", version = "0.28.1" }
+motor-rs = { path = "crates/motor-rs", version = "0.28.1" }
+std-rs = { path = "crates/std-rs", version = "0.28.1" }
+scaler-rs = { path = "crates/scaler-rs", version = "0.28.1" }
+optics-rs = { path = "crates/optics-rs", version = "0.28.1" }
+mca-rs = { path = "crates/mca-rs", version = "0.28.1" }
+mqtt-rs = { path = "crates/mqtt-rs", version = "0.28.1" }
+modbus-rs = { path = "crates/modbus-rs", version = "0.28.1", package = "epics-modbus-rs" }
+epics-tools-rs = { path = "crates/epics-tools-rs", version = "0.28.1" }
 
 # Deployable-image profile for the embedded targets (RTEMS / VxWorks), where
 # image size is a real resource: `cargo build --profile release-embedded ...`

--- a/crates/ad-plugins-rs/src/ioc.rs
+++ b/crates/ad-plugins-rs/src/ioc.rs
@@ -806,6 +806,21 @@ pub fn register_all_plugins(mut app: IocApplication, mgr: &Arc<PluginManager>) -
         ));
     }
 
+    // ad-core-rs's own templates use these record types — NDArrayBase (so
+    // every plugin) declares `busy` fields, NDStats/NDProcess `sseq` ones —
+    // the way every C ADCore IOC links busySupport.dbd and calcSupport.dbd
+    // through commonDriverMakefile:303-310. Both were dropped from the default
+    // registry with the stdRecords.dbd manifest, so any IOC that registers
+    // these plugins has to bring them back; registering here means every
+    // caller of `register_all_plugins` gets them, not just `AdIoc`. A later
+    // `register_record_type` call with the same name still overrides.
+    app = app.register_record_type("busy", || {
+        Box::new(epics_base_rs::server::records::busy::BusyRecord::default())
+    });
+    app = app.register_record_type("sseq", || {
+        Box::new(epics_base_rs::server::records::sseq::SseqRecord::default())
+    });
+
     app
 }
 
@@ -964,19 +979,9 @@ impl AdIoc {
         // creates its port and sets the EOS before `iocInit`.
         app = asyn_rs::iocsh::register_asyn_commands(app, ports.clone());
 
-        // ad-core-rs's own templates use these record types — NDArrayBase
-        // (so every plugin) declares `busy` fields, NDStats/NDProcess `sseq`
-        // ones — the way every C ADCore IOC links busySupport.dbd and
-        // calcSupport.dbd through commonDriverMakefile:303-310. Both were
-        // dropped from the default registry with the stdRecords.dbd
-        // manifest, so an AdIoc has to bring them back itself; a later
-        // `register_record_type` call with the same name still overrides.
-        app = app.register_record_type("busy", || {
-            Box::new(epics_base_rs::server::records::busy::BusyRecord::default())
-        });
-        app = app.register_record_type("sseq", || {
-            Box::new(epics_base_rs::server::records::sseq::SseqRecord::default())
-        });
+        // `busy` and `sseq` — the record types every AD plugin's templates
+        // need — are registered inside `register_all_plugins` above, so an
+        // `AdIoc` picks them up along that path.
 
         Self {
             app: Some(app),

--- a/crates/asyn-rs/Cargo.toml
+++ b/crates/asyn-rs/Cargo.toml
@@ -81,6 +81,10 @@ source-guard = { path = "../source-guard" }
 # chances to retry on the wrong evidence.
 named-port = { path = "../named-port" }
 tempfile = "3"
+# Already a normal dependency; named here too so `tests/` can open the
+# interruptAccept gate to the post-`iocInit` precondition a real port has
+# by the time records process (an integration test has no scan facility).
+epics-libcom-rs = { workspace = true }
 # The `#[epics_test]` attribute itself. Named directly rather than through
 # `epics_base_rs`, which re-exports it but is optional here: the lib's own
 # `#[cfg(test)]` bodies must build under `--no-default-features`, this crate's

--- a/crates/asyn-rs/src/port.rs
+++ b/crates/asyn-rs/src/port.rs
@@ -1371,6 +1371,17 @@ impl PortDriverBase {
     /// Flush changed parameters as interrupt notifications.
     /// Equivalent to C asyn's callParamCallbacks().
     pub fn call_param_callbacks(&mut self, addr: i32) -> AsynResult<()> {
+        // C asynPortDriver.cpp:838 — `callCallbacks` returns before the loop
+        // AND before `flags.clear()` (:871) while `interruptAccept` is false,
+        // so every callback fired during IOC build is a no-op that PRESERVES
+        // the accumulated changed-flags. Returning here, ahead of `take_changed`
+        // (which both reads and clears), is that early return: a driver's
+        // acquisition/array task can call this before `iocInit` has wired the
+        // `_RBV` records, and a read-only seed must survive to the one-shot
+        // flush the scan facility fires when the gate goes true.
+        if !epics_libcom_rs::runtime::interrupt_accept::interrupts_accepted() {
+            return Ok(());
+        }
         let changed = self.params.take_changed(addr)?;
         let now = self.current_timestamp();
         for reason in changed {
@@ -1424,6 +1435,12 @@ impl PortDriverBase {
     /// Use this instead of `call_param_callbacks` when you want to avoid
     /// flushing unrelated parameters (e.g. rapidly-updating CP-linked params).
     pub fn call_param_callback(&mut self, addr: i32, reason: usize) -> AsynResult<()> {
+        // C `interruptAccept` gate — see `call_param_callbacks`: preserve the
+        // changed-flag (do not `take_changed_single`) until the IOC accepts
+        // interrupts, so a pre-`iocInit` flush cannot strand a seeded value.
+        if !epics_libcom_rs::runtime::interrupt_accept::interrupts_accepted() {
+            return Ok(());
+        }
         if self.params.take_changed_single(reason, addr)? {
             let value = self.params.get_value(reason, addr)?.clone();
             // C asynPortDriver.cpp:845 — see `call_param_callbacks`: an
@@ -2632,12 +2649,85 @@ mod tests {
         );
     }
 
+    /// The `interruptAccept` gate: a `call_param_callbacks` fired before the
+    /// IOC accepts interrupts must PRESERVE the changed-flag, not consume it,
+    /// so a value seeded at construction still reaches the record on the
+    /// one-shot flush the scan facility fires at `iocInit`. C
+    /// `asynPortDriver.cpp:838` returns before `flags.clear()` (`:871`) while
+    /// `interruptAccept` is false.
+    ///
+    /// Before this gate existed, the first `call_param_callbacks` — a driver's
+    /// own acquisition/array task can fire it before the `_RBV` records
+    /// subscribe — cleared the flag, and a read-only seed
+    /// (`Manufacturer`, `MaxSizeX`) was lost for the life of the process.
+    ///
+    /// This mutates a process-global flag; nextest isolates each test in its
+    /// own process, so it does not race with the crate's other port tests.
+    #[test]
+    fn call_param_callbacks_before_interrupt_accept_preserves_the_seed() {
+        use crate::interrupt::{InterruptFilter, InterruptValue};
+        use epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted;
+        use std::sync::{Arc, Mutex};
+
+        let mut base = PortDriverBase::new("gate", 1, PortFlags::default());
+        let val = base.create_param("VAL", ParamType::Int32).unwrap();
+
+        let seen: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let _sub = base.interrupts.register_sync_callback(
+            InterruptFilter {
+                reason: Some(val),
+                addr: Some(0),
+                uint32_mask: None,
+                iface: None,
+            },
+            move |iv: &InterruptValue| {
+                if let ParamValue::Int32(v) = &iv.value {
+                    sink.lock().unwrap().push(*v);
+                }
+            },
+        );
+
+        // Pre-iocInit: interrupts not accepted. The subscriber exists (the
+        // record registered), the driver seeds a read-only value, and its own
+        // task fires a callback — which must deliver NOTHING and leave the flag
+        // pending.
+        set_interrupts_accepted(false);
+        base.set_int32_param(val, 0, 640).unwrap();
+        base.call_param_callbacks(0).unwrap();
+        assert!(
+            seen.lock().unwrap().is_empty(),
+            "a callback fired before interruptAccept must not deliver — got {:?}",
+            *seen.lock().unwrap()
+        );
+
+        // iocInit accepts interrupts; the flush the scan facility now performs
+        // delivers the preserved seed exactly once.
+        set_interrupts_accepted(true);
+        base.call_param_callbacks(0).unwrap();
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![640],
+            "the seed preserved across the gated call must reach the subscriber \
+             once interrupts are accepted"
+        );
+    }
+
     struct TestDriver {
         base: PortDriverBase,
     }
 
     impl TestDriver {
         fn new() -> Self {
+            // These tests exercise `call_param_callbacks` delivery with no
+            // `iocInit` to open the interruptAccept gate. Establish the
+            // precondition a real port has by the time records process — the
+            // scan facility has run `scan_run` — which is the direct analogue
+            // of C's non-IOC translation unit that unit tests link with
+            // `interruptAccept = 1` (`asynPortDriver.cpp:23-25`). The seed-
+            // preservation regression test builds its own `PortDriverBase` and
+            // drives the gate itself, so it is unaffected.
+            epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
             let mut base = PortDriverBase::new("test", 1, PortFlags::default());
             base.create_param("VAL", ParamType::Int32).unwrap();
             base.create_param("TEMP", ParamType::Float64).unwrap();
@@ -2979,6 +3069,8 @@ mod tests {
     fn test_enum_callback() {
         use crate::param::{EnumEntry, ParamValue};
 
+        // Post-`iocInit` precondition — see `TestDriver::new`.
+        epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
         let mut base = PortDriverBase::new("test_enum_cb", 1, PortFlags::default());
         base.create_param("MODE", ParamType::Enum).unwrap();
         let mut rx = base.interrupts.subscribe_async();
@@ -3048,6 +3140,8 @@ mod tests {
     fn test_generic_pointer_callback() {
         use crate::param::ParamValue;
 
+        // Post-`iocInit` precondition — see `TestDriver::new`.
+        epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
         let mut base = PortDriverBase::new("test_gp_cb", 1, PortFlags::default());
         base.create_param("PTR", ParamType::GenericPointer).unwrap();
         let mut rx = base.interrupts.subscribe_async();
@@ -3506,6 +3600,8 @@ mod tests {
 
     #[test]
     fn test_timestamp_source_in_callbacks() {
+        // Post-`iocInit` precondition — see `TestDriver::new`.
+        epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
         let mut base = PortDriverBase::new("ts_cb", 1, PortFlags::default());
         base.create_param("V", ParamType::Int32).unwrap();
         let mut rx = base.interrupts.subscribe_async();

--- a/crates/asyn-rs/src/port_actor.rs
+++ b/crates/asyn-rs/src/port_actor.rs
@@ -4142,6 +4142,9 @@ mod tests {
     /// normally.
     #[test]
     fn a_publish_flushes_every_address_list_it_wrote() {
+        // Post-`iocInit` precondition: the scan facility has opened the
+        // interruptAccept gate. See `TestDriver::new` in `port.rs`.
+        epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
         let mut base = PortDriverBase::new(
             "multi_addr",
             3,
@@ -4200,6 +4203,9 @@ mod tests {
     /// is delivered the same way.
     #[test]
     fn a_status_publish_delivers_the_alarm_without_touching_the_value() {
+        // Post-`iocInit` precondition: the scan facility has opened the
+        // interruptAccept gate. See `TestDriver::new` in `port.rs`.
+        epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
         let mut base = PortDriverBase::new("status_pub", 1, PortFlags::default());
         let val = base.create_param("VAL", ParamType::Int32).unwrap();
         let seen = Arc::new(parking_lot::Mutex::new(Vec::new()));

--- a/crates/asyn-rs/src/registry.rs
+++ b/crates/asyn-rs/src/registry.rs
@@ -126,7 +126,53 @@ fn global_registry() -> &'static PortRegistry {
 /// Errors with [`AsynError::PortAlreadyRegistered`] on a duplicate name —
 /// see [`PortRegistry::register`].
 pub fn register_port(name: &str, handle: PortHandle, trace: Arc<TraceManager>) -> AsynResult<()> {
-    global_registry().register(name, handle, trace)
+    global_registry().register(name, handle, trace)?;
+    arm_boot_flush();
+    Ok(())
+}
+
+/// Arm the one-shot boot flush, once per process.
+///
+/// C creates a `callbackThread` in every `asynPortDriver` constructor
+/// (`asynPortDriver.cpp:4111`) that waits for `interruptAccept` and then does
+/// `callParamCallbacks(addr, addr)` once per addr (`:923-937`), delivering the
+/// changed-flags that accumulated while the IOC was building. This is the
+/// crate-level equivalent: a single callback on the gate's `false → true` edge
+/// sweeps every published port instead of one thread per port. Registered on
+/// first port registration so the cost exists only in a process that has asyn
+/// ports; the edge itself never fires in a bare-port process because nothing
+/// lowers the gate there (see [`epics_libcom_rs::runtime::interrupt_accept`]).
+fn arm_boot_flush() {
+    static ARMED: OnceLock<()> = OnceLock::new();
+    ARMED.get_or_init(|| {
+        epics_libcom_rs::runtime::interrupt_accept::on_interrupts_accepted(|| {
+            // C's callbackThread is a dedicated thread precisely so it does not
+            // block the caller that set interruptAccept (the scan facility on
+            // the iocRun path). Match that: the sweep uses the port actors'
+            // blocking bridge, which must not run on the scan/setup thread.
+            let _ = std::thread::Builder::new()
+                .name("asyn-boot-flush".into())
+                .spawn(flush_all_ports_once);
+        });
+    });
+}
+
+/// Flush every published port's accumulated changed params once — C
+/// `callbackThread::run` (`asynPortDriver.cpp:923-937`), summed over all ports.
+///
+/// The gate is already `true` when this runs (the edge is what scheduled it),
+/// so each `call_param_callbacks` proceeds past the interruptAccept check and
+/// delivers the seeds to the now-subscribed `_RBV` records.
+fn flush_all_ports_once() {
+    for name in port_names() {
+        let Some(entry) = get_port(&name) else {
+            continue;
+        };
+        // C sweeps `addr` in `0..maxAddr`; a single-device port is `maxAddr == 1`.
+        for addr in 0..entry.handle.max_addr().max(1) {
+            let _ = entry.handle.call_param_callbacks_blocking(addr);
+        }
+    }
 }
 
 /// Look up a port via the global registry.

--- a/crates/asyn-rs/tests/port_driver_tests.rs
+++ b/crates/asyn-rs/tests/port_driver_tests.rs
@@ -273,6 +273,12 @@ fn unique_name(prefix: &str) -> String {
 }
 
 fn setup_scope() -> (PortManager, asyn_rs::port_handle::PortHandle) {
+    // Post-`iocInit` precondition: the scan facility has opened the
+    // interruptAccept gate, so `call_param_callbacks` delivers. An integration
+    // test has no scan facility, so it establishes the precondition itself —
+    // the analogue of C linking the non-IOC translation unit's
+    // `interruptAccept = 1`. See `interrupt_accept` in `epics-libcom-rs`.
+    epics_libcom_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
     let mgr = PortManager::new();
     let rt = mgr
         .register_port(TestScopeDriver::new(&unique_name("SCOPE")))

--- a/crates/epics-base-rs/src/server/database/mod.rs
+++ b/crates/epics-base-rs/src/server/database/mod.rs
@@ -531,6 +531,17 @@ struct PvDatabaseInner {
     /// in `records`, which is what makes "the init observes a registered
     /// record" hold by construction rather than by scheduler timing.
     record_init_waiting: std::sync::Mutex<HashMap<String, Vec<RecordInit>>>,
+    /// Records whose device-support binding and `init_record` passes are OWED
+    /// to [`PvDatabase::ioc_init`] because they were created during the LOAD
+    /// phase — C's `dbLoadRecords` links a record into `pdbbase` at once but
+    /// runs `init_record` only at `iocInit`. [`PvDatabase::add_loaded_record`]
+    /// used to bind the dset and run the passes eagerly at load time, so a
+    /// record whose device-support PORT is configured by a later `st.cmd`
+    /// command (ADCore's `NDTimeSeriesConfigure` builds the `*_TS` port AFTER
+    /// `dbLoadRecords(NDStats.template)`) bound to a missing port and lost its
+    /// device support. Names are pushed in load order and drained once, in that
+    /// order, by `ioc_init`. Empty on every path but a LOAD.
+    deferred_record_inits: std::sync::Mutex<Vec<String>>,
     /// C `plink->text != NULL` for the one case the port's link storage cannot
     /// tell apart on its own: a link field the `.db` assigned the EMPTY string.
     ///
@@ -1066,6 +1077,7 @@ impl PvDatabase {
                 registration_mutex: crate::runtime::sync::PriorityInheritanceMutex::new(()),
                 init_phase: std::sync::Mutex::new(DbInitPhase::Unloaded),
                 record_init_waiting: std::sync::Mutex::new(HashMap::new()),
+                deferred_record_inits: std::sync::Mutex::new(Vec::new()),
                 empty_link_assignments: std::sync::Mutex::new(HashMap::new()),
                 after_ioc_running: std::sync::Mutex::new(Vec::new()),
                 scan_started: std::sync::atomic::AtomicBool::new(false),
@@ -2212,6 +2224,15 @@ impl PvDatabase {
         // barrier is the one point every bring-up path crosses: the
         // `IocApplication` walk and `CaServer::run` both reach it, and only
         // one of them runs that lifecycle.
+        // C's `initDatabase` per-record init pass — bind each LOAD-deferred
+        // record's dset and run its `init_record`. The build lifecycle drains
+        // this explicitly BEFORE `setup_io_intr` (C's `scanInit`), so a record's
+        // dset is bound before I/O Intr wiring reads it; this call is the
+        // catch-all for a path that reaches the barrier directly (a unit test, a
+        // bare shell). Idempotent — the list is empty once drained. Before
+        // `ca_link_init` to keep the order the eager path had, where the init
+        // passes ran at load, ahead of the link worker.
+        self.drain_deferred_record_inits();
         self.ca_link_init();
         // C's `dbInitRecordLinks`: every link is typed, checked and opened at
         // `iocInit`, not at `dbLoadRecords`. That is where a `{state:"NAME"}`
@@ -2275,20 +2296,23 @@ impl PvDatabase {
     /// `lnkState_open` (`lnkState.c:110-116`) is `dbStateCreate`, find-or-create
     /// (`dbState.c:50-66`), and it is not called at all.
     ///
-    /// C runs this pass BEFORE `init_record`; this port still runs the init
-    /// passes in [`Self::add_loaded_record`], and that ordering IS observable.
-    /// Measured against softIoc R7.0.10 on
+    /// C runs this pass BEFORE `init_record`; this port runs the init passes
+    /// first — at load for a programmatic / `dbCreateRecord` record, and at the
+    /// barrier just above (`init_deferred_record` draining
+    /// `deferred_record_inits`) for a record loaded during the LOAD phase — so
+    /// the port's order is still init-then-link, and that ordering IS
+    /// observable. Measured against softIoc R7.0.10 on
     /// `record(calcout,"X"){field(INPA,"@instio p") field(OUT,"@instio q")}`:
     /// C reads `INAV`/`OUTV` as `Constant`, this port read `Ext PV NC`, because
-    /// calcout had classified both at load from text this pass then replaced.
+    /// calcout had classified both at init from text this pass then replaced.
     /// A record's cached link status is therefore re-derived where the text
     /// changes (see [`Self::set_link_text`]) and once per record at the end of
     /// the loop, which is the same seam a runtime re-point uses. What is NOT
-    /// closed is `init_record` itself: device support still reads the refused
-    /// text where C's reads the emptied link. That needs the init passes moved
-    /// to this barrier, which the two load callers that run the pass tail
-    /// (`iocsh::commands`' `dbLoadRecords` and `IocBuilder`) would have to
-    /// follow.
+    /// closed is the ORDER of the two passes: device support reads the refused
+    /// text at `init_record` where C reads the emptied link, because this pass
+    /// runs after the deferred-init drain rather than before it. Closing it
+    /// means running this pass ahead of that drain, a reordering the eager
+    /// (`IocBuilder`, non-LOAD `dbLoadRecords`) callers would have to follow too.
     async fn db_init_record_links(&self) {
         use crate::runtime::log::ERL_ERROR;
         use crate::server::record::{
@@ -2687,29 +2711,46 @@ impl PvDatabase {
         // — `ao`'s `prec->init = TRUE`, `sub`'s MLST/ALST/LALM seed and `ai`'s
         // are all BELOW that test, and running the passes first is what made
         // them reachable for a record C refuses.
-        crate::server::ioc_app::attach_device_support(
-            &mut instance,
-            name,
-            self.inner.device_support_resolver.load().as_deref(),
-        );
-        // C `registryFunctionFind` reads a process-global registry from inside
-        // `init_record` pass 1, so the record is handed the registry rather
-        // than resolved against it from out here: the lookup's failure is an
-        // early return that the init tail must not run past, and only the init
-        // owner can honour that.
-        instance.arm_init_subroutines(self.inner.subroutine_registry.load_full());
-        instance.run_init_passes(name);
+        //
+        // During the LOAD phase this whole span is OWED to `iocInit` instead:
+        // C links a record into `pdbbase` at `dbLoadRecords` but runs
+        // `init_record` at `iocInit`, and binding the dset eagerly here bound
+        // it against whatever device-support ports existed when the `.db` was
+        // parsed — wrong for a record whose port a later `st.cmd` command
+        // configures (ADCore's `NDTimeSeriesConfigure` builds the `*_TS` port
+        // AFTER `dbLoadRecords(NDStats.template)`). The record is still
+        // published below so a name check, an alias and `dbInitRecordLinks` all
+        // see it; only its device-support binding and passes wait for the
+        // barrier's drain of `deferred_record_inits`. Outside the LOAD phase —
+        // programmatic creation, `dbCreateRecord` after `iocInit` — there is no
+        // barrier to defer to, so the record is initialised in place, as before.
+        let defer = self.is_load_deferring();
+        if !defer {
+            crate::server::ioc_app::attach_device_support(
+                &mut instance,
+                name,
+                self.inner.device_support_resolver.load().as_deref(),
+            );
+            // C `registryFunctionFind` reads a process-global registry from
+            // inside `init_record` pass 1, so the record is handed the registry
+            // rather than resolved against it from out here: the lookup's
+            // failure is an early return that the init tail must not run past,
+            // and only the init owner can honour that.
+            instance.arm_init_subroutines(self.inner.subroutine_registry.load_full());
+            instance.run_init_passes(name);
 
-        // The init-seed owner: every CONSTANT link the record declares
-        // (`Record::constant_init_links`) is loaded into its value field ONCE,
-        // here — a constant delivers NOTHING at process time
-        // (`dbConstLink.c:219-225`). `add_record` is the creation sink every
-        // path funnels through, so this covers a record built programmatically
-        // as well as one loaded from a .db; `IocBuilder`/`dbLoadRecords` call
-        // the owner again after `init_record(1)`, once the record's final
-        // NELM/FTVL buffer exists for an array constant to land in. Seeding
-        // twice is a no-op — both run before any client put.
-        super::database::processing::seed_constant_links(&mut instance);
+            // The init-seed owner: every CONSTANT link the record declares
+            // (`Record::constant_init_links`) is loaded into its value field
+            // ONCE, here — a constant delivers NOTHING at process time
+            // (`dbConstLink.c:219-225`). `add_record` is the creation sink every
+            // path funnels through, so this covers a record built
+            // programmatically as well as one loaded from a .db;
+            // `IocBuilder`/`dbLoadRecords` call the owner again after
+            // `init_record(1)`, once the record's final NELM/FTVL buffer exists
+            // for an array constant to land in. Seeding twice is a no-op — both
+            // run before any client put.
+            super::database::processing::seed_constant_links(&mut instance);
+        }
 
         let scan = instance.common.scan;
         let phas = instance.common.phas;
@@ -2725,7 +2766,8 @@ impl PvDatabase {
         self.release_record_inits(name);
 
         // Assign a monotonic load-order sequence — the scan-index
-        // secondary sort key, so same-PHAS records keep load order.
+        // secondary sort key, so same-PHAS records keep load order. Assigned in
+        // both arms at load time so the deferred drain preserves load order.
         let seq = self
             .inner
             .load_order_counter
@@ -2733,6 +2775,18 @@ impl PvDatabase {
         self.inner.load_order.update(|m| {
             m.insert(name.to_string(), seq);
         });
+
+        if defer {
+            // The dset binding, init passes, scan-index insert and the
+            // `recGblInitSimm`/`wdogInit` tail are all owed to `ioc_init`; the
+            // record is published (above) so the barrier finds it by name.
+            self.inner
+                .deferred_record_inits
+                .lock()
+                .unwrap()
+                .push(name.to_string());
+            return Ok(());
+        }
 
         self.add_to_scan_list(scan, phas, record_type, seq, name);
 
@@ -2761,6 +2815,106 @@ impl PvDatabase {
         self.rec_gbl_init_simm(&rec_arc);
         self.arm_watchdog(name);
         Ok(())
+    }
+
+    /// Is the database in its LOAD phase, where a new record is published but
+    /// its device-support binding and `init_record` passes are deferred to
+    /// [`Self::ioc_init`]? See [`Self::add_loaded_record`] and
+    /// [`Self::init_deferred_record`].
+    fn is_load_deferring(&self) -> bool {
+        matches!(
+            *self.inner.init_phase.lock().unwrap(),
+            DbInitPhase::Loading(_)
+        )
+    }
+
+    /// Run every record's OWED init — C's `initDatabase` per-record pass — for
+    /// the records the LOAD phase deferred. The list is drained (`mem::take`),
+    /// so a second call is a no-op: the build lifecycle calls this BEFORE
+    /// `setup_io_intr`, and [`Self::ioc_init`] calls it again as a catch-all.
+    /// Load order is preserved because the list was pushed in load order.
+    pub(crate) fn drain_deferred_record_inits(&self) {
+        let owed = std::mem::take(&mut *self.inner.deferred_record_inits.lock().unwrap());
+        for name in owed {
+            self.init_deferred_record(&name);
+        }
+    }
+
+    /// Is `name` still awaiting its deferred init — created during the LOAD
+    /// phase and not yet drained by [`Self::drain_deferred_record_inits`]? The
+    /// merge arm of the iocsh loader uses this to tell a record it must init in
+    /// place (created before the load, already live) from one the barrier will
+    /// init against the final merged fields.
+    pub(crate) fn record_init_deferred(&self, name: &str) -> bool {
+        self.inner
+            .deferred_record_inits
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|n| n == name)
+    }
+
+    /// Run the OWED init half of [`Self::add_loaded_record`] for a record whose
+    /// creation was deferred to `iocInit` (the LOAD-phase arm). The record is
+    /// already published, its `.db` load applied and its load-order sequence
+    /// assigned; what runs here is C's `doInitRecord0`/`init_record` half —
+    /// bind the dset, arm subroutines, run the passes, seed constant links —
+    /// then the scan-index insert, the `recGblInitSimm`/`wdogInit` tail, and
+    /// the checkLinks / constant-INP seed the two loaders used to run right
+    /// after `add_loaded_record`. All in the same order the eager path ran them
+    /// across `add_loaded_record` and its caller.
+    ///
+    /// No registration gate is taken: the barrier drains this list from a
+    /// single synchronous loop with no `.await`, so no other creation
+    /// interleaves, and the gate's only job is to serialize concurrent
+    /// creation. Holding the record's write lock across the passes is safe —
+    /// no `init_record` path re-enters the records map for its own record
+    /// (the map-reading async-handle calls live only in processing/reentry).
+    /// `recGblInitSimm` reaches `update_scan_index`, which takes the gate
+    /// itself, so it runs after the write lock is dropped, exactly as the eager
+    /// arm runs it after its `drop(gate)`.
+    fn init_deferred_record(&self, name: &str) {
+        let Some(rec_arc) = self.get_record(name) else {
+            return;
+        };
+        let (scan, phas, record_type) = {
+            let mut guard = rec_arc.write();
+            let instance = &mut *guard;
+            crate::server::ioc_app::attach_device_support(
+                instance,
+                name,
+                self.inner.device_support_resolver.load().as_deref(),
+            );
+            instance.arm_init_subroutines(self.inner.subroutine_registry.load_full());
+            instance.run_init_passes(name);
+            super::database::processing::seed_constant_links(instance);
+            (
+                instance.common.scan,
+                instance.common.phas,
+                instance.record.record_type(),
+            )
+        };
+        let seq = self
+            .inner
+            .load_order
+            .load()
+            .get(name)
+            .copied()
+            .unwrap_or(u64::MAX);
+        self.add_to_scan_list(scan, phas, record_type, seq, name);
+        self.rec_gbl_init_simm(&rec_arc);
+        self.arm_watchdog(name);
+        // The tail both loaders ran right after `add_loaded_record`: C's
+        // `init_record` checkLinks (`init_links`), then the constant-INP seed /
+        // `dbLoadLinkArray` (`rec_gbl_init_constant_links`). For a deferred
+        // record they belong here, after the passes, in the eager path's order —
+        // the loaders no longer run them for a record the barrier owns.
+        {
+            let mut guard = rec_arc.write();
+            let inst = &mut *guard;
+            inst.record.init_links(&inst.common);
+        }
+        self.rec_gbl_init_constant_links(&rec_arc);
     }
 
     /// Verify that `name` is not currently registered in any of the

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -1135,7 +1135,7 @@ pub(crate) fn build_refusal() -> String {
 /// returned, leaving `iocState` at [`IocState::Void`], which is why a
 /// measured `iocBuild`/`iocRun` pair answered `iocRun: WARNING IOC not
 /// paused` where C answers `iocRun: All initialization complete`, why a
-/// second `iocBuild` was accepted where C refuses it, and why the five-line
+/// second `iocBuild` was accepted where C refuses it, and why the
 /// `coreRelease` banner C puts between the two command echoes was missing
 /// from stdout.
 ///

--- a/crates/epics-base-rs/src/server/ioc_app.rs
+++ b/crates/epics-base-rs/src/server/ioc_app.rs
@@ -1428,17 +1428,22 @@ impl IocBuild {
         // (autosave pass 0) → initDatabase() (per-record init_record, where
         // devMotorAsyn's init_controller runs).
         //
-        // Both halves of C's `initDatabase` — the dset bind and the driver's
-        // own `init_record` — now run at the record's creation, from the
-        // database's own init owner, because C binds the dset BEFORE
-        // `init_record(0)` and a whole-database pass here could only bind it
-        // after. A pass0-restored field still lands as a plain pre-init field
-        // write (C dbPut before init_record) for the reason it always did:
-        // this hook fires before the startup script's `iocInit` line, and the
-        // records it restores were loaded before that. What changed is that
-        // `DeviceSupport::init` no longer waits for this point to anchor the
-        // command state such a write armed.
+        // C's `initDatabase` runs HERE, as a whole-database pass that binds each
+        // record's dset and only then runs its `init_record`
+        // (`drain_deferred_record_inits` → per record `attach_device_support`
+        // ahead of `run_init_passes`). The record was published at
+        // `dbLoadRecords` but its init deferred to this point, because a
+        // record's device-support PORT can be configured by a startup command
+        // AFTER the `dbLoadRecords` that created it (ADCore's
+        // `NDTimeSeriesConfigure` builds the `*_TS` port), so binding the dset
+        // at load would bind it against a port that does not exist yet. The
+        // pass runs before `setup_io_intr` (C's `scanInit`) so a dset is bound
+        // before I/O Intr wiring reads it. A pass0-restored field still lands as
+        // a plain pre-init field write (C dbPut before init_record): this hook
+        // fires before the startup script's `iocInit` line, and the records it
+        // restores were loaded before that.
         announce!(InitHookState::AfterInitDevSup);
+        db.drain_deferred_record_inits();
         let record_count = db.records_with_device_support().await;
         let io_intr_count = setup_io_intr(db.clone()).await;
         setup_property_posts(db.clone()).await;

--- a/crates/epics-base-rs/src/server/ioc_builder.rs
+++ b/crates/epics-base-rs/src/server/ioc_builder.rs
@@ -433,33 +433,12 @@ impl IocBuilder {
                 }
             }
 
-            // Device support and the post-init owners for the RecordInstance
-            if let Some(rec_arc) = db.get_record(&def.name) {
-                // Hand the record its resolved common link fields so a
-                // link-classifying record (calcout INAV..INUV/OUTV) can run
-                // its C `init_record` checkLinks step now — the common OUT
-                // link is set above, after `set_async_context` already ran at
-                // `add_record`. Defaulted no-op for records that do not
-                // classify common links. The data guard is released at each
-                // block close before the init awaits below (parking_lot guards
-                // are `!Send`).
-                {
-                    let mut instance = rec_arc.write();
-                    let inst = &mut *instance;
-                    inst.record.init_links(&inst.common);
-                }
-                // C: a soft-channel INPUT dev support's `init_record` loads a
-                // CONSTANT INP into the record's value
-                // (`recGblInitConstantLink` / `dbLoadLinkArray`) — and it runs
-                // BEFORE the record seeds MLST/ALST/LALM from VAL (e.g.
-                // `aiRecord.c:115-129`: `pdset->common.init_record` first, then
-                // `prec->mlst = prec->val`). The owner ENDS in C's init tail —
-                // `init_record_tail` then `seed_deadband_tracking`, in that
-                // order — so running it here is what puts the tail after the
-                // constant load, and nothing outside the owner may run either
-                // half.
-                db.rec_gbl_init_constant_links(&rec_arc);
-            }
+            // The per-record init tail — `init_links` (checkLinks) and
+            // `rec_gbl_init_constant_links` (the constant-INP seed) — is not run
+            // here any more: `add_loaded_record` deferred this record's whole
+            // init to C's `initDatabase` pass, which `drain_deferred_record_inits`
+            // below runs once every record has loaded and every device-support
+            // port has been configured.
         }
 
         // File-scope `alias("record","new")` that no single `.db` could
@@ -495,6 +474,13 @@ impl IocBuilder {
                 eprintln!("autosave: restored {count} PVs");
             }
         }
+
+        // 4.5. C's `initDatabase` per-record pass: bind each record's dset and
+        // run its `init_record` now that every record has loaded — deferred from
+        // load time so a record's device-support port could be configured first.
+        // Before `setup_io_intr` (C's `scanInit`), so a dset is bound before I/O
+        // Intr wiring reads it.
+        db.drain_deferred_record_inits();
 
         // 5. I/O Intr setup — through the single owner shared with the
         // `IocApplication` iocInit path, so C `scanAdd`'s failure exits

--- a/crates/epics-base-rs/src/server/iocsh/commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/commands.rs
@@ -5873,6 +5873,15 @@ async fn install_record_defs(
                 install_alias(ctx, alias, &def.name, faults).await;
             }
 
+            // A record created during THIS load — fresh, or a merge whose
+            // original was created during the load — has its whole init deferred
+            // to C's `initDatabase` pass (`drain_deferred_record_inits` at
+            // `iocInit`), so none of the init tail below runs here for it: doing
+            // so would bind the dset against ports not yet configured and out of
+            // C's order. Only a merge into a record created BEFORE the load
+            // (programmatically, already eager-inited) re-inits in place.
+            let init_deferred = ctx.db().record_init_deferred(&def.name);
+
             // A MERGE re-applies the new block's fields to a record that
             // is already in the database and already initialised, so
             // the load-then-init ordering the creation sink guarantees
@@ -5928,47 +5937,43 @@ async fn install_record_defs(
                         }
                     }
                 }
-                // TODO: refactor to global two-pass if inter-record init dependencies arise.
-                // C `iocInit` calls init_record once per record AFTER
-                // all dbLoadRecords blocks, so init_record always
-                // sees the final merged field set. Rust shortcuts by
-                // running init_record inline at dbLoadRecords; on a
-                // merge we re-run it so the new field values
-                // (LINR / ESLO / ZRST / ...) take effect in
-                // convert routines and post-init derived state.
-                // The cost: stateful records (compress accum,
-                // first_output_done) get re-initialised. The
-                // alternative (skip init on merge) silently
-                // ignored field overrides that affect init —
-                // worse for typical use.
-                rec_arc.write().run_init_passes(&def.name);
+                // C `iocInit` calls init_record once per record AFTER all
+                // dbLoadRecords blocks, so init_record always sees the final
+                // merged field set. A merge into a record created during this
+                // load is left for that barrier pass (`init_deferred`); a merge
+                // into a record created BEFORE the load re-runs init in place so
+                // the new field values (LINR / ESLO / ZRST / ...) take effect in
+                // convert routines and post-init derived state. The cost of the
+                // in-place re-run: stateful records (compress accum,
+                // first_output_done) get re-initialised — still better than
+                // silently ignoring field overrides that affect init.
+                if !init_deferred {
+                    rec_arc.write().run_init_passes(&def.name);
+                }
             }
-            {
-                // Hand the record its resolved common link fields so
-                // a link-classifying record (calcout INAV..INUV/OUTV)
-                // runs its C `init_record` checkLinks step at load —
-                // the common OUT link is applied by the sink, after
-                // `set_async_context`. Defaulted no-op for records
-                // that do not classify common links.
-                let mut instance = rec_arc.write();
-                let inst = &mut *instance;
-                inst.record.init_links(&inst.common);
-            }
-            // C `recGblInitConstantLink(&prec->inp, …)` /
-            // `dbLoadLinkArray` from every soft INPUT dev support's
-            // `init_record` — the only site that loads a constant INP
-            // into the record's value.
-            ctx.db().rec_gbl_init_constant_links(&rec_arc);
-            if is_merge {
-                // A merge re-ran `run_init_passes` above against the new
-                // field set, so the rest of pass 1 owes a re-run too: a
-                // second block may have introduced SIML/SIOL or moved SDEL.
-                // A FRESH record takes both from the creation sink
-                // (`PvDatabase::add_loaded_record`) and must not repeat them
-                // here — `arm_watchdog` would spawn a second task and
-                // supersede the first for nothing.
-                ctx.db().rec_gbl_init_simm(&rec_arc);
-                ctx.db().arm_watchdog(&def.name);
+            // C's `init_record` checkLinks (`init_links`) and the constant-INP
+            // seed / `dbLoadLinkArray` (`rec_gbl_init_constant_links`). For a
+            // record whose init is deferred to `iocInit`, the barrier pass owns
+            // both; only an in-place re-init (pre-load record merged into) runs
+            // them here.
+            if !init_deferred {
+                {
+                    let mut instance = rec_arc.write();
+                    let inst = &mut *instance;
+                    inst.record.init_links(&inst.common);
+                }
+                ctx.db().rec_gbl_init_constant_links(&rec_arc);
+                if is_merge {
+                    // A merge re-ran `run_init_passes` above against the new
+                    // field set, so the rest of pass 1 owes a re-run too: a
+                    // second block may have introduced SIML/SIOL or moved SDEL.
+                    // A FRESH record takes both from the creation sink
+                    // (`PvDatabase::add_loaded_record`) and must not repeat them
+                    // here — `arm_watchdog` would spawn a second task and
+                    // supersede the first for nothing.
+                    ctx.db().rec_gbl_init_simm(&rec_arc);
+                    ctx.db().arm_watchdog(&def.name);
+                }
             }
             Ok(())
         }
@@ -12667,6 +12672,10 @@ record(mbboDirect, "MBD0") {{ }}
         ));
 
         ctx.block_on(async {
+            // C runs `init_record` at `iocInit`, not at `dbLoadRecords`, so the
+            // UDF tail this asserts is visible only after the barrier — the
+            // softIoc sequence the doc above cites is `dbLoadRecords` + `iocInit`.
+            db.ioc_init().await;
             let udf = |name: &'static str| {
                 let db = db.clone();
                 async move { db.get_record(name).unwrap().read().common.udf != 0 }

--- a/crates/epics-base-rs/src/server/iocsh/misc_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/misc_commands.rs
@@ -168,9 +168,17 @@ fn cmd_core_release() -> CommandDef {
 /// `printf` does.
 pub(crate) fn core_release_block() -> [String; 5] {
     let rule = "#".repeat(76);
+    // epics-rs brands its own name where C prints "EPICS R…"
+    // (`epicsReleaseVersion`, mirrored verbatim by EPICS_RELEASE_VERSION). The
+    // base-compat release token rides along unchanged so the line still names
+    // the EPICS Base level this tree tracks; the `-V` string
+    // (EPICS_VERSION_STRING) stays byte-identical to C for tool parity.
+    let release = crate::runtime::version::EPICS_RELEASE_VERSION
+        .strip_prefix("EPICS ")
+        .unwrap_or(crate::runtime::version::EPICS_RELEASE_VERSION);
     [
         rule.clone(),
-        format!("## {}", crate::runtime::version::EPICS_RELEASE_VERSION),
+        format!("## epics-rs {release}"),
         format!("## Rev. {VCS_VERSION}"),
         format!("## Rev. Date {VCS_VERSION_DATE}"),
         rule,
@@ -394,9 +402,13 @@ mod tests {
         assert_eq!(lines.len(), 5, "C prints five lines: {out:?}");
         assert_eq!(lines[0], "#".repeat(76));
         assert_eq!(lines[4], "#".repeat(76));
-        assert_eq!(
-            lines[1],
-            format!("## {}", crate::runtime::version::EPICS_RELEASE_VERSION)
+        let release = crate::runtime::version::EPICS_RELEASE_VERSION
+            .strip_prefix("EPICS ")
+            .expect("EPICS_RELEASE_VERSION mirrors C's \"EPICS R…\"");
+        assert_eq!(lines[1], format!("## epics-rs {release}"));
+        assert!(
+            !lines[1].contains("EPICS"),
+            "banner brands epics-rs, not EPICS: {out:?}"
         );
         assert_eq!(lines[2], format!("## Rev. {VCS_VERSION}"));
         assert_eq!(lines[3], format!("## Rev. Date {VCS_VERSION_DATE}"));

--- a/crates/epics-base-rs/src/server/iocsh/misc_commands.rs
+++ b/crates/epics-base-rs/src/server/iocsh/misc_commands.rs
@@ -133,8 +133,9 @@ fn cmd_ioc_pause() -> CommandDef {
 }
 
 /// `coreRelease` — C `coreRelease()` (`misc/epicsRelease.c:21-29`),
-/// a five-line banner around `epicsReleaseVersion` and the two
-/// `epicsVCS.h` macros.
+/// a banner around the two `epicsVCS.h` macros. C's identity line is
+/// `epicsReleaseVersion` ("EPICS R…"); this port drops it — see
+/// [`core_release_block`].
 ///
 /// C generates that header per build with `genVersionHeader.pl`, and it
 /// has two arms with no empty outcome between them: a VCS checkout gives
@@ -157,8 +158,17 @@ fn cmd_core_release() -> CommandDef {
     )
 }
 
-/// The five lines themselves, so the shell command and the build print one
+/// The banner lines themselves, so the shell command and the build print one
 /// text.
+///
+/// C prints five lines: a `#` rule, `epicsReleaseVersion` ("EPICS
+/// R7.0.10.1-DEV"), the two `epicsVCS.h` revision lines, and the rule again.
+/// This port drops the release-version line. epics-rs's release is not the
+/// EPICS Base version, and branding that line `## epics-rs R7.0.10.1-DEV` read
+/// as if the port claimed to BE that C dev build; the base level this tree
+/// tracks is named by `EPICS_VERSION_STRING` (every tool's `-V` banner)
+/// instead. What coreRelease keeps is this build's own revision and date — the
+/// port's real release identity.
 ///
 /// C has one `coreRelease()` and calls it from both places — the iocsh
 /// command and `iocBuild_1` (`iocInit.c:147`) — and the port had the wording
@@ -166,19 +176,10 @@ fn cmd_core_release() -> CommandDef {
 /// without a second copy. The command still renders through the iocsh
 /// context so a redirection applies to it; the build writes stdout, as C's
 /// `printf` does.
-pub(crate) fn core_release_block() -> [String; 5] {
+pub(crate) fn core_release_block() -> [String; 4] {
     let rule = "#".repeat(76);
-    // epics-rs brands its own name where C prints "EPICS R…"
-    // (`epicsReleaseVersion`, mirrored verbatim by EPICS_RELEASE_VERSION). The
-    // base-compat release token rides along unchanged so the line still names
-    // the EPICS Base level this tree tracks; the `-V` string
-    // (EPICS_VERSION_STRING) stays byte-identical to C for tool parity.
-    let release = crate::runtime::version::EPICS_RELEASE_VERSION
-        .strip_prefix("EPICS ")
-        .unwrap_or(crate::runtime::version::EPICS_RELEASE_VERSION);
     [
         rule.clone(),
-        format!("## epics-rs {release}"),
         format!("## Rev. {VCS_VERSION}"),
         format!("## Rev. Date {VCS_VERSION_DATE}"),
         rule,
@@ -391,32 +392,33 @@ mod tests {
         assert_eq!(get_ioc_state(), IocState::Running);
     }
 
-    /// C `coreRelease` prints exactly five lines: a 76-`#` rule, three
-    /// `## ` lines, and the rule again (`misc/epicsRelease.c:23-27`).
+    /// C `coreRelease` prints five lines: a 76-`#` rule, `epicsReleaseVersion`,
+    /// the two revision lines, and the rule again (`misc/epicsRelease.c:23-27`).
+    /// This port drops the `epicsReleaseVersion` line — epics-rs's release is
+    /// not the base version — so coreRelease prints four: the rule, the two
+    /// revision lines, the rule.
     #[test]
-    fn core_release_prints_c_s_five_line_banner() {
+    fn core_release_prints_four_lines_without_the_base_version() {
         let ctx = make_ctx();
         let (out, failed) = run(&ctx, "coreRelease", &[]);
         assert!(!failed, "coreRelease never fails in C");
         let lines: Vec<&str> = out.lines().collect();
-        assert_eq!(lines.len(), 5, "C prints five lines: {out:?}");
+        assert_eq!(lines.len(), 4, "the base-version line is dropped: {out:?}");
         assert_eq!(lines[0], "#".repeat(76));
-        assert_eq!(lines[4], "#".repeat(76));
-        let release = crate::runtime::version::EPICS_RELEASE_VERSION
-            .strip_prefix("EPICS ")
-            .expect("EPICS_RELEASE_VERSION mirrors C's \"EPICS R…\"");
-        assert_eq!(lines[1], format!("## epics-rs {release}"));
+        assert_eq!(lines[3], "#".repeat(76));
+        assert_eq!(lines[1], format!("## Rev. {VCS_VERSION}"));
+        assert_eq!(lines[2], format!("## Rev. Date {VCS_VERSION_DATE}"));
+        // No remaining line states a release version: the dropped line was the
+        // only "epics-rs …" identity line, and no line carries the base token.
         assert!(
-            !lines[1].contains("EPICS"),
-            "banner brands epics-rs, not EPICS: {out:?}"
+            !out.contains("epics-rs") && !out.contains("R7.0.10"),
+            "the base-version identity line is gone: {out:?}"
         );
-        assert_eq!(lines[2], format!("## Rev. {VCS_VERSION}"));
-        assert_eq!(lines[3], format!("## Rev. Date {VCS_VERSION_DATE}"));
         // The stamp reaches the line: neither renders as a bare label the
         // way `## Rev. Date ` did before `build.rs` filled the pair.
-        assert!(lines[2].len() > "## Rev. ".len(), "empty revision: {out:?}");
+        assert!(lines[1].len() > "## Rev. ".len(), "empty revision: {out:?}");
         assert!(
-            lines[3].len() > "## Rev. Date ".len(),
+            lines[2].len() > "## Rev. Date ".len(),
             "empty date: {out:?}"
         );
     }

--- a/crates/epics-base-rs/src/server/scan.rs
+++ b/crates/epics-base-rs/src/server/scan.rs
@@ -156,6 +156,10 @@ pub fn scan_is_running() -> bool {
 /// the `iocRun` transition, never by a protocol server.
 pub fn scan_run() {
     SCAN_CTL.store(SCAN_CTL_RUN, std::sync::atomic::Ordering::Release);
+    // C `scanRun` sets `interruptAccept = TRUE` here (`dbScan.c:218`). The
+    // false→true edge is what fires asyn's one-shot boot flush, delivering
+    // every seeded `_RBV` value to the records that registered during iocInit.
+    crate::runtime::interrupt_accept::set_interrupts_accepted(true);
 }
 
 /// C `scanPause` (`dbScan.c:225-237`). The periodic threads stay alive and
@@ -163,6 +167,8 @@ pub fn scan_run() {
 /// lets `iocRun` resume without rebuilding the facility.
 pub fn scan_pause() {
     SCAN_CTL.store(SCAN_CTL_PAUSE, std::sync::atomic::Ordering::Release);
+    // C `scanPause` clears `interruptAccept` (`dbScan.c:241`).
+    crate::runtime::interrupt_accept::set_interrupts_accepted(false);
 }
 
 /// C `scanStop` (`dbScan.c:154-178`), less the joins: the threads are
@@ -171,6 +177,8 @@ pub fn scan_pause() {
 /// the two see a stopped facility rather than a half-torn one.
 pub fn scan_stop() {
     SCAN_CTL.store(SCAN_CTL_EXIT, std::sync::atomic::Ordering::Release);
+    // C `scanStop` clears `interruptAccept` (`dbScan.c:165`).
+    crate::runtime::interrupt_accept::set_interrupts_accepted(false);
 }
 
 /// How this facility blocks a plain (banded) thread on a future — both a

--- a/crates/epics-base-rs/tests/bare_shell_build_runs_c_iocbuild.rs
+++ b/crates/epics-base-rs/tests/bare_shell_build_runs_c_iocbuild.rs
@@ -27,7 +27,7 @@
 //! lifecycle: `iocBuild` then `iocRun` answered `iocRun: WARNING IOC not
 //! paused` where C answers `iocRun: All initialization complete`; a second
 //! `iocBuild` was accepted where C refuses it; `iocPause` after `iocInit`
-//! said `WARNING IOC not running`; and the five-line `coreRelease` banner C
+//! said `WARNING IOC not running`; and the `coreRelease` banner C
 //! puts on stdout between the two command echoes was absent.
 //!
 //! The sink rule this also pins is uniform and countable: `iocInit.c` holds
@@ -102,14 +102,19 @@ fn run(script_body: &str) -> (String, String) {
 }
 
 /// The banner's two `Rev.` lines carry this tree's own VCS stamp, as C's carry
-/// C's, so its shape is what can be asserted.
+/// C's, so its shape is what can be asserted. The port drops C's
+/// `epicsReleaseVersion` line — epics-rs's release is not the base version —
+/// so four lines print where C prints five.
 fn assert_banner(lines: &[&str], out: &str) {
-    assert_eq!(lines.len(), 5, "stdout was {out:?}");
+    assert_eq!(lines.len(), 4, "stdout was {out:?}");
     assert!(lines[0].starts_with("###"), "stdout was {out:?}");
-    assert!(lines[1].starts_with("## epics-rs"), "stdout was {out:?}");
-    assert!(lines[2].starts_with("## Rev. "), "stdout was {out:?}");
-    assert!(lines[3].starts_with("## Rev. Date "), "stdout was {out:?}");
-    assert!(lines[4].starts_with("###"), "stdout was {out:?}");
+    assert!(lines[1].starts_with("## Rev. "), "stdout was {out:?}");
+    assert!(lines[2].starts_with("## Rev. Date "), "stdout was {out:?}");
+    assert!(lines[3].starts_with("###"), "stdout was {out:?}");
+    assert!(
+        !lines.iter().any(|l| l.contains("epics-rs")),
+        "the base-version identity line is dropped: {out:?}"
+    );
 }
 
 /// `iocBuild` then `iocRun`: C's banner lands between the two echoes and the
@@ -175,7 +180,7 @@ async fn eltc_zero_silences_everything_the_build_says() {
     assert_eq!(err, "", "eltc 0 leaves C's console empty");
 }
 
-/// `coreRelease` on its own still prints the same five lines, so the assertion
+/// `coreRelease` on its own still prints the same banner, so the assertion
 /// above is about where the build prints and not about a mute shell.
 #[epics_macros_rs::epics_test]
 async fn core_release_still_prints_its_banner_on_stdout() {

--- a/crates/epics-base-rs/tests/bare_shell_build_runs_c_iocbuild.rs
+++ b/crates/epics-base-rs/tests/bare_shell_build_runs_c_iocbuild.rs
@@ -106,7 +106,7 @@ fn run(script_body: &str) -> (String, String) {
 fn assert_banner(lines: &[&str], out: &str) {
     assert_eq!(lines.len(), 5, "stdout was {out:?}");
     assert!(lines[0].starts_with("###"), "stdout was {out:?}");
-    assert!(lines[1].starts_with("## EPICS"), "stdout was {out:?}");
+    assert!(lines[1].starts_with("## epics-rs"), "stdout was {out:?}");
     assert!(lines[2].starts_with("## Rev. "), "stdout was {out:?}");
     assert!(lines[3].starts_with("## Rev. Date "), "stdout was {out:?}");
     assert!(lines[4].starts_with("###"), "stdout was {out:?}");

--- a/crates/epics-bridge-rs/Cargo.toml
+++ b/crates/epics-bridge-rs/Cargo.toml
@@ -171,7 +171,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = tr
 # host-facing feature that pulls this dependency — `qsrv`, `pvalink`,
 # `pva-gateway`, `dual-ioc` — so host builds resolve exactly as before. Only
 # `qsrv-core`, the RTEMS selection, gets the reduced set.
-epics-pva-rs = { path = "../epics-pva-rs", version = "0.28.0", optional = true, default-features = false }
+epics-pva-rs = { path = "../epics-pva-rs", version = "0.28.1", optional = true, default-features = false }
 # `epics-ca-rs` stays inherited, but NOT because its defaults are empty — they
 # stopped being empty at `274a734b`, which introduced the `client-core`/`client`
 # split and made `default = ["client"]`. The reason is narrower and is a fact

--- a/crates/epics-ca-rs/src/server/tcp.rs
+++ b/crates/epics-ca-rs/src/server/tcp.rs
@@ -5061,6 +5061,35 @@ impl PendingWriteNotify {
     }
 }
 
+/// Read a record-field snapshot under the record's `dbScanLock` analogue — the
+/// per-record advisory gate (L1, [`PvDatabase::lock_record`]).
+///
+/// `dbPutField` commits the field's VAL under the record's `parking_lot` write
+/// lock, RELEASES it, and re-acquires a second write lock in the process cycle
+/// that stamps `TIME` (`field_io.rs` drops the put guard before
+/// `put_driven_process` re-locks). Only L1 — held by `acquire_put_gate` across
+/// the whole put+process — spans both. A snapshot that takes only the record's
+/// `RwLock` reads VAL and TIME atomically w.r.t. each other but NOT w.r.t. the
+/// put: landing in that gap it captures the put's new VAL with the pre-put
+/// TIME. C cannot produce that pair — `db_post_single_event` (the monitor
+/// initial event) and `dbGet` both run under `dbScanLock` — so it observes the
+/// pre-put or the post-process state and never the mix. Taking L1 here restores
+/// that serialisation for every record-field snapshot read the CA server does
+/// off the live record (initial monitor event, one-shot GET, access re-post);
+/// the steady-state monitor stream is unaffected, since those frames are posted
+/// by the process cycle itself, already under L1. The guard is `!Send` and
+/// dropped before return — the read is fully synchronous.
+fn record_field_snapshot_scan_locked(
+    db: &PvDatabase,
+    record: &Arc<parking_lot::RwLock<RecordInstance>>,
+    field: &str,
+    string_view: bool,
+) -> Option<epics_base_rs::server::snapshot::Snapshot> {
+    let name = record.read().name.clone();
+    let _scan_lock = db.lock_record(&name);
+    db.channel_snapshot_for_field(record, field, string_view)
+}
+
 fn get_full_snapshot(
     db: &PvDatabase,
     target: &ChannelTarget,
@@ -5081,7 +5110,7 @@ fn get_full_snapshot(
         // gate already ran at CREATE_CHANNEL (CREATE_CH_FAIL, this file's
         // `parse_channel_name` call site).
         ChannelTarget::RecordField { record, field } => {
-            db.channel_snapshot_for_field(record, field, false)
+            record_field_snapshot_scan_locked(db, record, field, false)
         }
     }
 }
@@ -5106,7 +5135,7 @@ async fn get_read_snapshot(
     match target {
         ChannelTarget::SimplePv(pv) => pv.read_snapshot().await.map(Some),
         ChannelTarget::RecordField { record, field } => {
-            Ok(db.channel_snapshot_for_field(record, field, false))
+            Ok(record_field_snapshot_scan_locked(db, record, field, false))
         }
     }
 }
@@ -5679,7 +5708,8 @@ pub(crate) async fn register_subscription(
                 // and points this way: C `event_add_action` registers first and
                 // posts second (`camessage.c:1853`), so a duplicate is the
                 // C-compatible direction and a drop is not.
-                let hoisted_snap = state.db.channel_snapshot_for_field(record, field, false);
+                let hoisted_snap =
+                    record_field_snapshot_scan_locked(&state.db, record, field, false);
                 let registered = 'registered: {
                     let mut instance = record.write();
                     let Some(rx) = instance.add_subscriber_on(
@@ -6556,7 +6586,7 @@ fn try_get_read_snapshot_local(
 ) -> Option<Option<epics_base_rs::server::snapshot::Snapshot>> {
     match target {
         ChannelTarget::RecordField { record, field } => {
-            Some(db.channel_snapshot_for_field(record, field, false))
+            Some(record_field_snapshot_scan_locked(db, record, field, false))
         }
         // `read_snapshot_local` is `None` exactly when a read hook is
         // installed — the async upstream-GET signal — so it maps straight to
@@ -12476,5 +12506,105 @@ mod cancel_confirmation_ordering_tests {
 
         drop(client);
         handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod snapshot_scan_lock_tests {
+    //! The CA server's record-field snapshot reads (initial monitor event,
+    //! one-shot GET, access re-post) serialise against `dbPutField` through the
+    //! record's `dbScanLock` analogue (L1), exactly as C's `dbGet`/
+    //! `db_post_single_event` do — so a snapshot can never capture a put's new
+    //! VAL beside the pre-put TIME.
+
+    use super::record_field_snapshot_scan_locked;
+    use epics_base_rs::server::database::PvDatabase;
+    use epics_base_rs::server::records::ai::AiRecord;
+    use epics_base_rs::types::EpicsValue;
+    use std::sync::{Arc, Barrier};
+    use std::time::{Duration, SystemTime};
+
+    /// A put commits VAL under one record write-lock and stamps TIME under a
+    /// SECOND — `put_record_field_from_ca_body` drops the put guard between them
+    /// (`field_io.rs`), and only L1, held across the whole put+process by
+    /// `acquire_put_gate`, spans both. A snapshot that took only the record's
+    /// `RwLock` reads VAL and TIME atomically w.r.t. each other but not w.r.t.
+    /// the put: landing in that gap it captures the new VAL with the stale TIME
+    /// — the torn `(newVAL, oldTIME)` initial subscription event this fix
+    /// closes. The reader below is released the instant the writer has committed
+    /// the new VAL under L1 but not yet stamped TIME; taking L1,
+    /// `record_field_snapshot_scan_locked` must block behind the whole put and
+    /// so observe the post-stamp `(newVAL, newTIME)`, never the tear. Without
+    /// the L1 acquisition it reads straight through the open window and the
+    /// timestamp assertion fails.
+    #[epics_macros_rs::epics_test]
+    async fn initial_snapshot_never_tears_val_from_time_across_a_put() {
+        let db = Arc::new(PvDatabase::new());
+        db.add_record("SCAN:ai", Box::new(AiRecord::new(1.0)))
+            .await
+            .unwrap();
+        let rec = db.get_record("SCAN:ai").expect("record");
+
+        // Capture how the snapshot renders each of the two stamps, so the
+        // assertion names the exact `WallTime` a torn read could not produce —
+        // independent of whatever `set_val` does to `common.time`.
+        let t0 = SystemTime::UNIX_EPOCH + Duration::new(1_000, 0);
+        let t1 = SystemTime::UNIX_EPOCH + Duration::new(2_000, 0);
+        let stamp = |t: SystemTime| {
+            rec.write().common.time = t;
+            record_field_snapshot_scan_locked(&db, &rec, "VAL", false)
+                .expect("snapshot")
+                .timestamp
+        };
+        let stale_ts = stamp(t0);
+        let fresh_ts = stamp(t1);
+        assert_ne!(stale_ts, fresh_ts, "the two stamps must render differently");
+
+        // Pre-race state: old VAL, old TIME.
+        {
+            let mut inst = rec.write();
+            inst.record.set_val(EpicsValue::Double(1.0)).unwrap();
+            inst.common.time = t0;
+        }
+
+        let barrier = Arc::new(Barrier::new(2));
+        let writer = {
+            let db = db.clone();
+            let rec = rec.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                // L1 spans lock A .. lock B, as `acquire_put_gate` does.
+                let _l1 = db.lock_record("SCAN:ai");
+                {
+                    // lock A: VAL only.
+                    rec.write().record.set_val(EpicsValue::Double(2.0)).unwrap();
+                }
+                // New VAL committed, TIME still t0, L1 held: open the window.
+                barrier.wait();
+                // Widen it so an L1-less reader would certainly land inside.
+                std::thread::sleep(Duration::from_millis(100));
+                {
+                    // lock B: TIME stamp, closing the put.
+                    rec.write().common.time = t1;
+                }
+                // _l1 dropped here.
+            })
+        };
+
+        barrier.wait();
+        let snap =
+            record_field_snapshot_scan_locked(&db, &rec, "VAL", false).expect("raced snapshot");
+        writer.join().expect("writer thread");
+
+        assert_eq!(
+            snap.value,
+            EpicsValue::Double(2.0),
+            "the put's new VAL is visible"
+        );
+        assert_eq!(
+            snap.timestamp, fresh_ts,
+            "the snapshot must carry the put's stamped TIME, not the pre-put one \
+             — L1 serialises the read behind the whole put+process"
+        );
     }
 }

--- a/crates/epics-libcom-rs/src/runtime/interrupt_accept.rs
+++ b/crates/epics-libcom-rs/src/runtime/interrupt_accept.rs
@@ -1,0 +1,146 @@
+//! `interruptAccept` — the process-global gate that says record processing and
+//! I/O Intr callbacks are live.
+//!
+//! # Why this exists
+//!
+//! C's asyn param library defers every `callParamCallbacks` until the IOC has
+//! finished wiring records to their driver. `paramList::callCallbacks` opens
+//! with `if (!interruptAccept) return asynSuccess;` and returns **before**
+//! `flags.clear()` (`asynPortDriver.cpp:838,871`), so every callback fired
+//! while the IOC is still building is a no-op that *preserves* the accumulated
+//! changed-flags. A per-port thread then does the callbacks exactly once, the
+//! moment `interruptAccept` goes true (`callbackThread::run`,
+//! `asynPortDriver.cpp:923-937`), delivering every seeded read-only value
+//! (`Manufacturer`, `MaxSizeX`, …) to the `_RBV` records that only just
+//! registered their interrupts.
+//!
+//! Without this gate the port's `call_param_callbacks` clears the changed-flags
+//! whenever it happens to run first — a driver's own acquisition/array task can
+//! fire it before `iocInit` wires the records — and a read-only parameter set
+//! once at construction is then lost for the life of the process: its `_RBV`
+//! record sits at the `.db` default forever. This is the owner of the flag that
+//! `asyn-rs`'s `PortDriverBase::call_param_callbacks` consults and that the
+//! scan facility drives.
+//!
+//! # The default, and its single owner
+//!
+//! C initialises the flag `FALSE` (`dbAccess.c:67`); so does this port. The gate
+//! is thus closed at process start by construction, and the scan facility is its
+//! single owner thereafter: `scan_run` sets it true (C `scanRun`,
+//! `dbScan.c:218`), `scan_pause`/`scan_stop` set it false (`dbScan.c:241,165`).
+//! No other code writes it, so the seeds a port sets at construction are
+//! guaranteed to survive to the `scan_run` boot flush without depending on any
+//! bring-up path having lowered a gate first.
+//!
+//! C's non-IOC translation unit compiles `static int interruptAccept = 1`
+//! instead (`asynPortDriver.cpp:23-25`) so a bare `asynPortDriver` used outside
+//! an IOC still delivers. This port does not take that convenience default: it
+//! serves IOCs, where the gate is opened by `scan_run` at `iocRun`. A unit test
+//! that exercises `call_param_callbacks` without an `iocInit` must therefore
+//! open the gate itself with [`set_interrupts_accepted`], the precondition that
+//! always holds by the time records process in a running IOC.
+//!
+//! # The one-shot flush
+//!
+//! [`set_interrupts_accepted`] invokes the callbacks registered through
+//! [`on_interrupts_accepted`] on each `false → true` edge — never when the flag
+//! is written `true` while already `true`, so a pause→resume does not re-flush.
+//! `asyn-rs` registers one such callback that sweeps every port's changed
+//! params once; it is this crate's stand-in for C's per-port `callbackThread`.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// C `volatile int interruptAccept`. Defaults `false` (`dbAccess.c:67`); the
+/// scan facility is its single owner thereafter — see the module docs.
+static ACCEPTED: AtomicBool = AtomicBool::new(false);
+
+/// Callbacks fired on the `false → true` edge — the crate-level analogue of the
+/// per-port `callbackThread` C creates in every `asynPortDriver` constructor.
+/// `Arc` so the list can be snapshotted and the lock dropped before any
+/// callback runs (a callback that registers another must not deadlock), the
+/// same discipline as `init_hook_announce`.
+type OnAccept = std::sync::Arc<dyn Fn() + Send + Sync + 'static>;
+static ON_ACCEPT: Mutex<Vec<OnAccept>> = Mutex::new(Vec::new());
+
+/// Whether record processing / I/O Intr callbacks are live — C `interruptAccept`.
+///
+/// The single reader is `asyn-rs`'s `PortDriverBase::call_param_callbacks`,
+/// which returns without consuming its changed-flags while this is `false`.
+pub fn interrupts_accepted() -> bool {
+    ACCEPTED.load(Ordering::Acquire)
+}
+
+/// Set the gate, and on a `false → true` edge run every [`on_interrupts_accepted`]
+/// callback once.
+///
+/// C reaches the true edge inside `scanRun` (`dbScan.c:218`) and the false edge
+/// inside `scanPause`/`scanStop` (`dbScan.c:241,165`); the IOC's scan facility
+/// is the single owner that calls this. The edge guard means a redundant
+/// `true`-while-`true` (a pause→resume that never lowered the flag, or two scan
+/// starts) fires nothing, matching C's once-per-process `callbackThread`.
+pub fn set_interrupts_accepted(accepted: bool) {
+    let was = ACCEPTED.swap(accepted, Ordering::AcqRel);
+    if accepted && !was {
+        let snapshot: Vec<OnAccept> = ON_ACCEPT.lock().unwrap().clone();
+        for cb in snapshot {
+            cb();
+        }
+    }
+}
+
+/// Register a callback for the next `false → true` edge of the gate.
+///
+/// Registration does **not** fire the callback, even if the flag is already
+/// `true`: the caller (`asyn-rs`'s boot-flush arm) registers this once, and a
+/// port that appears after the flag is already up is that caller's concern, not
+/// this edge's. Process-global, matching C's single per-port thread list.
+pub fn on_interrupts_accepted<F: Fn() + Send + Sync + 'static>(cb: F) {
+    ON_ACCEPT.lock().unwrap().push(std::sync::Arc::new(cb));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    // These tests mutate process-global state; nextest runs each in its own
+    // process, so they do not race. Under `cargo test` they would share the
+    // flag, which is why each restores it.
+
+    #[test]
+    fn edge_fires_the_callback_exactly_once_per_false_to_true() {
+        set_interrupts_accepted(false);
+        static HITS: AtomicUsize = AtomicUsize::new(0);
+        on_interrupts_accepted(|| {
+            HITS.fetch_add(1, Ordering::SeqCst);
+        });
+
+        // false -> true: one fire.
+        set_interrupts_accepted(true);
+        assert_eq!(HITS.load(Ordering::SeqCst), 1);
+        assert!(interrupts_accepted());
+
+        // true -> true: no fire (C's callbackThread is once-per-process).
+        set_interrupts_accepted(true);
+        assert_eq!(HITS.load(Ordering::SeqCst), 1);
+
+        // false -> true again: fires again (a resume delivers what changed).
+        set_interrupts_accepted(false);
+        set_interrupts_accepted(true);
+        assert_eq!(HITS.load(Ordering::SeqCst), 2);
+
+        set_interrupts_accepted(true);
+    }
+
+    #[test]
+    fn registration_alone_does_not_fire() {
+        set_interrupts_accepted(true);
+        static HITS: AtomicUsize = AtomicUsize::new(0);
+        on_interrupts_accepted(|| {
+            HITS.fetch_add(1, Ordering::SeqCst);
+        });
+        // Already true, no edge — must not have fired.
+        assert_eq!(HITS.load(Ordering::SeqCst), 0);
+    }
+}

--- a/crates/epics-libcom-rs/src/runtime/mod.rs
+++ b/crates/epics-libcom-rs/src/runtime/mod.rs
@@ -28,6 +28,7 @@ pub mod epics_string;
 pub mod exit;
 pub mod fs;
 pub mod general_time;
+pub mod interrupt_accept;
 pub mod ioc_role;
 pub mod json_string;
 pub mod log;

--- a/crates/modbus-rs/src/ioc.rs
+++ b/crates/modbus-rs/src/ioc.rs
@@ -4878,6 +4878,11 @@ mod tests {
         // must still post their monitors after a poll, because `publish_stats`
         // is independent of the per-record interrupt fan-out.
         let mut rx = driver.base.interrupts.subscribe_async();
+        // `publish_stats` posts through `call_param_callbacks`, which is gated on
+        // `interruptAccept` — a real IOC opens it at the `iocInit`/`scan_run`
+        // barrier. This unit test drives `poll_cycle` with no scan facility, so
+        // it must establish that post-`iocInit` precondition itself.
+        epics_base_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
         driver.poll_cycle().expect("poll_cycle must succeed");
 
         // The statistics params live at addr 0; their monitors must have

--- a/examples/modbus-ioc/ioc/st.cmd
+++ b/examples/modbus-ioc/ioc/st.cmd
@@ -29,7 +29,7 @@ drvModbusAsynConfigure("$(R)HR", "$(OCTET)", 0, 3, 0, 10, "UINT16", 100, "")
 # Write 10 holding registers (function 16) at address 100.
 drvModbusAsynConfigure("$(R)HW", "$(OCTET)", 0, 16, 100, 10, "UINT16", 0, "")
 
-dbLoadRecords("db/modbus.db", "P=$(P),R=$(R),HR=$(R)HR,HW=$(R)HW")
+dbLoadRecords("$(MODBUS_IOC)/db/modbus.db", "P=$(P),R=$(R),HR=$(R)HR,HW=$(R)HW")
 
 iocInit()
 

--- a/examples/sim-detector/tests/acquire_readback.rs
+++ b/examples/sim-detector/tests/acquire_readback.rs
@@ -34,6 +34,13 @@ use epics_base_rs::types::EpicsValue;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn acquire_bo_returns_to_zero_after_single() {
+    // The acquire-finalize monitor that drives the bo back to Done posts through
+    // `call_param_callbacks`, which is gated on `interruptAccept` — a real IOC
+    // opens it at the `iocInit`/`scan_run` barrier. This test wires the record
+    // and acquisition path by hand with no scan facility, so it must establish
+    // that post-`iocInit` precondition itself.
+    epics_base_rs::runtime::interrupt_accept::set_interrupts_accepted(true);
+
     let rt = create_sim_detector("RBK_TEST", 32, 32, 10_000_000, NDArrayOutput::new()).unwrap();
     let handle = rt.port_handle().clone();
 


### PR DESCRIPTION
Bundles the eight commits on this branch that diverge from main and bumps the workspace to 0.28.1. The substantive change gates call_param_callbacks on interruptAccept (default FALSE, owned by the scan facility) so an areaDetector driver's read-only RBV seeds — MaxSizeX/Y, Manufacturer, Model — set before iocInit are held and flushed once records are wired, instead of being cleared so CA keeps serving the .db defaults. The rest defer record init to the iocInit barrier, register busy/sseq through register_all_plugins, correct the coreRelease banner, and make the modbus st.cmd load its db via $(MODBUS_IOC) so it no longer depends on the launch directory.