### PR TITLE
build(deps): bump rust-hdf5 to 0.5.2 in ad-plugins-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "rust-hdf5"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6944dd9a338f0cc79d1b291f2216765669cc129ab5713451a7e6295d5c240a1"
+checksum = "faf22af9f7deddd9ac324ddc2833eb77e2b2e2c77ee76c6f63c768a690edc8c9"
 dependencies = [
  "bzip2",
  "flate2",

--- a/crates/ad-plugins-rs/Cargo.toml
+++ b/crates/ad-plugins-rs/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 netcdf3 = "0.6"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif", "tiff"] }
 rayon = { version = "1", optional = true }
-rust-hdf5 = { version = "0.5.1", features = ["threadsafe", "all_filters", "parallel"] }
+rust-hdf5 = { version = "0.5.2", features = ["threadsafe", "all_filters", "parallel"] }
 epics-pva-rs = { workspace = true, optional = true }
 epics-bridge-rs = { workspace = true, features = ["qsrv"], optional = true }
 


### PR DESCRIPTION
0.5.2 carries the upstream CVE-2026-19025 layout-check fix and review hardening. The 0.5.1→0.5.2 bump is API-compatible: ad-plugins-rs (the sole consumer) compiles unchanged and its full --all-features suite passes (563/563).